### PR TITLE
fix(ci): install postgresql-client-17 for integration suite

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,6 +55,24 @@ jobs:
         # start_period is 60s on a cold image; first run after a cache
         # miss can take ~90s before --wait returns.
 
+      - name: Install postgresql-client-17
+        # The backup-worker pg_dump integration test shells out to the
+        # host's pg_dump against the postgres:17 service in
+        # compose.local.yml. ubuntu-24.04 ships postgresql-client-16 by
+        # default, which refuses to dump a PG17 server ("aborting
+        # because of server version mismatch"). Pull pg17 from PGDG.
+        # Bump if compose.local.yml's postgres image moves past 17.
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          . /etc/os-release
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-17
+          pg_dump --version
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"


### PR DESCRIPTION
## Summary
- The backup-worker `pg_dump` integration test shells out to the runner host's `pg_dump` against `compose.local.yml`'s `postgres:17` service.
- `ubuntu-24.04` runners ship `postgresql-client-16`, which refuses to dump a PG17 server (`aborting because of server version mismatch`).
- Install `postgresql-client-17` from PGDG before the integration step so `/usr/bin/pg_dump` dispatches to v17 via `pg_wrapper`.

Reproduces the failure from [run 25246501095](https://github.com/UCSD-E4E/fishsense-lite/actions/runs/25246501095/job/74031583407):

```
subprocess.CalledProcessError: ... pg_dump ... returned non-zero exit status 1.
ERROR    fishsense_backup_worker.pg_dump:pg_dump.py:81 pg_dump failed db=fishsense rc=1 stderr=pg_dump: error: aborting because of server version mismatch
```

## Test plan
- [ ] Re-run the Integration workflow on this PR (add the `integration-tests` label or workflow_dispatch) and confirm `test_run_pg_dump_produces_a_pg_restore_listable_dump` passes.
- [ ] Confirm the `pg_dump --version` line in the new step prints `17.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)