### PR TITLE
fix: force fresh DSM login per NasClient (synology-api class-cache bug)

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/nas.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/nas.py
@@ -17,6 +17,7 @@ import logging
 from contextlib import contextmanager
 from urllib.parse import urlparse
 
+from synology_api.base_api import BaseApi
 from synology_api.exceptions import FileStationError
 from synology_api.filestation import FileStation
 
@@ -52,6 +53,16 @@ class NasClient:
             raise ValueError(
                 f"NAS url must include hostname + port; got {nas_url!r}"
             )
+        # synology-api 0.8.x caches `Authentication` on a class-level
+        # attribute (`BaseApi.shared_session`) and every subsequent
+        # `FileStation()` constructor reuses it instead of logging in
+        # fresh. After DSM's idle session timeout (default ~30 min)
+        # the SID server-side is gone but the worker keeps sending
+        # it, surfacing as "Invalid session / SID not found" on the
+        # very next FileStation call. Reset before construction so
+        # each client gets a real login. See the 2026-05-03 backup
+        # worker incident.
+        BaseApi.shared_session = None
         self._fs = FileStation(
             parsed.hostname,
             parsed.port,

--- a/services/fishsense-api-workflow-worker/tests/test_nas_client.py
+++ b/services/fishsense-api-workflow-worker/tests/test_nas_client.py
@@ -1,0 +1,83 @@
+# pylint: disable=protected-access
+"""Unit tests for the api-worker's NasClient.
+
+Pins the regression for the 2026-05-03 backup-worker incident:
+synology-api 0.8.x caches `Authentication` on
+`BaseApi.shared_session` (class-level), so successive
+`FileStation()` constructors reuse the same in-memory SID across
+activity attempts. After DSM idle-times-out the session, every
+subsequent call returns "Invalid session / SID not found".
+NasClient.__init__ must reset that class attribute before
+constructing FileStation so each client gets a real login. Mirror
+of the same test in the backup-worker package.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from synology_api.base_api import BaseApi
+
+
+def test_init_resets_shared_session_before_constructing_filestation(monkeypatch):
+    """Regression: a stale `BaseApi.shared_session` from a previous
+    activity attempt must be cleared so the new FileStation()
+    constructor logs in fresh, rather than reusing an SID DSM has
+    already idle-timed-out.
+    """
+    from fishsense_api_workflow_worker import nas as sut  # pylint: disable=import-outside-toplevel
+
+    BaseApi.shared_session = MagicMock(name="stale-prior-session")
+
+    seen_shared_session: list = []
+
+    def fake_filestation(*_args, **_kwargs):
+        seen_shared_session.append(BaseApi.shared_session)
+        return MagicMock(name="fs-client")
+
+    monkeypatch.setattr(sut, "FileStation", fake_filestation)
+
+    sut.NasClient(
+        nas_url="https://nas.example.com:6021",
+        username="u",
+        password="p",
+    )
+
+    assert seen_shared_session == [None], (
+        "FileStation was constructed while BaseApi.shared_session was "
+        f"still set to {seen_shared_session[0]!r}; the stale session "
+        "would be reused and DSM would reject calls after idle timeout."
+    )
+
+
+def test_init_resets_shared_session_on_each_construction(monkeypatch):
+    """Same contract repeated across constructions — every new client
+    gets a clean class state, regardless of what the previous one
+    left behind."""
+    from fishsense_api_workflow_worker import nas as sut  # pylint: disable=import-outside-toplevel
+
+    seen_shared_session: list = []
+
+    def fake_filestation(*_args, **_kwargs):
+        seen_shared_session.append(BaseApi.shared_session)
+        BaseApi.shared_session = MagicMock(name="fresh-session")
+        return MagicMock(name="fs-client")
+
+    monkeypatch.setattr(sut, "FileStation", fake_filestation)
+
+    for _ in range(3):
+        sut.NasClient(
+            nas_url="https://nas.example.com:6021", username="u", password="p"
+        )
+
+    assert seen_shared_session == [None, None, None]
+
+
+@pytest.fixture(autouse=True)
+def _restore_shared_session():
+    """Tests touch a module-global on synology-api; restore between runs
+    so an unrelated test that imports this module isn't affected."""
+    saved = BaseApi.shared_session
+    yield
+    BaseApi.shared_session = saved

--- a/services/fishsense-backup-worker/src/fishsense_backup_worker/nas.py
+++ b/services/fishsense-backup-worker/src/fishsense_backup_worker/nas.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 from typing import List
 from urllib.parse import urlparse
 
+from synology_api.base_api import BaseApi
 from synology_api.exceptions import FileStationError
 from synology_api.filestation import FileStation
 
@@ -47,6 +48,16 @@ class NasBackupClient:
             raise ValueError(
                 f"NAS url must include hostname + port; got {nas_url!r}"
             )
+        # synology-api 0.8.x caches `Authentication` on a class-level
+        # attribute (`BaseApi.shared_session`) and every subsequent
+        # `FileStation()` constructor reuses it instead of logging in
+        # fresh. After DSM's idle session timeout (default ~30 min)
+        # the SID server-side is gone but the worker keeps sending
+        # it, surfacing as "Invalid session / SID not found" on the
+        # very next FileStation call. Reset before construction so
+        # each client gets a real login. See the 2026-05-03 backup
+        # worker incident.
+        BaseApi.shared_session = None
         self._fs = FileStation(
             parsed.hostname,
             parsed.port,

--- a/services/fishsense-backup-worker/tests/test_nas_backup_client.py
+++ b/services/fishsense-backup-worker/tests/test_nas_backup_client.py
@@ -1,0 +1,90 @@
+# pylint: disable=protected-access
+"""Unit tests for NasBackupClient.
+
+Pins the regression for the 2026-05-03 backup-worker incident:
+synology-api 0.8.x caches `Authentication` on
+`BaseApi.shared_session` (class-level), so successive
+`FileStation()` constructors reuse the same in-memory SID across
+activity attempts. After DSM idle-times-out the session, every
+subsequent call returns "Invalid session / SID not found".
+NasBackupClient.__init__ must reset that class attribute before
+constructing FileStation so each client gets a real login.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from synology_api.base_api import BaseApi
+
+
+def test_init_resets_shared_session_before_constructing_filestation(monkeypatch):
+    """Regression: a stale `BaseApi.shared_session` from a previous
+    activity attempt must be cleared so the new FileStation()
+    constructor logs in fresh, rather than reusing an SID DSM has
+    already idle-timed-out.
+    """
+    from fishsense_backup_worker import nas as sut  # pylint: disable=import-outside-toplevel
+
+    # Pretend a previous activity attempt left a session on the class.
+    BaseApi.shared_session = MagicMock(name="stale-prior-session")
+
+    seen_shared_session: list = []
+
+    def fake_filestation(*_args, **_kwargs):
+        # Capture what `BaseApi.shared_session` looks like at the
+        # moment FileStation() runs — that's the contract we care
+        # about. By the real synology-api lib's logic this is what
+        # determines whether login() runs or the stale session is
+        # reused.
+        seen_shared_session.append(BaseApi.shared_session)
+        return MagicMock(name="fs-client")
+
+    monkeypatch.setattr(sut, "FileStation", fake_filestation)
+
+    sut.NasBackupClient(
+        nas_url="https://nas.example.com:6021",
+        username="u",
+        password="p",
+    )
+
+    assert seen_shared_session == [None], (
+        "FileStation was constructed while BaseApi.shared_session was "
+        f"still set to {seen_shared_session[0]!r}; the stale session "
+        "would be reused and DSM would reject calls after idle timeout."
+    )
+
+
+def test_init_resets_shared_session_on_each_construction(monkeypatch):
+    """Same contract repeated across constructions — every new client
+    gets a clean class state, regardless of what the previous one
+    left behind."""
+    from fishsense_backup_worker import nas as sut  # pylint: disable=import-outside-toplevel
+
+    seen_shared_session: list = []
+
+    def fake_filestation(*_args, **_kwargs):
+        seen_shared_session.append(BaseApi.shared_session)
+        # Simulate the real lib's behavior: when FileStation logs in,
+        # it stores its Authentication on the class attribute.
+        BaseApi.shared_session = MagicMock(name="fresh-session")
+        return MagicMock(name="fs-client")
+
+    monkeypatch.setattr(sut, "FileStation", fake_filestation)
+
+    for _ in range(3):
+        sut.NasBackupClient(
+            nas_url="https://nas.example.com:6021", username="u", password="p"
+        )
+
+    assert seen_shared_session == [None, None, None]
+
+
+@pytest.fixture(autouse=True)
+def _restore_shared_session():
+    """Tests touch a module-global on synology-api; restore between runs
+    so an unrelated test that imports this module isn't affected."""
+    saved = BaseApi.shared_session
+    yield
+    BaseApi.shared_session = saved


### PR DESCRIPTION
## Summary

Backup workflow has been failing every attempt with `RuntimeError: FileStation create_folder /fishsense_process_work/database_backups/<db> failed: Invalid session / SID not found.` despite the same credentials and path working from `curl` on the same host.

Root cause: [`synology-api` 0.8.x caches `Authentication` on a class-level attribute](.venv/lib/python3.13/site-packages/synology_api/base_api.py#L47):

```python
class BaseApi:
    shared_session: Optional[syn.Authentication] = None

    def __init__(self, ...):
        if BaseApi.shared_session:
            self.session = BaseApi.shared_session    # reuses stale!
        else:
            self.session = syn.Authentication(...)
            self.session.login()
            BaseApi.shared_session = self.session
```

Every subsequent `FileStation()` constructor in the same Python process reuses the same in-memory SID. After DSM idle-times-out the session (default ~30 min), the SID is invalid server-side but the worker keeps sending it. Hence "Invalid session / SID not found" on the very next FileStation call. Curl works because it always logs in fresh.

Affects both NAS clients (api-worker and backup-worker share this code shape).

## Fix

Reset `BaseApi.shared_session = None` in both `NasClient.__init__` and `NasBackupClient.__init__` before constructing `FileStation`. Forces a real login per client construction.

## Tests

Per-package regression test pinning the contract: the constructor must clear `BaseApi.shared_session` *before* `FileStation()` runs, so the lib's lazy-login branch is taken. Without this, a future "clean up that weird `BaseApi` import" change could silently re-introduce the bug — the test fails the moment `FileStation` is constructed with `BaseApi.shared_session` not equal to `None`.

## Test plan

- [x] `./check.sh unit` — 439 unit tests pass (+4 from this PR), 0 failures across all 6 packages.
- [x] `./check.sh lint` — 10.00/10.
- [ ] Operational: manually trigger `BackupDatabasesWorkflow` after deploy and verify all three DB dumps reach `/fishsense_process_work/database_backups/{fishsense,superset,temporal_db}/<timestamp>.dump`.
- [ ] Watch the next scheduled `0 3 * * * UTC` firing of `fishsense-daily-db-backup` and confirm activity history shows successful upload + prune for each DB.
- [ ] After the api-worker has the corresponding deploy, watch a stage 0.1 / 2 / 5.1 / 9 archive activity hit NAS and confirm no "Invalid session" failures.

## Diagnostic that confirmed the cause

```bash
# Same host, same creds, same path — works in curl, fails in worker.
curl -sk "https://e4e-nas.ucsd.edu:6021/webapi/auth.cgi?api=SYNO.API.Auth&version=3&method=login&account=$USER&passwd=$PASS&session=FileStation&format=sid"
# -> {"data":{"sid":"..."},"success":true}

SID=$(jq -r '.data.sid' /tmp/sid.json)
curl -sk "https://e4e-nas.ucsd.edu:6021/webapi/entry.cgi?api=SYNO.FileStation.CreateFolder&version=2&method=create&force_parent=true&folder_path=/fishsense_process_work/database_backups&name=%22test_curl%22&_sid=$SID"
# -> {"data":{"folders":[{"isdir":true,"name":"test_curl",...}]},"success":true}
```

The curl succeeded because it logged in fresh; the worker failed because it reused a class-cached SID DSM had already idle-timed-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)