### PR TITLE
chore(data-worker): cut 2.0.0 release

### DIFF
--- a/services/fishsense-data-processing-workflow-worker/README.md
+++ b/services/fishsense-data-processing-workflow-worker/README.md
@@ -92,8 +92,11 @@ uv run --package fishsense-data-processing-workflow-worker \
     fishsense_data_processing_workflow_worker
 ```
 
-The image is **not** auto-deployed by the
-[deploy.yml](../../.github/workflows/deploy.yml) workflow — its host
-isn't in this repo's compose files. `:v<version>` tags are still
-published by `promote.yml`, so manual rollout on the data-worker host
-is `docker compose pull && up -d`.
+Auto-deployed by the
+[deploy.yml](../../.github/workflows/deploy.yml) data-worker job: a
+merge of an `auto-deploy/fishsense-data-processing-workflow-worker-*`
+PR (opened by `promote.yml` against
+[deploy/compose.data-worker.yml](../../deploy/compose.data-worker.yml))
+routes to the `fishsense-data-worker` self-hosted runner, which runs
+`docker compose -f compose.data-worker.yml pull && up -d` in
+`$DATA_WORKER_DEPLOY_DIR` on the data-worker host.


### PR DESCRIPTION
## Summary
- Forces release-please to cut `fishsense-data-processing-workflow-worker` at `v2.0.0` via the `Release-As: 2.0.0` commit trailer (current pinned version is `0.4.0`; only a `chore:` commit has touched the package since `v0.4.0`, so the normal feat/fix path won't open a release PR).
- Fixes a stale README paragraph that still claimed the data-worker isn't auto-deployed — `deploy.yml` has had a data-worker job since `compose.data-worker.yml` landed.

## What happens after merge
1. `Release` workflow runs release-please; it sees the `Release-As: 2.0.0` trailer and opens a release PR that bumps `__init__.py`, `pyproject.toml`, manifest, and CHANGELOG to `2.0.0`.
2. Merging that release PR cuts tag `fishsense-data-processing-workflow-worker-v2.0.0` and a GitHub release.
3. `promote.yml` fires on `release: published`: retags the SHA-tagged GHCR image as `:v2.0.0` + `:latest` (manifest-only, no rebuild) and opens an `auto-deploy/fishsense-data-processing-workflow-worker-2.0.0` PR bumping the pin in `compose.data-worker.yml`.
4. Merging the auto-deploy PR triggers `deploy.yml`'s data-worker job — but only if a `[self-hosted, fishsense-data-worker]` runner is registered. (Per CLAUDE.md, that runner doesn't exist yet, so the deploy job will sit queued until ops registers one.)

## Test plan
- [ ] `Release` workflow runs cleanly on this merge and opens a release PR pinned to `2.0.0`
- [ ] Release PR diff shows `__init__.py`, `pyproject.toml`, manifest, CHANGELOG all bumped to `2.0.0` (no other packages affected)
- [ ] On release PR merge: `promote.yml` succeeds and opens `auto-deploy/fishsense-data-processing-workflow-worker-2.0.0`
- [ ] Auto-deploy PR diff shows only the pin change in `deploy/compose.data-worker.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)