### PR TITLE
fix: exclude NULL-project sentinel rows from cohort predicate

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_headtail_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_headtail_preprocess_inputs_activity.py
@@ -35,7 +35,13 @@ async def resolve_headtail_preprocess_inputs_activity(
 
         species_labels = await fs.labels.get_species_labels(dive_id) or []
         existing_headtail = await fs.labels.get_headtail_labels(dive_id) or []
-        labeled_ids = {label.image_id for label in existing_headtail}
+        # Skip sentinel rows (project_id IS NULL) — see API selector
+        # docstring for rationale.
+        labeled_ids = {
+            label.image_id
+            for label in existing_headtail
+            if label.label_studio_project_id is not None
+        }
 
         target_image_ids = [
             label.image_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_preprocess_inputs_activity.py
@@ -32,14 +32,20 @@ DEFAULT_LASER_BBOX: List[int] = [1800, 700, 2400, 1600]
 def _select_unlabeled_images(
     images: List[Image], existing_labels: List[LaserLabel]
 ) -> List[Image]:
-    """Return images that have no LaserLabel row at all (in any project).
+    """Return images that have no non-sentinel LaserLabel row.
 
-    Once populate seeds a row for an image (even an incomplete one),
-    the image's preprocessed JPEG is on the file-exchange and the
-    image drops out of the preprocess work set. Matches the API
-    selector predicate.
+    "Non-sentinel" = `label_studio_project_id is not None`. NULL-
+    project rows are legacy sentinels (see API selector docstring).
+    Once populate seeds a real row for an image, the image's
+    preprocessed JPEG is on the file-exchange and the image drops
+    out of the preprocess work set. Matches the API selector
+    predicate.
     """
-    labeled_image_ids = {label.image_id for label in existing_labels}
+    labeled_image_ids = {
+        label.image_id
+        for label in existing_labels
+        if label.label_studio_project_id is not None
+    }
     return [image for image in images if image.id not in labeled_image_ids]
 
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_slate_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_slate_preprocess_inputs_activity.py
@@ -58,7 +58,13 @@ async def resolve_slate_preprocess_inputs_activity(
         existing_slate_labels = (
             await fs.labels.get_dive_slate_labels(dive_id) or []
         )
-        labeled_ids = {label.image_id for label in existing_slate_labels}
+        # Skip sentinel rows (project_id IS NULL) — see API selector
+        # docstring for rationale.
+        labeled_ids = {
+            label.image_id
+            for label in existing_slate_labels
+            if label.label_studio_project_id is not None
+        }
 
         target_image_ids = [
             label.image_id

--- a/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
@@ -69,6 +69,32 @@ def test_select_unlabeled_excludes_images_with_any_completed_label():
     assert [img.id for img in result] == [2, 3]
 
 
+def test_select_unlabeled_treats_null_project_sentinel_as_unlabeled():
+    """Contract pin: populate's per-image filter is on `completed`, not
+    on `label_studio_project_id`. So an image whose only existing
+    LaserLabel is a NULL-project sentinel (legacy prod state, ~2000
+    such rows as of 2026-05-03) MUST still get a fresh task pushed
+    when populate runs against a real project — otherwise a freshly
+    deployed canonical project couldn't seed labels for any of those
+    images. The cohort selector and resolver intentionally diverge
+    here: they treat sentinels as 'no work needed' (so preprocess
+    doesn't redo JPEGs), but populate treats them as 'no completed
+    label, push a fresh task in this real project'.
+    """
+    images = [_image(1, "a"), _image(2, "b")]
+    existing = [
+        # Image 1: only a sentinel.
+        _label(1, completed=False, project_id=None),
+        # Image 2: completed real-project row -> already labeled.
+        _label(2, completed=True, project_id=43),
+    ]
+
+    result = sut._select_unlabeled_images(images, existing)  # pylint: disable=protected-access
+
+    # Image 1 still needs a task; image 2 doesn't.
+    assert [img.id for img in result] == [1]
+
+
 def test_select_unlabeled_handles_multi_row_state():
     """Mirrors the prod state on dive 393: each image carries a
     completed row in project 43 plus an incomplete sentinel row in

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_headtail_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_headtail_preprocess_inputs_activity.py
@@ -74,12 +74,17 @@ def _species(image_id: int, *, top_three: bool) -> SpeciesLabel:
     )
 
 
-def _headtail(image_id: int, *, completed: bool) -> HeadTailLabel:
+def _headtail(
+    image_id: int,
+    *,
+    completed: bool,
+    project_id: Optional[int] = 71,
+) -> HeadTailLabel:
     return HeadTailLabel(
         id=None,
         image_id=image_id,
         label_studio_task_id=image_id * 10,
-        label_studio_project_id=71,
+        label_studio_project_id=project_id,
         image_url=None,
         updated_at=None,
         completed=completed,
@@ -163,6 +168,37 @@ async def test_returns_only_top_three_without_any_headtail(monkeypatch):
     assert result.dive_id == 42
     assert result.camera_matrix == _K.tolist()
     assert result.distortion_coefficients == _D.tolist()
+
+
+@pytest.mark.asyncio
+async def test_image_with_only_null_project_sentinel_treated_as_unlabeled(
+    monkeypatch,
+):
+    """NULL-`project_id` HeadTailLabel rows are legacy sentinels — the
+    resolver must ignore them when deciding whether a top-three image
+    needs preprocessing. Matches the API selector predicate."""
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_intrinsics(),
+        images=[_image(1, "aaa"), _image(2, "bbb")],
+        species=[
+            _species(1, top_three=True),
+            _species(2, top_three=True),
+        ],
+        headtail=[
+            _headtail(1, completed=False, project_id=None),
+            _headtail(2, completed=False, project_id=71),
+        ],
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.resolve_headtail_preprocess_inputs_activity, 42
+    )
+
+    # Image 1: only a sentinel -> still needs work.
+    # Image 2: real-project row -> excluded.
+    assert result.image_checksums == ["aaa"]
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_laser_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_laser_preprocess_inputs_activity.py
@@ -189,15 +189,17 @@ async def test_returns_empty_checksums_when_only_incomplete_labels(monkeypatch):
 async def test_image_with_completed_and_incomplete_rows_treated_as_labeled(
     monkeypatch,
 ):
-    """Multi-row state: one image carries both a completed row in
-    project 43 and an incomplete sentinel in project NULL. Either
-    row is sufficient under the new "any row excludes" predicate."""
+    """Multi-row state: one image carries a completed row in project
+    43, an incomplete sentinel in project NULL, plus an incomplete
+    real-project row. Sentinels are ignored but the real-project
+    rows are sufficient to exclude.
+    """
     images = [_image(1, "aaa"), _image(2, "bbb")]
     labels = [
-        # Image 1: completed in 43 + incomplete sentinel.
+        # Image 1: completed real-project row + sentinel (sentinel ignored).
         _label(1, completed=True, project_id=43),
         _label(1, completed=False, project_id=None),
-        # Image 2: only an incomplete row.
+        # Image 2: incomplete real-project row.
         _label(2, completed=False, project_id=43),
     ]
     fs = _make_fs(
@@ -212,8 +214,40 @@ async def test_image_with_completed_and_incomplete_rows_treated_as_labeled(
         sut.resolve_laser_preprocess_inputs_activity, 42
     )
 
-    # Both images carry at least one row -> both excluded.
+    # Both images carry at least one non-sentinel row -> both excluded.
     assert result.image_checksums == []
+
+
+@pytest.mark.asyncio
+async def test_image_with_only_null_project_sentinel_treated_as_unlabeled(
+    monkeypatch,
+):
+    """NULL-`project_id` rows are legacy sentinels (~2000 of them in
+    prod). The resolver must ignore them when deciding whether an
+    image needs preprocessing — otherwise prod's existing sentinel
+    population would permanently drain the work set. Mirrors the
+    API selector predicate.
+    """
+    images = [_image(1, "aaa"), _image(2, "bbb")]
+    labels = [
+        # Image 1: only a sentinel row -> needs work.
+        _label(1, completed=False, project_id=None),
+        # Image 2: real-project incomplete row -> excluded.
+        _label(2, completed=False, project_id=99),
+    ]
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_intrinsics(),
+        images=images,
+        laser_labels=labels,
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.resolve_laser_preprocess_inputs_activity, 42
+    )
+
+    assert result.image_checksums == ["aaa"]
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_slate_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_slate_preprocess_inputs_activity.py
@@ -87,12 +87,17 @@ def _species(image_id: int, *, content: str | None) -> SpeciesLabel:
     )
 
 
-def _slate_label(image_id: int, *, completed: bool) -> DiveSlateLabel:
+def _slate_label(
+    image_id: int,
+    *,
+    completed: bool,
+    project_id: Optional[int] = 66,
+) -> DiveSlateLabel:
     return DiveSlateLabel(
         id=None,
         image_id=image_id,
         label_studio_task_id=image_id * 10,
-        label_studio_project_id=66,
+        label_studio_project_id=project_id,
         image_url=None,
         updated_at=None,
         completed=completed,
@@ -181,6 +186,37 @@ async def test_returns_only_slate_marked_without_any_slate_label(monkeypatch):
     assert result.reference_points == [(0.0, 0.0), (1.0, 1.0)]
     assert result.camera_matrix == _K.tolist()
     assert result.distortion_coefficients == _D.tolist()
+
+
+@pytest.mark.asyncio
+async def test_image_with_only_null_project_sentinel_treated_as_unlabeled(
+    monkeypatch,
+):
+    """NULL-`project_id` DiveSlateLabel rows are legacy sentinels — the
+    resolver must ignore them when deciding whether a slate-marked
+    image needs preprocessing. Matches the API selector predicate."""
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_intrinsics(),
+        slates=[_slate(7)],
+        images=[_image(1, "aaa"), _image(2, "bbb")],
+        species=[
+            _species(1, content=SLATE),
+            _species(2, content=SLATE),
+        ],
+        slate_labels=[
+            _slate_label(1, completed=False, project_id=None),
+            _slate_label(2, completed=False, project_id=66),
+        ],
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    result = await ActivityEnvironment().run(
+        sut.resolve_slate_preprocess_inputs_activity, 42
+    )
+
+    # Image 1: only a sentinel -> still needs work.
+    # Image 2: real-project row -> excluded.
+    assert result.image_checksums == ["aaa"]
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -78,24 +78,32 @@ async def get_canonical_dives(
 async def select_next_for_laser_preprocessing(
     session: AsyncSession = Depends(get_async_session),
 ) -> int | None:
-    """Stage 0.1: HIGH-priority + at least one image without ANY
-    LaserLabel row (in any project).
+    """Stage 0.1: HIGH-priority + at least one image without a
+    non-sentinel LaserLabel row (in any real project).
 
-    The predicate is "row exists?" not "row completed?" so a dive drops
-    out of the cohort the moment populate seeds even-incomplete rows
-    for every image. Without that, every preprocessed dive would stay
-    in the cohort until labelers finished it — an hourly firing of
-    stage 0.1 would re-stage raw `.ORF`s from NAS, re-rectify, and
-    re-archive (the data-worker child workflow's
+    "Non-sentinel" means `label_studio_project_id IS NOT NULL` —
+    NULL-project rows are legacy sentinels (prod has ~2000 of them, one
+    per HIGH-priority canonical image, source unclear but predates the
+    Create-on-populate flow). The convention is established already:
+    every discovery endpoint in `label_controller.py` filters
+    `project_id != None` for the same reason.
+
+    Predicate is "non-sentinel row exists?" not "row completed?" so a
+    dive drops out of the cohort the moment populate seeds even-
+    incomplete rows for every image. Without that, every preprocessed
+    dive would stay in the cohort until labelers finished it — an
+    hourly firing of stage 0.1 would re-stage raw `.ORF`s from NAS,
+    re-rectify, and re-archive (the data-worker child workflow's
     ALLOW_DUPLICATE_FAILED_ONLY policy makes that a no-op, but the NAS
     staging activity runs unconditionally on every parent firing).
     """
-    has_image_without_any_laser_label = (
+    has_image_without_real_laser_label = (
         select(Image.id)
         .where(Image.dive_id == Dive.id)
         .where(
             ~select(LaserLabel.id)
             .where(LaserLabel.image_id == Image.id)
+            .where(LaserLabel.label_studio_project_id != None)
             .exists()
         )
         .exists()
@@ -103,7 +111,7 @@ async def select_next_for_laser_preprocessing(
     query = (
         select(Dive.id)
         .where(Dive.priority == Priority.HIGH)
-        .where(has_image_without_any_laser_label)
+        .where(has_image_without_real_laser_label)
         .order_by(Dive.id)
         .limit(1)
     )
@@ -115,10 +123,11 @@ async def select_next_for_dive_image_preprocessing(
     session: AsyncSession = Depends(get_async_session),
 ) -> int | None:
     """Stage 2: HIGH-priority + has PREDICTION cluster + at least one
-    image without ANY SpeciesLabel row.
+    image without a non-sentinel SpeciesLabel row.
 
-    "Row exists" rather than "row completed" — see the laser cohort
-    docstring for the rationale.
+    "Non-sentinel" = `project_id IS NOT NULL`. See the laser cohort
+    docstring for the rationale (sentinels predate the new flow and
+    every other discovery query already filters them out).
     """
     has_prediction_cluster = (
         select(DiveFrameCluster.id)
@@ -126,12 +135,13 @@ async def select_next_for_dive_image_preprocessing(
         .where(DiveFrameCluster.data_source == DataSource.PREDICTION)
         .exists()
     )
-    has_image_without_any_species_label = (
+    has_image_without_real_species_label = (
         select(Image.id)
         .where(Image.dive_id == Dive.id)
         .where(
             ~select(SpeciesLabel.id)
             .where(SpeciesLabel.image_id == Image.id)
+            .where(SpeciesLabel.label_studio_project_id != None)
             .exists()
         )
         .exists()
@@ -140,7 +150,7 @@ async def select_next_for_dive_image_preprocessing(
         select(Dive.id)
         .where(Dive.priority == Priority.HIGH)
         .where(has_prediction_cluster)
-        .where(has_image_without_any_species_label)
+        .where(has_image_without_real_species_label)
         .order_by(Dive.id)
         .limit(1)
     )
@@ -153,12 +163,12 @@ async def select_next_for_headtail_preprocessing(
 ) -> int | None:
     """Stage 5.1: HIGH-priority + has at least one
     SpeciesLabel.top_three_photos_of_group=True whose image carries no
-    HeadTailLabel row at all.
+    non-sentinel HeadTailLabel row.
 
-    "Row exists" rather than "row completed" — see the laser cohort
+    "Non-sentinel" = `project_id IS NOT NULL`. See the laser cohort
     docstring for the rationale.
     """
-    has_top_three_image_without_any_headtail = (
+    has_top_three_image_without_real_headtail = (
         select(SpeciesLabel.id)
         .join(Image, Image.id == SpeciesLabel.image_id)
         .where(Image.dive_id == Dive.id)
@@ -166,6 +176,7 @@ async def select_next_for_headtail_preprocessing(
         .where(
             ~select(HeadTailLabel.id)
             .where(HeadTailLabel.image_id == Image.id)
+            .where(HeadTailLabel.label_studio_project_id != None)
             .exists()
         )
         .exists()
@@ -173,7 +184,7 @@ async def select_next_for_headtail_preprocessing(
     query = (
         select(Dive.id)
         .where(Dive.priority == Priority.HIGH)
-        .where(has_top_three_image_without_any_headtail)
+        .where(has_top_three_image_without_real_headtail)
         .order_by(Dive.id)
         .limit(1)
     )
@@ -186,12 +197,12 @@ async def select_next_for_slate_preprocessing(
 ) -> int | None:
     """Stage 9: HIGH-priority + dive_slate_id set + has at least one
     SpeciesLabel.content_of_image='Slate, Laser on slate' whose image
-    carries no DiveSlateLabel row at all.
+    carries no non-sentinel DiveSlateLabel row.
 
-    "Row exists" rather than "row completed" — see the laser cohort
+    "Non-sentinel" = `project_id IS NOT NULL`. See the laser cohort
     docstring for the rationale.
     """
-    has_slate_marked_image_without_any_dive_slate_label = (
+    has_slate_marked_image_without_real_dive_slate_label = (
         select(SpeciesLabel.id)
         .join(Image, Image.id == SpeciesLabel.image_id)
         .where(Image.dive_id == Dive.id)
@@ -199,6 +210,7 @@ async def select_next_for_slate_preprocessing(
         .where(
             ~select(DiveSlateLabel.id)
             .where(DiveSlateLabel.image_id == Image.id)
+            .where(DiveSlateLabel.label_studio_project_id != None)
             .exists()
         )
         .exists()
@@ -207,7 +219,7 @@ async def select_next_for_slate_preprocessing(
         select(Dive.id)
         .where(Dive.priority == Priority.HIGH)
         .where(Dive.dive_slate_id != None)
-        .where(has_slate_marked_image_without_any_dive_slate_label)
+        .where(has_slate_marked_image_without_real_dive_slate_label)
         .order_by(Dive.id)
         .limit(1)
     )

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 """Tests for the per-stage `GET /api/v1/dives/select-next/...` endpoints.
 
 These collapse the api-workflow-worker's previously O(N) selector
@@ -166,7 +167,8 @@ async def test_laser_preprocessing_treats_incomplete_label_as_labeled(session):
 
 
 async def test_laser_preprocessing_excludes_dive_with_only_incomplete_labels(session):
-    """All images have only incomplete labels — dive must drop out.
+    """All images have only incomplete labels (with real project_id) —
+    dive must drop out.
 
     This is the steady-state for the populate -> wait-for-labelers
     period. Without the predicate change, the dive would stay in the
@@ -192,6 +194,75 @@ async def test_laser_preprocessing_excludes_dive_with_only_incomplete_labels(ses
     await session.flush()
 
     assert await select_next_for_laser_preprocessing(session=session) is None
+
+
+async def test_laser_preprocessing_excludes_dive_when_sentinel_coexists_with_real_label(
+    session,
+):
+    """Defensive: an image carrying BOTH a NULL-project sentinel AND a
+    real-project row should still drop the dive (the real row counts).
+    Pinned because a future refactor that 'simplifies' the predicate
+    to ignore project_id entirely would silently break this."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+        LaserLabel,
+    )
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add_all(
+        [
+            LaserLabel(
+                image_id=11, completed=False, label_studio_project_id=None
+            ),
+            LaserLabel(
+                image_id=11, completed=False, label_studio_project_id=99
+            ),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_laser_preprocessing(session=session) is None
+
+
+async def test_laser_preprocessing_ignores_null_project_sentinels(session):
+    """NULL-`project_id` LaserLabel rows are legacy sentinels (~2000 in
+    prod, one per HIGH-priority canonical image, source predates the
+    Create-on-populate flow). The cohort selector must treat them as
+    'no real label' so prod's existing sentinel population doesn't
+    permanently drain the cohort. Mirrors the
+    `project_id != None` filter the discovery endpoint at
+    `label_controller.py:274` already has."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+        LaserLabel,
+    )
+
+    # dive 1: image 11 has only a NULL-project sentinel -> dive INCLUDED.
+    # dive 2: image 21 has a real-project incomplete row -> dive EXCLUDED.
+    session.add_all([_dive(1), _dive(2)])
+    await session.flush()
+    session.add_all([_image(11, 1), _image(21, 2)])
+    await session.flush()
+    session.add_all(
+        [
+            LaserLabel(
+                image_id=11, completed=False, label_studio_project_id=None
+            ),
+            LaserLabel(
+                image_id=21, completed=False, label_studio_project_id=99
+            ),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_laser_preprocessing(session=session) == 1
 
 
 async def test_laser_preprocessing_returns_none_when_no_unlabeled_images(session):
@@ -230,6 +301,104 @@ async def test_laser_preprocessing_returns_none_with_no_high_priority(session):
     await session.flush()
 
     assert await select_next_for_laser_preprocessing(session=session) is None
+
+
+async def test_laser_discovery_and_selector_agree_on_real_label_definition(session):
+    """Cross-controller consistency: the discovery endpoint
+    (`get_laser_label_studio_project_ids`) and the cohort selector
+    (`select_next_for_laser_preprocessing`) must use the same
+    definition of 'real label' — `label_studio_project_id IS NOT
+    NULL`. If a future refactor relaxes one but not the other, the
+    cohort and the populate fan-out would disagree about which images
+    are 'done' and either re-import duplicate LS tasks (selector too
+    permissive) or leak unprocessed images (selector too strict).
+
+    Concretely: a fixture where some images carry only sentinels and
+    others carry real-project rows must produce a discovery list that
+    excludes NULL and a selector pick that includes only the
+    sentinel-only dives.
+    """
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+    from fishsense_api.controllers.label_controller import (  # pylint: disable=import-outside-toplevel
+        get_laser_label_studio_project_ids,
+    )
+    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+        LaserLabel,
+    )
+
+    session.add_all([_dive(1), _dive(2)])
+    await session.flush()
+    session.add_all([_image(11, 1), _image(21, 2)])
+    await session.flush()
+    session.add_all(
+        [
+            # dive 1 / image 11: only a sentinel -> dive 1 stays in
+            # cohort. Sentinel must NOT show up in discovery.
+            LaserLabel(
+                image_id=11, completed=False, label_studio_project_id=None
+            ),
+            # dive 2 / image 21: real-project incomplete row -> dive 2
+            # drops out of cohort. Project 99 must appear in discovery.
+            LaserLabel(
+                image_id=21, completed=False, label_studio_project_id=99
+            ),
+        ]
+    )
+    await session.flush()
+
+    discovered = await get_laser_label_studio_project_ids(
+        incomplete=True, session=session
+    )
+    selected = await select_next_for_laser_preprocessing(session=session)
+
+    assert None not in discovered
+    assert set(discovered) == {99}
+    # Selector picks the dive whose only label is a sentinel — i.e.
+    # the dive whose images have no real-project rows.
+    assert selected == 1
+
+
+async def test_laser_preprocessing_prod_state_sentinels_dont_drain_cohort(session):
+    """Regression: 2026-05-03 prod incident. ~2000 NULL-`project_id`
+    LaserLabel sentinel rows existed (one per HIGH-priority canonical
+    image, source predates the Create-on-populate flow). The first
+    cut of the new cohort predicate treated those rows as 'image is
+    labeled' and the cohort drained to zero immediately on deploy.
+    Pinning the prod-state shape here so that bug can't come back:
+    multiple HIGH-priority dives, every image carrying ONLY a
+    sentinel row, must still produce the lowest-id dive from the
+    selector.
+    """
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+        LaserLabel,
+    )
+
+    session.add_all([_dive(1), _dive(2), _dive(3)])
+    await session.flush()
+    image_ids: list[int] = []
+    for dive_id in (1, 2, 3):
+        for img_id in (dive_id * 10 + 1, dive_id * 10 + 2):
+            session.add(_image(img_id, dive_id))
+            image_ids.append(img_id)
+    await session.flush()
+    session.add_all(
+        [
+            LaserLabel(
+                image_id=img_id,
+                completed=False,
+                label_studio_project_id=None,
+            )
+            for img_id in image_ids
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_laser_preprocessing(session=session) == 1
 
 
 async def test_laser_preprocessing_excludes_dive_with_no_images(session):
@@ -292,8 +461,8 @@ async def test_dive_image_preprocessing_skips_when_every_image_labeled(session):
     )
     session.add_all(
         [
-            SpeciesLabel(image_id=11, completed=True),
-            SpeciesLabel(image_id=21, completed=True),
+            SpeciesLabel(image_id=11, completed=True, label_studio_project_id=70),
+            SpeciesLabel(image_id=21, completed=True, label_studio_project_id=70),
             # image 22 has no species_label -> dive 2 stays in cohort.
         ]
     )
@@ -305,9 +474,9 @@ async def test_dive_image_preprocessing_skips_when_every_image_labeled(session):
 async def test_dive_image_preprocessing_excludes_dive_with_only_incomplete_labels(
     session,
 ):
-    """Once populate seeds an incomplete SpeciesLabel for every image,
-    the dive must drop from the cohort even though no labeler has
-    completed it yet."""
+    """Once populate seeds an incomplete SpeciesLabel (with a real
+    project_id) for every image, the dive must drop from the cohort
+    even though no labeler has completed it yet."""
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         select_next_for_dive_image_preprocessing,
     )
@@ -324,13 +493,82 @@ async def test_dive_image_preprocessing_excludes_dive_with_only_incomplete_label
     session.add(DiveFrameCluster(dive_id=1, data_source=DataSource.PREDICTION))
     session.add_all(
         [
-            SpeciesLabel(image_id=11, completed=False),
-            SpeciesLabel(image_id=12, completed=False),
+            SpeciesLabel(
+                image_id=11, completed=False, label_studio_project_id=70
+            ),
+            SpeciesLabel(
+                image_id=12, completed=False, label_studio_project_id=70
+            ),
         ]
     )
     await session.flush()
 
     assert await select_next_for_dive_image_preprocessing(session=session) is None
+
+
+async def test_dive_image_preprocessing_excludes_dive_when_sentinel_coexists_with_real_label(
+    session,
+):
+    """Defensive — see laser-stage analogue."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_dive_image_preprocessing,
+    )
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+    )
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add(DiveFrameCluster(dive_id=1, data_source=DataSource.PREDICTION))
+    session.add_all(
+        [
+            SpeciesLabel(
+                image_id=11, completed=False, label_studio_project_id=None
+            ),
+            SpeciesLabel(
+                image_id=11, completed=False, label_studio_project_id=70
+            ),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_dive_image_preprocessing(session=session) is None
+
+
+async def test_dive_image_preprocessing_ignores_null_project_sentinels(session):
+    """NULL-`project_id` rows are legacy sentinels (~2000 in prod, one
+    per HIGH-priority canonical image, source predates the
+    Create-on-populate flow). The cohort selector must treat them as
+    'no real label' so prod's existing sentinel population doesn't
+    permanently drain the cohort. Mirrors the
+    `project_id != None` filter every discovery endpoint already has.
+    """
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_dive_image_preprocessing,
+    )
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+    )
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add(DiveFrameCluster(dive_id=1, data_source=DataSource.PREDICTION))
+    session.add(
+        SpeciesLabel(
+            image_id=11, completed=False, label_studio_project_id=None
+        ),
+    )
+    await session.flush()
+
+    assert await select_next_for_dive_image_preprocessing(session=session) == 1
 
 
 async def test_dive_image_preprocessing_returns_none_when_only_label_studio_clusters(
@@ -379,7 +617,9 @@ async def test_headtail_preprocessing_requires_top_three_without_any_headtail(
             SpeciesLabel(image_id=31, top_three_photos_of_group=False),
         ]
     )
-    session.add(HeadTailLabel(image_id=11, completed=True))
+    session.add(
+        HeadTailLabel(image_id=11, completed=True, label_studio_project_id=71)
+    )
     await session.flush()
 
     assert await select_next_for_headtail_preprocessing(session=session) == 2
@@ -388,8 +628,9 @@ async def test_headtail_preprocessing_requires_top_three_without_any_headtail(
 async def test_headtail_preprocessing_excludes_dive_with_only_incomplete_headtail(
     session,
 ):
-    """Once populate seeds an incomplete HeadTailLabel for every
-    top-three image, the dive drops out of the cohort."""
+    """Once populate seeds an incomplete HeadTailLabel (with a real
+    project_id) for every top-three image, the dive drops out of the
+    cohort."""
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         select_next_for_headtail_preprocessing,
     )
@@ -400,10 +641,67 @@ async def test_headtail_preprocessing_excludes_dive_with_only_incomplete_headtai
     await session.flush()
     session.add(_image(11, 1))
     session.add(SpeciesLabel(image_id=11, top_three_photos_of_group=True))
-    session.add(HeadTailLabel(image_id=11, completed=False))
+    session.add(
+        HeadTailLabel(
+            image_id=11, completed=False, label_studio_project_id=71
+        )
+    )
     await session.flush()
 
     assert await select_next_for_headtail_preprocessing(session=session) is None
+
+
+async def test_headtail_preprocessing_excludes_dive_when_sentinel_coexists_with_real_label(
+    session,
+):
+    """Defensive — see laser-stage analogue."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_headtail_preprocessing,
+    )
+    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    session.add(SpeciesLabel(image_id=11, top_three_photos_of_group=True))
+    session.add_all(
+        [
+            HeadTailLabel(
+                image_id=11, completed=False, label_studio_project_id=None
+            ),
+            HeadTailLabel(
+                image_id=11, completed=False, label_studio_project_id=71
+            ),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_headtail_preprocessing(session=session) is None
+
+
+async def test_headtail_preprocessing_ignores_null_project_sentinels(session):
+    """NULL-`project_id` HeadTailLabel rows are legacy sentinels — see
+    the dive-image cohort docstring. They must NOT drop a dive from
+    the headtail cohort."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_headtail_preprocessing,
+    )
+    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    session.add(SpeciesLabel(image_id=11, top_three_photos_of_group=True))
+    session.add(
+        HeadTailLabel(
+            image_id=11, completed=False, label_studio_project_id=None
+        )
+    )
+    await session.flush()
+
+    assert await select_next_for_headtail_preprocessing(session=session) == 1
 
 
 async def test_headtail_preprocessing_returns_none_when_no_top_three(session):
@@ -472,7 +770,9 @@ async def test_slate_preprocessing_skips_when_every_slate_image_labeled(session)
         [
             SpeciesLabel(image_id=11, content_of_image=SLATE_CONTENT_MARKER),
             SpeciesLabel(image_id=21, content_of_image=SLATE_CONTENT_MARKER),
-            DiveSlateLabel(image_id=11, completed=True),
+            DiveSlateLabel(
+                image_id=11, completed=True, label_studio_project_id=66
+            ),
         ]
     )
     await session.flush()
@@ -483,8 +783,9 @@ async def test_slate_preprocessing_skips_when_every_slate_image_labeled(session)
 async def test_slate_preprocessing_excludes_dive_with_only_incomplete_slate_labels(
     session,
 ):
-    """Once populate seeds an incomplete DiveSlateLabel for every
-    slate-marked image, the dive drops out of the cohort."""
+    """Once populate seeds an incomplete DiveSlateLabel (with a real
+    project_id) for every slate-marked image, the dive drops out of
+    the cohort."""
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         SLATE_CONTENT_MARKER,
         select_next_for_slate_preprocessing,
@@ -496,10 +797,69 @@ async def test_slate_preprocessing_excludes_dive_with_only_incomplete_slate_labe
     await session.flush()
     session.add(_image(11, 1))
     session.add(SpeciesLabel(image_id=11, content_of_image=SLATE_CONTENT_MARKER))
-    session.add(DiveSlateLabel(image_id=11, completed=False))
+    session.add(
+        DiveSlateLabel(
+            image_id=11, completed=False, label_studio_project_id=66
+        )
+    )
     await session.flush()
 
     assert await select_next_for_slate_preprocessing(session=session) is None
+
+
+async def test_slate_preprocessing_excludes_dive_when_sentinel_coexists_with_real_label(
+    session,
+):
+    """Defensive — see laser-stage analogue."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        SLATE_CONTENT_MARKER,
+        select_next_for_slate_preprocessing,
+    )
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1, dive_slate_id=99))
+    await session.flush()
+    session.add(_image(11, 1))
+    session.add(SpeciesLabel(image_id=11, content_of_image=SLATE_CONTENT_MARKER))
+    session.add_all(
+        [
+            DiveSlateLabel(
+                image_id=11, completed=False, label_studio_project_id=None
+            ),
+            DiveSlateLabel(
+                image_id=11, completed=False, label_studio_project_id=66
+            ),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_slate_preprocessing(session=session) is None
+
+
+async def test_slate_preprocessing_ignores_null_project_sentinels(session):
+    """NULL-`project_id` DiveSlateLabel rows are legacy sentinels — see
+    the dive-image cohort docstring. They must NOT drop a dive from
+    the slate cohort."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        SLATE_CONTENT_MARKER,
+        select_next_for_slate_preprocessing,
+    )
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1, dive_slate_id=99))
+    await session.flush()
+    session.add(_image(11, 1))
+    session.add(SpeciesLabel(image_id=11, content_of_image=SLATE_CONTENT_MARKER))
+    session.add(
+        DiveSlateLabel(
+            image_id=11, completed=False, label_studio_project_id=None
+        )
+    )
+    await session.flush()
+
+    assert await select_next_for_slate_preprocessing(session=session) == 1
 
 
 # ---------- stage 13: laser-calibration ----------


### PR DESCRIPTION
## Summary

Follow-up to #60. After deploying that PR's "any row excludes" cohort predicate, the laser cohort drained to zero immediately because prod has ~2000 legacy `LaserLabel` rows with `label_studio_project_id IS NULL` — one per HIGH-priority canonical image, source predates the Create-on-populate flow. Every HIGH-priority dive dropped out on the first selector firing because the predicate treated those sentinels as "image is labeled."

This adds `label_studio_project_id != None` to the four cohort selectors and the three resolver per-image filters. Now matches the convention every discovery endpoint in [label_controller.py](services/fishsense-api/src/fishsense_api/controllers/label_controller.py) already uses (`project_id != None` filters at lines 47, 155, 274, 408). Definition of "labeled" is now consistent across the cohort selector, the resolver, and the discovery query: **"image carries at least one row with a non-NULL `project_id`."**

Populate's per-image `_select_unlabeled_images` filter intentionally keeps its `if label.completed` form — populate must still push tasks for sentinel-only images so a brand-new canonical project can seed real-project rows for the legacy population.

## Tests

Heavy emphasis on regression coverage for the exact prod incident:

- **`*_excludes_dive_when_sentinel_coexists_with_real_label`** — 4 stages × 1 test. An image with both a sentinel and a real-project row is correctly excluded (the real row counts).
- **`*_ignores_null_project_sentinels`** — 4 stages × 1 test. A dive whose images carry only sentinel rows is still selected.
- **`test_laser_preprocessing_prod_state_sentinels_dont_drain_cohort`** — explicit regression for the 2026-05-03 incident: 3 HIGH-priority dives, every image carrying only a sentinel, asserts the lowest-id dive is still picked.
- **`test_laser_discovery_and_selector_agree_on_real_label_definition`** — cross-controller consistency: discovery (`get_laser_label_studio_project_ids`) and the selector both agree on what counts as a real label. Pinning this prevents silent divergence between cohort and populate fan-out.
- **Resolver sentinel-only tests** for laser, headtail, slate.
- **`test_select_unlabeled_treats_null_project_sentinel_as_unlabeled`** — populate-side contract pin: sentinel-only image still gets a task pushed.

## Test plan

- [x] `./check.sh unit` — 435 unit tests pass, 0 failures across all 6 packages.
- [x] `./check.sh lint` — 10.00/10.
- [ ] Operational: after merge + deploy, re-run the cohort-counting SQL on prod and confirm the HIGH-priority dives expected to be eligible now appear in the cohort.
- [ ] Watch the next hourly firing of `PreprocessLaserImagesParentWorkflow` and confirm a dive_id is returned (or that the SQL above shows zero genuinely-unlabeled images).

## SQL diagnostic (used to find the issue)

```sql
SELECT COUNT(DISTINCT d.id) AS eligible_dives_under_new_predicate
FROM dive d
WHERE d.priority = 'HIGH'::priority
  AND EXISTS (
      SELECT 1 FROM image i
      WHERE i.dive_id = d.id
        AND NOT EXISTS (
            SELECT 1 FROM laserlabel ll
            WHERE ll.image_id = i.id
              AND ll.label_studio_project_id IS NOT NULL
        )
  );
```

This is the exact predicate the new selector uses. Pre-fix it returned 0; post-fix it should return however many HIGH-priority dives are genuinely uncalibrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)