### PR TITLE
feat(api-workflow-worker): re-cohort stage 0.1 by labeling state + fix multi-row predicate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,13 +123,12 @@ work split into two workflows:
      dive_id, id="populate-<stage>-{dive_id}",
      id_reuse_policy=ALLOW_DUPLICATE_FAILED_ONLY)` — on-demand
      populate child runs against the same task queue. The reuse
-     policy + deterministic id deduplicate against subsequent hourly
-     re-firings of the parent on the same cohort dive (stage 0.1's
-     cohort, in particular, retains a dive until stage 13 writes
-     LaserExtrinsics, so the parent re-fires on the same dive_id
-     hour after hour). The parent catches the resulting
-     `WorkflowAlreadyStartedError` so the post-archive run still
-     completes successfully.
+     policy + deterministic id deduplicate against re-firings of the
+     parent on the same cohort dive — once labels start completing,
+     the dive drops out of the cohort, but if the parent fires twice
+     on the same dive_id (for whatever reason) the second populate
+     hits `WorkflowAlreadyStartedError` and the parent catches it so
+     the post-archive run still completes successfully.
 * **Child** on data-worker (`fishsense_data_processing_queue`). Thin
   pre-input workflow that fans out per-image activities. No SDK
   calls and no NAS calls; all bytes already on the file-exchange,
@@ -180,7 +179,7 @@ but not scheduled (see notes below). Per-stage cohort:
 
 | Stage | Parent cohort definition |
 |---|---|
-| 0.1 | HIGH-priority + no `LaserExtrinsics` (matches `dry_run_stage13.py`) |
+| 0.1 | HIGH-priority + at least one image without a completed `LaserLabel` (in any project) |
 | 2   | HIGH-priority + has PREDICTION clusters + at least one image without a completed `SpeciesLabel` |
 | 5.1 | HIGH-priority + at least one `SpeciesLabel.top_three_photos_of_group=True` whose `HeadTailLabel` is incomplete |
 | 9   | HIGH-priority + `dive_slate_id` set + at least one `SpeciesLabel.content_of_image='Slate, Laser on slate'` whose `DiveSlateLabel` is incomplete |

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_laser_label_studio_project_activity.py
@@ -22,17 +22,23 @@ from fishsense_api_workflow_worker.activities.utils import get_fs_client
 PREPROCESS_FOLDER = "preprocess_jpeg"
 
 
-def _select_incomplete_images(
+def _select_unlabeled_images(
     images: List[Image], existing_labels: List[LaserLabel]
 ) -> List[Image]:
-    """Return only images that need a fresh LS task — no laser label
-    yet, or one whose `completed` is not True."""
-    by_image_id = {label.image_id: label for label in existing_labels}
-    return [
-        image
-        for image in images
-        if (label := by_image_id.get(image.id)) is None or not label.completed
-    ]
+    """Return only images that need a fresh LS task — no completed
+    LaserLabel exists for them in any project.
+
+    Multi-row-aware: an image carrying both a completed row in
+    project 43 and an incomplete sentinel row in project NULL is
+    treated as labeled. The previous shape collapsed labels into a
+    `{image_id: label}` dict and let SDK iteration order pick which
+    row won, which silently leaked already-labeled images into the
+    task-import set when the incomplete row happened to land last.
+    """
+    completed_image_ids = {
+        label.image_id for label in existing_labels if label.completed
+    }
+    return [image for image in images if image.id not in completed_image_ids]
 
 
 def _build_task(image: Image) -> dict:
@@ -54,15 +60,16 @@ async def populate_laser_label_studio_project_activity(
         images = await fs.images.get(dive_id=dive_id) or []
         existing_labels = await fs.labels.get_laser_labels(dive_id) or []
 
-        incomplete = _select_incomplete_images(images, existing_labels)
-        if not incomplete:
+        unlabeled = _select_unlabeled_images(images, existing_labels)
+        if not unlabeled:
             activity.logger.info(
-                "Dive %d has no incomplete laser images; nothing to import",
+                "Dive %d has a completed laser label for every image; "
+                "nothing to import",
                 dive_id,
             )
             return 0
 
-        tasks = [_build_task(image) for image in incomplete]
+        tasks = [_build_task(image) for image in unlabeled]
 
         async def _record(image: Image, task_id: int) -> None:
             label = LaserLabel(
@@ -85,5 +92,5 @@ async def populate_laser_label_studio_project_activity(
             project_id=project_id,
             tasks=tasks,
             record_label=_record,
-            items=incomplete,
+            items=unlabeled,
         )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_species_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_species_label_studio_project_activity.py
@@ -28,17 +28,22 @@ from fishsense_api_workflow_worker.activities.utils import get_fs_client
 SPECIES_FOLDER = "groups_jpeg"
 
 
-def _select_incomplete_images(
+def _select_unlabeled_images(
     images: List[Image], existing_labels: List[SpeciesLabel]
 ) -> List[Image]:
-    """Return only images that need a fresh LS task — no species
-    label yet, or one whose `completed` is not True."""
-    by_image_id = {label.image_id: label for label in existing_labels}
-    return [
-        image
-        for image in images
-        if (label := by_image_id.get(image.id)) is None or not label.completed
-    ]
+    """Return only images that need a fresh LS task — no completed
+    SpeciesLabel exists for them in any project.
+
+    Multi-row-aware: the previous shape collapsed labels into a
+    `{image_id: label}` dict and let SDK iteration order pick which
+    row won, which silently leaked already-labeled images into the
+    task-import set when the incomplete row happened to land last.
+    Mirrors `populate_laser_label_studio_project_activity._select_unlabeled_images`.
+    """
+    completed_image_ids = {
+        label.image_id for label in existing_labels if label.completed
+    }
+    return [image for image in images if image.id not in completed_image_ids]
 
 
 def _build_task(image: Image) -> dict:
@@ -61,15 +66,16 @@ async def populate_species_label_studio_project_activity(
         images = await fs.images.get(dive_id=dive_id) or []
         existing_labels = await fs.labels.get_species_labels(dive_id) or []
 
-        incomplete = _select_incomplete_images(images, existing_labels)
-        if not incomplete:
+        unlabeled = _select_unlabeled_images(images, existing_labels)
+        if not unlabeled:
             activity.logger.info(
-                "Dive %d has no incomplete species images; nothing to import",
+                "Dive %d has a completed species label for every image; "
+                "nothing to import",
                 dive_id,
             )
             return 0
 
-        tasks = [_build_task(image) for image in incomplete]
+        tasks = [_build_task(image) for image in unlabeled]
 
         async def _record(image: Image, task_id: int) -> None:
             label = SpeciesLabel(
@@ -99,5 +105,5 @@ async def populate_species_label_studio_project_activity(
             project_id=project_id,
             tasks=tasks,
             record_label=_record,
-            items=incomplete,
+            items=unlabeled,
         )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_preprocess_inputs_activity.py
@@ -1,10 +1,14 @@
 """Activity to resolve the per-image inputs stage 0.1 needs for a dive.
 
 Returns a fully-populated `PreprocessLaserImagesInput` ready to hand
-to the data-worker's child workflow. Image checksum filter matches
-stage 0.3's populate predicate (laser label missing or
-`completed=False`), so a re-run after some labels complete naturally
-narrows the work.
+to the data-worker's child workflow. Image filter mirrors the
+selector's "image with no completed LaserLabel in any project"
+predicate — multi-row-aware (a single image can carry rows for
+multiple LS projects, and any one completed row counts as
+"labeled"). The previous shape collapsed labels into a
+`{image_id: label}` dict and let iteration order pick which row won,
+which silently dropped "incomplete" images whenever a completed row
+happened to be returned last by the SDK.
 
 Default bbox is the original notebook constant — kept here rather
 than baked into the data-worker so the api-worker can swap to a
@@ -26,15 +30,14 @@ from fishsense_api_workflow_worker.activities.utils import get_fs_client
 DEFAULT_LASER_BBOX: List[int] = [1800, 700, 2400, 1600]
 
 
-def _select_incomplete_images(
+def _select_unlabeled_images(
     images: List[Image], existing_labels: List[LaserLabel]
 ) -> List[Image]:
-    by_image_id = {label.image_id: label for label in existing_labels}
-    return [
-        image
-        for image in images
-        if (label := by_image_id.get(image.id)) is None or not label.completed
-    ]
+    """Return images that have no completed LaserLabel in any project."""
+    completed_image_ids = {
+        label.image_id for label in existing_labels if label.completed
+    }
+    return [image for image in images if image.id not in completed_image_ids]
 
 
 @activity.defn
@@ -56,11 +59,11 @@ async def resolve_laser_preprocess_inputs_activity(
 
         images = await fs.images.get(dive_id=dive_id) or []
         existing_labels = await fs.labels.get_laser_labels(dive_id) or []
-        incomplete = _select_incomplete_images(images, existing_labels)
+        unlabeled = _select_unlabeled_images(images, existing_labels)
 
         return PreprocessLaserImagesInput(
             dive_id=dive_id,
-            image_checksums=[image.checksum for image in incomplete],
+            image_checksums=[image.checksum for image in unlabeled],
             camera_matrix=intrinsics.camera_matrix.tolist(),
             distortion_coefficients=intrinsics.distortion_coefficients.tolist(),
             bbox=list(DEFAULT_LASER_BBOX),

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_laser_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_laser_images_parent_workflow.py
@@ -1,12 +1,21 @@
 """Stage 0.1 parent workflow (api-worker side).
 
 Picks the next HIGH-priority dive needing laser preprocessing, resolves
-its incomplete-image-set + camera intrinsics via SDK, and dispatches
+its unlabeled-image-set + camera intrinsics via SDK, and dispatches
 the resolved inputs to the data-worker's `PreprocessLaserImagesWorkflow`
 on `fishsense_data_processing_queue`. After archive+cleanup, chains
 into `PopulateLaserLabelStudioProjectWorkflow` on the api-worker so a
 fresh dive lands in Label Studio in the same hourly run that produced
 its JPEGs — no operator-triggered populate needed.
+
+Cohort: HIGH-priority + at least one image with no completed
+`LaserLabel` in any project. Mirrors the work-state shape of the
+other three preprocess parents (dive-image / headtail / slate). The
+earlier "no `LaserExtrinsics`" cohort tied stage 0.1 to a downstream
+gate it doesn't actually advance, so dives whose laser side was done
+but slate-side blocked stage-13 calibration kept getting re-selected
+hourly with no work for the resolver to return — see
+`select_next_for_laser_preprocessing` in the api's `dive_controller`.
 
 Cluster-correctness invariants — relevant once the data-worker scales
 beyond a single replica:
@@ -29,12 +38,12 @@ beyond a single replica:
   failure self-heals on the next firing rather than redoing
   per-image work.
 * The populate child uses the same deterministic-id trick
-  (`populate-laser-{dive_id}`). Stage 0.1's cohort keeps a dive in the
-  selector pool until stage 13 writes its `LaserExtrinsics`, so this
-  parent re-runs hourly on the same dive_id — without dedup, every
-  re-run would re-import LS tasks for already-incomplete labels and
-  pile up duplicate tasks. WorkflowAlreadyStarted on the second+
-  attempt is the expected steady state.
+  (`populate-laser-{dive_id}`). With the work-state cohort, dives
+  drop out as labels complete, so re-firings on the same dive_id are
+  the exception (resurrected re-incomplete labels, manual triggers)
+  rather than the steady state — but the dedup still matters when
+  they happen, since populate's task-import would otherwise create
+  duplicate LS tasks for any image still flagged incomplete.
 """
 
 from datetime import timedelta

--- a/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
@@ -38,11 +38,13 @@ def _image(image_id: int, checksum: str) -> Image:
     )
 
 
-def _label(image_id: int, *, completed: bool) -> LaserLabel:
+def _label(
+    image_id: int, *, completed: bool, project_id: int | None = 73
+) -> LaserLabel:
     return LaserLabel(
         id=None,
         label_studio_task_id=image_id * 10,
-        label_studio_project_id=73,
+        label_studio_project_id=project_id,
         x=None,
         y=None,
         label=None,
@@ -55,13 +57,36 @@ def _label(image_id: int, *, completed: bool) -> LaserLabel:
     )
 
 
-def test_select_incomplete_filters_completed():
+def test_select_unlabeled_excludes_images_with_any_completed_label():
     images = [_image(1, "a"), _image(2, "b"), _image(3, "c")]
     existing = [_label(1, completed=True), _label(2, completed=False)]
 
-    result = sut._select_incomplete_images(images, existing)  # pylint: disable=protected-access
+    result = sut._select_unlabeled_images(images, existing)  # pylint: disable=protected-access
 
+    # Image 1 has a completed label -> excluded.
+    # Image 2's only label is incomplete -> included.
+    # Image 3 has no label at all -> included.
     assert [img.id for img in result] == [2, 3]
+
+
+def test_select_unlabeled_handles_multi_row_state():
+    """Mirrors the prod state on dive 393: each image carries a
+    completed row in project 43 plus an incomplete sentinel row in
+    project NULL. The dict-collapse filter would resolve to either
+    row depending on iteration order — the set-based filter doesn't.
+    """
+    images = [_image(1, "a"), _image(2, "b")]
+    existing = [
+        # Image 1: completed in 43 + incomplete sentinel.
+        _label(1, completed=True, project_id=43),
+        _label(1, completed=False, project_id=None),
+        # Image 2: only an incomplete row.
+        _label(2, completed=False, project_id=43),
+    ]
+
+    result = sut._select_unlabeled_images(images, existing)  # pylint: disable=protected-access
+
+    assert [img.id for img in result] == [2]
 
 
 def test_build_task_uses_configured_url_base(monkeypatch):

--- a/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_activity.py
@@ -30,11 +30,13 @@ def _image(image_id: int, checksum: str) -> Image:
     )
 
 
-def _label(image_id: int, *, completed: bool) -> SpeciesLabel:
+def _label(
+    image_id: int, *, completed: bool, project_id: int | None = 70
+) -> SpeciesLabel:
     return SpeciesLabel(
         id=None,
         label_studio_task_id=image_id * 10,
-        label_studio_project_id=70,
+        label_studio_project_id=project_id,
         image_url=None,
         updated_at=None,
         completed=completed,
@@ -54,13 +56,30 @@ def _label(image_id: int, *, completed: bool) -> SpeciesLabel:
     )
 
 
-def test_select_incomplete_filters_completed():
+def test_select_unlabeled_excludes_images_with_any_completed_label():
     images = [_image(1, "a"), _image(2, "b"), _image(3, "c")]
     existing = [_label(1, completed=True), _label(2, completed=False)]
 
-    result = sut._select_incomplete_images(images, existing)  # pylint: disable=protected-access
+    result = sut._select_unlabeled_images(images, existing)  # pylint: disable=protected-access
 
     assert [img.id for img in result] == [2, 3]
+
+
+def test_select_unlabeled_handles_multi_row_state():
+    """Same multi-row hardening as the laser populate. An image with
+    a completed row in one project plus an incomplete sentinel in
+    another is treated as labeled — the previous dict-collapse filter
+    could go either way depending on iteration order."""
+    images = [_image(1, "a"), _image(2, "b")]
+    existing = [
+        _label(1, completed=True, project_id=70),
+        _label(1, completed=False, project_id=None),
+        _label(2, completed=False, project_id=70),
+    ]
+
+    result = sut._select_unlabeled_images(images, existing)  # pylint: disable=protected-access
+
+    assert [img.id for img in result] == [2]
 
 
 def test_build_task_uses_groups_jpeg_folder(monkeypatch):

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_laser_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_laser_preprocess_inputs_activity.py
@@ -2,8 +2,12 @@
 """Unit tests for resolve_laser_preprocess_inputs_activity.
 
 Pins down:
-  1. Returns only checksums of images whose laser label is missing or
-     not completed (matches stage-0.3 populate semantics).
+  1. Returns only checksums of images that have no completed
+     LaserLabel in any project — multi-row state from prod (one
+     completed row in project 43, one incomplete sentinel in project
+     NULL) correctly resolves to "image is labeled". The earlier
+     dict-collapse filter could resolve either way depending on SDK
+     iteration order.
   2. Camera intrinsics are flattened from numpy to lists.
   3. Default bbox lands in the resolved input.
   4. Missing dive / camera_id / intrinsics raise ValueError so the
@@ -59,12 +63,14 @@ def _image(image_id: int, checksum: str) -> Image:
     )
 
 
-def _label(image_id: int, *, completed: bool) -> LaserLabel:
+def _label(
+    image_id: int, *, completed: bool, project_id: Optional[int] = 73
+) -> LaserLabel:
     return LaserLabel(
         id=None,
         image_id=image_id,
         label_studio_task_id=image_id * 10,
-        label_studio_project_id=73,
+        label_studio_project_id=project_id,
         updated_at=None,
         completed=completed,
         label_studio_json={},
@@ -110,7 +116,7 @@ def _make_fs(
 
 
 @pytest.mark.asyncio
-async def test_returns_only_incomplete_image_checksums(monkeypatch):
+async def test_returns_only_unlabeled_image_checksums(monkeypatch):
     images = [_image(1, "aaa"), _image(2, "bbb"), _image(3, "ccc")]
     labels = [_label(1, completed=True), _label(2, completed=False)]
     fs = _make_fs(
@@ -125,8 +131,8 @@ async def test_returns_only_incomplete_image_checksums(monkeypatch):
         sut.resolve_laser_preprocess_inputs_activity, 42
     )
 
-    # Image 1 is completed -> excluded. Image 2 is incomplete, image 3
-    # has no label at all -> both included.
+    # Image 1 has a completed label -> excluded. Image 2 has only an
+    # incomplete label, image 3 has no label at all -> both included.
     assert result.dive_id == 42
     assert set(result.image_checksums) == {"bbb", "ccc"}
     assert result.camera_matrix == _K.tolist()
@@ -154,6 +160,40 @@ async def test_returns_empty_checksums_when_all_labels_completed(monkeypatch):
     )
 
     assert result.image_checksums == []
+
+
+@pytest.mark.asyncio
+async def test_image_with_completed_and_incomplete_rows_treated_as_labeled(
+    monkeypatch,
+):
+    """Mirrors the prod state on dive 393: each image carries a
+    completed row in project 43 plus an incomplete sentinel row in
+    project NULL. Any one completed row is enough to count the image
+    as labeled, regardless of SDK iteration order."""
+    images = [_image(1, "aaa"), _image(2, "bbb")]
+    labels = [
+        # Image 1: completed in 43, also has an incomplete sentinel.
+        # Order: completed first, sentinel second — would have lost in
+        # the previous dict-collapse filter and leaked image 1 into
+        # the work set.
+        _label(1, completed=True, project_id=43),
+        _label(1, completed=False, project_id=None),
+        # Image 2: only an incomplete row -> still needs work.
+        _label(2, completed=False, project_id=43),
+    ]
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_intrinsics(),
+        images=images,
+        laser_labels=labels,
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.resolve_laser_preprocess_inputs_activity, 42
+    )
+
+    assert result.image_checksums == ["bbb"]
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -18,6 +18,7 @@ from fishsense_api.models.dive_slate_label import DiveSlateLabel
 from fishsense_api.models.head_tail_label import HeadTailLabel
 from fishsense_api.models.image import Image
 from fishsense_api.models.laser_extrinsics import LaserExtrinsics
+from fishsense_api.models.laser_label import LaserLabel
 from fishsense_api.models.priority import Priority
 from fishsense_api.models.species_label import SpeciesLabel
 from fishsense_api.server import app
@@ -77,15 +78,33 @@ async def get_canonical_dives(
 async def select_next_for_laser_preprocessing(
     session: AsyncSession = Depends(get_async_session),
 ) -> int | None:
-    """Stage 0.1: HIGH-priority + no LaserExtrinsics row yet."""
+    """Stage 0.1: HIGH-priority + at least one image without a completed
+    LaserLabel (in any project).
+
+    Mirrors the work-state shape of the other three preprocess cohorts
+    (dive-image / headtail / slate). Earlier this was tied to
+    `no LaserExtrinsics`, which kept dives in the cohort indefinitely
+    after their laser labels were complete but stage-13 calibration was
+    blocked elsewhere (e.g. missing `dive_slate_id` or unfilled slate
+    labels) — wasted hourly firings on a dive 0.1 had no remaining
+    work for. Stage 13 keeps its own "no LaserExtrinsics" cohort and
+    advances independently.
+    """
+    has_image_without_completed_laser_label = (
+        select(Image.id)
+        .where(Image.dive_id == Dive.id)
+        .where(
+            ~select(LaserLabel.id)
+            .where(LaserLabel.image_id == Image.id)
+            .where(LaserLabel.completed == True)
+            .exists()
+        )
+        .exists()
+    )
     query = (
         select(Dive.id)
         .where(Dive.priority == Priority.HIGH)
-        .where(
-            ~select(LaserExtrinsics.id)
-            .where(LaserExtrinsics.dive_id == Dive.id)
-            .exists()
-        )
+        .where(has_image_without_completed_laser_label)
         .order_by(Dive.id)
         .limit(1)
     )

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -59,15 +59,24 @@ def _image(image_id: int, dive_id: int):
 
 
 # ---------- stage 0.1: laser-preprocessing ----------
+#
+# Cohort is "HIGH + has at least one image without a completed
+# LaserLabel (in any project)" — work-state, not the downstream
+# `no LaserExtrinsics` proxy. See dive_controller.py docstring for
+# the why. A dive with zero images is excluded by the same
+# `EXISTS (image without ...)` predicate, which matches the
+# behavior at the resolver level (no images → no work).
 
 
-async def test_laser_preprocessing_picks_lowest_high_priority_without_extrinsics(
+async def test_laser_preprocessing_picks_lowest_high_priority_with_unlabeled_images(
     session,
 ):
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         select_next_for_laser_preprocessing,
     )
 
+    # dives 1 and 2 both have an unlabeled image; lowest id wins.
+    # dive 3 is LOW priority -> excluded.
     session.add_all(
         [
             _dive(2, priority="HIGH"),
@@ -76,43 +85,100 @@ async def test_laser_preprocessing_picks_lowest_high_priority_without_extrinsics
         ]
     )
     await session.flush()
+    session.add_all([_image(11, 1), _image(21, 2), _image(31, 3)])
+    await session.flush()
 
     assert await select_next_for_laser_preprocessing(session=session) == 1
 
 
-async def test_laser_preprocessing_skips_dives_with_extrinsics(session):
+async def test_laser_preprocessing_skips_dives_with_all_labels_completed(session):
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         select_next_for_laser_preprocessing,
     )
-    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
-        LaserExtrinsics,
+    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+        LaserLabel,
     )
 
+    # dive 1: every image has a completed laser label -> excluded.
+    # dive 2: one image still unlabeled -> picked.
+    # dive 3: every image has a completed label, in different projects -> excluded.
     session.add_all([_dive(1), _dive(2), _dive(3)])
     await session.flush()
     session.add_all(
         [
-            LaserExtrinsics(dive_id=1, camera_id=1),
-            LaserExtrinsics(dive_id=2, camera_id=1),
+            _image(11, 1),
+            _image(12, 1),
+            _image(21, 2),
+            _image(22, 2),
+            _image(31, 3),
+        ]
+    )
+    await session.flush()
+    session.add_all(
+        [
+            LaserLabel(image_id=11, completed=True, label_studio_project_id=43),
+            LaserLabel(image_id=12, completed=True, label_studio_project_id=72),
+            LaserLabel(image_id=21, completed=True, label_studio_project_id=43),
+            # image 22 has no laser_label -> dive 2 stays in cohort.
+            LaserLabel(image_id=31, completed=True, label_studio_project_id=43),
         ]
     )
     await session.flush()
 
-    assert await select_next_for_laser_preprocessing(session=session) == 3
+    assert await select_next_for_laser_preprocessing(session=session) == 2
 
 
-async def test_laser_preprocessing_returns_none_when_all_calibrated(session):
+async def test_laser_preprocessing_treats_incomplete_label_as_unlabeled(session):
+    """Multi-row state: one project's label completed, another's incomplete.
+
+    Mirrors the prod situation that motivated the cohort change — a
+    dict-collapsing `{image_id: label}` filter would race on iteration
+    order; the SQL `EXISTS (no completed label)` form is unambiguous.
+    """
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         select_next_for_laser_preprocessing,
     )
-    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
-        LaserExtrinsics,
+    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+        LaserLabel,
+    )
+
+    # dive 1: one image has a completed label in project 43 AND an
+    # incomplete sentinel in project NULL -> the completed one
+    # qualifies, dive is excluded.
+    # dive 2: one image has only an incomplete label -> dive included.
+    session.add_all([_dive(1), _dive(2)])
+    await session.flush()
+    session.add_all([_image(11, 1), _image(21, 2)])
+    await session.flush()
+    session.add_all(
+        [
+            LaserLabel(image_id=11, completed=True, label_studio_project_id=43),
+            LaserLabel(image_id=11, completed=False, label_studio_project_id=None),
+            LaserLabel(image_id=21, completed=False, label_studio_project_id=43),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_laser_preprocessing(session=session) == 2
+
+
+async def test_laser_preprocessing_returns_none_when_no_unlabeled_images(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+        LaserLabel,
     )
 
     session.add_all([_dive(1), _dive(2)])
     await session.flush()
+    session.add_all([_image(11, 1), _image(21, 2)])
+    await session.flush()
     session.add_all(
-        [LaserExtrinsics(dive_id=1, camera_id=1), LaserExtrinsics(dive_id=2, camera_id=1)]
+        [
+            LaserLabel(image_id=11, completed=True, label_studio_project_id=43),
+            LaserLabel(image_id=21, completed=True, label_studio_project_id=43),
+        ]
     )
     await session.flush()
 
@@ -124,7 +190,23 @@ async def test_laser_preprocessing_returns_none_with_no_high_priority(session):
         select_next_for_laser_preprocessing,
     )
 
+    # LOW dives with unlabeled images are still excluded by the
+    # priority filter.
     session.add_all([_dive(1, priority="LOW"), _dive(2, priority="LOW")])
+    await session.flush()
+    session.add_all([_image(11, 1), _image(21, 2)])
+    await session.flush()
+
+    assert await select_next_for_laser_preprocessing(session=session) is None
+
+
+async def test_laser_preprocessing_excludes_dive_with_no_images(session):
+    """A dive with no images has no work for stage 0.1 — excluded."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+
+    session.add(_dive(1))
     await session.flush()
 
     assert await select_next_for_laser_preprocessing(session=session) is None


### PR DESCRIPTION
## Summary

- **Cohort rewrite for stage 0.1.** `select_next_for_laser_preprocessing` now picks "HIGH + at least one image without a completed `LaserLabel` in any project" instead of "HIGH + no `LaserExtrinsics`". Previous shape tied 0.1 to a downstream gate (stage 13) it doesn't advance, leading to wasted hourly firings on dives whose laser side was done but whose slate-side blocked calibration. Dive 393 in prod was the visible case — selector kept picking it, resolver returned empty `image_checksums`, parent short-circuited before the populate dispatch.
- **Multi-row predicate fix.** Replaced `{image_id: label}` dict-collapse filter in three places (`resolve_laser_preprocess_inputs_activity`, `populate_laser_label_studio_project_activity`, `populate_species_label_studio_project_activity`) with a set-based "any completed row counts as labeled" predicate. Prod data carries multi-row state per image (e.g. completed row in project 43 + incomplete sentinel in project NULL); SDK iteration order silently decided which row won the dict, leading to false-incomplete leaks. `populate_headtail_*` and `populate_dive_slate_*` already used the correct shape and weren't touched.
- **Docs.** CLAUDE.md cohort table updated. Stage 0.1 parent docstring rewritten — drops the stale "retains until stage 13 writes LaserExtrinsics" note, explains the work-state framing.

## Test plan

- [x] api-worker: 140 passed (was 137, +3 new multi-row tests in resolver / laser populate / species populate).
- [x] api: 68 passed; rewrote 4 laser-preprocessing endpoint tests as 6 new tests covering: lowest-id-wins, all-labeled-skip, multi-row state, no-images, no-HIGH-priority, returns-none-when-no-unlabeled.
- [ ] Once deployed, re-fire `PreprocessLaserImagesParentWorkflow` against an in-cohort dive and confirm the populate child dispatches (workflow history shows `ChildWorkflowExecutionStarted` for `PopulateLaserLabelStudioProjectWorkflow`).
- [ ] Confirm dive 393 (currently the false-positive cohort member) drops out after deploy and the selector advances to a dive that actually has unlabeled images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)