### PR TITLE
perf(api-worker): collapse dive cohort selectors to single SDK call

### DIFF
--- a/deploy/compose.workers.yml
+++ b/deploy/compose.workers.yml
@@ -20,6 +20,13 @@ services:
       - ./worker_volumes/api_worker/config:/e4efs/config:ro
       - ./worker_volumes/api_worker/logs:/e4efs/logs:rw
       - ./mafl_volumes/data/config.yml:/config/dashboard_config.yaml:rw
+    # `default` for fishsense-temporal (compose.temporal.yml); `traefik_proxy`
+    # for fishsense-api + static_file_server (compose.orchestrator.yml). The
+    # SDK calls into fishsense-api on the internal hostname bypass the public
+    # Traefik route + authentik middleware — see settings.toml [fishsense_api].
+    networks:
+      - default
+      - traefik_proxy
     restart: on-failure:15
     deploy:
       replicas: 2

--- a/deploy/worker_volumes/api_worker/config/settings.toml
+++ b/deploy/worker_volumes/api_worker/config/settings.toml
@@ -23,8 +23,15 @@ image_url_base = "https://orchestrator.fishsense.e4e.ucsd.edu"
 [e4e_nas]
 url = "https://e4e-nas.ucsd.edu:6021"
 
+# Internal docker URL the api-worker uses for SDK calls into
+# fishsense-api. The api-worker runs on the orchestrator host alongside
+# fishsense-api on the same docker network (traefik_proxy, declared
+# explicitly on both services in compose), so this bypasses Traefik
+# and the authentik middleware in front of the public hostname. The
+# port matches `traefik.http.services.fishsense_api_server.loadbalancer.server.port`
+# in compose.orchestrator.yml.
 [fishsense_api]
-url = "https://orchestrator.fishsense.e4e.ucsd.edu"
+url = "http://fishsense-api:8000"
 
 # Internal docker URL the api-worker uses to GET slate PDFs / PUT
 # processed JPEGs / DELETE raw .ORF entries on the file-exchange

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
@@ -81,6 +81,39 @@ class DiveClient(ClientBase):
             _LaserExtrinsics.model_validate(json)
         )
 
+    async def select_next_for_laser_preprocessing(self) -> int | None:
+        """Stage 0.1 cohort selector: returns the next HIGH-priority
+        dive needing laser preprocessing, or None when the cohort is
+        empty. Server-side single-query equivalent of the api-worker's
+        `select_next_high_priority_dive_for_laser_preprocessing_activity`.
+        """
+        return await self._select_next("laser-preprocessing")
+
+    async def select_next_for_dive_image_preprocessing(self) -> int | None:
+        """Stage 2 cohort selector. See `select_next_for_laser_preprocessing`."""
+        return await self._select_next("dive-image-preprocessing")
+
+    async def select_next_for_headtail_preprocessing(self) -> int | None:
+        """Stage 5.1 cohort selector. See `select_next_for_laser_preprocessing`."""
+        return await self._select_next("headtail-preprocessing")
+
+    async def select_next_for_slate_preprocessing(self) -> int | None:
+        """Stage 9 cohort selector. See `select_next_for_laser_preprocessing`."""
+        return await self._select_next("slate-preprocessing")
+
+    async def select_next_for_laser_calibration(self) -> int | None:
+        """Stage 13 cohort selector. See `select_next_for_laser_preprocessing`."""
+        return await self._select_next("laser-calibration")
+
+    async def select_next_for_measure_fish(self) -> int | None:
+        """Stage 14 cohort selector. See `select_next_for_laser_preprocessing`."""
+        return await self._select_next("measure-fish")
+
+    async def _select_next(self, cohort: str) -> int | None:
+        response = await self._get(f"/api/v1/dives/select-next/{cohort}/")
+        response.raise_for_status()
+        return response.json()
+
     async def put_laser_extrinsics(
         self, dive_id: int, laser_extrinsics: LaserExtrinsics
     ) -> int:

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_dive_image_preprocessing_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_dive_image_preprocessing_activity.py
@@ -6,17 +6,12 @@ Cohort: HIGH priority + has at least one PREDICTION cluster (so stage
 label (matches `populate_species_label_studio_project_activity`'s
 predicate, so populate consumes exactly what preprocess produces).
 
-Lives on the api-worker so the SDK call runs on the orchestrator's
-docker network. Returns the lowest dive_id in the cohort, or None
-when the cohort is empty. Ordering by `id` is FIFO-ish; if dives
-ever get backfilled out of order, swap the sort key to
-`dive_datetime`.
+The selector is a single SDK call; the SQL predicate lives in the
+api's `select-next/dive-image-preprocessing` endpoint.
 """
 
 from __future__ import annotations
 
-from fishsense_api_sdk.models.data_source import DataSource
-from fishsense_api_sdk.models.priority import Priority
 from temporalio import activity
 
 from fishsense_api_workflow_worker.activities.utils import get_fs_client
@@ -27,38 +22,15 @@ async def select_next_high_priority_dive_for_dive_image_preprocessing_activity()
     int | None
 ):
     async with get_fs_client() as fs:
-        dives = await fs.dives.get() or []
-        candidates = [
-            d
-            for d in dives
-            if d.priority == Priority.HIGH and d.id is not None
-        ]
-        candidates.sort(key=lambda d: d.id)
+        dive_id = await fs.dives.select_next_for_dive_image_preprocessing()
 
-        for dive in candidates:
-            clusters = (
-                await fs.images.get_clusters(dive.id, DataSource.PREDICTION.value)
-                or []
-            )
-            if not clusters:
-                continue
-
-            images = await fs.images.get(dive_id=dive.id) or []
-            existing_labels = await fs.labels.get_species_labels(dive.id) or []
-            completed_ids = {
-                label.image_id for label in existing_labels if label.completed
-            }
-            has_incomplete = any(
-                image.id not in completed_ids for image in images
-            )
-            if has_incomplete:
-                activity.logger.info(
-                    "next HIGH-priority dive needing dive-image preprocessing: dive_id=%d",
-                    dive.id,
-                )
-                return dive.id
-
+    if dive_id is None:
         activity.logger.info(
             "no HIGH-priority dives needing dive-image preprocessing"
         )
-        return None
+    else:
+        activity.logger.info(
+            "next HIGH-priority dive needing dive-image preprocessing: dive_id=%d",
+            dive_id,
+        )
+    return dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_headtail_preprocessing_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_headtail_preprocessing_activity.py
@@ -6,14 +6,12 @@ Cohort: HIGH priority + has at least one species label with
 not yet completed (matches
 `populate_headtail_label_studio_project_activity`'s predicate).
 
-Returns the lowest dive_id in the cohort, or None. Ordering by `id`
-is FIFO-ish; if dives ever get backfilled out of order, swap the
-sort key to `dive_datetime`.
+The selector is a single SDK call; the SQL predicate lives in the
+api's `select-next/headtail-preprocessing` endpoint.
 """
 
 from __future__ import annotations
 
-from fishsense_api_sdk.models.priority import Priority
 from temporalio import activity
 
 from fishsense_api_workflow_worker.activities.utils import get_fs_client
@@ -24,36 +22,15 @@ async def select_next_high_priority_dive_for_headtail_preprocessing_activity() -
     int | None
 ):
     async with get_fs_client() as fs:
-        dives = await fs.dives.get() or []
-        candidates = [
-            d
-            for d in dives
-            if d.priority == Priority.HIGH and d.id is not None
-        ]
-        candidates.sort(key=lambda d: d.id)
+        dive_id = await fs.dives.select_next_for_headtail_preprocessing()
 
-        for dive in candidates:
-            species_labels = await fs.labels.get_species_labels(dive.id) or []
-            top_three_image_ids = {
-                label.image_id
-                for label in species_labels
-                if label.top_three_photos_of_group
-            }
-            if not top_three_image_ids:
-                continue
-
-            existing_headtail = await fs.labels.get_headtail_labels(dive.id) or []
-            completed_ids = {
-                label.image_id for label in existing_headtail if label.completed
-            }
-            if top_three_image_ids - completed_ids:
-                activity.logger.info(
-                    "next HIGH-priority dive needing headtail preprocessing: dive_id=%d",
-                    dive.id,
-                )
-                return dive.id
-
+    if dive_id is None:
         activity.logger.info(
             "no HIGH-priority dives needing headtail preprocessing"
         )
-        return None
+    else:
+        activity.logger.info(
+            "next HIGH-priority dive needing headtail preprocessing: dive_id=%d",
+            dive_id,
+        )
+    return dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_laser_calibration_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_laser_calibration_activity.py
@@ -2,26 +2,22 @@
 laser calibration.
 
 Cohort: HIGH priority + has `dive_slate_id` set + no `LaserExtrinsics`
-row yet + at least `MIN_COMPLETED_SLATE_LABELS` completed
+row yet + at least `MIN_COMPLETED_SLATE_LABELS` (=2) completed
 `DiveSlateLabel` rows. The minimum-2 floor matches the data-worker
 activity's `MIN_LASER_POINTS = 2` precondition; selecting a dive with
 fewer than two completed slate labels would dispatch a child that
-raises `ValueError` and re-fires every hour, since `put_laser_extrinsics`
-never gets written.
+raises `ValueError` and re-fires every hour, since
+`put_laser_extrinsics` never gets written.
 
-Returns the lowest dive_id in the cohort, or None. Ordering by `id`
-is FIFO-ish; if dives ever get backfilled out of order, swap the
-sort key to `dive_datetime`.
+The selector is a single SDK call; the SQL predicate lives in the
+api's `select-next/laser-calibration` endpoint.
 """
 
 from __future__ import annotations
 
-from fishsense_api_sdk.models.priority import Priority
 from temporalio import activity
 
 from fishsense_api_workflow_worker.activities.utils import get_fs_client
-
-MIN_COMPLETED_SLATE_LABELS = 2
 
 
 @activity.defn
@@ -29,31 +25,15 @@ async def select_next_high_priority_dive_for_laser_calibration_activity() -> (
     int | None
 ):
     async with get_fs_client() as fs:
-        dives = await fs.dives.get() or []
-        candidates = [
-            d
-            for d in dives
-            if d.priority == Priority.HIGH
-            and d.id is not None
-            and d.dive_slate_id is not None
-        ]
-        candidates.sort(key=lambda d: d.id)
+        dive_id = await fs.dives.select_next_for_laser_calibration()
 
-        for dive in candidates:
-            extrinsics = await fs.dives.get_laser_extrinsics(dive.id)
-            if extrinsics is not None:
-                continue
-
-            slate_labels = await fs.labels.get_dive_slate_labels(dive.id) or []
-            completed = [label for label in slate_labels if label.completed]
-            if len(completed) >= MIN_COMPLETED_SLATE_LABELS:
-                activity.logger.info(
-                    "next HIGH-priority dive needing laser calibration: dive_id=%d",
-                    dive.id,
-                )
-                return dive.id
-
+    if dive_id is None:
         activity.logger.info(
             "no HIGH-priority dives needing laser calibration"
         )
-        return None
+    else:
+        activity.logger.info(
+            "next HIGH-priority dive needing laser calibration: dive_id=%d",
+            dive_id,
+        )
+    return dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_laser_preprocessing_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_laser_preprocessing_activity.py
@@ -8,15 +8,15 @@ JPEGs for these dives is the work that unblocks downstream
 calibration.
 
 Lives on the api-worker so the SDK call runs on the orchestrator's
-docker network (no authentik / cross-host hop). Returns the lowest
-dive_id in the cohort, or None when the cohort is empty. Ordering by
-`id` is FIFO-ish; if dives ever get backfilled out of order, swap
-the sort key to `dive_datetime`.
+docker network (no authentik / cross-host hop). The selector itself
+is a single SDK call that returns the cohort answer in one query —
+the prior shape was a `dives.get()` plus a sequential
+`get_laser_extrinsics(dive_id)` per HIGH-priority dive, which timed
+out the activity's schedule_to_close on backlogs of a few hundred.
 """
 
 from __future__ import annotations
 
-from fishsense_api_sdk.models.priority import Priority
 from temporalio import activity
 
 from fishsense_api_workflow_worker.activities.utils import get_fs_client
@@ -27,24 +27,15 @@ async def select_next_high_priority_dive_for_laser_preprocessing_activity() -> (
     int | None
 ):
     async with get_fs_client() as fs:
-        dives = await fs.dives.get() or []
-        candidates = [
-            d
-            for d in dives
-            if d.priority == Priority.HIGH and d.id is not None
-        ]
-        candidates.sort(key=lambda d: d.id)
+        dive_id = await fs.dives.select_next_for_laser_preprocessing()
 
-        for dive in candidates:
-            extrinsics = await fs.dives.get_laser_extrinsics(dive.id)
-            if extrinsics is None:
-                activity.logger.info(
-                    "next HIGH-priority dive needing laser preprocessing: dive_id=%d",
-                    dive.id,
-                )
-                return dive.id
-
+    if dive_id is None:
         activity.logger.info(
             "no HIGH-priority dives without laser_extrinsics; nothing to preprocess"
         )
-        return None
+    else:
+        activity.logger.info(
+            "next HIGH-priority dive needing laser preprocessing: dive_id=%d",
+            dive_id,
+        )
+    return dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_measure_fish_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_measure_fish_activity.py
@@ -19,13 +19,12 @@ not scheduled** — operators trigger it on-demand per dive once the
 upstream context is ready. This selector exists so on-demand callers
 can ask "which dive is next?" without re-implementing the predicate.
 
-Returns the lowest dive_id in the cohort, or None.
+The selector is a single SDK call; the SQL predicate lives in the
+api's `select-next/measure-fish` endpoint.
 """
 
 from __future__ import annotations
 
-from fishsense_api_sdk.models.data_source import DataSource
-from fishsense_api_sdk.models.priority import Priority
 from temporalio import activity
 
 from fishsense_api_workflow_worker.activities.utils import get_fs_client
@@ -34,34 +33,13 @@ from fishsense_api_workflow_worker.activities.utils import get_fs_client
 @activity.defn
 async def select_next_high_priority_dive_for_measure_fish_activity() -> int | None:
     async with get_fs_client() as fs:
-        dives = await fs.dives.get() or []
-        candidates = [
-            d
-            for d in dives
-            if d.priority == Priority.HIGH and d.id is not None
-        ]
-        candidates.sort(key=lambda d: d.id)
+        dive_id = await fs.dives.select_next_for_measure_fish()
 
-        for dive in candidates:
-            extrinsics = await fs.dives.get_laser_extrinsics(dive.id)
-            if extrinsics is None:
-                continue
-
-            clusters = (
-                await fs.images.get_clusters(
-                    dive.id, DataSource.LABEL_STUDIO.value
-                )
-                or []
-            )
-            unbound = [c for c in clusters if c.fish_id is None]
-            if unbound:
-                activity.logger.info(
-                    "next HIGH-priority dive needing measurement: dive_id=%d "
-                    "(unbound_clusters=%d)",
-                    dive.id,
-                    len(unbound),
-                )
-                return dive.id
-
+    if dive_id is None:
         activity.logger.info("no HIGH-priority dives needing measurement")
-        return None
+    else:
+        activity.logger.info(
+            "next HIGH-priority dive needing measurement: dive_id=%d",
+            dive_id,
+        )
+    return dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_slate_preprocessing_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_slate_preprocessing_activity.py
@@ -6,19 +6,15 @@ species label with `content_of_image == 'Slate, Laser on slate'` whose
 dive_slate_label is missing or not yet completed (matches
 `populate_dive_slate_label_studio_project_activity`'s predicate).
 
-Returns the lowest dive_id in the cohort, or None. Ordering by `id`
-is FIFO-ish; if dives ever get backfilled out of order, swap the
-sort key to `dive_datetime`.
+The selector is a single SDK call; the SQL predicate lives in the
+api's `select-next/slate-preprocessing` endpoint.
 """
 
 from __future__ import annotations
 
-from fishsense_api_sdk.models.priority import Priority
 from temporalio import activity
 
 from fishsense_api_workflow_worker.activities.utils import get_fs_client
-
-SLATE_CONTENT_MARKER = "Slate, Laser on slate"
 
 
 @activity.defn
@@ -26,38 +22,15 @@ async def select_next_high_priority_dive_for_slate_preprocessing_activity() -> (
     int | None
 ):
     async with get_fs_client() as fs:
-        dives = await fs.dives.get() or []
-        candidates = [
-            d
-            for d in dives
-            if d.priority == Priority.HIGH
-            and d.id is not None
-            and d.dive_slate_id is not None
-        ]
-        candidates.sort(key=lambda d: d.id)
+        dive_id = await fs.dives.select_next_for_slate_preprocessing()
 
-        for dive in candidates:
-            species_labels = await fs.labels.get_species_labels(dive.id) or []
-            slate_marked_image_ids = {
-                label.image_id
-                for label in species_labels
-                if label.content_of_image == SLATE_CONTENT_MARKER
-            }
-            if not slate_marked_image_ids:
-                continue
-
-            existing_slate = await fs.labels.get_dive_slate_labels(dive.id) or []
-            completed_ids = {
-                label.image_id for label in existing_slate if label.completed
-            }
-            if slate_marked_image_ids - completed_ids:
-                activity.logger.info(
-                    "next HIGH-priority dive needing slate preprocessing: dive_id=%d",
-                    dive.id,
-                )
-                return dive.id
-
+    if dive_id is None:
         activity.logger.info(
             "no HIGH-priority dives needing slate preprocessing"
         )
-        return None
+    else:
+        activity.logger.info(
+            "next HIGH-priority dive needing slate preprocessing: dive_id=%d",
+            dive_id,
+        )
+    return dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/_retry_policies.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/_retry_policies.py
@@ -1,0 +1,27 @@
+"""Shared retry policies for parent-workflow activity calls.
+
+Activities that are pure SDK round-trips (selectors, resolvers) should
+fail fast on a 5xx instead of being retried until `schedule_to_close`.
+The default retry shape on `execute_activity` is unlimited attempts
+within the timeout window, which masks real bugs as latency: a
+consistent 500 from the API takes the activity's full timeout (5+ min
+for these) before surfacing.
+
+Caps attempts at 2 so a single transient blip can self-heal but a real
+bug shows up in seconds, and marks `HTTPStatusError` non-retryable
+because the SDK's `httpx`-level `@retry(tries=3)` already absorbed any
+transient status; if we still see one at this layer it's a real bug.
+
+Used by the selector + resolver `execute_activity` calls in the parent
+workflows (preprocess 0.1/2/5.1/9, calibration 13, measure-fish 14).
+"""
+
+from datetime import timedelta
+
+from temporalio.common import RetryPolicy
+
+SDK_FAIL_FAST_RETRY_POLICY = RetryPolicy(
+    initial_interval=timedelta(seconds=1),
+    maximum_attempts=2,
+    non_retryable_error_types=["HTTPStatusError"],
+)

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/measure_fish_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/measure_fish_parent_workflow.py
@@ -45,6 +45,11 @@ from datetime import timedelta
 
 from temporalio import workflow
 
+with workflow.unsafe.imports_passed_through():
+    from fishsense_api_workflow_worker.workflows._retry_policies import (
+        SDK_FAIL_FAST_RETRY_POLICY,
+    )
+
 DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
 
 
@@ -63,6 +68,7 @@ class MeasureFishParentWorkflow:
             "select_next_high_priority_dive_for_measure_fish_activity",
             args=(),
             schedule_to_close_timeout=timedelta(minutes=5),
+            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
         )
         if dive_id is None:
             return None

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/perform_laser_calibration_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/perform_laser_calibration_parent_workflow.py
@@ -29,6 +29,11 @@ from datetime import timedelta
 
 from temporalio import workflow
 
+with workflow.unsafe.imports_passed_through():
+    from fishsense_api_workflow_worker.workflows._retry_policies import (
+        SDK_FAIL_FAST_RETRY_POLICY,
+    )
+
 DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
 
 
@@ -49,6 +54,7 @@ class PerformLaserCalibrationParentWorkflow:
             "select_next_high_priority_dive_for_laser_calibration_activity",
             args=(),
             schedule_to_close_timeout=timedelta(minutes=5),
+            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
         )
         if dive_id is None:
             return None

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_dive_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_dive_images_parent_workflow.py
@@ -15,6 +15,11 @@ from datetime import timedelta
 from fishsense_shared import PreprocessDiveImagesInput
 from temporalio import workflow
 
+with workflow.unsafe.imports_passed_through():
+    from fishsense_api_workflow_worker.workflows._retry_policies import (
+        SDK_FAIL_FAST_RETRY_POLICY,
+    )
+
 DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
 EXCHANGE_FOLDER = "preprocess_groups_jpeg"
 NAS_WORKFLOW = "dive_images"
@@ -37,6 +42,7 @@ class PreprocessDiveImagesParentWorkflow:
             "select_next_high_priority_dive_for_dive_image_preprocessing_activity",
             args=(),
             schedule_to_close_timeout=timedelta(minutes=5),
+            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
         )
         if dive_id is None:
             return None
@@ -45,6 +51,7 @@ class PreprocessDiveImagesParentWorkflow:
             "resolve_dive_image_preprocess_inputs_activity",
             args=(dive_id,),
             schedule_to_close_timeout=timedelta(minutes=5),
+            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
             result_type=PreprocessDiveImagesInput,
         )
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_headtail_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_headtail_images_parent_workflow.py
@@ -12,6 +12,11 @@ from datetime import timedelta
 from fishsense_shared import PreprocessHeadtailImagesInput
 from temporalio import workflow
 
+with workflow.unsafe.imports_passed_through():
+    from fishsense_api_workflow_worker.workflows._retry_policies import (
+        SDK_FAIL_FAST_RETRY_POLICY,
+    )
+
 DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
 EXCHANGE_FOLDER = "preprocess_headtail_jpeg"
 NAS_WORKFLOW = "headtail"
@@ -32,6 +37,7 @@ class PreprocessHeadtailImagesParentWorkflow:
             "select_next_high_priority_dive_for_headtail_preprocessing_activity",
             args=(),
             schedule_to_close_timeout=timedelta(minutes=5),
+            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
         )
         if dive_id is None:
             return None
@@ -40,6 +46,7 @@ class PreprocessHeadtailImagesParentWorkflow:
             "resolve_headtail_preprocess_inputs_activity",
             args=(dive_id,),
             schedule_to_close_timeout=timedelta(minutes=5),
+            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
             result_type=PreprocessHeadtailImagesInput,
         )
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_laser_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_laser_images_parent_workflow.py
@@ -26,6 +26,11 @@ from datetime import timedelta
 from fishsense_shared import PreprocessLaserImagesInput
 from temporalio import workflow
 
+with workflow.unsafe.imports_passed_through():
+    from fishsense_api_workflow_worker.workflows._retry_policies import (
+        SDK_FAIL_FAST_RETRY_POLICY,
+    )
+
 DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
 EXCHANGE_FOLDER = "preprocess_jpeg"
 NAS_WORKFLOW = "laser"
@@ -48,6 +53,7 @@ class PreprocessLaserImagesParentWorkflow:
             "select_next_high_priority_dive_for_laser_preprocessing_activity",
             args=(),
             schedule_to_close_timeout=timedelta(minutes=5),
+            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
         )
         if dive_id is None:
             return None
@@ -56,6 +62,7 @@ class PreprocessLaserImagesParentWorkflow:
             "resolve_laser_preprocess_inputs_activity",
             args=(dive_id,),
             schedule_to_close_timeout=timedelta(minutes=5),
+            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
             result_type=PreprocessLaserImagesInput,
         )
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_slate_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_slate_images_parent_workflow.py
@@ -12,6 +12,11 @@ from datetime import timedelta
 from fishsense_shared import PreprocessSlateImagesInput
 from temporalio import workflow
 
+with workflow.unsafe.imports_passed_through():
+    from fishsense_api_workflow_worker.workflows._retry_policies import (
+        SDK_FAIL_FAST_RETRY_POLICY,
+    )
+
 DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
 EXCHANGE_FOLDER = "preprocess_slate_images_jpeg"
 NAS_WORKFLOW = "slate"
@@ -32,6 +37,7 @@ class PreprocessSlateImagesParentWorkflow:
             "select_next_high_priority_dive_for_slate_preprocessing_activity",
             args=(),
             schedule_to_close_timeout=timedelta(minutes=5),
+            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
         )
         if dive_id is None:
             return None
@@ -40,6 +46,7 @@ class PreprocessSlateImagesParentWorkflow:
             "resolve_slate_preprocess_inputs_activity",
             args=(dive_id,),
             schedule_to_close_timeout=timedelta(minutes=5),
+            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
             result_type=PreprocessSlateImagesInput,
         )
 

--- a/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_dive_image_preprocessing_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_dive_image_preprocessing_activity.py
@@ -1,219 +1,52 @@
 # pylint: disable=unused-argument
 """Unit tests for select_next_high_priority_dive_for_dive_image_preprocessing_activity.
 
-Pins down:
-  1. Skip LOW-priority dives.
-  2. Skip dives without PREDICTION clusters (stage 1 hasn't run).
-  3. Skip dives where every image has a completed species label.
-  4. Pick the lowest-id dive in the remaining cohort.
+Cohort predicate moved server-side; see
+`services/fishsense-api/tests/test_select_next_dive_endpoints.py`. The
+activity is now a passthrough to the SDK.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import List
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from temporalio.testing import ActivityEnvironment
 
-from fishsense_api_sdk.models.data_source import DataSource
-from fishsense_api_sdk.models.dive import Dive
-from fishsense_api_sdk.models.dive_frame_cluster import DiveFrameCluster
-from fishsense_api_sdk.models.image import Image
-from fishsense_api_sdk.models.species_label import SpeciesLabel
 from fishsense_api_workflow_worker.activities import (
     select_next_high_priority_dive_for_dive_image_preprocessing_activity as sut,
 )
 
 
-def _dive(dive_id: int, *, priority: str = "HIGH") -> Dive:
-    return Dive(
-        id=dive_id,
-        name=f"dive-{dive_id}",
-        path=f"/dev/null/{dive_id}",
-        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        priority=priority,
-        flip_dive_slate=False,
-        camera_id=1,
-        dive_slate_id=None,
-    )
-
-
-def _image(image_id: int) -> Image:
-    return Image(
-        id=image_id,
-        path=f"/dev/null/{image_id}",
-        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"chk-{image_id}",
-        is_canonical=True,
-        dive_id=42,
-        camera_id=1,
-    )
-
-
-def _cluster(cluster_id: int, image_ids: List[int]) -> DiveFrameCluster:
-    return DiveFrameCluster(
-        id=cluster_id,
-        image_ids=image_ids,
-        data_source=DataSource.PREDICTION,
-        updated_at=None,
-        dive_id=42,
-        fish_id=None,
-    )
-
-
-def _species(image_id: int, *, completed: bool) -> SpeciesLabel:
-    return SpeciesLabel(
-        id=None,
-        label_studio_task_id=image_id * 10,
-        label_studio_project_id=70,
-        image_url=None,
-        updated_at=None,
-        completed=completed,
-        grouping=None,
-        top_three_photos_of_group=None,
-        slate_upside_down=None,
-        laser_x=None,
-        laser_y=None,
-        laser_label=None,
-        content_of_image=None,
-        fish_measurable_category=None,
-        fish_angle_category=None,
-        fish_curved_category=None,
-        label_studio_json={},
-        image_id=image_id,
-        user_id=None,
-    )
-
-
-def _make_fs(
-    *,
-    dives: List[Dive],
-    clusters_by_dive: dict[int, List[DiveFrameCluster]],
-    images_by_dive: dict[int, List[Image]],
-    species_by_dive: dict[int, List[SpeciesLabel]],
-):
+def _make_fs(*, dive_id: int | None):
     fs = MagicMock()
     fs.__aenter__ = AsyncMock(return_value=fs)
     fs.__aexit__ = AsyncMock(return_value=None)
-
     fs.dives = MagicMock()
-    fs.dives.get = AsyncMock(return_value=dives)
-
-    fs.images = MagicMock()
-
-    async def _get_clusters(dive_id, data_source):
-        if data_source != DataSource.PREDICTION.value:
-            return []
-        return clusters_by_dive.get(dive_id, [])
-
-    fs.images.get_clusters = AsyncMock(side_effect=_get_clusters)
-
-    async def _get_images(dive_id=None, **_):
-        return images_by_dive.get(dive_id, [])
-
-    fs.images.get = AsyncMock(side_effect=_get_images)
-
-    fs.labels = MagicMock()
-
-    async def _get_species(dive_id):
-        return species_by_dive.get(dive_id, [])
-
-    fs.labels.get_species_labels = AsyncMock(side_effect=_get_species)
+    fs.dives.select_next_for_dive_image_preprocessing = AsyncMock(return_value=dive_id)
     return fs
 
 
 @pytest.mark.asyncio
-async def test_picks_lowest_id_high_dive_with_clusters_and_incomplete_species(
-    monkeypatch,
-):
-    fs = _make_fs(
-        dives=[_dive(2), _dive(1), _dive(3, priority="LOW")],
-        clusters_by_dive={
-            1: [_cluster(10, [101, 102])],
-            2: [_cluster(20, [201])],
-        },
-        images_by_dive={
-            1: [_image(101), _image(102)],
-            2: [_image(201)],
-        },
-        species_by_dive={
-            1: [_species(101, completed=False)],
-            2: [_species(201, completed=True)],
-        },
-    )
+async def test_passes_through_dive_id_from_sdk(monkeypatch):
+    fs = _make_fs(dive_id=42)
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_dive_image_preprocessing_activity
     )
-    assert result == 1
+
+    assert result == 42
+    fs.dives.select_next_for_dive_image_preprocessing.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
-async def test_skips_dive_without_prediction_clusters(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(1), _dive(2)],
-        clusters_by_dive={2: [_cluster(20, [201])]},
-        images_by_dive={1: [_image(101)], 2: [_image(201)]},
-        species_by_dive={
-            1: [_species(101, completed=False)],
-            2: [_species(201, completed=False)],
-        },
-    )
+async def test_returns_none_when_sdk_returns_none(monkeypatch):
+    fs = _make_fs(dive_id=None)
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_dive_image_preprocessing_activity
     )
-    assert result == 2
 
-
-@pytest.mark.asyncio
-async def test_skips_dive_when_all_species_labels_completed(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(1)],
-        clusters_by_dive={1: [_cluster(10, [101])]},
-        images_by_dive={1: [_image(101)]},
-        species_by_dive={1: [_species(101, completed=True)]},
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_dive_image_preprocessing_activity
-    )
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_picks_dive_when_image_has_no_species_label(monkeypatch):
-    # Image without any species label row -> counts as incomplete.
-    fs = _make_fs(
-        dives=[_dive(1)],
-        clusters_by_dive={1: [_cluster(10, [101])]},
-        images_by_dive={1: [_image(101)]},
-        species_by_dive={1: []},
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_dive_image_preprocessing_activity
-    )
-    assert result == 1
-
-
-@pytest.mark.asyncio
-async def test_returns_none_for_empty_dives_endpoint(monkeypatch):
-    fs = _make_fs(
-        dives=[],
-        clusters_by_dive={},
-        images_by_dive={},
-        species_by_dive={},
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_dive_image_preprocessing_activity
-    )
     assert result is None

--- a/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_headtail_preprocessing_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_headtail_preprocessing_activity.py
@@ -1,167 +1,52 @@
 # pylint: disable=unused-argument
-"""Unit tests for select_next_high_priority_dive_for_headtail_preprocessing_activity."""
+"""Unit tests for select_next_high_priority_dive_for_headtail_preprocessing_activity.
+
+Cohort predicate moved server-side; see
+`services/fishsense-api/tests/test_select_next_dive_endpoints.py`. The
+activity is now a passthrough to the SDK.
+"""
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import List
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from temporalio.testing import ActivityEnvironment
 
-from fishsense_api_sdk.models.dive import Dive
-from fishsense_api_sdk.models.headtail_label import HeadTailLabel
-from fishsense_api_sdk.models.species_label import SpeciesLabel
 from fishsense_api_workflow_worker.activities import (
     select_next_high_priority_dive_for_headtail_preprocessing_activity as sut,
 )
 
 
-def _dive(dive_id: int, *, priority: str = "HIGH") -> Dive:
-    return Dive(
-        id=dive_id,
-        name=f"dive-{dive_id}",
-        path=f"/dev/null/{dive_id}",
-        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        priority=priority,
-        flip_dive_slate=False,
-        camera_id=1,
-        dive_slate_id=None,
-    )
-
-
-def _species(image_id: int, *, top_three: bool) -> SpeciesLabel:
-    return SpeciesLabel(
-        id=None,
-        label_studio_task_id=image_id * 10,
-        label_studio_project_id=70,
-        image_url=None,
-        updated_at=None,
-        completed=True,
-        grouping=None,
-        top_three_photos_of_group=top_three,
-        slate_upside_down=None,
-        laser_x=None,
-        laser_y=None,
-        laser_label=None,
-        content_of_image=None,
-        fish_measurable_category=None,
-        fish_angle_category=None,
-        fish_curved_category=None,
-        label_studio_json={},
-        image_id=image_id,
-        user_id=None,
-    )
-
-
-def _headtail(image_id: int, *, completed: bool) -> HeadTailLabel:
-    return HeadTailLabel(
-        id=None,
-        image_id=image_id,
-        label_studio_task_id=image_id * 10,
-        label_studio_project_id=71,
-        image_url=None,
-        updated_at=None,
-        completed=completed,
-        head_x=None,
-        head_y=None,
-        tail_x=None,
-        tail_y=None,
-        label_studio_json={},
-        user_id=None,
-        superseded=False,
-    )
-
-
-def _make_fs(
-    *,
-    dives: List[Dive],
-    species_by_dive: dict[int, List[SpeciesLabel]],
-    headtail_by_dive: dict[int, List[HeadTailLabel]],
-):
+def _make_fs(*, dive_id: int | None):
     fs = MagicMock()
     fs.__aenter__ = AsyncMock(return_value=fs)
     fs.__aexit__ = AsyncMock(return_value=None)
-
     fs.dives = MagicMock()
-    fs.dives.get = AsyncMock(return_value=dives)
-
-    fs.labels = MagicMock()
-
-    async def _get_species(dive_id):
-        return species_by_dive.get(dive_id, [])
-
-    async def _get_headtail(dive_id):
-        return headtail_by_dive.get(dive_id, [])
-
-    fs.labels.get_species_labels = AsyncMock(side_effect=_get_species)
-    fs.labels.get_headtail_labels = AsyncMock(side_effect=_get_headtail)
+    fs.dives.select_next_for_headtail_preprocessing = AsyncMock(return_value=dive_id)
     return fs
 
 
 @pytest.mark.asyncio
-async def test_picks_dive_with_top_three_species_and_incomplete_headtail(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(2), _dive(1), _dive(3, priority="LOW")],
-        species_by_dive={
-            1: [_species(101, top_three=True)],
-            2: [_species(201, top_three=True)],
-        },
-        headtail_by_dive={
-            1: [_headtail(101, completed=False)],
-            2: [_headtail(201, completed=True)],
-        },
-    )
+async def test_passes_through_dive_id_from_sdk(monkeypatch):
+    fs = _make_fs(dive_id=42)
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_headtail_preprocessing_activity
     )
-    assert result == 1
+
+    assert result == 42
+    fs.dives.select_next_for_headtail_preprocessing.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
-async def test_skips_dive_without_top_three_species(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(1), _dive(2)],
-        species_by_dive={
-            1: [_species(101, top_three=False)],
-            2: [_species(201, top_three=True)],
-        },
-        headtail_by_dive={2: []},
-    )
+async def test_returns_none_when_sdk_returns_none(monkeypatch):
+    fs = _make_fs(dive_id=None)
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_headtail_preprocessing_activity
     )
-    assert result == 2
 
-
-@pytest.mark.asyncio
-async def test_skips_dive_when_all_top_three_have_completed_headtail(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(1)],
-        species_by_dive={1: [_species(101, top_three=True)]},
-        headtail_by_dive={1: [_headtail(101, completed=True)]},
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_headtail_preprocessing_activity
-    )
     assert result is None
-
-
-@pytest.mark.asyncio
-async def test_picks_dive_when_top_three_has_no_headtail_label(monkeypatch):
-    # No headtail row at all -> incomplete.
-    fs = _make_fs(
-        dives=[_dive(1)],
-        species_by_dive={1: [_species(101, top_three=True)]},
-        headtail_by_dive={1: []},
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_headtail_preprocessing_activity
-    )
-    assert result == 1

--- a/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_laser_calibration_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_laser_calibration_activity.py
@@ -1,224 +1,48 @@
 # pylint: disable=unused-argument
 """Unit tests for select_next_high_priority_dive_for_laser_calibration_activity.
 
-Pins down:
-  1. Skip LOW-priority dives.
-  2. Skip dives without a `dive_slate_id`.
-  3. Skip dives that already have laser_extrinsics.
-  4. Skip dives with fewer than `MIN_COMPLETED_SLATE_LABELS` (=2) completed
-     slate labels — under that floor the data-worker activity raises
-     `ValueError`, and the schedule would otherwise fire forever.
-  5. Pick the lowest-id dive among the remaining cohort.
-  6. Empty cohort -> None.
+Cohort predicate moved server-side; see
+`services/fishsense-api/tests/test_select_next_dive_endpoints.py`. The
+activity is now a passthrough to the SDK.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import List, Optional
 from unittest.mock import AsyncMock, MagicMock
 
-import numpy as np
 import pytest
 from temporalio.testing import ActivityEnvironment
 
-from fishsense_api_sdk.models.dive import Dive
-from fishsense_api_sdk.models.dive_slate_label import DiveSlateLabel
-from fishsense_api_sdk.models.laser_extrinsics import LaserExtrinsics
 from fishsense_api_workflow_worker.activities import (
     select_next_high_priority_dive_for_laser_calibration_activity as sut,
 )
 
 
-def _dive(
-    dive_id: int, *, priority: str = "HIGH", dive_slate_id: int | None = 7
-) -> Dive:
-    return Dive(
-        id=dive_id,
-        name=f"dive-{dive_id}",
-        path=f"/dev/null/{dive_id}",
-        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        priority=priority,
-        flip_dive_slate=False,
-        camera_id=1,
-        dive_slate_id=dive_slate_id,
-    )
-
-
-def _extrinsics() -> LaserExtrinsics:
-    return LaserExtrinsics(
-        laser_position=np.zeros(3),
-        laser_axis=np.array([0.0, 0.0, 1.0]),
-        dive_id=1,
-        camera_id=1,
-    )
-
-
-def _slate_label(image_id: int, *, completed: bool) -> DiveSlateLabel:
-    return DiveSlateLabel(
-        id=None,
-        label_studio_task_id=None,
-        label_studio_project_id=None,
-        image_url=None,
-        upside_down=False,
-        reference_points=[(0.0, 0.0)],
-        slate_rectangle=None,
-        skipped_points=[],
-        updated_at=None,
-        completed=completed,
-        label_studio_json=None,
-        image_id=image_id,
-        user_id=None,
-    )
-
-
-def _make_fs(
-    *,
-    dives: List[Dive],
-    extrinsics_for: dict[int, LaserExtrinsics],
-    slate_labels_for: dict[int, list[DiveSlateLabel]],
-):
+def _make_fs(*, dive_id: int | None):
     fs = MagicMock()
     fs.__aenter__ = AsyncMock(return_value=fs)
     fs.__aexit__ = AsyncMock(return_value=None)
-
     fs.dives = MagicMock()
-    fs.dives.get = AsyncMock(return_value=dives)
-
-    async def _get_le(dive_id: int) -> Optional[LaserExtrinsics]:
-        return extrinsics_for.get(dive_id)
-
-    fs.dives.get_laser_extrinsics = AsyncMock(side_effect=_get_le)
-
-    fs.labels = MagicMock()
-
-    async def _get_slate(dive_id: int) -> list[DiveSlateLabel]:
-        return slate_labels_for.get(dive_id, [])
-
-    fs.labels.get_dive_slate_labels = AsyncMock(side_effect=_get_slate)
+    fs.dives.select_next_for_laser_calibration = AsyncMock(return_value=dive_id)
     return fs
 
 
 @pytest.mark.asyncio
-async def test_picks_lowest_id_high_priority_dive_meeting_cohort(monkeypatch):
-    fs = _make_fs(
-        dives=[
-            _dive(2, priority="HIGH"),
-            _dive(1, priority="HIGH"),
-            _dive(3, priority="LOW"),
-        ],
-        extrinsics_for={},
-        slate_labels_for={
-            1: [
-                _slate_label(101, completed=True),
-                _slate_label(102, completed=True),
-            ],
-            2: [
-                _slate_label(201, completed=True),
-                _slate_label(202, completed=True),
-            ],
-        },
-    )
+async def test_passes_through_dive_id_from_sdk(monkeypatch):
+    fs = _make_fs(dive_id=42)
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_laser_calibration_activity
     )
 
-    assert result == 1
+    assert result == 42
+    fs.dives.select_next_for_laser_calibration.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
-async def test_skips_dives_without_dive_slate_id(monkeypatch):
-    fs = _make_fs(
-        dives=[
-            _dive(1, dive_slate_id=None),
-            _dive(2, dive_slate_id=7),
-        ],
-        extrinsics_for={},
-        slate_labels_for={
-            2: [
-                _slate_label(201, completed=True),
-                _slate_label(202, completed=True),
-            ],
-        },
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_laser_calibration_activity
-    )
-
-    assert result == 2
-
-
-@pytest.mark.asyncio
-async def test_skips_dives_already_calibrated(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(1), _dive(2), _dive(3)],
-        extrinsics_for={1: _extrinsics(), 2: _extrinsics()},
-        slate_labels_for={
-            3: [
-                _slate_label(301, completed=True),
-                _slate_label(302, completed=True),
-            ],
-        },
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_laser_calibration_activity
-    )
-
-    assert result == 3
-
-
-@pytest.mark.asyncio
-async def test_skips_dives_below_completed_slate_label_floor(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(1), _dive(2)],
-        extrinsics_for={},
-        slate_labels_for={
-            # Only 1 completed -> below the 2-label floor.
-            1: [
-                _slate_label(101, completed=True),
-                _slate_label(102, completed=False),
-            ],
-            # 2 completed -> selectable.
-            2: [
-                _slate_label(201, completed=True),
-                _slate_label(202, completed=True),
-            ],
-        },
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_laser_calibration_activity
-    )
-
-    assert result == 2
-
-
-@pytest.mark.asyncio
-async def test_returns_none_when_no_eligible_dives(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(1, priority="LOW"), _dive(2, dive_slate_id=None)],
-        extrinsics_for={},
-        slate_labels_for={},
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_laser_calibration_activity
-    )
-
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_returns_none_when_dives_endpoint_returns_empty(monkeypatch):
-    fs = _make_fs(dives=[], extrinsics_for={}, slate_labels_for={})
+async def test_returns_none_when_sdk_returns_none(monkeypatch):
+    fs = _make_fs(dive_id=None)
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(

--- a/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_laser_preprocessing_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_laser_preprocessing_activity.py
@@ -1,134 +1,49 @@
 # pylint: disable=unused-argument
 """Unit tests for select_next_high_priority_dive_for_laser_preprocessing_activity.
 
-Pins down:
-  1. Skip LOW-priority dives.
-  2. Skip HIGH-priority dives that already have laser_extrinsics.
-  3. Pick the lowest-id dive among the remaining cohort.
-  4. Empty cohort -> None.
+The cohort predicate moved to the api's `select-next/laser-preprocessing`
+endpoint (see `services/fishsense-api/tests/test_select_next_dive_endpoints.py`
+for cohort-shape coverage). All this activity does now is pass the SDK's
+answer through, so we just pin that down.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import List, Optional
 from unittest.mock import AsyncMock, MagicMock
 
-import numpy as np
 import pytest
 from temporalio.testing import ActivityEnvironment
 
-from fishsense_api_sdk.models.dive import Dive
-from fishsense_api_sdk.models.laser_extrinsics import LaserExtrinsics
 from fishsense_api_workflow_worker.activities import (
     select_next_high_priority_dive_for_laser_preprocessing_activity as sut,
 )
 
 
-def _dive(dive_id: int, *, priority: str = "HIGH") -> Dive:
-    return Dive(
-        id=dive_id,
-        name=f"dive-{dive_id}",
-        path=f"/dev/null/{dive_id}",
-        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        priority=priority,
-        flip_dive_slate=False,
-        camera_id=1,
-        dive_slate_id=None,
-    )
-
-
-def _extrinsics() -> LaserExtrinsics:
-    return LaserExtrinsics(
-        laser_position=np.zeros(3),
-        laser_axis=np.array([0.0, 0.0, 1.0]),
-        dive_id=1,
-        camera_id=1,
-    )
-
-
-def _make_fs(*, dives: List[Dive], extrinsics_for: dict[int, LaserExtrinsics]):
+def _make_fs(*, dive_id: int | None):
     fs = MagicMock()
     fs.__aenter__ = AsyncMock(return_value=fs)
     fs.__aexit__ = AsyncMock(return_value=None)
-
     fs.dives = MagicMock()
-    fs.dives.get = AsyncMock(return_value=dives)
-
-    async def _get_le(dive_id: int) -> Optional[LaserExtrinsics]:
-        return extrinsics_for.get(dive_id)
-
-    fs.dives.get_laser_extrinsics = AsyncMock(side_effect=_get_le)
+    fs.dives.select_next_for_laser_preprocessing = AsyncMock(return_value=dive_id)
     return fs
 
 
 @pytest.mark.asyncio
-async def test_picks_lowest_id_high_priority_dive_without_extrinsics(monkeypatch):
-    fs = _make_fs(
-        dives=[
-            _dive(2, priority="HIGH"),
-            _dive(1, priority="HIGH"),
-            _dive(3, priority="LOW"),
-        ],
-        extrinsics_for={},
-    )
+async def test_passes_through_dive_id_from_sdk(monkeypatch):
+    fs = _make_fs(dive_id=42)
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_laser_preprocessing_activity
     )
 
-    assert result == 1
+    assert result == 42
+    fs.dives.select_next_for_laser_preprocessing.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
-async def test_skips_high_priority_dives_with_extrinsics(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(1), _dive(2), _dive(3)],
-        extrinsics_for={1: _extrinsics(), 2: _extrinsics()},
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_laser_preprocessing_activity
-    )
-
-    assert result == 3
-
-
-@pytest.mark.asyncio
-async def test_returns_none_when_no_high_priority_dives(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(1, priority="LOW"), _dive(2, priority="LOW")],
-        extrinsics_for={},
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_laser_preprocessing_activity
-    )
-
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_returns_none_when_all_high_priority_dives_calibrated(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(1), _dive(2)],
-        extrinsics_for={1: _extrinsics(), 2: _extrinsics()},
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_laser_preprocessing_activity
-    )
-
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_returns_none_when_dives_endpoint_returns_empty(monkeypatch):
-    fs = _make_fs(dives=[], extrinsics_for={})
+async def test_returns_none_when_sdk_returns_none(monkeypatch):
+    fs = _make_fs(dive_id=None)
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(

--- a/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_measure_fish_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_measure_fish_activity.py
@@ -1,192 +1,48 @@
 # pylint: disable=unused-argument
 """Unit tests for select_next_high_priority_dive_for_measure_fish_activity.
 
-Pins down:
-  1. Skip LOW-priority dives.
-  2. Skip dives without `LaserExtrinsics` (stage 13 prerequisite).
-  3. Skip dives with no LABEL_STUDIO clusters.
-  4. Skip dives whose LABEL_STUDIO clusters all have `fish_id` set
-     (already measured on a fully-successful previous run).
-  5. Pick the lowest-id dive among the remaining cohort.
-  6. Empty cohort -> None.
+Cohort predicate moved server-side; see
+`services/fishsense-api/tests/test_select_next_dive_endpoints.py`. The
+activity is now a passthrough to the SDK.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import List, Optional
 from unittest.mock import AsyncMock, MagicMock
 
-import numpy as np
 import pytest
 from temporalio.testing import ActivityEnvironment
 
-from fishsense_api_sdk.models.data_source import DataSource
-from fishsense_api_sdk.models.dive import Dive
-from fishsense_api_sdk.models.dive_frame_cluster import DiveFrameCluster
-from fishsense_api_sdk.models.laser_extrinsics import LaserExtrinsics
 from fishsense_api_workflow_worker.activities import (
     select_next_high_priority_dive_for_measure_fish_activity as sut,
 )
 
 
-def _dive(dive_id: int, *, priority: str = "HIGH") -> Dive:
-    return Dive(
-        id=dive_id,
-        name=f"dive-{dive_id}",
-        path=f"/dev/null/{dive_id}",
-        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        priority=priority,
-        flip_dive_slate=False,
-        camera_id=1,
-        dive_slate_id=7,
-    )
-
-
-def _extrinsics() -> LaserExtrinsics:
-    return LaserExtrinsics(
-        laser_position=np.zeros(3),
-        laser_axis=np.array([0.0, 0.0, 1.0]),
-        dive_id=1,
-        camera_id=1,
-    )
-
-
-def _cluster(dive_id: int, *, fish_id: int | None) -> DiveFrameCluster:
-    return DiveFrameCluster(
-        id=None,
-        image_ids=[1],
-        data_source=DataSource.LABEL_STUDIO,
-        updated_at=None,
-        dive_id=dive_id,
-        fish_id=fish_id,
-    )
-
-
-def _make_fs(
-    *,
-    dives: List[Dive],
-    extrinsics_for: dict[int, LaserExtrinsics],
-    clusters_for: dict[int, list[DiveFrameCluster]],
-):
+def _make_fs(*, dive_id: int | None):
     fs = MagicMock()
     fs.__aenter__ = AsyncMock(return_value=fs)
     fs.__aexit__ = AsyncMock(return_value=None)
-
     fs.dives = MagicMock()
-    fs.dives.get = AsyncMock(return_value=dives)
-
-    async def _get_le(dive_id: int) -> Optional[LaserExtrinsics]:
-        return extrinsics_for.get(dive_id)
-
-    fs.dives.get_laser_extrinsics = AsyncMock(side_effect=_get_le)
-
-    fs.images = MagicMock()
-
-    async def _get_clusters(dive_id: int, data_source: str):
-        assert data_source == DataSource.LABEL_STUDIO.value
-        return clusters_for.get(dive_id, [])
-
-    fs.images.get_clusters = AsyncMock(side_effect=_get_clusters)
+    fs.dives.select_next_for_measure_fish = AsyncMock(return_value=dive_id)
     return fs
 
 
 @pytest.mark.asyncio
-async def test_picks_lowest_id_dive_with_unbound_clusters(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(2), _dive(1), _dive(3, priority="LOW")],
-        extrinsics_for={1: _extrinsics(), 2: _extrinsics()},
-        clusters_for={
-            1: [_cluster(1, fish_id=None)],
-            2: [_cluster(2, fish_id=None)],
-        },
-    )
+async def test_passes_through_dive_id_from_sdk(monkeypatch):
+    fs = _make_fs(dive_id=42)
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_measure_fish_activity
     )
 
-    assert result == 1
+    assert result == 42
+    fs.dives.select_next_for_measure_fish.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
-async def test_skips_dives_without_laser_extrinsics(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(1), _dive(2)],
-        extrinsics_for={2: _extrinsics()},
-        clusters_for={
-            1: [_cluster(1, fish_id=None)],
-            2: [_cluster(2, fish_id=None)],
-        },
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_measure_fish_activity
-    )
-
-    assert result == 2
-
-
-@pytest.mark.asyncio
-async def test_skips_dives_without_label_studio_clusters(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(1), _dive(2)],
-        extrinsics_for={1: _extrinsics(), 2: _extrinsics()},
-        clusters_for={
-            1: [],
-            2: [_cluster(2, fish_id=None)],
-        },
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_measure_fish_activity
-    )
-
-    assert result == 2
-
-
-@pytest.mark.asyncio
-async def test_skips_dives_with_all_clusters_already_bound(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(1), _dive(2)],
-        extrinsics_for={1: _extrinsics(), 2: _extrinsics()},
-        clusters_for={
-            1: [_cluster(1, fish_id=11), _cluster(1, fish_id=12)],
-            2: [_cluster(2, fish_id=None)],
-        },
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_measure_fish_activity
-    )
-
-    assert result == 2
-
-
-@pytest.mark.asyncio
-async def test_returns_none_when_no_eligible_dives(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(1, priority="LOW"), _dive(2)],
-        extrinsics_for={2: _extrinsics()},
-        # Dive 2 has all clusters bound -> not eligible.
-        clusters_for={2: [_cluster(2, fish_id=99)]},
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_measure_fish_activity
-    )
-
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_returns_none_when_dives_endpoint_returns_empty(monkeypatch):
-    fs = _make_fs(dives=[], extrinsics_for={}, clusters_for={})
+async def test_returns_none_when_sdk_returns_none(monkeypatch):
+    fs = _make_fs(dive_id=None)
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(

--- a/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_slate_preprocessing_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_slate_preprocessing_activity.py
@@ -1,164 +1,52 @@
 # pylint: disable=unused-argument
-"""Unit tests for select_next_high_priority_dive_for_slate_preprocessing_activity."""
+"""Unit tests for select_next_high_priority_dive_for_slate_preprocessing_activity.
+
+Cohort predicate moved server-side; see
+`services/fishsense-api/tests/test_select_next_dive_endpoints.py`. The
+activity is now a passthrough to the SDK.
+"""
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import List
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from temporalio.testing import ActivityEnvironment
 
-from fishsense_api_sdk.models.dive import Dive
-from fishsense_api_sdk.models.dive_slate_label import DiveSlateLabel
-from fishsense_api_sdk.models.species_label import SpeciesLabel
 from fishsense_api_workflow_worker.activities import (
     select_next_high_priority_dive_for_slate_preprocessing_activity as sut,
 )
 
 
-def _dive(dive_id: int, *, priority: str = "HIGH", dive_slate_id: int | None = 7) -> Dive:
-    return Dive(
-        id=dive_id,
-        name=f"dive-{dive_id}",
-        path=f"/dev/null/{dive_id}",
-        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        priority=priority,
-        flip_dive_slate=False,
-        camera_id=1,
-        dive_slate_id=dive_slate_id,
-    )
-
-
-def _species(image_id: int, *, content: str | None) -> SpeciesLabel:
-    return SpeciesLabel(
-        id=None,
-        label_studio_task_id=image_id * 10,
-        label_studio_project_id=70,
-        image_url=None,
-        updated_at=None,
-        completed=True,
-        grouping=None,
-        top_three_photos_of_group=None,
-        slate_upside_down=None,
-        laser_x=None,
-        laser_y=None,
-        laser_label=None,
-        content_of_image=content,
-        fish_measurable_category=None,
-        fish_angle_category=None,
-        fish_curved_category=None,
-        label_studio_json={},
-        image_id=image_id,
-        user_id=None,
-    )
-
-
-def _slate_label(image_id: int, *, completed: bool) -> DiveSlateLabel:
-    return DiveSlateLabel(
-        id=None,
-        image_id=image_id,
-        label_studio_task_id=image_id * 10,
-        label_studio_project_id=66,
-        image_url=None,
-        updated_at=None,
-        completed=completed,
-        upside_down=None,
-        reference_points=None,
-        slate_rectangle=None,
-        skipped_points=None,
-        label_studio_json={},
-        user_id=None,
-    )
-
-
-def _make_fs(
-    *,
-    dives: List[Dive],
-    species_by_dive: dict[int, List[SpeciesLabel]],
-    slate_by_dive: dict[int, List[DiveSlateLabel]],
-):
+def _make_fs(*, dive_id: int | None):
     fs = MagicMock()
     fs.__aenter__ = AsyncMock(return_value=fs)
     fs.__aexit__ = AsyncMock(return_value=None)
-
     fs.dives = MagicMock()
-    fs.dives.get = AsyncMock(return_value=dives)
-
-    fs.labels = MagicMock()
-
-    async def _get_species(dive_id):
-        return species_by_dive.get(dive_id, [])
-
-    async def _get_slate(dive_id):
-        return slate_by_dive.get(dive_id, [])
-
-    fs.labels.get_species_labels = AsyncMock(side_effect=_get_species)
-    fs.labels.get_dive_slate_labels = AsyncMock(side_effect=_get_slate)
+    fs.dives.select_next_for_slate_preprocessing = AsyncMock(return_value=dive_id)
     return fs
 
 
-SLATE = "Slate, Laser on slate"
-
-
 @pytest.mark.asyncio
-async def test_picks_dive_with_slate_marked_species_and_incomplete_slate(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(2), _dive(1), _dive(3, dive_slate_id=None)],
-        species_by_dive={
-            1: [_species(101, content=SLATE)],
-            2: [_species(201, content=SLATE)],
-        },
-        slate_by_dive={
-            1: [_slate_label(101, completed=False)],
-            2: [_slate_label(201, completed=True)],
-        },
-    )
+async def test_passes_through_dive_id_from_sdk(monkeypatch):
+    fs = _make_fs(dive_id=42)
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_slate_preprocessing_activity
     )
-    assert result == 1
+
+    assert result == 42
+    fs.dives.select_next_for_slate_preprocessing.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
-async def test_skips_dive_without_dive_slate_id(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(1, dive_slate_id=None), _dive(2)],
-        species_by_dive={2: [_species(201, content=SLATE)]},
-        slate_by_dive={2: []},
-    )
+async def test_returns_none_when_sdk_returns_none(monkeypatch):
+    fs = _make_fs(dive_id=None)
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_slate_preprocessing_activity
     )
-    assert result == 2
 
-
-@pytest.mark.asyncio
-async def test_skips_dive_without_slate_marked_species(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(1)],
-        species_by_dive={1: [_species(101, content="Fish")]},
-        slate_by_dive={},
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_slate_preprocessing_activity
-    )
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_skips_dive_when_all_slate_labels_completed(monkeypatch):
-    fs = _make_fs(
-        dives=[_dive(1)],
-        species_by_dive={1: [_species(101, content=SLATE)]},
-        slate_by_dive={1: [_slate_label(101, completed=True)]},
-    )
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
-    result = await ActivityEnvironment().run(
-        sut.select_next_high_priority_dive_for_slate_preprocessing_activity
-    )
     assert result is None

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -194,7 +194,7 @@ async def select_next_for_laser_calibration(
     """Stage 13: HIGH-priority + dive_slate_id set + no LaserExtrinsics +
     at least MIN_COMPLETED_SLATE_LABELS completed DiveSlateLabel rows."""
     completed_slate_label_count = (
-        select(func.count(DiveSlateLabel.id))
+        select(func.count(DiveSlateLabel.id))  # pylint: disable=not-callable
         .join(Image, Image.id == DiveSlateLabel.image_id)
         .where(Image.dive_id == Dive.id)
         .where(DiveSlateLabel.completed == True)

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -6,16 +6,32 @@ from typing import List
 
 from fastapi import Depends, HTTPException
 from fastapi.encoders import jsonable_encoder
+from sqlalchemy import func
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from fishsense_api.database import get_async_session
+from fishsense_api.models.data_source import DataSource
 from fishsense_api.models.dive import Dive
+from fishsense_api.models.dive_frame_cluster import DiveFrameCluster
+from fishsense_api.models.dive_slate_label import DiveSlateLabel
+from fishsense_api.models.head_tail_label import HeadTailLabel
 from fishsense_api.models.image import Image
 from fishsense_api.models.laser_extrinsics import LaserExtrinsics
+from fishsense_api.models.priority import Priority
+from fishsense_api.models.species_label import SpeciesLabel
 from fishsense_api.server import app
 
 logger = logging.getLogger(__name__)
+
+# Stage-13 cohort threshold; matches the data-worker calibration
+# activity's `MIN_LASER_POINTS = 2` precondition. Selecting a dive with
+# fewer than two completed slate labels would dispatch a child that
+# raises and re-fires every hour.
+MIN_COMPLETED_SLATE_LABELS = 2
+
+# Stage-9 species_label.content_of_image marker.
+SLATE_CONTENT_MARKER = "Slate, Laser on slate"
 
 
 @app.get("/api/v1/dives/")
@@ -42,6 +58,197 @@ async def get_canonical_dives(
 
     result = await session.exec(query)
     return result.all()
+
+
+# Cohort selectors used by the api-workflow-worker hourly schedules.
+# Each returns the lowest-id HIGH-priority dive whose pipeline state
+# matches the per-stage cohort, or None when the cohort is empty. The
+# predicate moves to a single SELECT … LIMIT 1 — the pre-existing
+# client-side N+1 loop in the worker activities was timing out
+# schedule_to_close on backlogs of a few hundred dives.
+#
+# These routes must be declared before `get_dive` because FastAPI
+# matches declaration order: `/dives/select-next/...` would otherwise
+# try to coerce "select-next" into the `{dive_id}: int` path param and
+# 422.
+
+
+@app.get("/api/v1/dives/select-next/laser-preprocessing/")
+async def select_next_for_laser_preprocessing(
+    session: AsyncSession = Depends(get_async_session),
+) -> int | None:
+    """Stage 0.1: HIGH-priority + no LaserExtrinsics row yet."""
+    query = (
+        select(Dive.id)
+        .where(Dive.priority == Priority.HIGH)
+        .where(
+            ~select(LaserExtrinsics.id)
+            .where(LaserExtrinsics.dive_id == Dive.id)
+            .exists()
+        )
+        .order_by(Dive.id)
+        .limit(1)
+    )
+    return (await session.exec(query)).first()
+
+
+@app.get("/api/v1/dives/select-next/dive-image-preprocessing/")
+async def select_next_for_dive_image_preprocessing(
+    session: AsyncSession = Depends(get_async_session),
+) -> int | None:
+    """Stage 2: HIGH-priority + has PREDICTION cluster + at least one
+    image without a completed SpeciesLabel."""
+    has_prediction_cluster = (
+        select(DiveFrameCluster.id)
+        .where(DiveFrameCluster.dive_id == Dive.id)
+        .where(DiveFrameCluster.data_source == DataSource.PREDICTION)
+        .exists()
+    )
+    has_image_without_completed_species_label = (
+        select(Image.id)
+        .where(Image.dive_id == Dive.id)
+        .where(
+            ~select(SpeciesLabel.id)
+            .where(SpeciesLabel.image_id == Image.id)
+            .where(SpeciesLabel.completed == True)
+            .exists()
+        )
+        .exists()
+    )
+    query = (
+        select(Dive.id)
+        .where(Dive.priority == Priority.HIGH)
+        .where(has_prediction_cluster)
+        .where(has_image_without_completed_species_label)
+        .order_by(Dive.id)
+        .limit(1)
+    )
+    return (await session.exec(query)).first()
+
+
+@app.get("/api/v1/dives/select-next/headtail-preprocessing/")
+async def select_next_for_headtail_preprocessing(
+    session: AsyncSession = Depends(get_async_session),
+) -> int | None:
+    """Stage 5.1: HIGH-priority + has at least one
+    SpeciesLabel.top_three_photos_of_group=True whose HeadTailLabel is
+    missing or incomplete."""
+    has_top_three_image_without_completed_headtail = (
+        select(SpeciesLabel.id)
+        .join(Image, Image.id == SpeciesLabel.image_id)
+        .where(Image.dive_id == Dive.id)
+        .where(SpeciesLabel.top_three_photos_of_group == True)
+        .where(
+            ~select(HeadTailLabel.id)
+            .where(HeadTailLabel.image_id == Image.id)
+            .where(HeadTailLabel.completed == True)
+            .exists()
+        )
+        .exists()
+    )
+    query = (
+        select(Dive.id)
+        .where(Dive.priority == Priority.HIGH)
+        .where(has_top_three_image_without_completed_headtail)
+        .order_by(Dive.id)
+        .limit(1)
+    )
+    return (await session.exec(query)).first()
+
+
+@app.get("/api/v1/dives/select-next/slate-preprocessing/")
+async def select_next_for_slate_preprocessing(
+    session: AsyncSession = Depends(get_async_session),
+) -> int | None:
+    """Stage 9: HIGH-priority + dive_slate_id set + has at least one
+    SpeciesLabel.content_of_image='Slate, Laser on slate' whose
+    DiveSlateLabel is missing or incomplete."""
+    has_slate_marked_image_without_completed_dive_slate_label = (
+        select(SpeciesLabel.id)
+        .join(Image, Image.id == SpeciesLabel.image_id)
+        .where(Image.dive_id == Dive.id)
+        .where(SpeciesLabel.content_of_image == SLATE_CONTENT_MARKER)
+        .where(
+            ~select(DiveSlateLabel.id)
+            .where(DiveSlateLabel.image_id == Image.id)
+            .where(DiveSlateLabel.completed == True)
+            .exists()
+        )
+        .exists()
+    )
+    query = (
+        select(Dive.id)
+        .where(Dive.priority == Priority.HIGH)
+        .where(Dive.dive_slate_id != None)
+        .where(has_slate_marked_image_without_completed_dive_slate_label)
+        .order_by(Dive.id)
+        .limit(1)
+    )
+    return (await session.exec(query)).first()
+
+
+@app.get("/api/v1/dives/select-next/laser-calibration/")
+async def select_next_for_laser_calibration(
+    session: AsyncSession = Depends(get_async_session),
+) -> int | None:
+    """Stage 13: HIGH-priority + dive_slate_id set + no LaserExtrinsics +
+    at least MIN_COMPLETED_SLATE_LABELS completed DiveSlateLabel rows."""
+    completed_slate_label_count = (
+        select(func.count(DiveSlateLabel.id))
+        .join(Image, Image.id == DiveSlateLabel.image_id)
+        .where(Image.dive_id == Dive.id)
+        .where(DiveSlateLabel.completed == True)
+        .scalar_subquery()
+    )
+    query = (
+        select(Dive.id)
+        .where(Dive.priority == Priority.HIGH)
+        .where(Dive.dive_slate_id != None)
+        .where(
+            ~select(LaserExtrinsics.id)
+            .where(LaserExtrinsics.dive_id == Dive.id)
+            .exists()
+        )
+        .where(completed_slate_label_count >= MIN_COMPLETED_SLATE_LABELS)
+        .order_by(Dive.id)
+        .limit(1)
+    )
+    return (await session.exec(query)).first()
+
+
+@app.get("/api/v1/dives/select-next/measure-fish/")
+async def select_next_for_measure_fish(
+    session: AsyncSession = Depends(get_async_session),
+) -> int | None:
+    """Stage 14: HIGH-priority + has LaserExtrinsics + has at least one
+    LABEL_STUDIO cluster with fish_id IS NULL.
+
+    First-run gate, not a strict idempotency gate — measure_fish_activity
+    is non-idempotent (POST measurement, no per-image filter), so a
+    partially-failed run will re-fire and duplicate measurements on
+    already-bound clusters. Caller (parent workflow) is operator-
+    triggered, not scheduled."""
+    has_laser_extrinsics = (
+        select(LaserExtrinsics.id)
+        .where(LaserExtrinsics.dive_id == Dive.id)
+        .exists()
+    )
+    has_unbound_label_studio_cluster = (
+        select(DiveFrameCluster.id)
+        .where(DiveFrameCluster.dive_id == Dive.id)
+        .where(DiveFrameCluster.data_source == DataSource.LABEL_STUDIO)
+        .where(DiveFrameCluster.fish_id == None)
+        .exists()
+    )
+    query = (
+        select(Dive.id)
+        .where(Dive.priority == Priority.HIGH)
+        .where(has_laser_extrinsics)
+        .where(has_unbound_label_studio_cluster)
+        .order_by(Dive.id)
+        .limit(1)
+    )
+    return (await session.exec(query)).first()
 
 
 @app.get("/api/v1/dives/{dive_id}")

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -67,9 +67,6 @@ async def test_laser_preprocessing_picks_lowest_high_priority_without_extrinsics
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         select_next_for_laser_preprocessing,
     )
-    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
-        LaserExtrinsics,
-    )
 
     session.add_all(
         [

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -1,0 +1,459 @@
+"""Tests for the per-stage `GET /api/v1/dives/select-next/...` endpoints.
+
+These collapse the api-workflow-worker's previously O(N) selector
+activities (one HTTP call per HIGH-priority dive) into a single
+SELECT … LIMIT 1. The cohort definitions live in CLAUDE.md; this file
+pins them down at the SQL layer.
+
+Uses the same FK-less in-memory sqlite fixture as
+test_get_clusters_data_source_filter.py — we're testing query
+composition, not referential integrity.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+def _dive(dive_id: int, *, priority="HIGH", dive_slate_id=None):
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+
+    return Dive(
+        id=dive_id,
+        path=f"/dev/null/{dive_id}",
+        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        priority=Priority[priority],
+        dive_slate_id=dive_slate_id,
+    )
+
+
+def _image(image_id: int, dive_id: int):
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    return Image(
+        id=image_id,
+        path=f"/dev/null/img-{image_id}",
+        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        checksum=f"img-{image_id:032d}"[:32],
+        dive_id=dive_id,
+    )
+
+
+# ---------- stage 0.1: laser-preprocessing ----------
+
+
+async def test_laser_preprocessing_picks_lowest_high_priority_without_extrinsics(
+    session,
+):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+        LaserExtrinsics,
+    )
+
+    session.add_all(
+        [
+            _dive(2, priority="HIGH"),
+            _dive(1, priority="HIGH"),
+            _dive(3, priority="LOW"),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_laser_preprocessing(session=session) == 1
+
+
+async def test_laser_preprocessing_skips_dives_with_extrinsics(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+        LaserExtrinsics,
+    )
+
+    session.add_all([_dive(1), _dive(2), _dive(3)])
+    await session.flush()
+    session.add_all(
+        [
+            LaserExtrinsics(dive_id=1, camera_id=1),
+            LaserExtrinsics(dive_id=2, camera_id=1),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_laser_preprocessing(session=session) == 3
+
+
+async def test_laser_preprocessing_returns_none_when_all_calibrated(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+        LaserExtrinsics,
+    )
+
+    session.add_all([_dive(1), _dive(2)])
+    await session.flush()
+    session.add_all(
+        [LaserExtrinsics(dive_id=1, camera_id=1), LaserExtrinsics(dive_id=2, camera_id=1)]
+    )
+    await session.flush()
+
+    assert await select_next_for_laser_preprocessing(session=session) is None
+
+
+async def test_laser_preprocessing_returns_none_with_no_high_priority(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+
+    session.add_all([_dive(1, priority="LOW"), _dive(2, priority="LOW")])
+    await session.flush()
+
+    assert await select_next_for_laser_preprocessing(session=session) is None
+
+
+# ---------- stage 2: dive-image-preprocessing ----------
+
+
+async def test_dive_image_preprocessing_requires_prediction_cluster(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_dive_image_preprocessing,
+    )
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+    )
+
+    # dive 1: no clusters -> excluded.
+    # dive 2: PREDICTION cluster + image without species_label -> picked.
+    session.add_all([_dive(1), _dive(2)])
+    await session.flush()
+    session.add_all([_image(101, 1), _image(202, 2)])
+    await session.flush()
+    session.add(DiveFrameCluster(dive_id=2, data_source=DataSource.PREDICTION))
+    await session.flush()
+
+    assert await select_next_for_dive_image_preprocessing(session=session) == 2
+
+
+async def test_dive_image_preprocessing_skips_when_all_images_completed(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_dive_image_preprocessing,
+    )
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+    )
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    # dive 1: 1 image, all completed -> excluded.
+    # dive 2: 2 images, only one completed -> picked.
+    session.add_all([_dive(1), _dive(2)])
+    await session.flush()
+    session.add_all([_image(11, 1), _image(21, 2), _image(22, 2)])
+    await session.flush()
+    session.add_all(
+        [
+            DiveFrameCluster(dive_id=1, data_source=DataSource.PREDICTION),
+            DiveFrameCluster(dive_id=2, data_source=DataSource.PREDICTION),
+        ]
+    )
+    session.add_all(
+        [
+            SpeciesLabel(image_id=11, completed=True),
+            SpeciesLabel(image_id=21, completed=True),
+            # image 22 has no species_label -> dive 2 stays in cohort.
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_dive_image_preprocessing(session=session) == 2
+
+
+async def test_dive_image_preprocessing_returns_none_when_only_label_studio_clusters(
+    session,
+):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_dive_image_preprocessing,
+    )
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+    )
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    session.add(DiveFrameCluster(dive_id=1, data_source=DataSource.LABEL_STUDIO))
+    await session.flush()
+
+    assert await select_next_for_dive_image_preprocessing(session=session) is None
+
+
+# ---------- stage 5.1: headtail-preprocessing ----------
+
+
+async def test_headtail_preprocessing_requires_top_three_without_completed_headtail(
+    session,
+):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_headtail_preprocessing,
+    )
+    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    # dive 1: top_three=True but headtail completed -> excluded.
+    # dive 2: top_three=True, no headtail -> picked.
+    # dive 3: only top_three=False -> excluded.
+    session.add_all([_dive(1), _dive(2), _dive(3)])
+    await session.flush()
+    session.add_all([_image(11, 1), _image(21, 2), _image(31, 3)])
+    await session.flush()
+    session.add_all(
+        [
+            SpeciesLabel(image_id=11, top_three_photos_of_group=True),
+            SpeciesLabel(image_id=21, top_three_photos_of_group=True),
+            SpeciesLabel(image_id=31, top_three_photos_of_group=False),
+        ]
+    )
+    session.add(HeadTailLabel(image_id=11, completed=True))
+    await session.flush()
+
+    assert await select_next_for_headtail_preprocessing(session=session) == 2
+
+
+async def test_headtail_preprocessing_returns_none_when_no_top_three(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_headtail_preprocessing,
+    )
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    session.add(SpeciesLabel(image_id=11, top_three_photos_of_group=False))
+    await session.flush()
+
+    assert await select_next_for_headtail_preprocessing(session=session) is None
+
+
+# ---------- stage 9: slate-preprocessing ----------
+
+
+async def test_slate_preprocessing_requires_dive_slate_id_and_marker(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        SLATE_CONTENT_MARKER,
+        select_next_for_slate_preprocessing,
+    )
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    # dive 1: HIGH but no dive_slate_id -> excluded.
+    # dive 2: HIGH + dive_slate_id but no slate-marked species_label -> excluded.
+    # dive 3: HIGH + dive_slate_id + slate-marked + no completed slate label -> picked.
+    session.add_all(
+        [
+            _dive(1, dive_slate_id=None),
+            _dive(2, dive_slate_id=99),
+            _dive(3, dive_slate_id=99),
+        ]
+    )
+    await session.flush()
+    session.add_all([_image(11, 1), _image(21, 2), _image(31, 3)])
+    await session.flush()
+    session.add_all(
+        [
+            SpeciesLabel(image_id=11, content_of_image=SLATE_CONTENT_MARKER),
+            SpeciesLabel(image_id=21, content_of_image="Fish"),
+            SpeciesLabel(image_id=31, content_of_image=SLATE_CONTENT_MARKER),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_slate_preprocessing(session=session) == 3
+
+
+async def test_slate_preprocessing_skips_when_slate_label_completed(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        SLATE_CONTENT_MARKER,
+        select_next_for_slate_preprocessing,
+    )
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add_all([_dive(1, dive_slate_id=99), _dive(2, dive_slate_id=99)])
+    await session.flush()
+    session.add_all([_image(11, 1), _image(21, 2)])
+    await session.flush()
+    session.add_all(
+        [
+            SpeciesLabel(image_id=11, content_of_image=SLATE_CONTENT_MARKER),
+            SpeciesLabel(image_id=21, content_of_image=SLATE_CONTENT_MARKER),
+            DiveSlateLabel(image_id=11, completed=True),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_slate_preprocessing(session=session) == 2
+
+
+# ---------- stage 13: laser-calibration ----------
+
+
+async def test_laser_calibration_requires_min_completed_slate_labels(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_calibration,
+    )
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
+
+    # dive 1: 1 completed slate label -> below threshold, excluded.
+    # dive 2: 2 completed slate labels -> picked.
+    # dive 3: 3 completed slate labels but already has extrinsics -> excluded.
+    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+        LaserExtrinsics,
+    )
+
+    session.add_all(
+        [
+            _dive(1, dive_slate_id=99),
+            _dive(2, dive_slate_id=99),
+            _dive(3, dive_slate_id=99),
+        ]
+    )
+    await session.flush()
+    session.add_all(
+        [
+            _image(11, 1),
+            _image(21, 2),
+            _image(22, 2),
+            _image(31, 3),
+            _image(32, 3),
+            _image(33, 3),
+        ]
+    )
+    await session.flush()
+    session.add_all(
+        [
+            DiveSlateLabel(image_id=11, completed=True),
+            DiveSlateLabel(image_id=21, completed=True),
+            DiveSlateLabel(image_id=22, completed=True),
+            DiveSlateLabel(image_id=31, completed=True),
+            DiveSlateLabel(image_id=32, completed=True),
+            DiveSlateLabel(image_id=33, completed=True),
+            LaserExtrinsics(dive_id=3, camera_id=1),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_laser_calibration(session=session) == 2
+
+
+async def test_laser_calibration_requires_dive_slate_id(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_calibration,
+    )
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1, dive_slate_id=None))
+    await session.flush()
+    session.add_all([_image(11, 1), _image(12, 1)])
+    session.add_all(
+        [
+            DiveSlateLabel(image_id=11, completed=True),
+            DiveSlateLabel(image_id=12, completed=True),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_laser_calibration(session=session) is None
+
+
+# ---------- stage 14: measure-fish ----------
+
+
+async def test_measure_fish_requires_extrinsics_and_unbound_label_studio_cluster(
+    session,
+):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_measure_fish,
+    )
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+    )
+    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+        LaserExtrinsics,
+    )
+
+    # dive 1: no extrinsics -> excluded.
+    # dive 2: extrinsics + LABEL_STUDIO cluster all bound -> excluded.
+    # dive 3: extrinsics + unbound LABEL_STUDIO cluster -> picked.
+    # dive 4: extrinsics + only PREDICTION clusters -> excluded.
+    session.add_all([_dive(1), _dive(2), _dive(3), _dive(4)])
+    await session.flush()
+    session.add_all(
+        [
+            LaserExtrinsics(dive_id=2, camera_id=1),
+            LaserExtrinsics(dive_id=3, camera_id=1),
+            LaserExtrinsics(dive_id=4, camera_id=1),
+            DiveFrameCluster(
+                dive_id=2, data_source=DataSource.LABEL_STUDIO, fish_id=42
+            ),
+            DiveFrameCluster(
+                dive_id=3, data_source=DataSource.LABEL_STUDIO, fish_id=None
+            ),
+            DiveFrameCluster(
+                dive_id=4, data_source=DataSource.PREDICTION, fish_id=None
+            ),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_measure_fish(session=session) == 3
+
+
+async def test_measure_fish_returns_none_when_all_clusters_bound(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_measure_fish,
+    )
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+    )
+    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+        LaserExtrinsics,
+    )
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add_all(
+        [
+            LaserExtrinsics(dive_id=1, camera_id=1),
+            DiveFrameCluster(
+                dive_id=1, data_source=DataSource.LABEL_STUDIO, fish_id=42
+            ),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_measure_fish(session=session) is None


### PR DESCRIPTION
## Summary

- Push the 6 dive-cohort selectors (stages 0.1, 2, 5.1, 9, 13, 14) from a client-side N+1 (`dives.get()` + per-dive `get_*`) to a single `SELECT … LIMIT 1` server-side, fixing the stage-0.1 schedule_to_close timeout in prod.
- Flip the api-worker's `[fishsense_api].url` from the public authentik-fronted hostname to the internal docker hostname; explicitly attach `[default, traefik_proxy]` to the worker compose entry.
- Add `SDK_FAIL_FAST_RETRY_POLICY` (`maximum_attempts=2`, `non_retryable_error_types=["HTTPStatusError"]`) on the selector + resolver `execute_activity` calls so real 5xx surface in seconds, not after `schedule_to_close`.

## Endpoints added

```
GET /api/v1/dives/select-next/laser-preprocessing/        -> int | None
GET /api/v1/dives/select-next/dive-image-preprocessing/   -> int | None
GET /api/v1/dives/select-next/headtail-preprocessing/     -> int | None
GET /api/v1/dives/select-next/slate-preprocessing/        -> int | None
GET /api/v1/dives/select-next/laser-calibration/          -> int | None  (server-side MIN_COMPLETED_SLATE_LABELS=2)
GET /api/v1/dives/select-next/measure-fish/               -> int | None
```

Cohort definitions match the per-stage table in CLAUDE.md. Routes are registered before `get_dive` so the literal `select-next` path doesn't get coerced into the `{dive_id}: int` parameter.

## Test plan

- [x] `pytest` (api): 66 passed, including 15 new endpoint tests against an in-memory SQLite fixture covering each cohort.
- [x] `pytest` (api-workflow-worker): 136 passed; selector activity tests collapsed to passthrough coverage.
- [x] `pytest` (fishsense-api-sdk): 102 passed.
- [ ] After deploy: confirm the api-worker is on `traefik_proxy` (`docker network inspect traefik_proxy`); the worker should be reachable to `fishsense-api:8000` and `static_file_server:80`.
- [ ] After deploy: confirm a stage-0.1 hourly schedule firing now completes in seconds instead of timing out at 5 min.
- [ ] After deploy: trigger one of the parent workflows manually and confirm the selector activity completes well within `schedule_to_close`.

## Notes for the reviewer

* The compose change to `fishsense-api-workflow-worker` is non-trivial — the worker previously had no `networks:` attribute, which by docker-compose-v2 semantics puts it on the project default network only. CLAUDE.md says workers reach `static_file_server` via the internal docker hostname (and the prior `[file_exchange].url = "http://static_file_server"` config implies this works in prod), so something on the host must already be bridging the networks. Adding `networks: [default, traefik_proxy]` makes that explicit and self-documenting; if anything was relying on a manual `docker network connect` to bootstrap the worker, this change makes it permanent.
* The SDK's `httpx`-level `@retry(tries=3)` already absorbs transient 5xx, so a `HTTPStatusError` at the activity layer is almost certainly a real bug — that's why `non_retryable_error_types=["HTTPStatusError"]`. Temporal Python matches by `type(error).__name__`, so the bare class name is correct.
* Stages 13 and 14's selectors got the same single-query treatment for consistency, even though CLAUDE.md notes those stages "intentionally inline their fetches" — that note refers to the **data-worker** math activity, not the api-worker selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)