### PR TITLE
feat(api-worker): wire stage 13 + 14 parents to data-worker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,8 @@ DB (negligible). To add or remove, override
 | 9   | preprocess_slate_images | api-worker (parent) + data-worker (child) | ported (hourly, +45min offset) |
 | 11  | populate_label_studio_project | api-worker | ported |
 | 12  | sync_slate_label | api-worker | ported (hourly) |
-| 13  | perform_laser_calibration | data-worker | ported (kernel in fishsense-core) |
-| 14  | measure_fish | data-worker | ported (kernel in fishsense-core) |
+| 13  | perform_laser_calibration | api-worker (parent) + data-worker (child) | ported (hourly, +50min offset) |
+| 14  | measure_fish | api-worker (parent) + data-worker (child) | ported (on-demand; idempotency caveat — see notes) |
 
 Create and populate are split into separate workflows per stage:
 
@@ -85,7 +85,7 @@ exist — the cluster API has no DELETE, so a re-POST would silently
 double-count. To re-group after labels change, an operator must
 manually drop the existing LABEL_STUDIO clusters first.
 
-## Cross-worker orchestration pattern (stages 0.1, 2, 5.1, 9)
+## Cross-worker orchestration pattern (stages 0.1, 2, 5.1, 9, 13, 14)
 
 The api-worker is the brains; the data-worker is the executor. Stages
 that need both SDK-side decision-making *and* CPU-heavy per-image
@@ -138,11 +138,11 @@ one replica):
 * Per-image activities are idempotent: nginx DAV PUT overwrites,
   SDK upserts.
 
-Applied to stages 0.1, 2, 5.1, 9 — each parent runs hourly with a
-15-minute offset between them
-(`preprocess-{laser,dive-images,headtail,slate}-images-workflow-schedule`)
-so their selectors don't all hit `dives.get()` at the top of the
-hour. Per-stage cohort:
+Applied to stages 0.1, 2, 5.1, 9, 13 — each parent runs hourly. The
+four preprocess parents are slotted at +0/+15/+30/+45 min so their
+selectors don't all hit `dives.get()` at the top of the hour; stage
+13 calibration sits at +50 min. Stage 14 measurement is registered
+but not scheduled (see notes below). Per-stage cohort:
 
 | Stage | Parent cohort definition |
 |---|---|
@@ -150,6 +150,8 @@ hour. Per-stage cohort:
 | 2   | HIGH-priority + has PREDICTION clusters + at least one image without a completed `SpeciesLabel` |
 | 5.1 | HIGH-priority + at least one `SpeciesLabel.top_three_photos_of_group=True` whose `HeadTailLabel` is incomplete |
 | 9   | HIGH-priority + `dive_slate_id` set + at least one `SpeciesLabel.content_of_image='Slate, Laser on slate'` whose `DiveSlateLabel` is incomplete |
+| 13  | HIGH-priority + `dive_slate_id` set + no `LaserExtrinsics` + ≥2 completed `DiveSlateLabel` rows (matches the data-worker activity's `MIN_LASER_POINTS=2` precondition) |
+| 14  | HIGH-priority + has `LaserExtrinsics` + has LABEL_STUDIO clusters with at least one `fish_id is None` |
 
 Stage 1 (clustering) does NOT yet have a parent — its data-worker
 workflow returns clusters but doesn't write them back to the DB, so
@@ -157,9 +159,31 @@ adding a parent requires deciding whether the parent persists the
 output (via `images.post_cluster`) or whether the workflow itself
 gains a write step. Defer until a real consumer needs it.
 
-Stages 13 and 14 deliberately keep their SDK fetches inline (the
-math kernels need opencv + fishsense-core, so splitting fetch/math
-across workers would add 5+ activity handoffs per dive for no gain).
+Stages 13 and 14 are structurally lighter than the four preprocess
+parents: pure SDK math, no NAS staging, no file-exchange JPEGs, no
+per-image fan-out. Their selector + child-dispatch parents have only
+two activity calls (selector → `start_child_workflow`); the data-worker
+keeps SDK fetches inline because the math kernels need opencv +
+fishsense-core, so splitting fetch/math across workers would add 5+
+activity handoffs per dive for no gain.
+
+**Stage 14 deliberately is not scheduled.** `measure_fish_activity` is
+non-idempotent (`post_measurement` is a POST and the SDK has no
+per-image measurement query), so a re-run on a partially-failed dive
+would duplicate measurements on already-bound clusters. Until that's
+resolved (likely by adding a `get_measurements` SDK method and
+per-image filtering in the activity), `MeasureFishParentWorkflow` is
+operator-triggered:
+
+```
+temporal workflow start \
+    --task-queue fishsense_api_queue \
+    --type MeasureFishParentWorkflow \
+    --workflow-id measure-fish-parent-<run-tag>
+```
+
+Each invocation drains exactly one dive — call it repeatedly to clear
+a backlog.
 
 ## Data-worker activity pattern
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_laser_calibration_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_laser_calibration_activity.py
@@ -1,0 +1,59 @@
+"""Activity to pick the next HIGH-priority dive that needs stage 13
+laser calibration.
+
+Cohort: HIGH priority + has `dive_slate_id` set + no `LaserExtrinsics`
+row yet + at least `MIN_COMPLETED_SLATE_LABELS` completed
+`DiveSlateLabel` rows. The minimum-2 floor matches the data-worker
+activity's `MIN_LASER_POINTS = 2` precondition; selecting a dive with
+fewer than two completed slate labels would dispatch a child that
+raises `ValueError` and re-fires every hour, since `put_laser_extrinsics`
+never gets written.
+
+Returns the lowest dive_id in the cohort, or None. Ordering by `id`
+is FIFO-ish; if dives ever get backfilled out of order, swap the
+sort key to `dive_datetime`.
+"""
+
+from __future__ import annotations
+
+from fishsense_api_sdk.models.priority import Priority
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.utils import get_fs_client
+
+MIN_COMPLETED_SLATE_LABELS = 2
+
+
+@activity.defn
+async def select_next_high_priority_dive_for_laser_calibration_activity() -> (
+    int | None
+):
+    async with get_fs_client() as fs:
+        dives = await fs.dives.get() or []
+        candidates = [
+            d
+            for d in dives
+            if d.priority == Priority.HIGH
+            and d.id is not None
+            and d.dive_slate_id is not None
+        ]
+        candidates.sort(key=lambda d: d.id)
+
+        for dive in candidates:
+            extrinsics = await fs.dives.get_laser_extrinsics(dive.id)
+            if extrinsics is not None:
+                continue
+
+            slate_labels = await fs.labels.get_dive_slate_labels(dive.id) or []
+            completed = [label for label in slate_labels if label.completed]
+            if len(completed) >= MIN_COMPLETED_SLATE_LABELS:
+                activity.logger.info(
+                    "next HIGH-priority dive needing laser calibration: dive_id=%d",
+                    dive.id,
+                )
+                return dive.id
+
+        activity.logger.info(
+            "no HIGH-priority dives needing laser calibration"
+        )
+        return None

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_measure_fish_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_measure_fish_activity.py
@@ -1,0 +1,67 @@
+"""Activity to pick the next HIGH-priority dive that needs stage 14
+fish measurement.
+
+Cohort: HIGH priority + has `LaserExtrinsics` (stage 13 done) + has at
+least one `data_source=LABEL_STUDIO` cluster (stage 6.1 done) where
+`fish_id` is None — i.e., a cluster that hasn't yet been bound to a
+fish by `measure_fish_activity._ensure_fish`.
+
+The `fish_id is None` predicate is a first-run gate: after a successful
+measurement run, every reachable cluster has `fish_id` set, so the dive
+falls out of the cohort. **It is not a strict idempotency gate** —
+`measure_fish_activity` is non-idempotent (`post_measurement` is a POST,
+not a PUT, and the SDK has no per-image measurement query), so a
+partially-failed run that left some clusters bound and others not will
+re-fire and *duplicate* measurements on the already-bound clusters.
+
+Because of that, the parent workflow is registered but **deliberately
+not scheduled** — operators trigger it on-demand per dive once the
+upstream context is ready. This selector exists so on-demand callers
+can ask "which dive is next?" without re-implementing the predicate.
+
+Returns the lowest dive_id in the cohort, or None.
+"""
+
+from __future__ import annotations
+
+from fishsense_api_sdk.models.data_source import DataSource
+from fishsense_api_sdk.models.priority import Priority
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.utils import get_fs_client
+
+
+@activity.defn
+async def select_next_high_priority_dive_for_measure_fish_activity() -> int | None:
+    async with get_fs_client() as fs:
+        dives = await fs.dives.get() or []
+        candidates = [
+            d
+            for d in dives
+            if d.priority == Priority.HIGH and d.id is not None
+        ]
+        candidates.sort(key=lambda d: d.id)
+
+        for dive in candidates:
+            extrinsics = await fs.dives.get_laser_extrinsics(dive.id)
+            if extrinsics is None:
+                continue
+
+            clusters = (
+                await fs.images.get_clusters(
+                    dive.id, DataSource.LABEL_STUDIO.value
+                )
+                or []
+            )
+            unbound = [c for c in clusters if c.fish_id is None]
+            if unbound:
+                activity.logger.info(
+                    "next HIGH-priority dive needing measurement: dive_id=%d "
+                    "(unbound_clusters=%d)",
+                    dive.id,
+                    len(unbound),
+                )
+                return dive.id
+
+        activity.logger.info("no HIGH-priority dives needing measurement")
+        return None

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -92,6 +92,9 @@ from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for
 from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for_headtail_preprocessing_activity import (  # pylint: disable=line-too-long
     select_next_high_priority_dive_for_headtail_preprocessing_activity,
 )
+from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for_laser_calibration_activity import (  # pylint: disable=line-too-long
+    select_next_high_priority_dive_for_laser_calibration_activity,
+)
 from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for_laser_preprocessing_activity import (  # pylint: disable=line-too-long
     select_next_high_priority_dive_for_laser_preprocessing_activity,
 )
@@ -149,6 +152,9 @@ from fishsense_api_workflow_worker.workflows.populate_laser_label_studio_project
 )
 from fishsense_api_workflow_worker.workflows.populate_species_label_studio_project_workflow import (  # pylint: disable=line-too-long
     PopulateSpeciesLabelStudioProjectWorkflow,
+)
+from fishsense_api_workflow_worker.workflows.perform_laser_calibration_parent_workflow import (  # pylint: disable=line-too-long
+    PerformLaserCalibrationParentWorkflow,
 )
 from fishsense_api_workflow_worker.workflows.preprocess_dive_images_parent_workflow import (  # pylint: disable=line-too-long
     PreprocessDiveImagesParentWorkflow,
@@ -329,6 +335,22 @@ async def schedule_workflows(client: Client):
                     overlap=ScheduleOverlapPolicy.SKIP,
                 )
             )
+            # Stage 13 calibration parent: hourly, slotted at +50 min so
+            # its selector doesn't collide with the four preprocess
+            # parents at +0/+15/+30/+45. Calibration is pure math (no
+            # NAS/exchange) so a 15-minute child execution_timeout is
+            # plenty.
+            tg.create_task(
+                schedule_workflow(
+                    client,
+                    "perform-laser-calibration-workflow-schedule",
+                    PerformLaserCalibrationParentWorkflow,
+                    timedelta(hours=1),
+                    offset=timedelta(minutes=50),
+                    run_timeout=timedelta(minutes=30),
+                    overlap=ScheduleOverlapPolicy.SKIP,
+                )
+            )
 
 
 async def main():
@@ -366,6 +388,7 @@ async def main():
                 PreprocessDiveImagesParentWorkflow,
                 PreprocessHeadtailImagesParentWorkflow,
                 PreprocessSlateImagesParentWorkflow,
+                PerformLaserCalibrationParentWorkflow,
             ],
             activity_executor=executor,
             activities=[
@@ -401,6 +424,7 @@ async def main():
                 select_next_high_priority_dive_for_dive_image_preprocessing_activity,
                 select_next_high_priority_dive_for_headtail_preprocessing_activity,
                 select_next_high_priority_dive_for_slate_preprocessing_activity,
+                select_next_high_priority_dive_for_laser_calibration_activity,
                 stage_raw_bytes_for_dive_activity,
                 stage_slate_pdf_activity,
                 archive_processed_jpegs_to_nas_activity,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -98,6 +98,9 @@ from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for
 from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for_laser_preprocessing_activity import (  # pylint: disable=line-too-long
     select_next_high_priority_dive_for_laser_preprocessing_activity,
 )
+from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for_measure_fish_activity import (  # pylint: disable=line-too-long
+    select_next_high_priority_dive_for_measure_fish_activity,
+)
 from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for_slate_preprocessing_activity import (  # pylint: disable=line-too-long
     select_next_high_priority_dive_for_slate_preprocessing_activity,
 )
@@ -152,6 +155,9 @@ from fishsense_api_workflow_worker.workflows.populate_laser_label_studio_project
 )
 from fishsense_api_workflow_worker.workflows.populate_species_label_studio_project_workflow import (  # pylint: disable=line-too-long
     PopulateSpeciesLabelStudioProjectWorkflow,
+)
+from fishsense_api_workflow_worker.workflows.measure_fish_parent_workflow import (  # pylint: disable=line-too-long
+    MeasureFishParentWorkflow,
 )
 from fishsense_api_workflow_worker.workflows.perform_laser_calibration_parent_workflow import (  # pylint: disable=line-too-long
     PerformLaserCalibrationParentWorkflow,
@@ -389,6 +395,7 @@ async def main():
                 PreprocessHeadtailImagesParentWorkflow,
                 PreprocessSlateImagesParentWorkflow,
                 PerformLaserCalibrationParentWorkflow,
+                MeasureFishParentWorkflow,
             ],
             activity_executor=executor,
             activities=[
@@ -425,6 +432,7 @@ async def main():
                 select_next_high_priority_dive_for_headtail_preprocessing_activity,
                 select_next_high_priority_dive_for_slate_preprocessing_activity,
                 select_next_high_priority_dive_for_laser_calibration_activity,
+                select_next_high_priority_dive_for_measure_fish_activity,
                 stage_raw_bytes_for_dive_activity,
                 stage_slate_pdf_activity,
                 archive_processed_jpegs_to_nas_activity,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/measure_fish_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/measure_fish_parent_workflow.py
@@ -1,0 +1,82 @@
+"""Stage 14 parent workflow (api-worker side).
+
+Picks the next HIGH-priority dive ready for fish measurement and
+dispatches it to the data-worker's `MeasureFishWorkflow` on
+`fishsense_data_processing_queue`.
+
+Lighter than the four preprocess parents (0.1 / 2 / 5.1 / 9): no NAS
+staging, no file-exchange JPEGs, no per-image fan-out. Measurement is
+pure SDK math against already-stored laser/headtail/cluster data. The
+data-worker activity does its own SDK fetches inline (per CLAUDE.md,
+stages 13 and 14 keep SDK fetches in the data-worker because the math
+kernels need fishsense-core anyway).
+
+**Deliberately not scheduled.** `measure_fish_activity` is non-idempotent
+(`post_measurement` is a POST and the SDK has no per-image measurement
+query), so a re-run on a partially-failed dive will duplicate
+measurements on already-bound clusters. Until that's resolved
+(probably by adding an SDK get-measurements query and per-image
+filtering in the activity), this parent is invoked on-demand:
+
+```
+temporal workflow start \
+    --task-queue fishsense_api_queue \
+    --type MeasureFishParentWorkflow \
+    --workflow-id measure-fish-parent-<run-tag>
+```
+
+The selector activity returns the next eligible dive_id (HIGH priority
++ has laser_extrinsics + has LABEL_STUDIO clusters with at least one
+unbound `fish_id`); the parent then dispatches the child and returns
+the dive_id processed.
+
+Cluster-correctness invariants — relevant once the data-worker scales
+beyond a single replica:
+
+* The child workflow is started with a deterministic id
+  (`measure-fish-{dive_id}`); a duplicate parent run targeting the
+  same dive hits `WorkflowAlreadyStarted` and is a no-op while the
+  first child is still running.
+* Per-cluster `fish_id` rebinds via `put_cluster` on the activity side
+  are idempotent under retry within a single child run.
+"""
+
+from datetime import timedelta
+
+from temporalio import workflow
+
+DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
+
+
+@workflow.defn
+class MeasureFishParentWorkflow:
+    # pylint: disable=too-few-public-methods
+    """Auto-pick the next HIGH-priority dive ready for measurement and
+    dispatch its child workflow to the data-worker.
+
+    Returns the dive_id processed (or None when the cohort is empty).
+    """
+
+    @workflow.run
+    async def run(self) -> int | None:
+        dive_id = await workflow.execute_activity(
+            "select_next_high_priority_dive_for_measure_fish_activity",
+            args=(),
+            schedule_to_close_timeout=timedelta(minutes=5),
+        )
+        if dive_id is None:
+            return None
+
+        workflow.logger.info(
+            "dispatching fish measurement to data-worker dive_id=%d", dive_id
+        )
+
+        await workflow.execute_child_workflow(
+            "MeasureFishWorkflow",
+            dive_id,
+            id=f"measure-fish-{dive_id}",
+            task_queue=DATA_PROCESSING_TASK_QUEUE,
+            execution_timeout=timedelta(hours=1),
+        )
+
+        return dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/perform_laser_calibration_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/perform_laser_calibration_parent_workflow.py
@@ -1,0 +1,68 @@
+"""Stage 13 parent workflow (api-worker side).
+
+Picks the next HIGH-priority dive needing laser calibration and
+dispatches it to the data-worker's `PerformLaserCalibrationWorkflow`
+on `fishsense_data_processing_queue`.
+
+Lighter than the four preprocess parents (0.1 / 2 / 5.1 / 9): no NAS
+staging, no file-exchange JPEGs, no per-image fan-out. Calibration is
+pure SDK math against already-stored slate + laser labels + camera
+intrinsics. The activity itself does its own SDK fetches inline (per
+CLAUDE.md, stages 13 and 14 deliberately keep SDK fetches in the
+data-worker because the math kernels need fishsense-core anyway).
+
+Cluster-correctness invariants — relevant once the data-worker scales
+beyond a single replica:
+
+* The schedule that fires this workflow uses
+  `overlap_policy=ScheduleOverlapPolicy.SKIP`, so a run still in
+  flight when the next firing arrives is dropped at the schedule level.
+* The child workflow is started with a deterministic id
+  (`perform-laser-calibration-{dive_id}`); if a parent run somehow
+  races past the schedule guard, the second child-workflow start hits
+  `WorkflowAlreadyStarted` and is a no-op rather than redoing the dive.
+* `put_laser_extrinsics` on the activity side is an upsert — even
+  outright re-runs of a successful call land on the same row.
+"""
+
+from datetime import timedelta
+
+from temporalio import workflow
+
+DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
+
+
+@workflow.defn
+class PerformLaserCalibrationParentWorkflow:
+    # pylint: disable=too-few-public-methods
+    """Auto-pick the next HIGH-priority dive lacking laser extrinsics
+    and dispatch its calibration to the data-worker.
+
+    Returns the dive_id processed (or None when the backlog is empty).
+    Each invocation drains exactly one dive — an N-dive backlog clears
+    in N hourly schedule firings.
+    """
+
+    @workflow.run
+    async def run(self) -> int | None:
+        dive_id = await workflow.execute_activity(
+            "select_next_high_priority_dive_for_laser_calibration_activity",
+            args=(),
+            schedule_to_close_timeout=timedelta(minutes=5),
+        )
+        if dive_id is None:
+            return None
+
+        workflow.logger.info(
+            "dispatching laser calibration to data-worker dive_id=%d", dive_id
+        )
+
+        await workflow.execute_child_workflow(
+            "PerformLaserCalibrationWorkflow",
+            dive_id,
+            id=f"perform-laser-calibration-{dive_id}",
+            task_queue=DATA_PROCESSING_TASK_QUEUE,
+            execution_timeout=timedelta(minutes=15),
+        )
+
+        return dive_id

--- a/services/fishsense-api-workflow-worker/tests/test_measure_fish_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_measure_fish_parent_workflow.py
@@ -1,0 +1,131 @@
+# pylint: disable=unused-argument
+"""Workflow contract test for MeasureFishParentWorkflow.
+
+Pins down:
+  1. Selector returns None -> parent returns None, no child dispatch.
+  2. Selector returns an id -> child dispatched on the data-worker task
+     queue with a deterministic id (`measure-fish-{dive_id}`) and the
+     dive_id payload, parent returns the dive_id.
+
+The child stub forwards its workflow_id + payload through a recording
+activity so the contract test can observe what the parent dispatched
+across the workflow sandbox boundary.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from typing import List, Optional
+
+import pytest
+from temporalio import activity, workflow
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from fishsense_api_workflow_worker.workflows.measure_fish_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    DATA_PROCESSING_TASK_QUEUE,
+    MeasureFishParentWorkflow,
+)
+
+
+@workflow.defn(name="MeasureFishWorkflow")
+class _StubChildWorkflow:
+    # pylint: disable=too-few-public-methods
+    """Stand-in for the data-worker's MeasureFishWorkflow."""
+
+    @workflow.run
+    async def run(self, dive_id: int) -> dict:
+        await workflow.execute_activity(
+            "_record_child_dispatch",
+            args=(workflow.info().workflow_id, dive_id),
+            schedule_to_close_timeout=timedelta(seconds=5),
+        )
+        return {
+            "measured": 0,
+            "dropped_nan": 0,
+            "missing_laser_or_headtail": 0,
+            "missing_cluster": 0,
+        }
+
+
+def _make_recording_activity(captures: List[tuple]):
+    @activity.defn(name="_record_child_dispatch")
+    async def record_child_dispatch(workflow_id: str, dive_id: int) -> None:
+        captures.append((workflow_id, dive_id))
+
+    return record_child_dispatch
+
+
+def _make_stub_selector(selector_result: Optional[int]):
+    selector_calls: List[None] = []
+
+    @activity.defn(
+        name="select_next_high_priority_dive_for_measure_fish_activity"
+    )
+    async def stub_select() -> Optional[int]:
+        selector_calls.append(None)
+        return selector_result
+
+    return stub_select, selector_calls
+
+
+@pytest.mark.asyncio
+async def test_dispatches_child_with_deterministic_id_and_dive_payload():
+    stub_select, selector_calls = _make_stub_selector(440)
+    child_runs: List[tuple] = []
+    record = _make_recording_activity(child_runs)
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-stage14-parent",
+            workflows=[MeasureFishParentWorkflow],
+            activities=[stub_select],
+        ), Worker(
+            env.client,
+            task_queue=DATA_PROCESSING_TASK_QUEUE,
+            workflows=[_StubChildWorkflow],
+            activities=[record],
+        ):
+            result = await env.client.execute_workflow(
+                MeasureFishParentWorkflow.run,
+                id=f"test-stage14-parent-{uuid.uuid4()}",
+                task_queue="test-stage14-parent",
+            )
+
+    assert result == 440
+    assert len(selector_calls) == 1
+    assert len(child_runs) == 1
+    child_id, child_dive_id = child_runs[0]
+    assert child_id == "measure-fish-440"
+    assert child_dive_id == 440
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_selector_finds_no_dive():
+    stub_select, selector_calls = _make_stub_selector(None)
+    child_runs: List[tuple] = []
+    record = _make_recording_activity(child_runs)
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-stage14-parent-empty",
+            workflows=[MeasureFishParentWorkflow],
+            activities=[stub_select],
+        ), Worker(
+            env.client,
+            task_queue=DATA_PROCESSING_TASK_QUEUE,
+            workflows=[_StubChildWorkflow],
+            activities=[record],
+        ):
+            result = await env.client.execute_workflow(
+                MeasureFishParentWorkflow.run,
+                id=f"test-stage14-parent-empty-{uuid.uuid4()}",
+                task_queue="test-stage14-parent-empty",
+            )
+
+    assert result is None
+    assert len(selector_calls) == 1
+    assert not child_runs

--- a/services/fishsense-api-workflow-worker/tests/test_perform_laser_calibration_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_perform_laser_calibration_parent_workflow.py
@@ -1,0 +1,126 @@
+# pylint: disable=unused-argument
+"""Workflow contract test for PerformLaserCalibrationParentWorkflow.
+
+Pins down:
+  1. Selector returns None -> parent returns None, no child dispatch.
+  2. Selector returns an id -> child dispatched on the data-worker task
+     queue with a deterministic id (`perform-laser-calibration-{dive_id}`)
+     and the dive_id payload, parent returns the dive_id.
+
+The child stub forwards its workflow_id + payload through a recording
+activity so the contract test can observe what the parent dispatched
+across the workflow sandbox boundary.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from typing import List, Optional
+
+import pytest
+from temporalio import activity, workflow
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from fishsense_api_workflow_worker.workflows.perform_laser_calibration_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    DATA_PROCESSING_TASK_QUEUE,
+    PerformLaserCalibrationParentWorkflow,
+)
+
+
+@workflow.defn(name="PerformLaserCalibrationWorkflow")
+class _StubChildWorkflow:
+    # pylint: disable=too-few-public-methods
+    """Stand-in for the data-worker's PerformLaserCalibrationWorkflow."""
+
+    @workflow.run
+    async def run(self, dive_id: int) -> int | None:
+        await workflow.execute_activity(
+            "_record_child_dispatch",
+            args=(workflow.info().workflow_id, dive_id),
+            schedule_to_close_timeout=timedelta(seconds=5),
+        )
+        return 9001  # arbitrary "extrinsics row id" stand-in
+
+
+def _make_recording_activity(captures: List[tuple]):
+    @activity.defn(name="_record_child_dispatch")
+    async def record_child_dispatch(workflow_id: str, dive_id: int) -> None:
+        captures.append((workflow_id, dive_id))
+
+    return record_child_dispatch
+
+
+def _make_stub_selector(selector_result: Optional[int]):
+    selector_calls: List[None] = []
+
+    @activity.defn(
+        name="select_next_high_priority_dive_for_laser_calibration_activity"
+    )
+    async def stub_select() -> Optional[int]:
+        selector_calls.append(None)
+        return selector_result
+
+    return stub_select, selector_calls
+
+
+@pytest.mark.asyncio
+async def test_dispatches_child_with_deterministic_id_and_dive_payload():
+    stub_select, selector_calls = _make_stub_selector(440)
+    child_runs: List[tuple] = []
+    record = _make_recording_activity(child_runs)
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-stage13-parent",
+            workflows=[PerformLaserCalibrationParentWorkflow],
+            activities=[stub_select],
+        ), Worker(
+            env.client,
+            task_queue=DATA_PROCESSING_TASK_QUEUE,
+            workflows=[_StubChildWorkflow],
+            activities=[record],
+        ):
+            result = await env.client.execute_workflow(
+                PerformLaserCalibrationParentWorkflow.run,
+                id=f"test-stage13-parent-{uuid.uuid4()}",
+                task_queue="test-stage13-parent",
+            )
+
+    assert result == 440
+    assert len(selector_calls) == 1
+    assert len(child_runs) == 1
+    child_id, child_dive_id = child_runs[0]
+    assert child_id == "perform-laser-calibration-440"
+    assert child_dive_id == 440
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_selector_finds_no_dive():
+    stub_select, selector_calls = _make_stub_selector(None)
+    child_runs: List[tuple] = []
+    record = _make_recording_activity(child_runs)
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-stage13-parent-empty",
+            workflows=[PerformLaserCalibrationParentWorkflow],
+            activities=[stub_select],
+        ), Worker(
+            env.client,
+            task_queue=DATA_PROCESSING_TASK_QUEUE,
+            workflows=[_StubChildWorkflow],
+            activities=[record],
+        ):
+            result = await env.client.execute_workflow(
+                PerformLaserCalibrationParentWorkflow.run,
+                id=f"test-stage13-parent-empty-{uuid.uuid4()}",
+                task_queue="test-stage13-parent-empty",
+            )
+
+    assert result is None
+    assert len(selector_calls) == 1
+    assert not child_runs

--- a/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_laser_calibration_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_laser_calibration_activity.py
@@ -1,0 +1,228 @@
+# pylint: disable=unused-argument
+"""Unit tests for select_next_high_priority_dive_for_laser_calibration_activity.
+
+Pins down:
+  1. Skip LOW-priority dives.
+  2. Skip dives without a `dive_slate_id`.
+  3. Skip dives that already have laser_extrinsics.
+  4. Skip dives with fewer than `MIN_COMPLETED_SLATE_LABELS` (=2) completed
+     slate labels — under that floor the data-worker activity raises
+     `ValueError`, and the schedule would otherwise fire forever.
+  5. Pick the lowest-id dive among the remaining cohort.
+  6. Empty cohort -> None.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
+from temporalio.testing import ActivityEnvironment
+
+from fishsense_api_sdk.models.dive import Dive
+from fishsense_api_sdk.models.dive_slate_label import DiveSlateLabel
+from fishsense_api_sdk.models.laser_extrinsics import LaserExtrinsics
+from fishsense_api_workflow_worker.activities import (
+    select_next_high_priority_dive_for_laser_calibration_activity as sut,
+)
+
+
+def _dive(
+    dive_id: int, *, priority: str = "HIGH", dive_slate_id: int | None = 7
+) -> Dive:
+    return Dive(
+        id=dive_id,
+        name=f"dive-{dive_id}",
+        path=f"/dev/null/{dive_id}",
+        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        priority=priority,
+        flip_dive_slate=False,
+        camera_id=1,
+        dive_slate_id=dive_slate_id,
+    )
+
+
+def _extrinsics() -> LaserExtrinsics:
+    return LaserExtrinsics(
+        laser_position=np.zeros(3),
+        laser_axis=np.array([0.0, 0.0, 1.0]),
+        dive_id=1,
+        camera_id=1,
+    )
+
+
+def _slate_label(image_id: int, *, completed: bool) -> DiveSlateLabel:
+    return DiveSlateLabel(
+        id=None,
+        label_studio_task_id=None,
+        label_studio_project_id=None,
+        image_url=None,
+        upside_down=False,
+        reference_points=[(0.0, 0.0)],
+        slate_rectangle=None,
+        skipped_points=[],
+        updated_at=None,
+        completed=completed,
+        label_studio_json=None,
+        image_id=image_id,
+        user_id=None,
+    )
+
+
+def _make_fs(
+    *,
+    dives: List[Dive],
+    extrinsics_for: dict[int, LaserExtrinsics],
+    slate_labels_for: dict[int, list[DiveSlateLabel]],
+):
+    fs = MagicMock()
+    fs.__aenter__ = AsyncMock(return_value=fs)
+    fs.__aexit__ = AsyncMock(return_value=None)
+
+    fs.dives = MagicMock()
+    fs.dives.get = AsyncMock(return_value=dives)
+
+    async def _get_le(dive_id: int) -> Optional[LaserExtrinsics]:
+        return extrinsics_for.get(dive_id)
+
+    fs.dives.get_laser_extrinsics = AsyncMock(side_effect=_get_le)
+
+    fs.labels = MagicMock()
+
+    async def _get_slate(dive_id: int) -> list[DiveSlateLabel]:
+        return slate_labels_for.get(dive_id, [])
+
+    fs.labels.get_dive_slate_labels = AsyncMock(side_effect=_get_slate)
+    return fs
+
+
+@pytest.mark.asyncio
+async def test_picks_lowest_id_high_priority_dive_meeting_cohort(monkeypatch):
+    fs = _make_fs(
+        dives=[
+            _dive(2, priority="HIGH"),
+            _dive(1, priority="HIGH"),
+            _dive(3, priority="LOW"),
+        ],
+        extrinsics_for={},
+        slate_labels_for={
+            1: [
+                _slate_label(101, completed=True),
+                _slate_label(102, completed=True),
+            ],
+            2: [
+                _slate_label(201, completed=True),
+                _slate_label(202, completed=True),
+            ],
+        },
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.select_next_high_priority_dive_for_laser_calibration_activity
+    )
+
+    assert result == 1
+
+
+@pytest.mark.asyncio
+async def test_skips_dives_without_dive_slate_id(monkeypatch):
+    fs = _make_fs(
+        dives=[
+            _dive(1, dive_slate_id=None),
+            _dive(2, dive_slate_id=7),
+        ],
+        extrinsics_for={},
+        slate_labels_for={
+            2: [
+                _slate_label(201, completed=True),
+                _slate_label(202, completed=True),
+            ],
+        },
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.select_next_high_priority_dive_for_laser_calibration_activity
+    )
+
+    assert result == 2
+
+
+@pytest.mark.asyncio
+async def test_skips_dives_already_calibrated(monkeypatch):
+    fs = _make_fs(
+        dives=[_dive(1), _dive(2), _dive(3)],
+        extrinsics_for={1: _extrinsics(), 2: _extrinsics()},
+        slate_labels_for={
+            3: [
+                _slate_label(301, completed=True),
+                _slate_label(302, completed=True),
+            ],
+        },
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.select_next_high_priority_dive_for_laser_calibration_activity
+    )
+
+    assert result == 3
+
+
+@pytest.mark.asyncio
+async def test_skips_dives_below_completed_slate_label_floor(monkeypatch):
+    fs = _make_fs(
+        dives=[_dive(1), _dive(2)],
+        extrinsics_for={},
+        slate_labels_for={
+            # Only 1 completed -> below the 2-label floor.
+            1: [
+                _slate_label(101, completed=True),
+                _slate_label(102, completed=False),
+            ],
+            # 2 completed -> selectable.
+            2: [
+                _slate_label(201, completed=True),
+                _slate_label(202, completed=True),
+            ],
+        },
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.select_next_high_priority_dive_for_laser_calibration_activity
+    )
+
+    assert result == 2
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_eligible_dives(monkeypatch):
+    fs = _make_fs(
+        dives=[_dive(1, priority="LOW"), _dive(2, dive_slate_id=None)],
+        extrinsics_for={},
+        slate_labels_for={},
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.select_next_high_priority_dive_for_laser_calibration_activity
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_dives_endpoint_returns_empty(monkeypatch):
+    fs = _make_fs(dives=[], extrinsics_for={}, slate_labels_for={})
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.select_next_high_priority_dive_for_laser_calibration_activity
+    )
+
+    assert result is None

--- a/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_measure_fish_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_measure_fish_activity.py
@@ -1,0 +1,196 @@
+# pylint: disable=unused-argument
+"""Unit tests for select_next_high_priority_dive_for_measure_fish_activity.
+
+Pins down:
+  1. Skip LOW-priority dives.
+  2. Skip dives without `LaserExtrinsics` (stage 13 prerequisite).
+  3. Skip dives with no LABEL_STUDIO clusters.
+  4. Skip dives whose LABEL_STUDIO clusters all have `fish_id` set
+     (already measured on a fully-successful previous run).
+  5. Pick the lowest-id dive among the remaining cohort.
+  6. Empty cohort -> None.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
+from temporalio.testing import ActivityEnvironment
+
+from fishsense_api_sdk.models.data_source import DataSource
+from fishsense_api_sdk.models.dive import Dive
+from fishsense_api_sdk.models.dive_frame_cluster import DiveFrameCluster
+from fishsense_api_sdk.models.laser_extrinsics import LaserExtrinsics
+from fishsense_api_workflow_worker.activities import (
+    select_next_high_priority_dive_for_measure_fish_activity as sut,
+)
+
+
+def _dive(dive_id: int, *, priority: str = "HIGH") -> Dive:
+    return Dive(
+        id=dive_id,
+        name=f"dive-{dive_id}",
+        path=f"/dev/null/{dive_id}",
+        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        priority=priority,
+        flip_dive_slate=False,
+        camera_id=1,
+        dive_slate_id=7,
+    )
+
+
+def _extrinsics() -> LaserExtrinsics:
+    return LaserExtrinsics(
+        laser_position=np.zeros(3),
+        laser_axis=np.array([0.0, 0.0, 1.0]),
+        dive_id=1,
+        camera_id=1,
+    )
+
+
+def _cluster(dive_id: int, *, fish_id: int | None) -> DiveFrameCluster:
+    return DiveFrameCluster(
+        id=None,
+        image_ids=[1],
+        data_source=DataSource.LABEL_STUDIO,
+        updated_at=None,
+        dive_id=dive_id,
+        fish_id=fish_id,
+    )
+
+
+def _make_fs(
+    *,
+    dives: List[Dive],
+    extrinsics_for: dict[int, LaserExtrinsics],
+    clusters_for: dict[int, list[DiveFrameCluster]],
+):
+    fs = MagicMock()
+    fs.__aenter__ = AsyncMock(return_value=fs)
+    fs.__aexit__ = AsyncMock(return_value=None)
+
+    fs.dives = MagicMock()
+    fs.dives.get = AsyncMock(return_value=dives)
+
+    async def _get_le(dive_id: int) -> Optional[LaserExtrinsics]:
+        return extrinsics_for.get(dive_id)
+
+    fs.dives.get_laser_extrinsics = AsyncMock(side_effect=_get_le)
+
+    fs.images = MagicMock()
+
+    async def _get_clusters(dive_id: int, data_source: str):
+        assert data_source == DataSource.LABEL_STUDIO.value
+        return clusters_for.get(dive_id, [])
+
+    fs.images.get_clusters = AsyncMock(side_effect=_get_clusters)
+    return fs
+
+
+@pytest.mark.asyncio
+async def test_picks_lowest_id_dive_with_unbound_clusters(monkeypatch):
+    fs = _make_fs(
+        dives=[_dive(2), _dive(1), _dive(3, priority="LOW")],
+        extrinsics_for={1: _extrinsics(), 2: _extrinsics()},
+        clusters_for={
+            1: [_cluster(1, fish_id=None)],
+            2: [_cluster(2, fish_id=None)],
+        },
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.select_next_high_priority_dive_for_measure_fish_activity
+    )
+
+    assert result == 1
+
+
+@pytest.mark.asyncio
+async def test_skips_dives_without_laser_extrinsics(monkeypatch):
+    fs = _make_fs(
+        dives=[_dive(1), _dive(2)],
+        extrinsics_for={2: _extrinsics()},
+        clusters_for={
+            1: [_cluster(1, fish_id=None)],
+            2: [_cluster(2, fish_id=None)],
+        },
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.select_next_high_priority_dive_for_measure_fish_activity
+    )
+
+    assert result == 2
+
+
+@pytest.mark.asyncio
+async def test_skips_dives_without_label_studio_clusters(monkeypatch):
+    fs = _make_fs(
+        dives=[_dive(1), _dive(2)],
+        extrinsics_for={1: _extrinsics(), 2: _extrinsics()},
+        clusters_for={
+            1: [],
+            2: [_cluster(2, fish_id=None)],
+        },
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.select_next_high_priority_dive_for_measure_fish_activity
+    )
+
+    assert result == 2
+
+
+@pytest.mark.asyncio
+async def test_skips_dives_with_all_clusters_already_bound(monkeypatch):
+    fs = _make_fs(
+        dives=[_dive(1), _dive(2)],
+        extrinsics_for={1: _extrinsics(), 2: _extrinsics()},
+        clusters_for={
+            1: [_cluster(1, fish_id=11), _cluster(1, fish_id=12)],
+            2: [_cluster(2, fish_id=None)],
+        },
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.select_next_high_priority_dive_for_measure_fish_activity
+    )
+
+    assert result == 2
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_eligible_dives(monkeypatch):
+    fs = _make_fs(
+        dives=[_dive(1, priority="LOW"), _dive(2)],
+        extrinsics_for={2: _extrinsics()},
+        # Dive 2 has all clusters bound -> not eligible.
+        clusters_for={2: [_cluster(2, fish_id=99)]},
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.select_next_high_priority_dive_for_measure_fish_activity
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_dives_endpoint_returns_empty(monkeypatch):
+    fs = _make_fs(dives=[], extrinsics_for={}, clusters_for={})
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.select_next_high_priority_dive_for_measure_fish_activity
+    )
+
+    assert result is None


### PR DESCRIPTION
## Summary

- **Stage 13 parent (scheduled, hourly +50min)** — picks the next HIGH-priority dive that's missing `LaserExtrinsics` and has ≥2 completed `DiveSlateLabel` rows, dispatches the data-worker's `PerformLaserCalibrationWorkflow` with a deterministic child id (`perform-laser-calibration-{dive_id}`). The 2-label floor matches the data-worker activity's `MIN_LASER_POINTS=2` precondition — without it, half-labeled dives would re-fail every hour since `put_laser_extrinsics` never gets written.
- **Stage 14 parent (on-demand only)** — picks the next HIGH-priority dive with `LaserExtrinsics` set and at least one LABEL_STUDIO cluster with `fish_id is None`, dispatches `MeasureFishWorkflow` with id `measure-fish-{dive_id}`. **Deliberately NOT scheduled**: `measure_fish_activity` is non-idempotent (`post_measurement` is a POST and the SDK has no per-image measurement query), so a re-run on a partial-failure dive would duplicate measurements. Until that's resolved (probably by adding a `get_measurements` SDK method + per-image filtering inside the activity), this parent is operator-triggered:
  ```
  temporal workflow start --task-queue fishsense_api_queue \
      --type MeasureFishParentWorkflow \
      --workflow-id measure-fish-parent-<run-tag>
  ```
- CLAUDE.md updated: notebook port table now lists 13/14 with parents; cross-worker section gains stage-13 and stage-14 cohort rows + the stage-14 idempotency caveat.

Both parents are structurally lighter than the existing four preprocess parents (0.1/2/5.1/9): pure SDK math, no NAS staging, no file-exchange JPEGs, no per-image fan-out — selector → child workflow, two activities total.

## Test plan

All passing locally:
- [x] `uv run --package fishsense-api-workflow-worker pytest services/fishsense-api-workflow-worker/tests/` — **154 passed, 4 deselected** (integration)
- [x] `uv run --package fishsense-data-processing-workflow-worker pytest services/fishsense-data-processing-workflow-worker/tests/` — **67 passed, 9 deselected** (no regressions on the data-worker side)
- [x] `uv run --package fishsense-api pytest services/fishsense-api/tests/` — **51 passed** (SDK drift sentinel green)
- [x] Smoke `python -c "from fishsense_api_workflow_worker import worker"` — clean import after activity/workflow registration changes

New tests added:
- `tests/test_select_next_high_priority_dive_for_laser_calibration_activity.py` (6 cohort cases)
- `tests/test_perform_laser_calibration_parent_workflow.py` (2 contract cases — deterministic child id + payload, empty-cohort no-op)
- `tests/test_select_next_high_priority_dive_for_measure_fish_activity.py` (6 cohort cases)
- `tests/test_measure_fish_parent_workflow.py` (2 contract cases)

## Follow-ups (not in this PR)

- Stage 14 idempotency: add `get_measurements` to fishsense-api + SDK, then have `measure_fish_activity` skip per-image labels that already have a measurement; once that lands, swap the parent over to a scheduled cadence.
- Stage 14 real-frame regression vs historical `Measurement` rows is still the open verification step from CLAUDE.md's "stage14 sign flip" memo. Doesn't gate this PR (math layer covered by synthetic tests in `15a545a`/`a5e92c6`) but is the right thing to run before declaring stage 14 prod-blessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)