### PR TITLE
fix(api): scope GET /dives/{id}/images/clusters/{ds} to data_source

### DIFF
--- a/services/fishsense-api/src/fishsense_api/controllers/image_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/image_controller.py
@@ -79,7 +79,11 @@ async def get_clusters(
         dive_id,
         data_source,
     )
-    query = select(DiveFrameCluster).where(DiveFrameCluster.dive_id == dive_id)
+    query = (
+        select(DiveFrameCluster)
+        .where(DiveFrameCluster.dive_id == dive_id)
+        .where(DiveFrameCluster.data_source == data_source)
+    )
 
     clusters = (await session.exec(query)).all()
     cluster_mapping_query = (
@@ -103,7 +107,7 @@ async def get_clusters(
     return [
         DiveFrameClusterJson(
             id=c.id,
-            image_ids=[m.image_id for m in cluster_mappings_dict[c.id]],
+            image_ids=[m.image_id for m in cluster_mappings_dict.get(c.id, [])],
             data_source=c.data_source,
             updated_at=c.updated_at,
             dive_id=c.dive_id,


### PR DESCRIPTION
## Summary

The cluster query in `image_controller.get_clusters` was returning `DiveFrameCluster` rows of every `data_source` for the dive, while the mapping query was filtered to the requested source. Two consequences:

- **KeyError 500** when any cluster of a *different* data_source had no entry in `cluster_mappings_dict`. This is what burned the api-worker stage-2 selector activity (`select_next_high_priority_dive_for_dive_image_preprocessing_activity`) into its 10-min `schedule_to_close` wall — confirmed via fishsense-api logs:

  ```
  File "fishsense_api/controllers/image_controller.py", line 106, in get_clusters
      image_ids=[m.image_id for m in cluster_mappings_dict[c.id]],
  KeyError: 2732
  ```

  Cluster 2732 is on dive 279 but has a different `data_source` than `PREDICTION`, so it was never in `cluster_mappings_dict`.

- **Wrong-data-source mixing** even on success: the response would include clusters of other data_sources paired with `image_ids` drawn only from the requested source. Quietly wrong.

## Fix

- Filter `select(DiveFrameCluster)` by `data_source` so the response is internally consistent.
- Switch the mapping lookup to `cluster_mappings_dict.get(c.id, [])` so a future legitimately-empty cluster (no images yet) doesn't reintroduce the KeyError.

6 lines added, 2 changed.

## Test plan

- [x] `./check.sh lint` — clean (10.00/10)
- [x] `uv run --package fishsense-api python -m pytest services/fishsense-api/tests/` — 49 passed
- [ ] After deploy: re-run the `preprocess-dive-images-workflow-schedule` and confirm the selector activity completes (no more 500 → schedule_to_close timeout)
- [ ] Future: add a regression test against a dive with mixed-`data_source` clusters

🤖 Generated with [Claude Code](https://claude.com/claude-code)