### PR TITLE
feat(api-workflow-worker): self-bootstrap populate + drop preprocessed dives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,24 +56,35 @@ Create and populate are split into separate workflows per stage:
   `create_<stage>_label_studio_project_activity` which idempotently
   finds the LS project by title (`FishSense — <Stage> Labeling`) or
   creates it from a stored labeling-config XML constant. Returns
-  `project_id`. The XML constants in
-  `activities/create_*_label_studio_project_activity.py` are empty
-  placeholders by default — paste from the existing prod LS project
-  (Project Settings -> Labeling Interface -> Code) before relying on
-  the create branch. With existing prod projects already in place,
-  re-running the create workflow just returns their IDs.
+  `project_id`. The four `<STAGE>_LABELING_CONFIG_XML` constants in
+  `activities/create_*_label_studio_project_activity.py` are real
+  pasted-from-prod XML (laser, species, headtail, dive-slate) — re-
+  running create against an existing prod LS project just returns
+  the existing ID via title match. The Create workflow can be invoked
+  on-demand, but `Populate<Stage>LabelStudioProjectWorkflow` also
+  calls the Create activity internally (see below) so a manual
+  Create run is rarely needed.
 * **`Populate<Stage>LabelStudioProjectWorkflow(dive_id)`** — calls
+  `create_<stage>_label_studio_project_activity` first to ensure the
+  canonical project exists (idempotent), then
   `get_active_<stage>_label_studio_project_ids_activity` (SDK query
   for projects with at least one incomplete label of this kind), then
   fans out `populate_<stage>_label_studio_project_activity(dive_id,
-  project_id)` across the returned set with a workflow-level
-  `Semaphore(4)`. No config IDs — populate's target set is computed
-  from SQL. Empty result is a no-op.
+  project_id)` across the **union** of the canonical project ID and
+  the discovery result, deduplicated, with a workflow-level
+  `Semaphore(4)`. The Create-then-discovery union closes the
+  bootstrap chicken-and-egg: a freshly-created project has zero
+  incomplete labels, so the discovery query alone wouldn't pick it
+  up — including its ID in the fan-out set seeds the first round of
+  `LaserLabel` / `SpeciesLabel` / `HeadTailLabel` / `DiveSlateLabel`
+  rows. Steady-state: discovery still picks up legacy/additional
+  projects (e.g. the prod laser project from before Create's XML
+  was checked in).
 
-Both are registered but not scheduled — they're on-demand
-(`temporal workflow start` with a `dive_id` for populate, no args for
-create). The eight workflows are: Create/Populate × Laser/Species/
-HeadTail/DiveSlate.
+Both Create and Populate are registered but not scheduled — they're
+on-demand (`temporal workflow start` with a `dive_id` for populate,
+no args for create). The eight workflows are: Create/Populate ×
+Laser/Species/HeadTail/DiveSlate.
 
 The four populate workflows are also dispatched automatically as
 child workflows from the matching preprocess parent (stages 0.1 →
@@ -179,12 +190,25 @@ but not scheduled (see notes below). Per-stage cohort:
 
 | Stage | Parent cohort definition |
 |---|---|
-| 0.1 | HIGH-priority + at least one image without a completed `LaserLabel` (in any project) |
-| 2   | HIGH-priority + has PREDICTION clusters + at least one image without a completed `SpeciesLabel` |
-| 5.1 | HIGH-priority + at least one `SpeciesLabel.top_three_photos_of_group=True` whose `HeadTailLabel` is incomplete |
-| 9   | HIGH-priority + `dive_slate_id` set + at least one `SpeciesLabel.content_of_image='Slate, Laser on slate'` whose `DiveSlateLabel` is incomplete |
+| 0.1 | HIGH-priority + at least one image without ANY `LaserLabel` row (in any project) |
+| 2   | HIGH-priority + has PREDICTION clusters + at least one image without ANY `SpeciesLabel` row |
+| 5.1 | HIGH-priority + at least one `SpeciesLabel.top_three_photos_of_group=True` whose image carries no `HeadTailLabel` row at all |
+| 9   | HIGH-priority + `dive_slate_id` set + at least one `SpeciesLabel.content_of_image='Slate, Laser on slate'` whose image carries no `DiveSlateLabel` row at all |
 | 13  | HIGH-priority + `dive_slate_id` set + no `LaserExtrinsics` + ≥2 completed `DiveSlateLabel` rows (matches the data-worker activity's `MIN_LASER_POINTS=2` precondition) |
 | 14  | HIGH-priority + has `LaserExtrinsics` + has LABEL_STUDIO clusters with at least one `fish_id is None` |
+
+The four preprocess cohorts (0.1, 2, 5.1, 9) check "no row at all"
+rather than "no completed row" so a dive drops out the moment
+populate seeds even-incomplete sentinel rows for every image. The
+earlier `completed`-only predicate kept dives in the cohort
+indefinitely between populate and labelers finishing — every hourly
+firing re-staged raw `.ORF`s from NAS, re-rectified, and re-archived
+(child-workflow `ALLOW_DUPLICATE_FAILED_ONLY` made the per-image
+work a no-op, but the NAS staging activity ran unconditionally on
+every parent firing). Resolver activities mirror the same predicate:
+`resolve_laser/headtail/slate_preprocess_inputs_activity` filter
+images on "no label row" so the dispatched per-image work matches
+what the cohort selector promised.
 
 Stage 1 (clustering) does NOT yet have a parent — its data-worker
 workflow returns clusters but doesn't write them back to the DB, so
@@ -604,12 +628,17 @@ once available, a few-pixel comparison vs old measurements is the
 gold-standard verification. Don't claim "fully verified" until that
 runs.
 
-### Label Studio create-then-populate bootstrap
+### Label Studio create-then-populate
 
 Eight workflows: Create + Populate × {Laser, Species, HeadTail,
-DiveSlate}. Populate's target set is queried via SDK
-`get_<stage>_label_studio_project_ids(incomplete=True)` — projects
-with at least one not-yet-completed label.
+DiveSlate}. Populate now self-bootstraps: it calls the matching
+Create activity inside the workflow body, then unions the canonical
+project ID with the SDK
+`get_<stage>_label_studio_project_ids(incomplete=True)` discovery
+result, deduplicates, and fans out per-project populate activities
+across the union. The four `<STAGE>_LABELING_CONFIG_XML` constants
+are real pasted-from-prod XML, so Create-on-fresh-deploy stands up a
+usable project immediately.
 
 The populate workflows are dispatched automatically by the four
 preprocess parents (see "Cross-worker orchestration pattern"); manual
@@ -620,17 +649,13 @@ runs (e.g. `populate-laser-393-manual`) so the auto-chain's
 deterministic id (`populate-laser-393`) stays available for future
 hourly firings.
 
-**Bootstrap chicken-and-egg:** a freshly-created project from the
-Create workflow has zero labels and won't be returned by the populate
-query until something seeds it. Existing prod projects (laser=73,
-species=70, headtail=71, dive_slate=66 as of 2026-01-26) already
-have labels, so populate finds them. For brand-new deployments this
-gap will need to be closed — likely by Create pushing a sentinel
-initial label, or by composing Create + Populate into a parent
-workflow. Surface this when rolling out a fresh stage.
-
-The four `<STAGE>_LABELING_CONFIG_XML` constants in
-`activities/create_*_label_studio_project_activity.py` are empty
-placeholders — paste from the existing prod LS project (Project
-Settings → Labeling Interface → Code) before relying on the create
-branch in a fresh deployment.
+Existing prod projects (laser=73, species=70, headtail=71,
+dive_slate=66 as of 2026-01-26) keep being picked up by the
+discovery query as long as they hold incomplete labels. The Create
+title-match returns the canonical project's ID; if a deployment
+ever ends up with the canonical title pointing at a different
+project than the one prod is using, both IDs flow through the
+union and populate fans out across both — which is the right
+behavior during a migration window but not the desired steady
+state. Resolve by aligning `<STAGE>_PROJECT_TITLE` in the Create
+activity with whatever the operator wants as canonical.

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_headtail_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_headtail_preprocess_inputs_activity.py
@@ -2,10 +2,10 @@
 
 Returns a fully-populated `PreprocessHeadtailImagesInput` ready to
 hand to the data-worker's child workflow. Image set is filtered to
-species labels with `top_three_photos_of_group=True` whose head/tail
-label is not yet complete — same predicate
-`populate_headtail_label_studio_project_activity` uses, so populate
-consumes exactly what preprocess produces.
+species labels with `top_three_photos_of_group=True` whose image has
+no HeadTailLabel row at all — once populate seeds a (possibly
+incomplete) row, the headtail JPEG is on the file-exchange and we
+don't regenerate it. Matches the API selector predicate.
 """
 
 from __future__ import annotations
@@ -35,15 +35,13 @@ async def resolve_headtail_preprocess_inputs_activity(
 
         species_labels = await fs.labels.get_species_labels(dive_id) or []
         existing_headtail = await fs.labels.get_headtail_labels(dive_id) or []
-        completed_ids = {
-            label.image_id for label in existing_headtail if label.completed
-        }
+        labeled_ids = {label.image_id for label in existing_headtail}
 
         target_image_ids = [
             label.image_id
             for label in species_labels
             if label.top_three_photos_of_group
-            and label.image_id not in completed_ids
+            and label.image_id not in labeled_ids
         ]
 
         images = await fs.images.get(dive_id=dive_id) or []

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_preprocess_inputs_activity.py
@@ -1,14 +1,13 @@
 """Activity to resolve the per-image inputs stage 0.1 needs for a dive.
 
 Returns a fully-populated `PreprocessLaserImagesInput` ready to hand
-to the data-worker's child workflow. Image filter mirrors the
-selector's "image with no completed LaserLabel in any project"
-predicate — multi-row-aware (a single image can carry rows for
-multiple LS projects, and any one completed row counts as
-"labeled"). The previous shape collapsed labels into a
-`{image_id: label}` dict and let iteration order pick which row won,
-which silently dropped "incomplete" images whenever a completed row
-happened to be returned last by the SDK.
+to the data-worker's child workflow. Image filter mirrors the API
+selector's "image with no LaserLabel row at all" predicate — once
+any row exists for an image (even an incomplete one seeded by
+populate), the image's preprocessed JPEG is on the file-exchange and
+shouldn't be regenerated. Without this matching filter the parent
+selector would drop the dive but the resolver would still return
+fresh per-image work for any partially-seeded dive — wasted CPU.
 
 Default bbox is the original notebook constant — kept here rather
 than baked into the data-worker so the api-worker can swap to a
@@ -33,11 +32,15 @@ DEFAULT_LASER_BBOX: List[int] = [1800, 700, 2400, 1600]
 def _select_unlabeled_images(
     images: List[Image], existing_labels: List[LaserLabel]
 ) -> List[Image]:
-    """Return images that have no completed LaserLabel in any project."""
-    completed_image_ids = {
-        label.image_id for label in existing_labels if label.completed
-    }
-    return [image for image in images if image.id not in completed_image_ids]
+    """Return images that have no LaserLabel row at all (in any project).
+
+    Once populate seeds a row for an image (even an incomplete one),
+    the image's preprocessed JPEG is on the file-exchange and the
+    image drops out of the preprocess work set. Matches the API
+    selector predicate.
+    """
+    labeled_image_ids = {label.image_id for label in existing_labels}
+    return [image for image in images if image.id not in labeled_image_ids]
 
 
 @activity.defn

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_slate_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_slate_preprocess_inputs_activity.py
@@ -1,10 +1,15 @@
 """Activity to resolve the per-image inputs stage 9 needs for a dive.
 
 Returns a fully-populated `PreprocessSlateImagesInput` ready to hand
-to the data-worker's child workflow. Slate metadata (id, dpi,
-reference_points) travels alongside the image set so the data-worker
-renders the PDF-composite overlay without an extra fishsense-api
-call.
+to the data-worker's child workflow. Image set is filtered to species
+labels with `content_of_image == SLATE_CONTENT_MARKER` whose image
+has no DiveSlateLabel row at all — once populate seeds a (possibly
+incomplete) row, the slate JPEG is on the file-exchange and we don't
+regenerate it. Matches the API selector predicate.
+
+Slate metadata (id, dpi, reference_points) travels alongside the
+image set so the data-worker renders the PDF-composite overlay
+without an extra fishsense-api call.
 """
 
 from __future__ import annotations
@@ -53,15 +58,13 @@ async def resolve_slate_preprocess_inputs_activity(
         existing_slate_labels = (
             await fs.labels.get_dive_slate_labels(dive_id) or []
         )
-        completed_ids = {
-            label.image_id for label in existing_slate_labels if label.completed
-        }
+        labeled_ids = {label.image_id for label in existing_slate_labels}
 
         target_image_ids = [
             label.image_id
             for label in species_labels
             if label.content_of_image == SLATE_CONTENT_MARKER
-            and label.image_id not in completed_ids
+            and label.image_id not in labeled_ids
         ]
 
         images = await fs.images.get(dive_id=dive_id) or []

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/populate_dive_slate_label_studio_project_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/populate_dive_slate_label_studio_project_workflow.py
@@ -15,8 +15,10 @@ class PopulateDiveSlateLabelStudioProjectWorkflow:
     # pylint: disable=too-few-public-methods
     """Workflow to populate every active dive-slate-labeling LS project for one dive.
 
-    Active = "currently has at least one incomplete dive-slate label."
-    Project creation is a separate workflow's responsibility.
+    Target set is the union of the canonical project (Create) and any
+    additional projects currently holding incomplete dive-slate labels.
+    See `PopulateLaserLabelStudioProjectWorkflow` for the bootstrap
+    rationale.
     """
 
     @workflow.run
@@ -25,17 +27,18 @@ class PopulateDiveSlateLabelStudioProjectWorkflow:
 
         Returns the total number of tasks imported across all projects.
         """
-        project_ids = await workflow.execute_activity(
+        canonical_project_id = await workflow.execute_activity(
+            "create_dive_slate_label_studio_project_activity",
+            args=(),
+            schedule_to_close_timeout=timedelta(minutes=5),
+        )
+        discovered = await workflow.execute_activity(
             "get_active_dive_slate_label_studio_project_ids_activity",
             args=(),
             schedule_to_close_timeout=timedelta(minutes=5),
         )
 
-        if not project_ids:
-            workflow.logger.info(
-                "No active dive-slate LS projects found; nothing to populate"
-            )
-            return 0
+        project_ids = sorted({canonical_project_id, *discovered})
 
         sem = asyncio.Semaphore(PROJECT_CONCURRENCY)
         results: list[int] = []

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/populate_headtail_label_studio_project_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/populate_headtail_label_studio_project_workflow.py
@@ -15,8 +15,10 @@ class PopulateHeadTailLabelStudioProjectWorkflow:
     # pylint: disable=too-few-public-methods
     """Workflow to populate every active headtail-labeling LS project for one dive.
 
-    Active = "currently has at least one incomplete headtail label."
-    Project creation is a separate workflow's responsibility.
+    Target set is the union of the canonical project (Create) and any
+    additional projects currently holding incomplete headtail labels.
+    See `PopulateLaserLabelStudioProjectWorkflow` for the bootstrap
+    rationale.
     """
 
     @workflow.run
@@ -25,17 +27,18 @@ class PopulateHeadTailLabelStudioProjectWorkflow:
 
         Returns the total number of tasks imported across all projects.
         """
-        project_ids = await workflow.execute_activity(
+        canonical_project_id = await workflow.execute_activity(
+            "create_headtail_label_studio_project_activity",
+            args=(),
+            schedule_to_close_timeout=timedelta(minutes=5),
+        )
+        discovered = await workflow.execute_activity(
             "get_active_headtail_label_studio_project_ids_activity",
             args=(),
             schedule_to_close_timeout=timedelta(minutes=5),
         )
 
-        if not project_ids:
-            workflow.logger.info(
-                "No active headtail LS projects found; nothing to populate"
-            )
-            return 0
+        project_ids = sorted({canonical_project_id, *discovered})
 
         sem = asyncio.Semaphore(PROJECT_CONCURRENCY)
         results: list[int] = []

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/populate_laser_label_studio_project_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/populate_laser_label_studio_project_workflow.py
@@ -15,10 +15,19 @@ class PopulateLaserLabelStudioProjectWorkflow:
     # pylint: disable=too-few-public-methods
     """Workflow to populate every active laser-labeling LS project for one dive.
 
-    Active = "currently has at least one incomplete laser label" — so
-    legacy/retired projects are excluded. The set is computed at run
-    time rather than carried in config; project creation happens in a
-    separate workflow.
+    Target set is the union of:
+      * The canonical project ID returned by
+        `create_laser_label_studio_project_activity` (idempotent
+        title-lookup-or-create, see `LASER_PROJECT_TITLE`).
+      * Every project ID returned by the discovery query (LS projects
+        currently holding at least one incomplete laser label).
+
+    Bootstrap: a freshly-created project has zero LaserLabel rows, so
+    the discovery query alone wouldn't pick it up — calling Create
+    first and unioning its return solves the chicken-and-egg.
+    Steady-state: the discovery query continues to cover legacy/
+    additional projects (e.g. the prod laser project from before the
+    Create XML was first checked in).
     """
 
     @workflow.run
@@ -27,17 +36,18 @@ class PopulateLaserLabelStudioProjectWorkflow:
 
         Returns the total number of tasks imported across all projects.
         """
-        project_ids = await workflow.execute_activity(
+        canonical_project_id = await workflow.execute_activity(
+            "create_laser_label_studio_project_activity",
+            args=(),
+            schedule_to_close_timeout=timedelta(minutes=5),
+        )
+        discovered = await workflow.execute_activity(
             "get_active_laser_label_studio_project_ids_activity",
             args=(),
             schedule_to_close_timeout=timedelta(minutes=5),
         )
 
-        if not project_ids:
-            workflow.logger.info(
-                "No active laser LS projects found; nothing to populate"
-            )
-            return 0
+        project_ids = sorted({canonical_project_id, *discovered})
 
         sem = asyncio.Semaphore(PROJECT_CONCURRENCY)
         results: list[int] = []

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/populate_species_label_studio_project_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/populate_species_label_studio_project_workflow.py
@@ -15,8 +15,10 @@ class PopulateSpeciesLabelStudioProjectWorkflow:
     # pylint: disable=too-few-public-methods
     """Workflow to populate every active species-labeling LS project for one dive.
 
-    Active = "currently has at least one incomplete species label."
-    Project creation is a separate workflow's responsibility.
+    Target set is the union of the canonical project (Create) and any
+    additional projects currently holding incomplete species labels.
+    See `PopulateLaserLabelStudioProjectWorkflow` for the bootstrap
+    rationale.
     """
 
     @workflow.run
@@ -25,17 +27,18 @@ class PopulateSpeciesLabelStudioProjectWorkflow:
 
         Returns the total number of tasks imported across all projects.
         """
-        project_ids = await workflow.execute_activity(
+        canonical_project_id = await workflow.execute_activity(
+            "create_species_label_studio_project_activity",
+            args=(),
+            schedule_to_close_timeout=timedelta(minutes=5),
+        )
+        discovered = await workflow.execute_activity(
             "get_active_species_label_studio_project_ids_activity",
             args=(),
             schedule_to_close_timeout=timedelta(minutes=5),
         )
 
-        if not project_ids:
-            workflow.logger.info(
-                "No active species LS projects found; nothing to populate"
-            )
-            return 0
+        project_ids = sorted({canonical_project_id, *discovered})
 
         sem = asyncio.Semaphore(PROJECT_CONCURRENCY)
         results: list[int] = []

--- a/services/fishsense-api-workflow-worker/tests/test_label_studio_integration.py
+++ b/services/fishsense-api-workflow-worker/tests/test_label_studio_integration.py
@@ -30,7 +30,9 @@ from typing import List
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from temporalio.testing import ActivityEnvironment
+from temporalio import activity
+from temporalio.testing import ActivityEnvironment, WorkflowEnvironment
+from temporalio.worker import Worker
 
 from fishsense_api_sdk.models.image import Image
 from fishsense_api_sdk.models.laser_label import LaserLabel
@@ -39,6 +41,9 @@ from fishsense_api_workflow_worker.activities import (
     populate_laser_label_studio_project_activity as populate_sut,
 )
 from fishsense_api_workflow_worker.activities.utils import get_ls_client
+from fishsense_api_workflow_worker.workflows.populate_laser_label_studio_project_workflow import (  # pylint: disable=line-too-long
+    PopulateLaserLabelStudioProjectWorkflow,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -249,3 +254,83 @@ async def test_populate_skips_completed_against_real_ls(
     # is the correctness gate.)
     ls_tasks = list(ls.tasks.list(project=project_id))
     assert len(ls_tasks) == 8
+
+
+# ---------------------------------------------------------------------------
+# Full workflow: Create -> populate fan-out against real LS.
+# ---------------------------------------------------------------------------
+
+
+async def test_populate_workflow_creates_then_imports_tasks_against_real_ls(
+    monkeypatch,
+):
+    """End-to-end: PopulateLaserLabelStudioProjectWorkflow against real
+    LS. The workflow's internal Create activity must stand up a
+    project, the discovery stub (returning [] for a freshly-named
+    test project) must not interfere, and the populate fan-out must
+    push tasks to the canonical project.
+
+    This is the integration-level proof that wiring Create into
+    Populate solves the bootstrap chicken-and-egg: a brand-new
+    deployment with no legacy LS project gets its first dive's tasks
+    imported on the first invocation, without any pre-seeding.
+    """
+    title = f"fs-int-flow-{uuid.uuid4().hex[:8]}"
+    monkeypatch.setattr(create_sut, "LASER_PROJECT_TITLE", title)
+    monkeypatch.setattr(create_sut, "LASER_LABELING_CONFIG_XML", _MIN_LASER_XML)
+
+    images = [_image(i + 1, f"flow-{i:03d}") for i in range(4)]
+    fs = _make_fs_client(images, existing_labels=[])
+    monkeypatch.setattr(populate_sut, "get_fs_client", lambda: fs)
+
+    # Discovery stub returns [] — no legacy LS project for this
+    # freshly-titled canonical one. Stubbing avoids needing a real
+    # fishsense-api in this test; the populate side already mocks
+    # get_fs_client above.
+    @activity.defn(name="get_active_laser_label_studio_project_ids_activity")
+    async def stub_get_active() -> List[int]:
+        return []
+
+    ls = get_ls_client()
+    project_id_holder: List[int] = []
+
+    queue = f"test-populate-flow-{uuid.uuid4().hex[:8]}"
+    try:
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=queue,
+                workflows=[PopulateLaserLabelStudioProjectWorkflow],
+                activities=[
+                    create_sut.create_laser_label_studio_project_activity,
+                    stub_get_active,
+                    populate_sut.populate_laser_label_studio_project_activity,
+                ],
+            ):
+                count = await env.client.execute_workflow(
+                    PopulateLaserLabelStudioProjectWorkflow.run,
+                    42,
+                    id=f"{queue}-wf",
+                    task_queue=queue,
+                )
+
+        assert count == 4
+
+        # The created project must exist in LS and carry exactly four tasks.
+        matches = [p for p in ls.projects.list() if p.title == title]
+        assert len(matches) == 1
+        project_id_holder.append(matches[0].id)
+
+        ls_tasks = list(ls.tasks.list(project=matches[0].id))
+        assert len(ls_tasks) == 4
+
+        # Populate also wrote one LaserLabel row per task.
+        assert fs.labels.put_laser_label.await_count == 4
+        written = [c.args[1] for c in fs.labels.put_laser_label.await_args_list]
+        assert all(label.label_studio_project_id == matches[0].id for label in written)
+    finally:
+        for pid in project_id_holder:
+            try:
+                ls.projects.delete(pid)
+            except Exception:  # pylint: disable=broad-except
+                pass

--- a/services/fishsense-api-workflow-worker/tests/test_populate_label_studio_project_workflows.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_label_studio_project_workflows.py
@@ -1,12 +1,19 @@
 """Workflow contract tests for the four populate-LS-project workflows.
 
-Each workflow does the same thing: query SQL for the set of LS
-project IDs that are actively being labeled for this stage, then fan
+Each workflow does the same thing: idempotently create-or-get the
+canonical LS project, query SQL for any additional projects already
+holding incomplete labels of this kind, union the two sets, then fan
 out the per-project populate activity with bounded concurrency.
 
-These tests cover three invariants per workflow:
-  * Empty project list short-circuits to 0 with no populate calls.
-  * Non-empty list invokes the per-project activity exactly once per ID.
+These tests cover:
+  * Create returns project id N, discovery returns []  -> fan-out
+    runs once for {N}. (Bootstrap: a brand-new deployment with no
+    legacy project still gets populated.)
+  * Create returns N, discovery returns [N, M, ...]    -> fan-out
+    deduplicates {N} and runs once for each unique id.
+  * Create returns N, discovery returns []             -> when
+    populate returns 0 for the new project (no images), the workflow
+    still returns 0 cleanly.
   * Returned counts sum across projects.
 
 A separate concurrency test guards the workflow-level
@@ -42,21 +49,25 @@ from fishsense_api_workflow_worker.workflows.populate_species_label_studio_proje
 _STAGES = [
     (
         PopulateLaserLabelStudioProjectWorkflow,
+        "create_laser_label_studio_project_activity",
         "get_active_laser_label_studio_project_ids_activity",
         "populate_laser_label_studio_project_activity",
     ),
     (
         PopulateSpeciesLabelStudioProjectWorkflow,
+        "create_species_label_studio_project_activity",
         "get_active_species_label_studio_project_ids_activity",
         "populate_species_label_studio_project_activity",
     ),
     (
         PopulateHeadTailLabelStudioProjectWorkflow,
+        "create_headtail_label_studio_project_activity",
         "get_active_headtail_label_studio_project_ids_activity",
         "populate_headtail_label_studio_project_activity",
     ),
     (
         PopulateDiveSlateLabelStudioProjectWorkflow,
+        "create_dive_slate_label_studio_project_activity",
         "get_active_dive_slate_label_studio_project_ids_activity",
         "populate_dive_slate_label_studio_project_activity",
     ),
@@ -64,28 +75,40 @@ _STAGES = [
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("workflow_cls,get_active_name,populate_name", _STAGES)
-async def test_workflow_fans_out_one_populate_per_active_project(
-    workflow_cls: Type, get_active_name: str, populate_name: str
+@pytest.mark.parametrize(
+    "workflow_cls,create_name,get_active_name,populate_name", _STAGES
+)
+async def test_workflow_unions_canonical_and_discovered_projects(
+    workflow_cls: Type,
+    create_name: str,
+    get_active_name: str,
+    populate_name: str,
 ):
+    """Canonical (Create) project ID is unioned with the discovery
+    query result. Duplicates are deduplicated so populate doesn't
+    fan out twice for the same project."""
     populate_calls: List[tuple] = []
+
+    @activity.defn(name=create_name)
+    async def stub_create() -> int:
+        return 101
 
     @activity.defn(name=get_active_name)
     async def stub_get_active() -> List[int]:
-        return [101, 202, 303]
+        return [101, 202, 303]  # 101 overlaps with canonical -> dedupe
 
     @activity.defn(name=populate_name)
     async def stub_populate(dive_id: int, project_id: int) -> int:
         populate_calls.append((dive_id, project_id))
         return 5
 
-    queue = f"test-{workflow_cls.__name__}-fanout"
+    queue = f"test-{workflow_cls.__name__}-union"
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue=queue,
             workflows=[workflow_cls],
-            activities=[stub_get_active, stub_populate],
+            activities=[stub_create, stub_get_active, stub_populate],
         ):
             result = await env.client.execute_workflow(
                 workflow_cls.run,
@@ -94,17 +117,77 @@ async def test_workflow_fans_out_one_populate_per_active_project(
                 task_queue=queue,
             )
 
-    assert result == 15  # 3 projects * 5 each
+    # 3 unique projects (101 deduped) * 5 each.
+    assert result == 15
     assert {p for _, p in populate_calls} == {101, 202, 303}
     assert {d for d, _ in populate_calls} == {427}
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("workflow_cls,get_active_name,populate_name", _STAGES)
-async def test_workflow_short_circuits_when_no_active_projects(
-    workflow_cls: Type, get_active_name: str, populate_name: str
+@pytest.mark.parametrize(
+    "workflow_cls,create_name,get_active_name,populate_name", _STAGES
+)
+async def test_workflow_self_bootstraps_when_discovery_empty(
+    workflow_cls: Type,
+    create_name: str,
+    get_active_name: str,
+    populate_name: str,
 ):
-    populate_called = False
+    """Discovery returns []; Create returns a single canonical id ->
+    populate must still run for that one project. This is the
+    bootstrap case for a brand-new deployment (no legacy LS project,
+    fresh project from Create has zero incomplete labels yet)."""
+    populate_calls: List[tuple] = []
+
+    @activity.defn(name=create_name)
+    async def stub_create() -> int:
+        return 555
+
+    @activity.defn(name=get_active_name)
+    async def stub_get_active() -> List[int]:
+        return []
+
+    @activity.defn(name=populate_name)
+    async def stub_populate(dive_id: int, project_id: int) -> int:
+        populate_calls.append((dive_id, project_id))
+        return 3
+
+    queue = f"test-{workflow_cls.__name__}-bootstrap"
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=queue,
+            workflows=[workflow_cls],
+            activities=[stub_create, stub_get_active, stub_populate],
+        ):
+            result = await env.client.execute_workflow(
+                workflow_cls.run,
+                427,
+                id=f"{queue}-{uuid.uuid4()}",
+                task_queue=queue,
+            )
+
+    assert result == 3
+    assert populate_calls == [(427, 555)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "workflow_cls,create_name,get_active_name,populate_name", _STAGES
+)
+async def test_workflow_returns_zero_when_canonical_has_no_work(
+    workflow_cls: Type,
+    create_name: str,
+    get_active_name: str,
+    populate_name: str,
+):
+    """Canonical project exists but the dive has nothing to push
+    (e.g. every image is already labeled). Populate runs and returns
+    0; the workflow propagates 0 without erroring."""
+
+    @activity.defn(name=create_name)
+    async def stub_create() -> int:
+        return 555
 
     @activity.defn(name=get_active_name)
     async def stub_get_active() -> List[int]:
@@ -112,17 +195,15 @@ async def test_workflow_short_circuits_when_no_active_projects(
 
     @activity.defn(name=populate_name)
     async def stub_populate(_dive_id: int, _project_id: int) -> int:
-        nonlocal populate_called
-        populate_called = True
         return 0
 
-    queue = f"test-{workflow_cls.__name__}-empty"
+    queue = f"test-{workflow_cls.__name__}-noop"
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue=queue,
             workflows=[workflow_cls],
-            activities=[stub_get_active, stub_populate],
+            activities=[stub_create, stub_get_active, stub_populate],
         ):
             result = await env.client.execute_workflow(
                 workflow_cls.run,
@@ -132,7 +213,6 @@ async def test_workflow_short_circuits_when_no_active_projects(
             )
 
     assert result == 0
-    assert populate_called is False
 
 
 @pytest.mark.asyncio
@@ -144,6 +224,12 @@ async def test_workflow_caps_per_project_concurrency():
     peak_in_flight = 0
     started: List[int] = []
     release_gate = asyncio.Event()
+
+    @activity.defn(name="create_laser_label_studio_project_activity")
+    async def stub_create() -> int:
+        # Canonical id distinct from the discovered range so the
+        # union has 21 unique projects to fan out.
+        return 9999
 
     @activity.defn(name="get_active_laser_label_studio_project_ids_activity")
     async def stub_get_active() -> List[int]:
@@ -167,7 +253,7 @@ async def test_workflow_caps_per_project_concurrency():
             env.client,
             task_queue=queue,
             workflows=[PopulateLaserLabelStudioProjectWorkflow],
-            activities=[stub_get_active, stub_populate],
+            activities=[stub_create, stub_get_active, stub_populate],
             max_concurrent_activities=50,
         ):
             wf_task = asyncio.create_task(
@@ -183,4 +269,4 @@ async def test_workflow_caps_per_project_concurrency():
             await wf_task
 
     assert peak_in_flight <= 4, f"peak {peak_in_flight}, expected <= 4"
-    assert len(started) == 20
+    assert len(started) == 21  # 20 discovered + 1 canonical, all unique

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_headtail_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_headtail_preprocess_inputs_activity.py
@@ -127,17 +127,26 @@ def _make_fs(
 
 
 @pytest.mark.asyncio
-async def test_returns_only_top_three_with_incomplete_headtail(monkeypatch):
+async def test_returns_only_top_three_without_any_headtail(monkeypatch):
     fs = _make_fs(
         dive=_dive(),
         intrinsics=_intrinsics(),
-        images=[_image(1, "aaa"), _image(2, "bbb"), _image(3, "ccc")],
+        images=[
+            _image(1, "aaa"),
+            _image(2, "bbb"),
+            _image(3, "ccc"),
+            _image(4, "ddd"),
+        ],
         species=[
             _species(1, top_three=True),
             _species(2, top_three=False),
             _species(3, top_three=True),
+            _species(4, top_three=True),
         ],
-        headtail=[_headtail(1, completed=True)],
+        headtail=[
+            _headtail(1, completed=True),
+            _headtail(4, completed=False),
+        ],
     )
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
 
@@ -145,9 +154,11 @@ async def test_returns_only_top_three_with_incomplete_headtail(monkeypatch):
         sut.resolve_headtail_preprocess_inputs_activity, 42
     )
 
-    # 1: top-three but completed -> dropped.
+    # 1: top-three but headtail row exists (completed) -> dropped.
     # 2: not top-three -> dropped.
-    # 3: top-three + no headtail -> kept.
+    # 3: top-three + no headtail row -> kept.
+    # 4: top-three + headtail row exists (incomplete) -> dropped (any
+    #    row excludes — matches API selector predicate).
     assert result.image_checksums == ["ccc"]
     assert result.dive_id == 42
     assert result.camera_matrix == _K.tolist()

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_laser_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_laser_preprocess_inputs_activity.py
@@ -2,12 +2,11 @@
 """Unit tests for resolve_laser_preprocess_inputs_activity.
 
 Pins down:
-  1. Returns only checksums of images that have no completed
-     LaserLabel in any project — multi-row state from prod (one
-     completed row in project 43, one incomplete sentinel in project
-     NULL) correctly resolves to "image is labeled". The earlier
-     dict-collapse filter could resolve either way depending on SDK
-     iteration order.
+  1. Returns only checksums of images that have no LaserLabel row at
+     all (in any project). Once populate seeds even an incomplete
+     row, the image's preprocessed JPEG is on the file-exchange and
+     the resolver must not return it. Matches the API selector
+     predicate.
   2. Camera intrinsics are flattened from numpy to lists.
   3. Default bbox lands in the resolved input.
   4. Missing dive / camera_id / intrinsics raise ValueError so the
@@ -131,10 +130,11 @@ async def test_returns_only_unlabeled_image_checksums(monkeypatch):
         sut.resolve_laser_preprocess_inputs_activity, 42
     )
 
-    # Image 1 has a completed label -> excluded. Image 2 has only an
-    # incomplete label, image 3 has no label at all -> both included.
+    # Image 1 has a completed label -> excluded.
+    # Image 2 has an incomplete label -> excluded (any row excludes).
+    # Image 3 has no label at all -> included.
     assert result.dive_id == 42
-    assert set(result.image_checksums) == {"bbb", "ccc"}
+    assert set(result.image_checksums) == {"ccc"}
     assert result.camera_matrix == _K.tolist()
     assert result.distortion_coefficients == _D.tolist()
     assert result.bbox == sut.DEFAULT_LASER_BBOX
@@ -163,22 +163,41 @@ async def test_returns_empty_checksums_when_all_labels_completed(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_returns_empty_checksums_when_only_incomplete_labels(monkeypatch):
+    """Steady-state after populate seeds incomplete sentinel rows: every
+    image has at least one row, so the resolver must return no work
+    even though no label is completed yet. Mirrors the API selector's
+    drop-out predicate."""
+    images = [_image(1, "aaa"), _image(2, "bbb")]
+    labels = [_label(1, completed=False), _label(2, completed=False)]
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_intrinsics(),
+        images=images,
+        laser_labels=labels,
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.resolve_laser_preprocess_inputs_activity, 42
+    )
+
+    assert result.image_checksums == []
+
+
+@pytest.mark.asyncio
 async def test_image_with_completed_and_incomplete_rows_treated_as_labeled(
     monkeypatch,
 ):
-    """Mirrors the prod state on dive 393: each image carries a
-    completed row in project 43 plus an incomplete sentinel row in
-    project NULL. Any one completed row is enough to count the image
-    as labeled, regardless of SDK iteration order."""
+    """Multi-row state: one image carries both a completed row in
+    project 43 and an incomplete sentinel in project NULL. Either
+    row is sufficient under the new "any row excludes" predicate."""
     images = [_image(1, "aaa"), _image(2, "bbb")]
     labels = [
-        # Image 1: completed in 43, also has an incomplete sentinel.
-        # Order: completed first, sentinel second — would have lost in
-        # the previous dict-collapse filter and leaked image 1 into
-        # the work set.
+        # Image 1: completed in 43 + incomplete sentinel.
         _label(1, completed=True, project_id=43),
         _label(1, completed=False, project_id=None),
-        # Image 2: only an incomplete row -> still needs work.
+        # Image 2: only an incomplete row.
         _label(2, completed=False, project_id=43),
     ]
     fs = _make_fs(
@@ -193,7 +212,8 @@ async def test_image_with_completed_and_incomplete_rows_treated_as_labeled(
         sut.resolve_laser_preprocess_inputs_activity, 42
     )
 
-    assert result.image_checksums == ["bbb"]
+    # Both images carry at least one row -> both excluded.
+    assert result.image_checksums == []
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_slate_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_slate_preprocess_inputs_activity.py
@@ -143,26 +143,37 @@ def _make_fs(
 
 
 @pytest.mark.asyncio
-async def test_returns_only_slate_marked_with_incomplete_slate_label(monkeypatch):
+async def test_returns_only_slate_marked_without_any_slate_label(monkeypatch):
     fs = _make_fs(
         dive=_dive(),
         intrinsics=_intrinsics(),
         slates=[_slate(7)],
-        images=[_image(1, "aaa"), _image(2, "bbb"), _image(3, "ccc")],
+        images=[
+            _image(1, "aaa"),
+            _image(2, "bbb"),
+            _image(3, "ccc"),
+            _image(4, "ddd"),
+        ],
         species=[
             _species(1, content=SLATE),
             _species(2, content="Fish"),
             _species(3, content=SLATE),
+            _species(4, content=SLATE),
         ],
-        slate_labels=[_slate_label(1, completed=True)],
+        slate_labels=[
+            _slate_label(1, completed=True),
+            _slate_label(4, completed=False),
+        ],
     )
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
     result = await ActivityEnvironment().run(
         sut.resolve_slate_preprocess_inputs_activity, 42
     )
-    # 1: slate-marked but completed -> dropped.
+    # 1: slate-marked but slate label exists (completed) -> dropped.
     # 2: not slate-marked -> dropped.
-    # 3: slate-marked, no slate label -> kept.
+    # 3: slate-marked, no slate label row -> kept.
+    # 4: slate-marked but slate label exists (incomplete) -> dropped
+    #    (any row excludes — matches API selector predicate).
     assert result.image_checksums == ["ccc"]
     assert result.dive_id == 42
     assert result.slate_id == 7

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -78,25 +78,24 @@ async def get_canonical_dives(
 async def select_next_for_laser_preprocessing(
     session: AsyncSession = Depends(get_async_session),
 ) -> int | None:
-    """Stage 0.1: HIGH-priority + at least one image without a completed
-    LaserLabel (in any project).
+    """Stage 0.1: HIGH-priority + at least one image without ANY
+    LaserLabel row (in any project).
 
-    Mirrors the work-state shape of the other three preprocess cohorts
-    (dive-image / headtail / slate). Earlier this was tied to
-    `no LaserExtrinsics`, which kept dives in the cohort indefinitely
-    after their laser labels were complete but stage-13 calibration was
-    blocked elsewhere (e.g. missing `dive_slate_id` or unfilled slate
-    labels) — wasted hourly firings on a dive 0.1 had no remaining
-    work for. Stage 13 keeps its own "no LaserExtrinsics" cohort and
-    advances independently.
+    The predicate is "row exists?" not "row completed?" so a dive drops
+    out of the cohort the moment populate seeds even-incomplete rows
+    for every image. Without that, every preprocessed dive would stay
+    in the cohort until labelers finished it — an hourly firing of
+    stage 0.1 would re-stage raw `.ORF`s from NAS, re-rectify, and
+    re-archive (the data-worker child workflow's
+    ALLOW_DUPLICATE_FAILED_ONLY policy makes that a no-op, but the NAS
+    staging activity runs unconditionally on every parent firing).
     """
-    has_image_without_completed_laser_label = (
+    has_image_without_any_laser_label = (
         select(Image.id)
         .where(Image.dive_id == Dive.id)
         .where(
             ~select(LaserLabel.id)
             .where(LaserLabel.image_id == Image.id)
-            .where(LaserLabel.completed == True)
             .exists()
         )
         .exists()
@@ -104,7 +103,7 @@ async def select_next_for_laser_preprocessing(
     query = (
         select(Dive.id)
         .where(Dive.priority == Priority.HIGH)
-        .where(has_image_without_completed_laser_label)
+        .where(has_image_without_any_laser_label)
         .order_by(Dive.id)
         .limit(1)
     )
@@ -116,20 +115,23 @@ async def select_next_for_dive_image_preprocessing(
     session: AsyncSession = Depends(get_async_session),
 ) -> int | None:
     """Stage 2: HIGH-priority + has PREDICTION cluster + at least one
-    image without a completed SpeciesLabel."""
+    image without ANY SpeciesLabel row.
+
+    "Row exists" rather than "row completed" — see the laser cohort
+    docstring for the rationale.
+    """
     has_prediction_cluster = (
         select(DiveFrameCluster.id)
         .where(DiveFrameCluster.dive_id == Dive.id)
         .where(DiveFrameCluster.data_source == DataSource.PREDICTION)
         .exists()
     )
-    has_image_without_completed_species_label = (
+    has_image_without_any_species_label = (
         select(Image.id)
         .where(Image.dive_id == Dive.id)
         .where(
             ~select(SpeciesLabel.id)
             .where(SpeciesLabel.image_id == Image.id)
-            .where(SpeciesLabel.completed == True)
             .exists()
         )
         .exists()
@@ -138,7 +140,7 @@ async def select_next_for_dive_image_preprocessing(
         select(Dive.id)
         .where(Dive.priority == Priority.HIGH)
         .where(has_prediction_cluster)
-        .where(has_image_without_completed_species_label)
+        .where(has_image_without_any_species_label)
         .order_by(Dive.id)
         .limit(1)
     )
@@ -150,9 +152,13 @@ async def select_next_for_headtail_preprocessing(
     session: AsyncSession = Depends(get_async_session),
 ) -> int | None:
     """Stage 5.1: HIGH-priority + has at least one
-    SpeciesLabel.top_three_photos_of_group=True whose HeadTailLabel is
-    missing or incomplete."""
-    has_top_three_image_without_completed_headtail = (
+    SpeciesLabel.top_three_photos_of_group=True whose image carries no
+    HeadTailLabel row at all.
+
+    "Row exists" rather than "row completed" — see the laser cohort
+    docstring for the rationale.
+    """
+    has_top_three_image_without_any_headtail = (
         select(SpeciesLabel.id)
         .join(Image, Image.id == SpeciesLabel.image_id)
         .where(Image.dive_id == Dive.id)
@@ -160,7 +166,6 @@ async def select_next_for_headtail_preprocessing(
         .where(
             ~select(HeadTailLabel.id)
             .where(HeadTailLabel.image_id == Image.id)
-            .where(HeadTailLabel.completed == True)
             .exists()
         )
         .exists()
@@ -168,7 +173,7 @@ async def select_next_for_headtail_preprocessing(
     query = (
         select(Dive.id)
         .where(Dive.priority == Priority.HIGH)
-        .where(has_top_three_image_without_completed_headtail)
+        .where(has_top_three_image_without_any_headtail)
         .order_by(Dive.id)
         .limit(1)
     )
@@ -180,9 +185,13 @@ async def select_next_for_slate_preprocessing(
     session: AsyncSession = Depends(get_async_session),
 ) -> int | None:
     """Stage 9: HIGH-priority + dive_slate_id set + has at least one
-    SpeciesLabel.content_of_image='Slate, Laser on slate' whose
-    DiveSlateLabel is missing or incomplete."""
-    has_slate_marked_image_without_completed_dive_slate_label = (
+    SpeciesLabel.content_of_image='Slate, Laser on slate' whose image
+    carries no DiveSlateLabel row at all.
+
+    "Row exists" rather than "row completed" — see the laser cohort
+    docstring for the rationale.
+    """
+    has_slate_marked_image_without_any_dive_slate_label = (
         select(SpeciesLabel.id)
         .join(Image, Image.id == SpeciesLabel.image_id)
         .where(Image.dive_id == Dive.id)
@@ -190,7 +199,6 @@ async def select_next_for_slate_preprocessing(
         .where(
             ~select(DiveSlateLabel.id)
             .where(DiveSlateLabel.image_id == Image.id)
-            .where(DiveSlateLabel.completed == True)
             .exists()
         )
         .exists()
@@ -199,7 +207,7 @@ async def select_next_for_slate_preprocessing(
         select(Dive.id)
         .where(Dive.priority == Priority.HIGH)
         .where(Dive.dive_slate_id != None)
-        .where(has_slate_marked_image_without_completed_dive_slate_label)
+        .where(has_slate_marked_image_without_any_dive_slate_label)
         .order_by(Dive.id)
         .limit(1)
     )

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -60,12 +60,16 @@ def _image(image_id: int, dive_id: int):
 
 # ---------- stage 0.1: laser-preprocessing ----------
 #
-# Cohort is "HIGH + has at least one image without a completed
-# LaserLabel (in any project)" — work-state, not the downstream
-# `no LaserExtrinsics` proxy. See dive_controller.py docstring for
-# the why. A dive with zero images is excluded by the same
-# `EXISTS (image without ...)` predicate, which matches the
-# behavior at the resolver level (no images → no work).
+# Cohort is "HIGH + has at least one image without ANY LaserLabel row
+# (in any project)" — once populate seeds even an incomplete row, the
+# image's preprocessed JPEG is on the file-exchange and the dive
+# drops out. The earlier "no completed label" predicate kept dives in
+# the cohort indefinitely after populate seeded incomplete sentinel
+# rows, re-staging raw `.ORF`s from NAS every hour for no benefit.
+# See dive_controller.py docstring for the rationale. A dive with
+# zero images is excluded by the same `EXISTS (image without ...)`
+# predicate, which matches the behavior at the resolver level
+# (no images → no work).
 
 
 async def test_laser_preprocessing_picks_lowest_high_priority_with_unlabeled_images(
@@ -91,7 +95,7 @@ async def test_laser_preprocessing_picks_lowest_high_priority_with_unlabeled_ima
     assert await select_next_for_laser_preprocessing(session=session) == 1
 
 
-async def test_laser_preprocessing_skips_dives_with_all_labels_completed(session):
+async def test_laser_preprocessing_skips_dives_with_every_image_labeled(session):
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         select_next_for_laser_preprocessing,
     )
@@ -99,9 +103,9 @@ async def test_laser_preprocessing_skips_dives_with_all_labels_completed(session
         LaserLabel,
     )
 
-    # dive 1: every image has a completed laser label -> excluded.
-    # dive 2: one image still unlabeled -> picked.
-    # dive 3: every image has a completed label, in different projects -> excluded.
+    # dive 1: every image has a laser label (mix of completed) -> excluded.
+    # dive 2: one image still has no label at all -> picked.
+    # dive 3: every image labeled in different projects -> excluded.
     session.add_all([_dive(1), _dive(2), _dive(3)])
     await session.flush()
     session.add_all(
@@ -128,12 +132,15 @@ async def test_laser_preprocessing_skips_dives_with_all_labels_completed(session
     assert await select_next_for_laser_preprocessing(session=session) == 2
 
 
-async def test_laser_preprocessing_treats_incomplete_label_as_unlabeled(session):
-    """Multi-row state: one project's label completed, another's incomplete.
+async def test_laser_preprocessing_treats_incomplete_label_as_labeled(session):
+    """Once populate seeds an incomplete LaserLabel row, the dive must
+    drop out of the cohort even though no labeler has touched it yet.
 
-    Mirrors the prod situation that motivated the cohort change — a
-    dict-collapsing `{image_id: label}` filter would race on iteration
-    order; the SQL `EXISTS (no completed label)` form is unambiguous.
+    This is the change that prevents the steady-state waste of re-
+    staging raw bytes from NAS every hour for already-preprocessed
+    dives. An incomplete sentinel row is what populate writes
+    immediately after pushing an LS task — the JPEG already exists on
+    the file-exchange and on NAS.
     """
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         select_next_for_laser_preprocessing,
@@ -142,24 +149,49 @@ async def test_laser_preprocessing_treats_incomplete_label_as_unlabeled(session)
         LaserLabel,
     )
 
-    # dive 1: one image has a completed label in project 43 AND an
-    # incomplete sentinel in project NULL -> the completed one
-    # qualifies, dive is excluded.
-    # dive 2: one image has only an incomplete label -> dive included.
+    # dive 1: image 11 has only an incomplete label -> dive excluded.
+    # dive 2: image 21 has no label at all -> dive included.
     session.add_all([_dive(1), _dive(2)])
     await session.flush()
     session.add_all([_image(11, 1), _image(21, 2)])
     await session.flush()
     session.add_all(
         [
-            LaserLabel(image_id=11, completed=True, label_studio_project_id=43),
-            LaserLabel(image_id=11, completed=False, label_studio_project_id=None),
-            LaserLabel(image_id=21, completed=False, label_studio_project_id=43),
+            LaserLabel(image_id=11, completed=False, label_studio_project_id=99),
         ]
     )
     await session.flush()
 
     assert await select_next_for_laser_preprocessing(session=session) == 2
+
+
+async def test_laser_preprocessing_excludes_dive_with_only_incomplete_labels(session):
+    """All images have only incomplete labels — dive must drop out.
+
+    This is the steady-state for the populate -> wait-for-labelers
+    period. Without the predicate change, the dive would stay in the
+    cohort and re-fire preprocess hourly until labelers completed.
+    """
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+        LaserLabel,
+    )
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add_all([_image(11, 1), _image(12, 1)])
+    await session.flush()
+    session.add_all(
+        [
+            LaserLabel(image_id=11, completed=False, label_studio_project_id=99),
+            LaserLabel(image_id=12, completed=False, label_studio_project_id=99),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_laser_preprocessing(session=session) is None
 
 
 async def test_laser_preprocessing_returns_none_when_no_unlabeled_images(session):
@@ -236,7 +268,7 @@ async def test_dive_image_preprocessing_requires_prediction_cluster(session):
     assert await select_next_for_dive_image_preprocessing(session=session) == 2
 
 
-async def test_dive_image_preprocessing_skips_when_all_images_completed(session):
+async def test_dive_image_preprocessing_skips_when_every_image_labeled(session):
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         select_next_for_dive_image_preprocessing,
     )
@@ -246,8 +278,8 @@ async def test_dive_image_preprocessing_skips_when_all_images_completed(session)
     )
     from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
 
-    # dive 1: 1 image, all completed -> excluded.
-    # dive 2: 2 images, only one completed -> picked.
+    # dive 1: 1 image, all labeled -> excluded.
+    # dive 2: 2 images, only one labeled -> picked.
     session.add_all([_dive(1), _dive(2)])
     await session.flush()
     session.add_all([_image(11, 1), _image(21, 2), _image(22, 2)])
@@ -268,6 +300,37 @@ async def test_dive_image_preprocessing_skips_when_all_images_completed(session)
     await session.flush()
 
     assert await select_next_for_dive_image_preprocessing(session=session) == 2
+
+
+async def test_dive_image_preprocessing_excludes_dive_with_only_incomplete_labels(
+    session,
+):
+    """Once populate seeds an incomplete SpeciesLabel for every image,
+    the dive must drop from the cohort even though no labeler has
+    completed it yet."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_dive_image_preprocessing,
+    )
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+    )
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add_all([_image(11, 1), _image(12, 1)])
+    await session.flush()
+    session.add(DiveFrameCluster(dive_id=1, data_source=DataSource.PREDICTION))
+    session.add_all(
+        [
+            SpeciesLabel(image_id=11, completed=False),
+            SpeciesLabel(image_id=12, completed=False),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_dive_image_preprocessing(session=session) is None
 
 
 async def test_dive_image_preprocessing_returns_none_when_only_label_studio_clusters(
@@ -293,7 +356,7 @@ async def test_dive_image_preprocessing_returns_none_when_only_label_studio_clus
 # ---------- stage 5.1: headtail-preprocessing ----------
 
 
-async def test_headtail_preprocessing_requires_top_three_without_completed_headtail(
+async def test_headtail_preprocessing_requires_top_three_without_any_headtail(
     session,
 ):
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
@@ -302,8 +365,8 @@ async def test_headtail_preprocessing_requires_top_three_without_completed_headt
     from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
     from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
 
-    # dive 1: top_three=True but headtail completed -> excluded.
-    # dive 2: top_three=True, no headtail -> picked.
+    # dive 1: top_three=True but headtail row exists -> excluded.
+    # dive 2: top_three=True, no headtail row -> picked.
     # dive 3: only top_three=False -> excluded.
     session.add_all([_dive(1), _dive(2), _dive(3)])
     await session.flush()
@@ -320,6 +383,27 @@ async def test_headtail_preprocessing_requires_top_three_without_completed_headt
     await session.flush()
 
     assert await select_next_for_headtail_preprocessing(session=session) == 2
+
+
+async def test_headtail_preprocessing_excludes_dive_with_only_incomplete_headtail(
+    session,
+):
+    """Once populate seeds an incomplete HeadTailLabel for every
+    top-three image, the dive drops out of the cohort."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_headtail_preprocessing,
+    )
+    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    session.add(SpeciesLabel(image_id=11, top_three_photos_of_group=True))
+    session.add(HeadTailLabel(image_id=11, completed=False))
+    await session.flush()
+
+    assert await select_next_for_headtail_preprocessing(session=session) is None
 
 
 async def test_headtail_preprocessing_returns_none_when_no_top_three(session):
@@ -372,7 +456,7 @@ async def test_slate_preprocessing_requires_dive_slate_id_and_marker(session):
     assert await select_next_for_slate_preprocessing(session=session) == 3
 
 
-async def test_slate_preprocessing_skips_when_slate_label_completed(session):
+async def test_slate_preprocessing_skips_when_every_slate_image_labeled(session):
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         SLATE_CONTENT_MARKER,
         select_next_for_slate_preprocessing,
@@ -394,6 +478,28 @@ async def test_slate_preprocessing_skips_when_slate_label_completed(session):
     await session.flush()
 
     assert await select_next_for_slate_preprocessing(session=session) == 2
+
+
+async def test_slate_preprocessing_excludes_dive_with_only_incomplete_slate_labels(
+    session,
+):
+    """Once populate seeds an incomplete DiveSlateLabel for every
+    slate-marked image, the dive drops out of the cohort."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        SLATE_CONTENT_MARKER,
+        select_next_for_slate_preprocessing,
+    )
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1, dive_slate_id=99))
+    await session.flush()
+    session.add(_image(11, 1))
+    session.add(SpeciesLabel(image_id=11, content_of_image=SLATE_CONTENT_MARKER))
+    session.add(DiveSlateLabel(image_id=11, completed=False))
+    await session.flush()
+
+    assert await select_next_for_slate_preprocessing(session=session) is None
 
 
 # ---------- stage 13: laser-calibration ----------


### PR DESCRIPTION
## Summary

Three commits on this branch — the first two were quick fixes for the populate task data shape and a lint chore; the third is the larger change that closes the LS-bootstrap gap and stops re-staging already-preprocessed dives every hour.

- **`7a3109e` fix**: populate task data now emits both `image` and `img` keys so legacy LS labeling-config XML (`<Image value=\"\$img\"/>`) and newer XML (`value=\"\$image\"`) both accept the import. Reverting either key reintroduces the HTTP 400 (\"img key is expected in task data\") regression observed when a fresh LS project's XML used the older convention.
- **`bc01ce1` chore**: silences the pylint `use-implicit-booleaness-not-comparison` warning introduced by the prior commit.
- **`e03b7a6` feat**: the substantive change.

### What `e03b7a6` does

Wires `create_<stage>_label_studio_project_activity` into all four `Populate<Stage>LabelStudioProjectWorkflow` runs so populate's fan-out target set is the union of the canonical project ID and the SDK discovery query. Closes the bootstrap chicken-and-egg: a freshly-created project has zero incomplete labels, so the `incomplete=True` discovery query alone wouldn't pick it up — including its ID via Create seeds the first round of label rows.

Flips the cohort predicate on stages 0.1, 2, 5.1, 9 from \"image without a completed label\" to \"image without ANY label row\" — both in the API selectors (`dive_controller.py`) and the matching resolver activities. Once populate seeds even-incomplete sentinel rows, the dive's preprocessed JPEGs are on the file-exchange and on NAS, and the dive must drop out of the cohort. The earlier predicate kept preprocessed dives in the cohort indefinitely while waiting for labelers; every hourly firing re-staged raw `.ORF`s from NAS for no benefit (per-image work was idempotent under `ALLOW_DUPLICATE_FAILED_ONLY`, but the staging activity ran unconditionally on every parent firing).

CLAUDE.md updated: cohort table, populate description, and bootstrap section now reflect the new semantics.

## Test plan

- [x] Unit tests pass on all 6 packages (421 total, 0 failures): `./check.sh unit`
- [x] Pylint clean (10.00/10): `./check.sh lint`
- [ ] Integration tests against local LS: `./check.sh integration` — includes the new `test_populate_workflow_creates_then_imports_tasks_against_real_ls` end-to-end test that runs `PopulateLaserLabelStudioProjectWorkflow` against real LS and asserts the Create-then-fan-out path imports tasks for a fresh project. Needs the local devcontainer stack up.
- [ ] Operational: trigger `PopulateLaserLabelStudioProjectWorkflow(<dive_id>)` against prod once and confirm a fresh LS project gets created and tasks are imported.
- [ ] Watch the next two hourly firings of `PreprocessLaserImagesParentWorkflow` after a populate succeeds and confirm the preprocessed dive drops out of the cohort.

## New / updated tests

**Unit (added):**
- `test_*_excludes_dive_with_only_incomplete_labels` for all 4 cohorts in [test_select_next_dive_endpoints.py](services/fishsense-api/tests/test_select_next_dive_endpoints.py)
- `test_returns_empty_checksums_when_only_incomplete_labels` ([test_resolve_laser_preprocess_inputs_activity.py](services/fishsense-api-workflow-worker/tests/test_resolve_laser_preprocess_inputs_activity.py))
- `test_workflow_unions_canonical_and_discovered_projects`, `test_workflow_self_bootstraps_when_discovery_empty`, `test_workflow_returns_zero_when_canonical_has_no_work` (parametrized across all 4 stages in [test_populate_label_studio_project_workflows.py](services/fishsense-api-workflow-worker/tests/test_populate_label_studio_project_workflows.py))

**Integration (added):**
- `test_populate_workflow_creates_then_imports_tasks_against_real_ls` ([test_label_studio_integration.py](services/fishsense-api-workflow-worker/tests/test_label_studio_integration.py))

**Updated:** existing selector / resolver / populate-workflow tests across the four stages to match the new predicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)