### PR TITLE
ci: rebuild-from-main recovery workflow + bump fishsense-api pin

### DIFF
--- a/.github/workflows/rebuild-from-main.yml
+++ b/.github/workflows/rebuild-from-main.yml
@@ -1,0 +1,77 @@
+name: Rebuild images from main
+
+# Manual recovery workflow. Builds every service image at current
+# main HEAD and pushes it tagged with the version recorded in
+# .release-please-manifest.json plus :latest, :main, and
+# :sha-<short>. Use when GHCR packages have been deleted/relinked
+# and need to be repopulated end-to-end without going through a
+# full release-please cycle.
+#
+# This is additive to build.yml + promote.yml — it doesn't replace
+# them. Future releases still land via the normal flow; this
+# workflow exists for one-off recovery.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - fishsense-api
+          - fishsense-api-workflow-worker
+          - fishsense-backup-worker
+          - fishsense-data-processing-workflow-worker
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Read version from release-please manifest
+        id: ver
+        run: |
+          v="$(jq -r --arg k "services/${{ matrix.service }}" '.[$k]' .release-please-manifest.json)"
+          if [ -z "$v" ] || [ "$v" = "null" ]; then
+            echo "::error::no manifest entry for services/${{ matrix.service }}"
+            exit 1
+          fi
+          echo "version=v${v}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute lowercased image name
+        id: img
+        run: |
+          owner_lc="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          echo "name=${{ env.REGISTRY }}/${owner_lc}/${{ matrix.service }}" >> "$GITHUB_OUTPUT"
+
+      - name: Compute short SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: services/${{ matrix.service }}/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.img.outputs.name }}:${{ steps.ver.outputs.version }}
+            ${{ steps.img.outputs.name }}:latest
+            ${{ steps.img.outputs.name }}:main
+            ${{ steps.img.outputs.name }}:sha-${{ steps.sha.outputs.short }}
+          cache-from: type=registry,ref=${{ steps.img.outputs.name }}:buildcache
+          cache-to: type=registry,ref=${{ steps.img.outputs.name }}:buildcache,mode=max

--- a/deploy/compose.local.yml
+++ b/deploy/compose.local.yml
@@ -95,7 +95,7 @@ services:
     # local `build:` here also requires fixing services/fishsense-api/Dockerfile
     # (and .github/workflows/docker.yml) to use a workspace-aware build.
     # Tracked as a follow-up; not needed for data-worker TDD work.
-    image: ghcr.io/ucsd-e4e/fishsense-api:v1.18.1
+    image: ghcr.io/ucsd-e4e/fishsense-api:v1.19.0
     restart: on-failure:15
     depends_on:
       postgres:

--- a/deploy/compose.orchestrator.yml
+++ b/deploy/compose.orchestrator.yml
@@ -18,7 +18,7 @@ services:
     restart: on-failure:15
 
   fishsense-api:
-    image: ghcr.io/ucsd-e4e/fishsense-api:v1.18.1
+    image: ghcr.io/ucsd-e4e/fishsense-api:v1.19.0
     volumes:
       - ./fishsense_api_volumes/config:/e4efs/config:ro
     labels:


### PR DESCRIPTION
## Summary
- Add a manual recovery workflow (workflow_dispatch only) that rebuilds every service at current main HEAD and pushes all the version tags GHCR needs to be useful (`:v<manifest-version>`, `:latest`, `:main`, `:sha-<short>`).
- Bump compose pin for `fishsense-api` from `:v1.18.1` to `:v1.19.0`. The old pin referenced the polyrepo's last release; that image never existed in the monorepo-owned GHCR namespace. `:v1.19.0` matches `.release-please-manifest.json` and the GitHub release `fishsense-api-v1.19.0` cut earlier today.

## How to use after merge
1. Actions → "Rebuild images from main" → Run workflow → main.
2. Wait for matrix (4 services) to finish. All packages now exist in GHCR linked to this monorepo, with their correct version tags.
3. Deploy chain (compose pull) will succeed on the next auto-deploy/* PR merge.

## Test plan
- [ ] Merge PR
- [ ] Confirm rebuild-from-main workflow appears in Actions UI
- [ ] Dispatch it; all 4 matrix jobs succeed
- [ ] `docker pull ghcr.io/ucsd-e4e/fishsense-api:v1.19.0` works
- [ ] Re-run last failed deploy.yml; compose pull succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)