### PR TITLE
fix(api-workflow-worker): emit both `image` and `img` keys in populate task data

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_dive_slate_label_studio_project_activity.py
@@ -44,8 +44,12 @@ def _select_target_image_ids(
 
 
 def _build_task(image: Image) -> dict:
+    """Build an LS task. Emits both `image` and `img` keys to satisfy
+    legacy LS labeling-config XML across prod projects — see
+    `populate_laser_label_studio_project_activity._build_task`."""
+    url = build_image_url(DIVE_SLATE_FOLDER, image.checksum)
     return {
-        "data": {"image": build_image_url(DIVE_SLATE_FOLDER, image.checksum)},
+        "data": {"image": url, "img": url},
         "predictions": [],
         "annotations": [],
     }

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_headtail_label_studio_project_activity.py
@@ -64,8 +64,12 @@ def _select_target_images(
 
 
 def _build_task(image: Image) -> dict:
+    """Build an LS task. Emits both `image` and `img` keys to satisfy
+    legacy LS labeling-config XML across prod projects — see
+    `populate_laser_label_studio_project_activity._build_task`."""
+    url = build_image_url(HEADTAIL_FOLDER, image.checksum)
     return {
-        "data": {"image": build_image_url(HEADTAIL_FOLDER, image.checksum)},
+        "data": {"image": url, "img": url},
         "predictions": [],
         "annotations": [],
     }

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_laser_label_studio_project_activity.py
@@ -42,8 +42,20 @@ def _select_unlabeled_images(
 
 
 def _build_task(image: Image) -> dict:
+    """Build an LS task referencing the preprocessed JPEG.
+
+    Emits BOTH `image` and `img` keys in `data` because legacy prod
+    LS projects' labeling-config XML uses different conventions —
+    older projects bind `<Image value="$img"/>`, newer ones use
+    `value="$image"`. LS's `import_tasks` rejects a payload outright
+    if its labeling config's required key is missing (HTTP 400
+    "img key is expected in task data"), but extra keys are inert.
+    Dual-emission lets `populate` fan out across both shapes without
+    interrogating each project's `label_config` first.
+    """
+    url = build_image_url(PREPROCESS_FOLDER, image.checksum)
     return {
-        "data": {"image": build_image_url(PREPROCESS_FOLDER, image.checksum)},
+        "data": {"image": url, "img": url},
         "annotations": [],
     }
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_species_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_species_label_studio_project_activity.py
@@ -47,8 +47,13 @@ def _select_unlabeled_images(
 
 
 def _build_task(image: Image) -> dict:
+    """Build an LS task. Emits both `image` and `img` keys to satisfy
+    legacy LS labeling-config XML across prod projects — see the
+    docstring on `populate_laser_label_studio_project_activity._build_task`
+    for the rationale. Extra keys are inert in LS."""
+    url = build_image_url(SPECIES_FOLDER, image.checksum)
     return {
-        "data": {"image": build_image_url(SPECIES_FOLDER, image.checksum)},
+        "data": {"image": url, "img": url},
         "predictions": [],
         "annotations": [],
     }

--- a/services/fishsense-api-workflow-worker/tests/test_populate_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_dive_slate_label_studio_project_activity.py
@@ -86,6 +86,23 @@ def test_select_targets_filters_by_slate_marker_and_completion():
     assert result == [3]
 
 
+def test_build_task_emits_dual_image_and_img_keys(monkeypatch):
+    """Pinned: dual-key `image` + `img` shape for legacy LS project
+    XML compatibility — see laser populate test of the same name."""
+    monkeypatch.setenv(
+        "E4EFS_LABEL_STUDIO__IMAGE_URL_BASE", "https://orchestrator.example.com"
+    )
+    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    cfg.settings.reload()
+
+    expected_url = "https://orchestrator.example.com/api/v1/data/dive_slate_jpgs/abc123"
+    task = sut._build_task(_image(7, "abc123"))  # pylint: disable=protected-access
+
+    assert task["data"] == {"image": expected_url, "img": expected_url}
+    assert task["annotations"] == []
+    assert task["predictions"] == []
+
+
 def _make_fs_client(
     species_labels: List[SpeciesLabel],
     existing_slate: List[DiveSlateLabel],

--- a/services/fishsense-api-workflow-worker/tests/test_populate_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_dive_slate_label_studio_project_activity.py
@@ -99,8 +99,8 @@ def test_build_task_emits_dual_image_and_img_keys(monkeypatch):
     task = sut._build_task(_image(7, "abc123"))  # pylint: disable=protected-access
 
     assert task["data"] == {"image": expected_url, "img": expected_url}
-    assert task["annotations"] == []
-    assert task["predictions"] == []
+    assert not task["annotations"]
+    assert not task["predictions"]
 
 
 def _make_fs_client(

--- a/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
@@ -103,6 +103,25 @@ def test_select_targets_filters_by_top_three_and_drops_completed():
     assert [img.id for img in selected] == [3]
 
 
+def test_build_task_emits_dual_image_and_img_keys(monkeypatch):
+    """Pinned: dual-key `image` + `img` shape for legacy LS project
+    XML compatibility — see laser populate test of the same name.
+    Reverting either key would re-introduce the populate regression
+    observed on 2026-05-03."""
+    monkeypatch.setenv(
+        "E4EFS_LABEL_STUDIO__IMAGE_URL_BASE", "https://orchestrator.example.com"
+    )
+    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    cfg.settings.reload()
+
+    expected_url = "https://orchestrator.example.com/api/v1/data/headtail_jpeg/abc123"
+    task = sut._build_task(_image(7, "abc123"))  # pylint: disable=protected-access
+
+    assert task["data"] == {"image": expected_url, "img": expected_url}
+    assert task["annotations"] == []
+    assert task["predictions"] == []
+
+
 def _make_fs_client(
     species_labels: List[SpeciesLabel],
     existing_headtail: List[HeadTailLabel],

--- a/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
@@ -118,8 +118,8 @@ def test_build_task_emits_dual_image_and_img_keys(monkeypatch):
     task = sut._build_task(_image(7, "abc123"))  # pylint: disable=protected-access
 
     assert task["data"] == {"image": expected_url, "img": expected_url}
-    assert task["annotations"] == []
-    assert task["predictions"] == []
+    assert not task["annotations"]
+    assert not task["predictions"]
 
 
 def _make_fs_client(

--- a/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
@@ -89,19 +89,26 @@ def test_select_unlabeled_handles_multi_row_state():
     assert [img.id for img in result] == [2]
 
 
-def test_build_task_uses_configured_url_base(monkeypatch):
+def test_build_task_uses_configured_url_base_and_dual_keys(monkeypatch):
+    """Pinned: the LS task `data` must carry BOTH `image` and `img`
+    keys with identical URLs. Legacy prod LS projects' labeling-config
+    XML uses different conventions across stages and across project
+    generations — emitting only one key gets `import_tasks` rejected
+    with HTTP 400 ('img key is expected in task data') against the
+    older projects. Reverting either key would re-introduce the
+    populate regression observed on 2026-05-03.
+    """
     monkeypatch.setenv(
         "E4EFS_LABEL_STUDIO__IMAGE_URL_BASE", "https://orchestrator.example.com"
     )
     from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
     cfg.settings.reload()
 
+    expected_url = "https://orchestrator.example.com/api/v1/data/preprocess_jpeg/abc123"
     task = sut._build_task(_image(7, "abc123"))  # pylint: disable=protected-access
 
     assert task == {
-        "data": {
-            "image": "https://orchestrator.example.com/api/v1/data/preprocess_jpeg/abc123"
-        },
+        "data": {"image": expected_url, "img": expected_url},
         "annotations": [],
     }
 

--- a/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_activity.py
@@ -82,18 +82,21 @@ def test_select_unlabeled_handles_multi_row_state():
     assert [img.id for img in result] == [2]
 
 
-def test_build_task_uses_groups_jpeg_folder(monkeypatch):
+def test_build_task_uses_groups_jpeg_folder_and_dual_keys(monkeypatch):
+    """Pinned: dual-key `image` + `img` shape — see the laser populate
+    test of the same name for the rationale (legacy LS project XML
+    uses both conventions; emitting one fails import_tasks)."""
     monkeypatch.setenv(
         "E4EFS_LABEL_STUDIO__IMAGE_URL_BASE", "https://orchestrator.example.com"
     )
     from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
     cfg.settings.reload()
 
+    expected_url = "https://orchestrator.example.com/api/v1/data/groups_jpeg/abc123"
     task = sut._build_task(_image(7, "abc123"))  # pylint: disable=protected-access
 
-    assert task["data"]["image"] == (
-        "https://orchestrator.example.com/api/v1/data/groups_jpeg/abc123"
-    )
+    assert task["data"]["image"] == expected_url
+    assert task["data"]["img"] == expected_url
     assert not task["predictions"]
 
 


### PR DESCRIPTION
## Summary

Legacy LS project labeling-config XML across prod uses inconsistent conventions: older projects bind \`<Image value="\$img"/>\`, newer ones bind \`value="\$image"\`. The populate activities hardcoded \`image\` only, so \`import_tasks\` against any older project returned **HTTP 400** with \`"img" key is expected in task data\`.

**Visible symptom:** the auto-chained populate from \`PreprocessLaserImagesParentWorkflow\` failed every run once the data-worker child started succeeding (immediately after PR #54's NAS-prefix fix landed). Workflow history shows \`BadRequestError\` from \`label_studio_sdk.projects.import_tasks\` on the laser populate activity.

## Fix

Emit both \`image\` and \`img\` keys in \`data\` — LS ignores extra keys in task data; only the one named by \`value="\$X"\` in the labeling config is read by the UI. Dual-emission lets a single \`populate\` invocation fan out across active projects with mixed schemas without first interrogating each project's \`label_config\`.

Applied symmetrically across all four populate activities (laser / species / headtail / dive_slate) — the same XML inconsistency risk applies to any of them, and the change is mechanical and inert in projects that already use \`image\`.

## Test plan

- [x] api-worker: 145 passed (was 143 after PR #54; +2 new dual-key regression tests for headtail and dive_slate, existing laser/species \`_build_task\` tests updated to assert both keys present).
- [ ] Once deployed, re-fire \`PreprocessLaserImagesParentWorkflow\` against the same dive that previously hit \`BadRequestError\`. Expect \`PopulateLaserLabelStudioProjectWorkflow\` child to succeed and tasks to land in the active LS laser project.
- [ ] Confirm tasks render correctly in the LS UI — extra key isn't visible to labelers, only the configured \`\$image\` / \`\$img\` URL.

## Long-term

Worth tracking a follow-up: query each project's \`label_config\` via the SDK and synthesize a task with the correct single key. Cleaner than dual-emission, but adds an SDK call per active project per dive — and the dual-key approach has zero downside in practice (LS treats extra task data as inert metadata). Defer until/unless we see another mismatch surface that dual-key can't cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)