### PR TITLE
feat(deploy): wire fishsense-backup-worker into compose.workers.yml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,8 +237,10 @@ a separate host and that host's compose isn't in this repo yet.
 services running on the orchestrator host. Currently has
 `fishsense-api-workflow-worker` (moved out of `compose.temporal.yml`
 on 2026-04-29 — workers consume Temporal but aren't part of the
-cluster). `fishsense-backup-worker`'s stanza will land here once the
-prod `backup` Postgres role + NAS creds are set up.
+cluster) and `fishsense-backup-worker`. The backup worker reads its
+postgres + NAS credentials from `./backup_worker_volumes/config/`
+(`settings.toml` + `.secrets.toml`); that directory must be
+populated on the host before the service will start successfully.
 
 Race guard: promote.yml polls for the `:sha-<short>` image to appear
 (up to 20 min) before retagging. build.yml is triggered by the same

--- a/deploy/compose.workers.yml
+++ b/deploy/compose.workers.yml
@@ -8,10 +8,6 @@
 # fishsense-data-processing-workflow-worker is intentionally NOT here:
 # it runs on a separate host (held off auto-deploy for now) — see the
 # corresponding compose file on that host once it exists.
-#
-# fishsense-backup-worker is intentionally NOT here yet: it needs a
-# narrow `backup` Postgres role + NAS creds in .secrets/ before its
-# stanza can be added. See services/fishsense-backup-worker/README.md.
 
 services:
   fishsense-api-workflow-worker:
@@ -26,3 +22,13 @@ services:
     restart: on-failure:15
     deploy:
       replicas: 2
+
+  fishsense-backup-worker:
+    image: ghcr.io/ucsd-e4e/fishsense-backup-worker:v0.2.0
+    depends_on:
+      - temporal
+    volumes:
+      - ./temporal_volumes/certs:/certs:ro
+      - ./backup_worker_volumes/config:/e4efs/config:ro
+      - ./backup_worker_volumes/logs:/e4efs/logs:rw
+    restart: on-failure:15

--- a/deploy/worker_volumes/backup_config/settings.toml
+++ b/deploy/worker_volumes/backup_config/settings.toml
@@ -1,0 +1,29 @@
+[general]
+max_workers = 8
+
+[temporal]
+host = "fishsense-temporal"
+port = 7233
+tls = true
+client_cert = "/certs/client/fishsense-backup-worker.pem"
+client_private_key = "/certs/client/fishsense-backup-worker.key"
+domain = "workflows.fishsense.e4e.ucsd.edu"
+server_root_ca_cert = "/certs/ca/root-ca.pem"
+
+[postgres]
+host = "postgres"
+port = 5432
+username = "backup"
+
+[e4e_nas]
+# Synology DSM URL — must include hostname AND port (synology-api needs both).
+# Default DSM HTTPS is :5001. Replace with the actual NAS host+port.
+url = "https://nas.e4e.ucsd.edu:6021"
+
+[backup]
+databases = ["fishsense", "superset", "temporal_db"]
+retention_count = 14
+nas_root_path = "/fishsense_data"
+schedule_id = "fishsense-daily-db-backup"
+schedule_cron = "0 3 * * *"
+task_queue = "fishsense_backup_queue"


### PR DESCRIPTION
## Summary
Add the fishsense-backup-worker service stanza to `deploy/compose.workers.yml`, modeled on the api-workflow-worker stanza:

- Same image-pin format (`:v0.2.0`, the current release)
- Same `depends_on: [temporal]` (backup runs as a Temporal worker; reads/writes happen via activities)
- Same temporal certs bind mount
- Separate config dir (`./backup_worker_volumes/config:/e4efs/config:ro`) so backup credentials don't share a settings file with the api worker
- Separate logs dir (`./backup_worker_volumes/logs:/e4efs/logs:rw`)
- No mafl dashboard mount (backup doesn't surface status there)
- No `replicas:` key — single instance is enough for a once-daily schedule

## Host-side prereq before merging

Populate `./backup_worker_volumes/config/` on the prod host with:
- `settings.toml` — non-secret config (`[backup]` section, `[temporal]` host/port, NAS root path, etc.)
- `.secrets.toml` — `[postgres]` creds for the new `backup` role, `[e4e_nas]` creds

The container expects `/e4efs/config/` to be readable on startup. If the dir is missing or files are unreadable, the worker will crash-loop (handled by `restart: on-failure:15`).

## Test plan
- [ ] Confirm `./backup_worker_volumes/config/{settings.toml,.secrets.toml}` exist on the prod host
- [ ] Merge PR
- [ ] auto-deploy/* PR opened on next backup-worker release (compose pin already at v0.2.0, so no bump PR this time — the next release will trigger one)
- [ ] After deploy: `docker compose ps` shows fishsense-backup-worker running
- [ ] Temporal UI shows `fishsense-daily-db-backup` schedule registered
- [ ] First scheduled run at 03:00 UTC writes a `.dump` to NAS

🤖 Generated with [Claude Code](https://claude.com/claude-code)