### PR TITLE
fix(backup-worker): isolate per-DB tempfile so parallel dumps don't race

### DIFF
--- a/services/fishsense-backup-worker/src/fishsense_backup_worker/activities/pg_dump_database.py
+++ b/services/fishsense-backup-worker/src/fishsense_backup_worker/activities/pg_dump_database.py
@@ -5,6 +5,14 @@ The dump-and-upload are intentionally one activity. If we split them,
 the tmpfile lives only on the worker pod that ran pg_dump — a retry
 on a different pod wouldn't see it. Keeping them together also means
 a partial dump never reaches the NAS.
+
+Each invocation gets its own `TemporaryDirectory`, so concurrent
+per-DB activities (the workflow fans out across `fishsense`,
+`superset`, `temporal_db` in parallel) can't collide on a shared
+`/tmp/<timestamp>.dump` filename. The 2026-05-03 incident traced to
+the prior shape: all three activities' rename targets resolved to
+the same path, the fastest-finishing one's `finally` deleted it,
+and the others raised `FileNotFoundError` on upload.
 """
 
 import asyncio
@@ -38,15 +46,13 @@ def _dump_and_upload(*, db_name: str, nas_root_path: str) -> str:
     filename = backup_filename(datetime.now(tz=timezone.utc))
     nas_dir = f"{nas_root_path.rstrip('/')}/{db_name}"
 
-    # tempfile.NamedTemporaryFile with delete=False so we can pass the
-    # path to pg_dump (which won't reuse our open handle); we delete
-    # in finally.
-    with tempfile.NamedTemporaryFile(
-        prefix=f"{db_name}-", suffix=".dump", delete=False
-    ) as tmp:
-        local_path = tmp.name
+    with tempfile.TemporaryDirectory(prefix=f"backup-{db_name}-") as tmpdir:
+        # The local path's basename is what `synology-api`'s
+        # `upload_file` preserves on the NAS, so write directly to
+        # the canonical filename inside our isolated tempdir — no
+        # rename, no shared `/tmp` path collision possible.
+        local_path = os.path.join(tmpdir, filename)
 
-    try:
         run_pg_dump(
             db_name=db_name,
             host=settings.postgres.host,
@@ -56,13 +62,6 @@ def _dump_and_upload(*, db_name: str, nas_root_path: str) -> str:
             output_path=local_path,
         )
 
-        # Rename the tmpfile to the final filename so the NAS upload
-        # carries the canonical name (synology-api's upload preserves
-        # the local file's basename).
-        renamed = os.path.join(os.path.dirname(local_path), filename)
-        os.replace(local_path, renamed)
-        local_path = renamed
-
         nas = NasBackupClient(
             nas_url=settings.e4e_nas.url,
             username=settings.e4e_nas.username,
@@ -70,11 +69,6 @@ def _dump_and_upload(*, db_name: str, nas_root_path: str) -> str:
         )
         nas.upload(dest_dir=nas_dir, src_file_path=local_path)
         return nas_dir
-    finally:
-        try:
-            os.remove(local_path)
-        except FileNotFoundError:
-            pass
 
 
 @activity.defn

--- a/services/fishsense-backup-worker/tests/test_pg_dump_database_activity.py
+++ b/services/fishsense-backup-worker/tests/test_pg_dump_database_activity.py
@@ -1,0 +1,150 @@
+# pylint: disable=protected-access
+"""Unit tests for `_dump_and_upload`.
+
+Pins the regression for the 2026-05-03 incident: when the workflow
+fans out per-DB activities in parallel, all three resolved their
+rename target to the same `/tmp/<timestamp>.dump` path, raced on
+`os.replace`, and the fastest-finishing activity's `finally`
+cleanup deleted the file out from under the others' upload —
+surfacing as `FileNotFoundError: File not found:
+/tmp/2026-05-03T06-52-46Z.dump` on the slower siblings.
+
+The fix is a per-activity `TemporaryDirectory`, so concurrent
+invocations cannot share a path. These tests assert that.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import List
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch):
+    """Dynaconf eagerly validates every Validator; seed placeholders so
+    importing the activity module doesn't fail before we get to the
+    actual test logic."""
+    monkeypatch.setenv("E4EFS_TEMPORAL__HOST", "temporal")
+    monkeypatch.setenv("E4EFS_E4E_NAS__URL", "https://nas.example.com:6021")
+    monkeypatch.setenv("E4EFS_E4E_NAS__USERNAME", "u")
+    monkeypatch.setenv("E4EFS_E4E_NAS__PASSWORD", "p")
+    monkeypatch.setenv("E4EFS_POSTGRES__HOST", "postgres")
+    monkeypatch.setenv("E4EFS_POSTGRES__USERNAME", "backup")
+    monkeypatch.setenv("E4EFS_POSTGRES__PASSWORD", "secret")
+    yield
+
+
+def test_each_invocation_uses_an_isolated_tempdir(monkeypatch):
+    """A single call must produce a path that's unique to its own
+    tempdir, not a shared `/tmp` location. This is the static
+    property that makes parallel callers safe."""
+    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+        pg_dump_database as sut,
+    )
+
+    captured: List[str] = []
+
+    def fake_pg_dump(*, output_path: str, **_kwargs):
+        # Touch the file so the (mocked) upload sees a real file.
+        with open(output_path, "wb") as fh:
+            fh.write(b"")
+        captured.append(output_path)
+
+    class FakeNas:
+        def __init__(self, **_kwargs):
+            pass
+
+        def upload(self, *, dest_dir, src_file_path):  # pylint: disable=unused-argument
+            assert os.path.exists(src_file_path), (
+                f"upload called with non-existent {src_file_path!r} — "
+                "the tempdir lifecycle is wrong"
+            )
+
+    monkeypatch.setattr(sut, "run_pg_dump", fake_pg_dump)
+    monkeypatch.setattr(sut, "NasBackupClient", FakeNas)
+
+    sut._dump_and_upload(db_name="fishsense", nas_root_path="/backups")
+
+    assert len(captured) == 1
+    # Path must be inside a per-activity tempdir whose name includes
+    # the db_name prefix — pins that an operator following a `lsof`
+    # or `ls -la /tmp` can attribute the dir to a specific activity.
+    parent = os.path.basename(os.path.dirname(captured[0]))
+    assert parent.startswith("backup-fishsense-"), (
+        f"tempdir parent {parent!r} doesn't carry the db_name prefix; "
+        "operators won't be able to identify which activity owns a "
+        "leftover dir if pg_dump ever wedges"
+    )
+
+
+def test_concurrent_calls_for_three_dbs_all_succeed(monkeypatch):
+    """Regression for the 2026-05-03 incident: three concurrent
+    `_dump_and_upload` invocations (one per DB) executing in
+    parallel threads must each upload a real file. Pre-fix, all
+    three resolved their rename target to the same
+    `/tmp/<timestamp>.dump` and the first one's `finally` would
+    delete the file before its siblings could upload, surfacing
+    as `FileNotFoundError`.
+
+    We test this by making `fake_pg_dump` block on a barrier so all
+    three threads sit between `run_pg_dump` and `nas.upload`
+    simultaneously — exactly the window the prior bug raced on.
+    """
+    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+        pg_dump_database as sut,
+    )
+
+    upload_paths: List[str] = []
+    upload_lock = threading.Lock()
+    barrier = threading.Barrier(3)
+
+    def fake_pg_dump(*, output_path: str, **_kwargs):
+        with open(output_path, "wb") as fh:
+            fh.write(b"\xff\xff")  # non-empty so a real file lands
+        # Stall until all three sibling activities have written
+        # their dump — exact window the prior bug raced on.
+        barrier.wait(timeout=5.0)
+
+    class FakeNas:
+        def __init__(self, **_kwargs):
+            pass
+
+        def upload(self, *, dest_dir, src_file_path):  # pylint: disable=unused-argument
+            assert os.path.exists(src_file_path), (
+                f"upload called with non-existent {src_file_path!r} — "
+                "a sibling's tempdir cleanup raced ahead"
+            )
+            with upload_lock:
+                upload_paths.append(src_file_path)
+
+    monkeypatch.setattr(sut, "run_pg_dump", fake_pg_dump)
+    monkeypatch.setattr(sut, "NasBackupClient", FakeNas)
+
+    threads = [
+        threading.Thread(
+            target=sut._dump_and_upload,
+            kwargs={"db_name": db, "nas_root_path": "/backups"},
+        )
+        for db in ("fishsense", "superset", "temporal_db")
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10.0)
+
+    assert all(not t.is_alive() for t in threads), "thread deadlocked"
+    assert len(upload_paths) == 3
+    # All three paths must be distinct — that's the property that
+    # rules out the cross-activity race.
+    assert len(set(upload_paths)) == 3, (
+        f"two activities resolved to the same path: {upload_paths!r}"
+    )
+    # Each path must live in its own tempdir (different parent
+    # directories).
+    parents = {os.path.dirname(p) for p in upload_paths}
+    assert len(parents) == 3, (
+        f"two activities shared a tempdir parent: {parents!r}"
+    )


### PR DESCRIPTION
## Summary

Sibling fix to #68. Once #68 lets `_dump_and_upload` get past `create_folder`, the activity now fails on `upload_file` with:

```
FileNotFoundError: File not found: /tmp/2026-05-03T06-52-46Z.dump
```

Cause: `BackupDatabasesWorkflow` fans out a `pg_dump_database` activity per DB (`fishsense`, `superset`, `temporal_db`) in parallel. All three resolve their post-dump rename target to the **same** `/tmp/<timestamp>.dump` path because `backup_filename(now)` is timestamp-only and they share a wall-clock second. `os.replace` is atomic but overwrites; the first activity's `finally` then `os.remove`s the file out from under its still-running siblings.

Worse, even when uploads succeed before the `finally` fires, the file's content is whichever activity renamed *last* — `superset`'s data could get uploaded as `fishsense`'s backup. Silent data corruption.

## Fix

Replace the [`NamedTemporaryFile` + `os.replace`](services/fishsense-backup-worker/src/fishsense_backup_worker/activities/pg_dump_database.py#L62-L63) shape with a per-activity `tempfile.TemporaryDirectory(prefix="backup-<db>-")`. Write pg_dump directly to the canonical filename inside the isolated tempdir. `synology-api`'s `upload_file` preserves the basename, so no rename is needed. The `with` block cleans up on success or failure — replaces the explicit `finally`/`os.remove`.

## Tests

- `test_each_invocation_uses_an_isolated_tempdir` — single-call static property: upload sees a real file at a path inside a per-activity tempdir whose name carries the `db_name` prefix (so an operator's `ls -la /tmp` after a wedge can attribute leftovers).
- `test_concurrent_calls_for_three_dbs_all_succeed` — direct regression for the prod incident. Three threads block on a `Barrier` *between pg_dump and upload* (exactly the window the prior bug raced on), and the test asserts each upload sees its own existing file at a distinct path with a distinct parent dir. Pre-fix this would have failed the `os.path.exists` assertion inside the mocked `upload`.

## Test plan

- [x] `./check.sh unit` — 441 unit tests pass (+2 from this PR), 0 failures across all 6 packages.
- [x] `./check.sh lint` — 10.00/10.
- [ ] Operational: after deploy of #68 + this, manually trigger `BackupDatabasesWorkflow` and confirm three distinct `.dump` files land at `/fishsense_process_work/database_backups/{fishsense,superset,temporal_db}/<timestamp>.dump`.
- [ ] Spot-check: pull each `.dump` off NAS and run `pg_restore --list` to confirm the dump's TOC matches the expected DB (catches the silent-data-corruption case if any pre-fix bytes happened to make it through).

## Relationship to #68

Independent. #68 fixes the synology-api class-cached session bug; this fixes the parallel tempfile race. They share an activity but no overlapping code paths, so either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)