### PR TITLE
test(api): regression for get_clusters data_source filter

### DIFF
--- a/services/fishsense-api/pyproject.toml
+++ b/services/fishsense-api/pyproject.toml
@@ -22,6 +22,7 @@ fishsense-api-sdk = { workspace = true }
 
 [dependency-groups]
 dev = [
+    "aiosqlite>=0.20.0",
     "alembic>=1.16.5",
     "black>=25.9.0",
     "pylint>=4.0.2",

--- a/services/fishsense-api/tests/test_get_clusters_data_source_filter.py
+++ b/services/fishsense-api/tests/test_get_clusters_data_source_filter.py
@@ -1,0 +1,119 @@
+"""Regression: GET /dives/{id}/images/clusters/{ds} must filter clusters by
+data_source.
+
+The bug: the cluster query was scoped only by dive_id, while the mapping
+query was scoped by (dive_id, data_source). On a dive carrying both
+PREDICTION and LABEL_STUDIO clusters, every LABEL_STUDIO cluster ended up
+in the cluster list with no entry in the PREDICTION-only mapping dict,
+which raised KeyError on lookup. The api-worker's stage-2 selector
+activity retried the resulting 500 into its 10-min schedule_to_close
+wall in prod (cluster id 2732 on dive 279).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    # FK-less in-memory sqlite is enough — we're testing the controller's
+    # query composition, not referential integrity. Bypass the prod
+    # Database class because it hardcodes pool_size/max_overflow/pool_timeout
+    # which the sqlite/StaticPool combo rejects.
+    # Importing fishsense_api.database wires every model into SQLModel.metadata
+    # so create_all sees them.
+    from sqlalchemy.ext.asyncio import create_async_engine  # pylint: disable=import-outside-toplevel
+
+    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+async def test_get_clusters_returns_only_requested_data_source(session):
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        get_clusters,
+    )
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+        DiveFrameClusterImageMapping,
+    )
+
+    dive_id = 279
+
+    pred_a = DiveFrameCluster(dive_id=dive_id, data_source=DataSource.PREDICTION)
+    pred_b = DiveFrameCluster(dive_id=dive_id, data_source=DataSource.PREDICTION)
+    # The exact bug shape: a LABEL_STUDIO cluster on the same dive that
+    # has zero PREDICTION mappings (because LABEL_STUDIO mappings are
+    # scoped to the LS data source, which the controller's mapping query
+    # already filters out).
+    ls_orphan = DiveFrameCluster(dive_id=dive_id, data_source=DataSource.LABEL_STUDIO)
+    # Sanity sibling: a different dive must not leak in either.
+    other_dive = DiveFrameCluster(dive_id=dive_id + 1, data_source=DataSource.PREDICTION)
+
+    session.add_all([pred_a, pred_b, ls_orphan, other_dive])
+    await session.flush()
+
+    session.add_all(
+        [
+            DiveFrameClusterImageMapping(dive_frame_cluster_id=pred_a.id, image_id=11),
+            DiveFrameClusterImageMapping(dive_frame_cluster_id=pred_a.id, image_id=12),
+            DiveFrameClusterImageMapping(dive_frame_cluster_id=pred_b.id, image_id=21),
+            DiveFrameClusterImageMapping(
+                dive_frame_cluster_id=ls_orphan.id, image_id=31
+            ),
+            DiveFrameClusterImageMapping(
+                dive_frame_cluster_id=other_dive.id, image_id=99
+            ),
+        ]
+    )
+    await session.flush()
+
+    result = await get_clusters(
+        dive_id=dive_id, data_source=DataSource.PREDICTION, session=session
+    )
+
+    assert result is not None
+    returned_ids = {c.id for c in result}
+    assert returned_ids == {pred_a.id, pred_b.id}
+
+    by_id = {c.id: c for c in result}
+    assert set(by_id[pred_a.id].image_ids) == {11, 12}
+    assert by_id[pred_b.id].image_ids == [21]
+    for c in result:
+        assert c.data_source == DataSource.PREDICTION
+
+
+async def test_get_clusters_handles_cluster_with_no_mappings(session):
+    """Defensive: a cluster of the requested data_source with zero rows in
+    the mapping table must surface as image_ids=[], not KeyError."""
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        get_clusters,
+    )
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+    )
+
+    empty = DiveFrameCluster(dive_id=42, data_source=DataSource.PREDICTION)
+    session.add(empty)
+    await session.flush()
+
+    result = await get_clusters(
+        dive_id=42, data_source=DataSource.PREDICTION, session=session
+    )
+
+    assert result is not None
+    assert len(result) == 1
+    assert result[0].id == empty.id
+    assert result[0].image_ids == []

--- a/uv.lock
+++ b/uv.lock
@@ -23,6 +23,15 @@ members = [
 overrides = [{ name = "fishsense-api-sdk", editable = "libs/fishsense-api-sdk" }]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.18.4"
 source = { registry = "https://pypi.org/simple" }
@@ -647,6 +656,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aiosqlite" },
     { name = "alembic" },
     { name = "black" },
     { name = "datamodel-code-generator" },
@@ -671,6 +681,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "alembic", specifier = ">=1.16.5" },
     { name = "black", specifier = ">=25.9.0" },
     { name = "datamodel-code-generator", specifier = "==0.26.1" },


### PR DESCRIPTION
## Summary

Adds a regression test for the bug fixed in #33. The fix shipped without a test because diagnosis was the priority; this PR back-fills coverage so the same shape can't regress silently.

The test seeds an in-memory aiosqlite DB with the prod bug shape — a dive carrying both `PREDICTION` and `LABEL_STUDIO` clusters (cluster 2732 on dive 279, in prod) — calls \`get_clusters\` directly, and asserts the response contains only the requested data_source's clusters with their correct \`image_ids\`.

A second test pins the \`.get(c.id, [])\` defensive read by exercising a cluster of the requested data_source that has zero mappings.

Verified the test catches the bug: against the pre-#33 controller it fails with \`KeyError: 1\` (same shape as prod's \`KeyError: 2732\`); against the merged fix it passes.

## Notes

- Adds \`aiosqlite>=0.20.0\` to fishsense-api's dev deps.
- Bypasses the prod \`Database\` class because it hardcodes \`pool_size\` / \`max_overflow\` / \`pool_timeout\`, which the sqlite/StaticPool combo rejects. The fixture uses \`create_async_engine\` directly.
- FK-less in-memory sqlite is enough — we're testing the controller's query composition, not referential integrity. The \`fishsense_api.database\` import inside the fixture wires every model into \`SQLModel.metadata\` so \`create_all\` sees them.

## Test plan

- [x] \`./check.sh lint\` — clean (10/10)
- [x] \`uv run --package fishsense-api python -m pytest services/fishsense-api/tests/\` — 51 passed
- [x] Manually reverted the controller fix → both new tests fail with KeyError; restored fix → both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)