### PR TITLE
feat(api-workflow-worker): chain populate from preprocess parents + dedup child dispatches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,22 @@ Both are registered but not scheduled — they're on-demand
 create). The eight workflows are: Create/Populate × Laser/Species/
 HeadTail/DiveSlate.
 
+The four populate workflows are also dispatched automatically as
+child workflows from the matching preprocess parent (stages 0.1 →
+laser, 2 → species, 5.1 → headtail, 9 → dive-slate). After
+`archive_processed_jpegs_to_nas_activity` and
+`cleanup_raw_bytes_for_dive_activity`, the parent runs
+`execute_child_workflow("Populate<Stage>LabelStudioProjectWorkflow",
+dive_id, id="populate-<stage>-{dive_id}",
+id_reuse_policy=ALLOW_DUPLICATE_FAILED_ONLY)`. Steady-state behavior
+on the same cohort dive: hour 1 imports tasks; hours 2+ catch
+`WorkflowAlreadyStartedError` and no-op rather than re-importing
+duplicate LS tasks. On-demand invocation is still supported for
+backfill or operator intervention; if you trigger it manually, use a
+non-colliding workflow id (e.g. `populate-laser-393-manual`) so the
+auto-chain's deterministic id stays available for future hourly
+firings.
+
 `UpdateDiveImageGroupsWorkflow(dive_id)` is the stage-6.1 on-demand
 workflow: it walks the dive's PREDICTION clusters, looks up each
 entry's `SpeciesLabel.grouping`, and POSTs LABEL_STUDIO clusters
@@ -92,7 +108,8 @@ that need both SDK-side decision-making *and* CPU-heavy per-image
 work split into two workflows:
 
 * **Parent** on api-worker (`fishsense_api_queue`). Hourly schedule.
-  Five activity calls per dive bracketing the child:
+  Activity calls per dive, bracketing the data-worker child plus the
+  in-process LS-populate child:
   1. Selector — returns next dive_id in cohort, or None.
   2. Resolver — returns a fully-populated workflow-input DTO.
   3. `stage_raw_bytes_for_dive_activity` — NAS → file-exchange.
@@ -102,6 +119,17 @@ work split into two workflows:
      → NAS (`processed_jpegs/<workflow>/<dive_id>/<checksum>.JPG`).
      Then `cleanup_raw_bytes_for_dive_activity` deletes the dive's
      raw `.ORF`s from the file-exchange.
+  6. `execute_child_workflow("Populate<Stage>LabelStudioProjectWorkflow",
+     dive_id, id="populate-<stage>-{dive_id}",
+     id_reuse_policy=ALLOW_DUPLICATE_FAILED_ONLY)` — on-demand
+     populate child runs against the same task queue. The reuse
+     policy + deterministic id deduplicate against subsequent hourly
+     re-firings of the parent on the same cohort dive (stage 0.1's
+     cohort, in particular, retains a dive until stage 13 writes
+     LaserExtrinsics, so the parent re-fires on the same dive_id
+     hour after hour). The parent catches the resulting
+     `WorkflowAlreadyStartedError` so the post-archive run still
+     completes successfully.
 * **Child** on data-worker (`fishsense_data_processing_queue`). Thin
   pre-input workflow that fans out per-image activities. No SDK
   calls and no NAS calls; all bytes already on the file-exchange,
@@ -130,11 +158,17 @@ one replica):
   `overlap=ScheduleOverlapPolicy.SKIP` — a previous run still in
   flight blocks the next firing, so two selectors can't race past
   the same `dives.get()` and pick the same dive.
-* Child workflow id is deterministic (`preprocess-laser-{dive_id}`).
-  If a parent run *does* race past the schedule guard (e.g. manual
-  trigger overlapping a scheduled one), the second
-  `start_child_workflow` hits `WorkflowAlreadyStarted` and is a
-  no-op rather than redoing the dive.
+* Child workflow id is deterministic (`preprocess-laser-{dive_id}`)
+  and dispatched with
+  `id_reuse_policy=ALLOW_DUPLICATE_FAILED_ONLY`. If a parent run
+  *does* race past the schedule guard (e.g. manual trigger
+  overlapping a scheduled one), the second `start_child_workflow`
+  raises `WorkflowAlreadyStartedError` which the parent catches —
+  archive + cleanup + populate then still run, so a child-then-parent
+  split failure self-heals on the next firing without redoing
+  per-image work. **Note:** temporalio's default child
+  `id_reuse_policy` is `ALLOW_DUPLICATE`, which lets duplicates
+  through silently — the explicit setting is required.
 * Per-image activities are idempotent: nginx DAV PUT overwrites,
   SDK upserts.
 
@@ -577,6 +611,15 @@ Eight workflows: Create + Populate × {Laser, Species, HeadTail,
 DiveSlate}. Populate's target set is queried via SDK
 `get_<stage>_label_studio_project_ids(incomplete=True)` — projects
 with at least one not-yet-completed label.
+
+The populate workflows are dispatched automatically by the four
+preprocess parents (see "Cross-worker orchestration pattern"); manual
+`temporal workflow start` is only needed for backfill of dives the
+auto-chain has already cleared, or to recover from a populate that
+previously errored out. Use a non-colliding workflow id for manual
+runs (e.g. `populate-laser-393-manual`) so the auto-chain's
+deterministic id (`populate-laser-393`) stays available for future
+hourly firings.
 
 **Bootstrap chicken-and-egg:** a freshly-created project from the
 Create workflow has zero labels and won't be returned by the populate

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/measure_fish_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/measure_fish_parent_workflow.py
@@ -34,9 +34,12 @@ Cluster-correctness invariants — relevant once the data-worker scales
 beyond a single replica:
 
 * The child workflow is started with a deterministic id
-  (`measure-fish-{dive_id}`); a duplicate parent run targeting the
-  same dive hits `WorkflowAlreadyStarted` and is a no-op while the
-  first child is still running.
+  (`measure-fish-{dive_id}`) and
+  `id_reuse_policy=ALLOW_DUPLICATE_FAILED_ONLY`; a duplicate parent
+  run targeting the same dive hits `WorkflowAlreadyStarted` (whether
+  the prior child is still running or completed successfully) and
+  the parent catches it — duplicate dispatch can't double-write
+  measurements.
 * Per-cluster `fish_id` rebinds via `put_cluster` on the activity side
   are idempotent under retry within a single child run.
 """
@@ -44,6 +47,8 @@ beyond a single replica:
 from datetime import timedelta
 
 from temporalio import workflow
+from temporalio.common import WorkflowIDReusePolicy
+from temporalio.exceptions import WorkflowAlreadyStartedError
 
 with workflow.unsafe.imports_passed_through():
     from fishsense_api_workflow_worker.workflows._retry_policies import (
@@ -77,12 +82,21 @@ class MeasureFishParentWorkflow:
             "dispatching fish measurement to data-worker dive_id=%d", dive_id
         )
 
-        await workflow.execute_child_workflow(
-            "MeasureFishWorkflow",
-            dive_id,
-            id=f"measure-fish-{dive_id}",
-            task_queue=DATA_PROCESSING_TASK_QUEUE,
-            execution_timeout=timedelta(hours=1),
-        )
+        try:
+            await workflow.execute_child_workflow(
+                "MeasureFishWorkflow",
+                dive_id,
+                id=f"measure-fish-{dive_id}",
+                task_queue=DATA_PROCESSING_TASK_QUEUE,
+                execution_timeout=timedelta(hours=1),
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+            )
+        except WorkflowAlreadyStartedError:
+            workflow.logger.info(
+                "measure-fish-%d already ran successfully; skipping "
+                "duplicate dispatch (re-run requires manual cleanup of "
+                "existing measurements per the stage-14 idempotency note)",
+                dive_id,
+            )
 
         return dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/perform_laser_calibration_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/perform_laser_calibration_parent_workflow.py
@@ -18,9 +18,11 @@ beyond a single replica:
   `overlap_policy=ScheduleOverlapPolicy.SKIP`, so a run still in
   flight when the next firing arrives is dropped at the schedule level.
 * The child workflow is started with a deterministic id
-  (`perform-laser-calibration-{dive_id}`); if a parent run somehow
-  races past the schedule guard, the second child-workflow start hits
-  `WorkflowAlreadyStarted` and is a no-op rather than redoing the dive.
+  (`perform-laser-calibration-{dive_id}`) and
+  `id_reuse_policy=ALLOW_DUPLICATE_FAILED_ONLY`; if a parent run
+  somehow races past the schedule guard, the second child-workflow
+  start hits `WorkflowAlreadyStarted` and is caught — the parent
+  treats the prior success as authoritative.
 * `put_laser_extrinsics` on the activity side is an upsert — even
   outright re-runs of a successful call land on the same row.
 """
@@ -28,6 +30,8 @@ beyond a single replica:
 from datetime import timedelta
 
 from temporalio import workflow
+from temporalio.common import WorkflowIDReusePolicy
+from temporalio.exceptions import WorkflowAlreadyStartedError
 
 with workflow.unsafe.imports_passed_through():
     from fishsense_api_workflow_worker.workflows._retry_policies import (
@@ -63,12 +67,20 @@ class PerformLaserCalibrationParentWorkflow:
             "dispatching laser calibration to data-worker dive_id=%d", dive_id
         )
 
-        await workflow.execute_child_workflow(
-            "PerformLaserCalibrationWorkflow",
-            dive_id,
-            id=f"perform-laser-calibration-{dive_id}",
-            task_queue=DATA_PROCESSING_TASK_QUEUE,
-            execution_timeout=timedelta(minutes=15),
-        )
+        try:
+            await workflow.execute_child_workflow(
+                "PerformLaserCalibrationWorkflow",
+                dive_id,
+                id=f"perform-laser-calibration-{dive_id}",
+                task_queue=DATA_PROCESSING_TASK_QUEUE,
+                execution_timeout=timedelta(minutes=15),
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+            )
+        except WorkflowAlreadyStartedError:
+            workflow.logger.info(
+                "perform-laser-calibration-%d already ran successfully; "
+                "skipping duplicate dispatch",
+                dive_id,
+            )
 
         return dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_dive_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_dive_images_parent_workflow.py
@@ -3,17 +3,25 @@
 Picks the next HIGH-priority dive needing dive-image preprocessing,
 resolves its PREDICTION clusters + camera intrinsics via SDK, and
 dispatches `PreprocessDiveImagesWorkflow` as a child on the
-data-worker (`fishsense_data_processing_queue`).
+data-worker (`fishsense_data_processing_queue`). After archive+cleanup,
+chains into `PopulateSpeciesLabelStudioProjectWorkflow` so the
+group-preprocessed JPEGs land in the species LS project in the same
+hourly run that produced them.
 
 Same cluster-correctness invariants as
 `PreprocessLaserImagesParentWorkflow` — see CLAUDE.md's "Cross-worker
-orchestration pattern" section.
+orchestration pattern" section. The populate child uses a
+deterministic id (`populate-species-{dive_id}`) so subsequent
+re-firings on the same cohort dive no-op via WorkflowAlreadyStarted
+rather than re-importing duplicate LS tasks.
 """
 
 from datetime import timedelta
 
 from fishsense_shared import PreprocessDiveImagesInput
 from temporalio import workflow
+from temporalio.common import WorkflowIDReusePolicy
+from temporalio.exceptions import WorkflowAlreadyStartedError
 
 with workflow.unsafe.imports_passed_through():
     from fishsense_api_workflow_worker.workflows._retry_policies import (
@@ -74,13 +82,22 @@ class PreprocessDiveImagesParentWorkflow:
             heartbeat_timeout=timedelta(minutes=5),
         )
 
-        await workflow.execute_child_workflow(
-            "PreprocessDiveImagesWorkflow",
-            inputs,
-            id=f"preprocess-dive-images-{dive_id}",
-            task_queue=DATA_PROCESSING_TASK_QUEUE,
-            execution_timeout=timedelta(hours=2),
-        )
+        try:
+            await workflow.execute_child_workflow(
+                "PreprocessDiveImagesWorkflow",
+                inputs,
+                id=f"preprocess-dive-images-{dive_id}",
+                task_queue=DATA_PROCESSING_TASK_QUEUE,
+                execution_timeout=timedelta(hours=2),
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+            )
+        except WorkflowAlreadyStartedError:
+            workflow.logger.info(
+                "preprocess-dive-images-%d already ran successfully in a "
+                "prior firing; skipping data-worker dispatch and continuing "
+                "to archive + cleanup + populate",
+                dive_id,
+            )
 
         await workflow.execute_activity(
             "archive_processed_jpegs_to_nas_activity",
@@ -94,5 +111,20 @@ class PreprocessDiveImagesParentWorkflow:
             schedule_to_close_timeout=timedelta(minutes=15),
             heartbeat_timeout=timedelta(minutes=5),
         )
+
+        try:
+            await workflow.execute_child_workflow(
+                "PopulateSpeciesLabelStudioProjectWorkflow",
+                dive_id,
+                id=f"populate-species-{dive_id}",
+                execution_timeout=timedelta(minutes=30),
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+            )
+        except WorkflowAlreadyStartedError:
+            workflow.logger.info(
+                "populate-species-%d already ran in a prior hourly firing; "
+                "skipping LS task import",
+                dive_id,
+            )
 
         return inputs.dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_headtail_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_headtail_images_parent_workflow.py
@@ -2,15 +2,22 @@
 
 Picks the next HIGH-priority dive needing head/tail preprocessing and
 dispatches `PreprocessHeadtailImagesWorkflow` to the data-worker.
+After archive+cleanup, chains into
+`PopulateHeadTailLabelStudioProjectWorkflow` so head/tail JPEGs land
+in their LS project in the same hourly firing that produced them.
 
 Same cluster-correctness invariants as
-`PreprocessLaserImagesParentWorkflow` — see CLAUDE.md.
+`PreprocessLaserImagesParentWorkflow` — see CLAUDE.md. Populate child
+uses deterministic id `populate-headtail-{dive_id}` so re-firings on
+the same cohort dive no-op via WorkflowAlreadyStarted.
 """
 
 from datetime import timedelta
 
 from fishsense_shared import PreprocessHeadtailImagesInput
 from temporalio import workflow
+from temporalio.common import WorkflowIDReusePolicy
+from temporalio.exceptions import WorkflowAlreadyStartedError
 
 with workflow.unsafe.imports_passed_through():
     from fishsense_api_workflow_worker.workflows._retry_policies import (
@@ -66,13 +73,22 @@ class PreprocessHeadtailImagesParentWorkflow:
             heartbeat_timeout=timedelta(minutes=5),
         )
 
-        await workflow.execute_child_workflow(
-            "PreprocessHeadtailImagesWorkflow",
-            inputs,
-            id=f"preprocess-headtail-{dive_id}",
-            task_queue=DATA_PROCESSING_TASK_QUEUE,
-            execution_timeout=timedelta(hours=1),
-        )
+        try:
+            await workflow.execute_child_workflow(
+                "PreprocessHeadtailImagesWorkflow",
+                inputs,
+                id=f"preprocess-headtail-{dive_id}",
+                task_queue=DATA_PROCESSING_TASK_QUEUE,
+                execution_timeout=timedelta(hours=1),
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+            )
+        except WorkflowAlreadyStartedError:
+            workflow.logger.info(
+                "preprocess-headtail-%d already ran successfully in a prior "
+                "firing; skipping data-worker dispatch and continuing to "
+                "archive + cleanup + populate",
+                dive_id,
+            )
 
         await workflow.execute_activity(
             "archive_processed_jpegs_to_nas_activity",
@@ -86,5 +102,20 @@ class PreprocessHeadtailImagesParentWorkflow:
             schedule_to_close_timeout=timedelta(minutes=15),
             heartbeat_timeout=timedelta(minutes=5),
         )
+
+        try:
+            await workflow.execute_child_workflow(
+                "PopulateHeadTailLabelStudioProjectWorkflow",
+                dive_id,
+                id=f"populate-headtail-{dive_id}",
+                execution_timeout=timedelta(minutes=30),
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+            )
+        except WorkflowAlreadyStartedError:
+            workflow.logger.info(
+                "populate-headtail-%d already ran in a prior hourly firing; "
+                "skipping LS task import",
+                dive_id,
+            )
 
         return inputs.dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_laser_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_laser_images_parent_workflow.py
@@ -3,7 +3,10 @@
 Picks the next HIGH-priority dive needing laser preprocessing, resolves
 its incomplete-image-set + camera intrinsics via SDK, and dispatches
 the resolved inputs to the data-worker's `PreprocessLaserImagesWorkflow`
-on `fishsense_data_processing_queue`.
+on `fishsense_data_processing_queue`. After archive+cleanup, chains
+into `PopulateLaserLabelStudioProjectWorkflow` on the api-worker so a
+fresh dive lands in Label Studio in the same hourly run that produced
+its JPEGs — no operator-triggered populate needed.
 
 Cluster-correctness invariants — relevant once the data-worker scales
 beyond a single replica:
@@ -14,17 +17,32 @@ beyond a single replica:
 * The schedule that fires this workflow uses
   `overlap_policy=ScheduleOverlapPolicy.SKIP`, so a run still in
   flight when the next firing arrives is dropped at the schedule level.
-* The child workflow is started with a deterministic id
-  (`preprocess-laser-{dive_id}`); if a parent run somehow races past
-  the schedule guard (manual + scheduled trigger overlap), the second
-  child-workflow start hits `WorkflowAlreadyStarted` and is a no-op
-  rather than redoing the dive.
+* The data-worker child workflow is started with a deterministic id
+  (`preprocess-laser-{dive_id}`) and
+  `id_reuse_policy=ALLOW_DUPLICATE_FAILED_ONLY`; if a parent run
+  somehow races past the schedule guard (manual + scheduled trigger
+  overlap), or if a previous parent run failed *after* the child
+  succeeded but *before* archive completed and the next firing
+  re-targets the same dive, the second child dispatch hits
+  `WorkflowAlreadyStarted` and the parent catches it. Archive +
+  cleanup + populate then still run, so a child-then-parent split
+  failure self-heals on the next firing rather than redoing
+  per-image work.
+* The populate child uses the same deterministic-id trick
+  (`populate-laser-{dive_id}`). Stage 0.1's cohort keeps a dive in the
+  selector pool until stage 13 writes its `LaserExtrinsics`, so this
+  parent re-runs hourly on the same dive_id — without dedup, every
+  re-run would re-import LS tasks for already-incomplete labels and
+  pile up duplicate tasks. WorkflowAlreadyStarted on the second+
+  attempt is the expected steady state.
 """
 
 from datetime import timedelta
 
 from fishsense_shared import PreprocessLaserImagesInput
 from temporalio import workflow
+from temporalio.common import WorkflowIDReusePolicy
+from temporalio.exceptions import WorkflowAlreadyStartedError
 
 with workflow.unsafe.imports_passed_through():
     from fishsense_api_workflow_worker.workflows._retry_policies import (
@@ -88,13 +106,22 @@ class PreprocessLaserImagesParentWorkflow:
             heartbeat_timeout=timedelta(minutes=5),
         )
 
-        await workflow.execute_child_workflow(
-            "PreprocessLaserImagesWorkflow",
-            inputs,
-            id=f"preprocess-laser-{dive_id}",
-            task_queue=DATA_PROCESSING_TASK_QUEUE,
-            execution_timeout=timedelta(hours=1),
-        )
+        try:
+            await workflow.execute_child_workflow(
+                "PreprocessLaserImagesWorkflow",
+                inputs,
+                id=f"preprocess-laser-{dive_id}",
+                task_queue=DATA_PROCESSING_TASK_QUEUE,
+                execution_timeout=timedelta(hours=1),
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+            )
+        except WorkflowAlreadyStartedError:
+            workflow.logger.info(
+                "preprocess-laser-%d already ran successfully in a prior "
+                "firing; skipping data-worker dispatch and continuing to "
+                "archive + cleanup + populate",
+                dive_id,
+            )
 
         # Phase 3b: archive processed JPEGs to NAS, then drop the raw
         # `.ORF` bytes from the file-exchange. JPEGs intentionally stay
@@ -112,5 +139,20 @@ class PreprocessLaserImagesParentWorkflow:
             schedule_to_close_timeout=timedelta(minutes=15),
             heartbeat_timeout=timedelta(minutes=5),
         )
+
+        try:
+            await workflow.execute_child_workflow(
+                "PopulateLaserLabelStudioProjectWorkflow",
+                dive_id,
+                id=f"populate-laser-{dive_id}",
+                execution_timeout=timedelta(minutes=30),
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+            )
+        except WorkflowAlreadyStartedError:
+            workflow.logger.info(
+                "populate-laser-%d already ran in a prior hourly firing; "
+                "skipping LS task import",
+                dive_id,
+            )
 
         return inputs.dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_slate_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_slate_images_parent_workflow.py
@@ -1,16 +1,24 @@
 """Stage 9 parent workflow (api-worker side).
 
 Picks the next HIGH-priority dive needing slate preprocessing and
-dispatches `PreprocessSlateImagesWorkflow` to the data-worker.
+dispatches `PreprocessSlateImagesWorkflow` to the data-worker. After
+archive+cleanup, chains into
+`PopulateDiveSlateLabelStudioProjectWorkflow` so slate JPEGs land in
+the dive-slate LS project in the same hourly firing that produced
+them.
 
 Same cluster-correctness invariants as
-`PreprocessLaserImagesParentWorkflow` — see CLAUDE.md.
+`PreprocessLaserImagesParentWorkflow` — see CLAUDE.md. Populate child
+uses deterministic id `populate-dive-slate-{dive_id}` so re-firings
+on the same cohort dive no-op via WorkflowAlreadyStarted.
 """
 
 from datetime import timedelta
 
 from fishsense_shared import PreprocessSlateImagesInput
 from temporalio import workflow
+from temporalio.common import WorkflowIDReusePolicy
+from temporalio.exceptions import WorkflowAlreadyStartedError
 
 with workflow.unsafe.imports_passed_through():
     from fishsense_api_workflow_worker.workflows._retry_policies import (
@@ -74,13 +82,22 @@ class PreprocessSlateImagesParentWorkflow:
             schedule_to_close_timeout=timedelta(minutes=5),
         )
 
-        await workflow.execute_child_workflow(
-            "PreprocessSlateImagesWorkflow",
-            inputs,
-            id=f"preprocess-slate-{dive_id}",
-            task_queue=DATA_PROCESSING_TASK_QUEUE,
-            execution_timeout=timedelta(hours=1),
-        )
+        try:
+            await workflow.execute_child_workflow(
+                "PreprocessSlateImagesWorkflow",
+                inputs,
+                id=f"preprocess-slate-{dive_id}",
+                task_queue=DATA_PROCESSING_TASK_QUEUE,
+                execution_timeout=timedelta(hours=1),
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+            )
+        except WorkflowAlreadyStartedError:
+            workflow.logger.info(
+                "preprocess-slate-%d already ran successfully in a prior "
+                "firing; skipping data-worker dispatch and continuing to "
+                "archive + cleanup + populate",
+                dive_id,
+            )
 
         await workflow.execute_activity(
             "archive_processed_jpegs_to_nas_activity",
@@ -94,5 +111,20 @@ class PreprocessSlateImagesParentWorkflow:
             schedule_to_close_timeout=timedelta(minutes=15),
             heartbeat_timeout=timedelta(minutes=5),
         )
+
+        try:
+            await workflow.execute_child_workflow(
+                "PopulateDiveSlateLabelStudioProjectWorkflow",
+                dive_id,
+                id=f"populate-dive-slate-{dive_id}",
+                execution_timeout=timedelta(minutes=30),
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+            )
+        except WorkflowAlreadyStartedError:
+            workflow.logger.info(
+                "populate-dive-slate-%d already ran in a prior hourly firing; "
+                "skipping LS task import",
+                dive_id,
+            )
 
         return inputs.dive_id

--- a/services/fishsense-api-workflow-worker/tests/test_preprocess_dive_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preprocess_dive_images_parent_workflow.py
@@ -36,6 +36,19 @@ class _StubChildWorkflow:
         )
 
 
+@workflow.defn(name="PopulateSpeciesLabelStudioProjectWorkflow")
+class _StubPopulateWorkflow:
+    # pylint: disable=too-few-public-methods
+    @workflow.run
+    async def run(self, dive_id: int) -> int:
+        await workflow.execute_activity(
+            "_record_populate_dispatch",
+            args=(workflow.info().workflow_id, dive_id),
+            schedule_to_close_timeout=timedelta(seconds=5),
+        )
+        return 0
+
+
 def _make_recording_activity(captures: List[tuple]):
     @activity.defn(name="_record_child_dispatch")
     async def record_child_dispatch(
@@ -44,6 +57,14 @@ def _make_recording_activity(captures: List[tuple]):
         captures.append((workflow_id, dive_id, checksums))
 
     return record_child_dispatch
+
+
+def _make_populate_recording_activity(captures: List[tuple]):
+    @activity.defn(name="_record_populate_dispatch")
+    async def record_populate_dispatch(workflow_id: str, dive_id: int) -> None:
+        captures.append((workflow_id, dive_id))
+
+    return record_populate_dispatch
 
 
 def _make_stubs(
@@ -101,13 +122,20 @@ async def test_dispatches_child_with_deterministic_id_and_clusters():
     )
     activities, selector_calls, resolver_calls = _make_stubs(440, inputs)
     child_runs: List[tuple] = []
+    populate_runs: List[tuple] = []
 
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue="test-stage2-parent",
-            workflows=[PreprocessDiveImagesParentWorkflow],
-            activities=activities,
+            workflows=[
+                PreprocessDiveImagesParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[
+                *activities,
+                _make_populate_recording_activity(populate_runs),
+            ],
         ), Worker(
             env.client,
             task_queue=DATA_PROCESSING_TASK_QUEUE,
@@ -128,19 +156,27 @@ async def test_dispatches_child_with_deterministic_id_and_clusters():
     assert child_id == "preprocess-dive-images-440"
     assert child_dive_id == 440
     assert flat == ["a", "b", "c"]
+    assert populate_runs == [("populate-species-440", 440)]
 
 
 @pytest.mark.asyncio
 async def test_returns_none_when_selector_finds_no_dive():
     activities, _, resolver_calls = _make_stubs(None, None)
     child_runs: List[tuple] = []
+    populate_runs: List[tuple] = []
 
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue="test-stage2-parent-empty",
-            workflows=[PreprocessDiveImagesParentWorkflow],
-            activities=activities,
+            workflows=[
+                PreprocessDiveImagesParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[
+                *activities,
+                _make_populate_recording_activity(populate_runs),
+            ],
         ), Worker(
             env.client,
             task_queue=DATA_PROCESSING_TASK_QUEUE,
@@ -156,6 +192,7 @@ async def test_returns_none_when_selector_finds_no_dive():
     assert result is None
     assert not resolver_calls
     assert not child_runs
+    assert not populate_runs
 
 
 @pytest.mark.asyncio
@@ -168,13 +205,20 @@ async def test_skips_child_dispatch_when_no_clusters():
     )
     activities, _, _ = _make_stubs(440, inputs)
     child_runs: List[tuple] = []
+    populate_runs: List[tuple] = []
 
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue="test-stage2-parent-empty-clusters",
-            workflows=[PreprocessDiveImagesParentWorkflow],
-            activities=activities,
+            workflows=[
+                PreprocessDiveImagesParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[
+                *activities,
+                _make_populate_recording_activity(populate_runs),
+            ],
         ), Worker(
             env.client,
             task_queue=DATA_PROCESSING_TASK_QUEUE,
@@ -189,3 +233,4 @@ async def test_skips_child_dispatch_when_no_clusters():
 
     assert result == 440
     assert not child_runs
+    assert not populate_runs

--- a/services/fishsense-api-workflow-worker/tests/test_preprocess_headtail_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preprocess_headtail_images_parent_workflow.py
@@ -39,6 +39,19 @@ class _StubChildWorkflow:
         )
 
 
+@workflow.defn(name="PopulateHeadTailLabelStudioProjectWorkflow")
+class _StubPopulateWorkflow:
+    # pylint: disable=too-few-public-methods
+    @workflow.run
+    async def run(self, dive_id: int) -> int:
+        await workflow.execute_activity(
+            "_record_populate_dispatch",
+            args=(workflow.info().workflow_id, dive_id),
+            schedule_to_close_timeout=timedelta(seconds=5),
+        )
+        return 0
+
+
 def _make_recording_activity(captures: List[tuple]):
     @activity.defn(name="_record_child_dispatch")
     async def record_child_dispatch(
@@ -47,6 +60,14 @@ def _make_recording_activity(captures: List[tuple]):
         captures.append((workflow_id, dive_id, checksums))
 
     return record_child_dispatch
+
+
+def _make_populate_recording_activity(captures: List[tuple]):
+    @activity.defn(name="_record_populate_dispatch")
+    async def record_populate_dispatch(workflow_id: str, dive_id: int) -> None:
+        captures.append((workflow_id, dive_id))
+
+    return record_populate_dispatch
 
 
 def _make_stubs(
@@ -95,13 +116,20 @@ async def test_dispatches_child_with_deterministic_id():
     )
     activities = _make_stubs(440, inputs)
     child_runs: List[tuple] = []
+    populate_runs: List[tuple] = []
 
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue="test-stage5-1-parent",
-            workflows=[PreprocessHeadtailImagesParentWorkflow],
-            activities=activities,
+            workflows=[
+                PreprocessHeadtailImagesParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[
+                *activities,
+                _make_populate_recording_activity(populate_runs),
+            ],
         ), Worker(
             env.client,
             task_queue=DATA_PROCESSING_TASK_QUEUE,
@@ -120,19 +148,27 @@ async def test_dispatches_child_with_deterministic_id():
     assert child_id == "preprocess-headtail-440"
     assert child_dive_id == 440
     assert checksums == ["a", "b"]
+    assert populate_runs == [("populate-headtail-440", 440)]
 
 
 @pytest.mark.asyncio
 async def test_returns_none_when_no_dive():
     activities = _make_stubs(None, None)
     child_runs: List[tuple] = []
+    populate_runs: List[tuple] = []
 
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue="test-stage5-1-parent-none",
-            workflows=[PreprocessHeadtailImagesParentWorkflow],
-            activities=activities,
+            workflows=[
+                PreprocessHeadtailImagesParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[
+                *activities,
+                _make_populate_recording_activity(populate_runs),
+            ],
         ), Worker(
             env.client,
             task_queue=DATA_PROCESSING_TASK_QUEUE,
@@ -147,6 +183,7 @@ async def test_returns_none_when_no_dive():
 
     assert result is None
     assert not child_runs
+    assert not populate_runs
 
 
 @pytest.mark.asyncio
@@ -159,13 +196,20 @@ async def test_skips_child_when_no_image_checksums():
     )
     activities = _make_stubs(440, inputs)
     child_runs: List[tuple] = []
+    populate_runs: List[tuple] = []
 
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue="test-stage5-1-parent-empty",
-            workflows=[PreprocessHeadtailImagesParentWorkflow],
-            activities=activities,
+            workflows=[
+                PreprocessHeadtailImagesParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[
+                *activities,
+                _make_populate_recording_activity(populate_runs),
+            ],
         ), Worker(
             env.client,
             task_queue=DATA_PROCESSING_TASK_QUEUE,
@@ -180,3 +224,4 @@ async def test_skips_child_when_no_image_checksums():
 
     assert result == 440
     assert not child_runs
+    assert not populate_runs

--- a/services/fishsense-api-workflow-worker/tests/test_preprocess_laser_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preprocess_laser_images_parent_workflow.py
@@ -6,6 +6,14 @@ Pins down:
   2. Selector + resolver dispatch a child workflow on the data-worker
      task queue with a deterministic id (`preprocess-laser-{dive_id}`).
   3. Resolver returning 0 checksums skips the child dispatch.
+  4. After archive+cleanup, the parent dispatches
+     `PopulateLaserLabelStudioProjectWorkflow` as a child with
+     deterministic id `populate-laser-{dive_id}` on the parent's
+     own task queue.
+  5. A second invocation against the same dive_id catches the
+     WorkflowAlreadyStartedError and still completes successfully —
+     this is the steady-state for the stage-0.1 cohort, since dives
+     stay in the cohort until stage 13 writes LaserExtrinsics.
 
 The child-workflow stub records its dispatch via an activity (rather
 than module-level state) so the recording survives the workflow
@@ -58,6 +66,25 @@ class _StubChildWorkflow:
         )
 
 
+@workflow.defn(name="PopulateLaserLabelStudioProjectWorkflow")
+class _StubPopulateWorkflow:
+    # pylint: disable=too-few-public-methods
+    """Stand-in for the LS populate child the parent now chains.
+
+    Records its workflow_id + dive_id via an activity so the contract
+    test can observe the deterministic id (`populate-laser-{dive_id}`).
+    """
+
+    @workflow.run
+    async def run(self, dive_id: int) -> int:
+        await workflow.execute_activity(
+            "_record_populate_dispatch",
+            args=(workflow.info().workflow_id, dive_id),
+            schedule_to_close_timeout=timedelta(seconds=5),
+        )
+        return 0
+
+
 def _make_recording_activity(captures: List[tuple]):
     @activity.defn(name="_record_child_dispatch")
     async def record_child_dispatch(
@@ -66,6 +93,14 @@ def _make_recording_activity(captures: List[tuple]):
         captures.append((workflow_id, dive_id, checksums))
 
     return record_child_dispatch
+
+
+def _make_populate_recording_activity(captures: List[tuple]):
+    @activity.defn(name="_record_populate_dispatch")
+    async def record_populate_dispatch(workflow_id: str, dive_id: int) -> None:
+        captures.append((workflow_id, dive_id))
+
+    return record_populate_dispatch
 
 
 def _make_stub_activities(
@@ -123,13 +158,18 @@ async def test_dispatches_child_with_deterministic_id_and_correct_payload():
     )
     child_runs: List[tuple] = []
     record = _make_recording_activity(child_runs)
+    populate_runs: List[tuple] = []
+    record_populate = _make_populate_recording_activity(populate_runs)
 
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue="test-stage01-parent",
-            workflows=[PreprocessLaserImagesParentWorkflow],
-            activities=activities,
+            workflows=[
+                PreprocessLaserImagesParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[*activities, record_populate],
         ), Worker(
             env.client,
             task_queue=DATA_PROCESSING_TASK_QUEUE,
@@ -151,6 +191,7 @@ async def test_dispatches_child_with_deterministic_id_and_correct_payload():
     assert child_id == "preprocess-laser-440"
     assert child_dive_id == 440
     assert child_checksums == ["a", "b", "c"]
+    assert populate_runs == [("populate-laser-440", 440)]
 
 
 @pytest.mark.asyncio
@@ -160,13 +201,18 @@ async def test_returns_none_when_selector_finds_no_dive():
     )
     child_runs: List[tuple] = []
     record = _make_recording_activity(child_runs)
+    populate_runs: List[tuple] = []
+    record_populate = _make_populate_recording_activity(populate_runs)
 
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue="test-stage01-parent-empty",
-            workflows=[PreprocessLaserImagesParentWorkflow],
-            activities=activities,
+            workflows=[
+                PreprocessLaserImagesParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[*activities, record_populate],
         ), Worker(
             env.client,
             task_queue=DATA_PROCESSING_TASK_QUEUE,
@@ -184,6 +230,7 @@ async def test_returns_none_when_selector_finds_no_dive():
     assert not resolver_calls
     assert not stage_calls
     assert not child_runs
+    assert not populate_runs
 
 
 @pytest.mark.asyncio
@@ -200,13 +247,18 @@ async def test_skips_child_dispatch_when_no_incomplete_images():
     )
     child_runs: List[tuple] = []
     record = _make_recording_activity(child_runs)
+    populate_runs: List[tuple] = []
+    record_populate = _make_populate_recording_activity(populate_runs)
 
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue="test-stage01-parent-empty-images",
-            workflows=[PreprocessLaserImagesParentWorkflow],
-            activities=activities,
+            workflows=[
+                PreprocessLaserImagesParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[*activities, record_populate],
         ), Worker(
             env.client,
             task_queue=DATA_PROCESSING_TASK_QUEUE,
@@ -223,3 +275,65 @@ async def test_skips_child_dispatch_when_no_incomplete_images():
     assert resolver_calls == [440]
     assert not stage_calls
     assert not child_runs
+    assert not populate_runs
+
+
+@pytest.mark.asyncio
+async def test_repeat_invocation_swallows_workflow_already_started():
+    """Stage-0.1's cohort keeps a dive selectable until stage-13 writes
+    LaserExtrinsics, so the parent re-runs hourly on the same dive_id.
+    The deterministic populate child id makes the second+ firing's
+    populate dispatch hit WorkflowAlreadyStarted, which the parent
+    catches so the run still completes successfully.
+    """
+    inputs = PreprocessLaserImagesInput(
+        dive_id=441,
+        image_checksums=["x"],
+        camera_matrix=_K,
+        distortion_coefficients=_D,
+        bbox=_BBOX,
+    )
+    activities, _, _, _ = _make_stub_activities(
+        selector_result=441, resolver_result=inputs
+    )
+    child_runs: List[tuple] = []
+    record = _make_recording_activity(child_runs)
+    populate_runs: List[tuple] = []
+    record_populate = _make_populate_recording_activity(populate_runs)
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        # Pre-seed: start a populate child with the same id that the
+        # parent will try to use, then let it complete.
+        existing = await env.client.start_workflow(
+            _StubPopulateWorkflow.run,
+            441,
+            id="populate-laser-441",
+            task_queue="test-stage01-parent-rerun",
+        )
+        async with Worker(
+            env.client,
+            task_queue="test-stage01-parent-rerun",
+            workflows=[
+                PreprocessLaserImagesParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[*activities, record_populate],
+        ), Worker(
+            env.client,
+            task_queue=DATA_PROCESSING_TASK_QUEUE,
+            workflows=[_StubChildWorkflow],
+            activities=[record],
+        ):
+            await existing.result()
+            result = await env.client.execute_workflow(
+                PreprocessLaserImagesParentWorkflow.run,
+                id=f"test-stage01-parent-rerun-{uuid.uuid4()}",
+                task_queue="test-stage01-parent-rerun",
+            )
+
+    assert result == 441
+    assert len(child_runs) == 1
+    # Pre-seeded populate ran once; the parent's attempt was rejected
+    # with WorkflowAlreadyStarted and caught, so no second populate
+    # invocation happened.
+    assert populate_runs == [("populate-laser-441", 441)]

--- a/services/fishsense-api-workflow-worker/tests/test_preprocess_slate_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preprocess_slate_images_parent_workflow.py
@@ -39,6 +39,19 @@ class _StubChildWorkflow:
         )
 
 
+@workflow.defn(name="PopulateDiveSlateLabelStudioProjectWorkflow")
+class _StubPopulateWorkflow:
+    # pylint: disable=too-few-public-methods
+    @workflow.run
+    async def run(self, dive_id: int) -> int:
+        await workflow.execute_activity(
+            "_record_populate_dispatch",
+            args=(workflow.info().workflow_id, dive_id),
+            schedule_to_close_timeout=timedelta(seconds=5),
+        )
+        return 0
+
+
 def _make_recording_activity(captures: List[tuple]):
     @activity.defn(name="_record_child_dispatch")
     async def record_child_dispatch(
@@ -47,6 +60,14 @@ def _make_recording_activity(captures: List[tuple]):
         captures.append((workflow_id, dive_id, summary))
 
     return record_child_dispatch
+
+
+def _make_populate_recording_activity(captures: List[tuple]):
+    @activity.defn(name="_record_populate_dispatch")
+    async def record_populate_dispatch(workflow_id: str, dive_id: int) -> None:
+        captures.append((workflow_id, dive_id))
+
+    return record_populate_dispatch
 
 
 def _make_stubs(
@@ -103,13 +124,20 @@ async def test_dispatches_child_with_deterministic_id():
     )
     activities = _make_stubs(440, inputs)
     child_runs: List[tuple] = []
+    populate_runs: List[tuple] = []
 
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue="test-stage9-parent",
-            workflows=[PreprocessSlateImagesParentWorkflow],
-            activities=activities,
+            workflows=[
+                PreprocessSlateImagesParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[
+                *activities,
+                _make_populate_recording_activity(populate_runs),
+            ],
         ), Worker(
             env.client,
             task_queue=DATA_PROCESSING_TASK_QUEUE,
@@ -129,19 +157,27 @@ async def test_dispatches_child_with_deterministic_id():
     assert child_dive_id == 440
     assert checksums == ["a"]
     assert slate_id == 7
+    assert populate_runs == [("populate-dive-slate-440", 440)]
 
 
 @pytest.mark.asyncio
 async def test_returns_none_when_no_dive():
     activities = _make_stubs(None, None)
     child_runs: List[tuple] = []
+    populate_runs: List[tuple] = []
 
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue="test-stage9-parent-none",
-            workflows=[PreprocessSlateImagesParentWorkflow],
-            activities=activities,
+            workflows=[
+                PreprocessSlateImagesParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[
+                *activities,
+                _make_populate_recording_activity(populate_runs),
+            ],
         ), Worker(
             env.client,
             task_queue=DATA_PROCESSING_TASK_QUEUE,
@@ -156,6 +192,7 @@ async def test_returns_none_when_no_dive():
 
     assert result is None
     assert not child_runs
+    assert not populate_runs
 
 
 @pytest.mark.asyncio
@@ -171,13 +208,20 @@ async def test_skips_child_when_no_image_checksums():
     )
     activities = _make_stubs(440, inputs)
     child_runs: List[tuple] = []
+    populate_runs: List[tuple] = []
 
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue="test-stage9-parent-empty",
-            workflows=[PreprocessSlateImagesParentWorkflow],
-            activities=activities,
+            workflows=[
+                PreprocessSlateImagesParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[
+                *activities,
+                _make_populate_recording_activity(populate_runs),
+            ],
         ), Worker(
             env.client,
             task_queue=DATA_PROCESSING_TASK_QUEUE,
@@ -192,3 +236,4 @@ async def test_skips_child_when_no_image_checksums():
 
     assert result == 440
     assert not child_runs
+    assert not populate_runs


### PR DESCRIPTION
## Summary

- The four preprocess parents (stages 0.1, 2, 5.1, 9) now dispatch their matching `Populate*LabelStudioProjectWorkflow` as a child after archive+cleanup, so labelers see fresh LS tasks in the same hourly firing that produced the JPEGs — no more operator-triggered populate.
- Dedup via deterministic id (`populate-<stage>-{dive_id}`) + `id_reuse_policy=ALLOW_DUPLICATE_FAILED_ONLY` + caught `WorkflowAlreadyStartedError`. Stage 0.1's cohort retains a dive until stage 13 writes `LaserExtrinsics`, so the parent re-fires hourly on the same dive_id; without dedup, every hour would re-import LS tasks for already-incomplete labels and pile up duplicate tasks.
- Same fix applied to the pre-existing data-worker child dispatches (stages 0.1, 2, 5.1, 9, 13, 14) whose docstrings claimed `WorkflowAlreadyStarted`-based dedup but were silently relying on temporalio's default child `id_reuse_policy=ALLOW_DUPLICATE` — which let duplicates through. The explicit policy + try/except now match the documented behavior.
- CLAUDE.md updated to flag the temporalio default-policy gotcha.

## Test plan

- [x] `uv run pytest` in `services/fishsense-api-workflow-worker` — 137 passed, 4 deselected (integration), 0 failed
- [x] New test `test_repeat_invocation_swallows_workflow_already_started` pins dedup behavior on the laser parent
- [x] All four parent-workflow tests assert the populate child is dispatched with the correct deterministic id
- [ ] Real-prod soak: confirm next hourly firing of `PreprocessLaserImagesParentWorkflow` against an in-cohort dive (393) imports LS tasks once, then hours 2+ no-op the populate dispatch
- [ ] Manual `temporal workflow start` of `PopulateLaserLabelStudioProjectWorkflow` with a non-colliding id (e.g. `populate-laser-393-manual`) still works for backfill scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)