### PR TITLE
feat(laser): post-sync line-fit validation of laser labels (observe-only)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -659,3 +659,49 @@ union and populate fans out across both — which is the right
 behavior during a migration window but not the desired steady
 state. Resolve by aligning `<STAGE>_PROJECT_TITLE` in the Create
 activity with whatever the operator wants as canonical.
+
+### Laser-label validation (Phase 1: observe-only)
+
+`SyncLabelStudioLaserLabelsWorkflow` (api-worker) now dispatches a
+`ValidateLaserLabelsForDiveWorkflow` child on the data-worker for
+each dive whose laser labeling is fully complete (every non-superseded
+`LaserLabel` has `completed=True`). The child fits a per-dive RANSAC
+line through the positives, flags labels >3σ off it (with a 1-px MAD
+floor for tight small-N dives), and **logs** outliers. **No
+`superseded` writes happen yet** — Phase 1 is observe-only so the
+threshold can be calibrated against real prod label distributions
+before mass-flagging.
+
+Two open follow-ups before Phase 2 (writeback):
+
+1. **Replace the vendored copy of `line_fit.py` with a real
+   dependency.** The kernel was duplicated from
+   `UCSD-E4E/2026-05-02_laser_detector` @ commit 3d5d2e8 into
+   `services/fishsense-data-processing-workflow-worker/src/.../laser_label_validation/line_fit.py`
+   because that repo says "early — nothing trained yet" and isn't
+   published. Once the laser-detector cuts a versioned release, drop
+   the vendored module and add it as a workspace / git dep in the
+   data-processing worker's `pyproject.toml`. The vendored file has a
+   header comment pointing at the source.
+
+2. **Calibrate the threshold + flip writeback on.** Phase 1 runs every
+   hour with the laser sync. After ~1 week of observe-only logs:
+   - Sample the OUTLIER log lines and confirm flagged labels are
+     genuinely wrong (cross-reference the LS task URL via
+     `label_studio_project_id` + `label_studio_task_id`).
+   - If the false-flag rate is acceptable, modify
+     `validate_laser_labels_for_dive_activity` to set
+     `superseded=True` on each flagged label via
+     `fs.labels.put_laser_label`, and remove the
+     "would set superseded=True" suffix from the OUTLIER log line.
+   - If the false-flag rate is not acceptable, raise the
+     `DEFAULT_OUTLIER_SIGMA` (currently 3.0) or the
+     `LABEL_NOISE_MAD_FLOOR_PX` (currently 1.0) in the vendored
+     `line_fit.py` based on what the logs show.
+
+   Note: stage-13 calibration consumes laser labels via the
+   `superseded=False` filter on `get_laser_labels`, so once writeback
+   is enabled an outlier-flagged label will automatically drop out of
+   subsequent calibration runs. That's the intended behavior, but the
+   first writeback run will retroactively change the input set for any
+   re-calibration — coordinate the deploy.

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/label_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/label_client.py
@@ -330,6 +330,18 @@ class LabelClient(ClientBase):
         response.raise_for_status()
         return list(response.json() or [])
 
+    async def get_dives_with_complete_laser_labeling(self) -> List[int]:
+        """Get dive IDs whose laser labeling is fully complete.
+
+        A dive qualifies iff every non-superseded `LaserLabel` on its
+        images has `completed=True` and at least one such label exists.
+        """
+        response = await self._get(
+            "/api/v1/labels/laser/dives-with-complete-labeling"
+        )
+        response.raise_for_status()
+        return list(response.json() or [])
+
     async def put_laser_label(self, image_id: int, laser_label: LaserLabel) -> int:
         """Put a laser label to an image .
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/get_dives_with_complete_laser_labeling_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/get_dives_with_complete_laser_labeling_activity.py
@@ -1,0 +1,24 @@
+"""Activity returning dive IDs whose laser labeling is fully complete."""
+
+from typing import List
+
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.utils import get_fs_client
+
+
+@activity.defn
+async def get_dives_with_complete_laser_labeling_activity() -> List[int]:
+    """Get dive IDs where every non-superseded laser label is completed.
+
+    Used by `SyncLabelStudioLaserLabelsWorkflow` after the per-project
+    sync to gate the per-dive RANSAC-line validation step on a stable
+    label population.
+    """
+    async with get_fs_client() as fs:
+        dive_ids = await fs.labels.get_dives_with_complete_laser_labeling()
+
+    activity.logger.info(
+        "Found %d dives with complete laser labeling", len(dive_ids)
+    )
+    return dive_ids

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -50,6 +50,9 @@ from fishsense_api_workflow_worker.activities.get_active_label_studio_project_id
 from fishsense_api_workflow_worker.activities.get_dive_slate_label_studio_project_ids_activity import (  # pylint: disable=line-too-long
     get_dive_slate_label_studio_project_ids_activity,
 )
+from fishsense_api_workflow_worker.activities.get_dives_with_complete_laser_labeling_activity import (  # pylint: disable=line-too-long
+    get_dives_with_complete_laser_labeling_activity,
+)
 from fishsense_api_workflow_worker.activities.get_headtail_label_studio_project_ids_activity import (  # pylint: disable=line-too-long
     get_headtail_label_studio_project_ids_activity,
 )
@@ -403,6 +406,7 @@ async def main():
                 get_laser_label_studio_project_ids_activity,
                 get_headtail_label_studio_project_ids_activity,
                 get_dive_slate_label_studio_project_ids_activity,
+                get_dives_with_complete_laser_labeling_activity,
                 get_species_label_studio_project_ids_activity,
                 sync_laser_labels_for_label_studio_project_activity,
                 sync_headtail_labels_for_label_studio_project_activity,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/sync_label_studio_laser_labels_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/sync_label_studio_laser_labels_workflow.py
@@ -4,10 +4,19 @@ import asyncio
 from datetime import timedelta
 
 from temporalio import workflow
+from temporalio.common import WorkflowIDReusePolicy
+from temporalio.exceptions import WorkflowAlreadyStartedError
 
 from fishsense_shared import ExceptionGroupErrorLogging
 
 PROJECT_CONCURRENCY = 4
+
+# Bound on concurrent per-dive validation child workflows. Each child
+# is one SDK fetch + numpy line fit (~100 points), so the cap is sized
+# to avoid pegging the api-worker on SDK roundtrips rather than CPU.
+VALIDATION_CONCURRENCY = 8
+
+DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
 
 
 @workflow.defn
@@ -51,3 +60,45 @@ class SyncLabelStudioLaserLabelsWorkflow:
             async with asyncio.TaskGroup() as tg:
                 for project_id in label_studio_project_ids:
                     tg.create_task(__run_for_project(project_id))
+
+        # Post-sync validation pass. Once the per-project syncs land,
+        # walk dives whose laser labeling is complete and fan out a
+        # RANSAC line-fit child workflow per dive on the data-worker.
+        # Phase 1 is observe-only — the child logs outlier labels but
+        # doesn't write `superseded`. Failures inside the validation
+        # pass shouldn't roll back a successful sync, so the pass is
+        # wrapped in its own ExceptionGroup logger.
+        complete_dive_ids = await workflow.execute_activity(
+            "get_dives_with_complete_laser_labeling_activity",
+            args=(),
+            schedule_to_close_timeout=timedelta(minutes=10),
+        )
+
+        validation_sem = asyncio.Semaphore(VALIDATION_CONCURRENCY)
+
+        async def __validate_dive(dive_id: int):
+            async with validation_sem:
+                try:
+                    await workflow.execute_child_workflow(
+                        "ValidateLaserLabelsForDiveWorkflow",
+                        dive_id,
+                        # Re-firing on the same complete dive every hour
+                        # is wasted work but cheap (one SDK fetch +
+                        # numpy fit). ALLOW_DUPLICATE so re-runs aren't
+                        # blocked by the prior firing's success.
+                        id=f"validate-laser-labels-{dive_id}",
+                        task_queue=DATA_PROCESSING_TASK_QUEUE,
+                        execution_timeout=timedelta(minutes=10),
+                        id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+                    )
+                except WorkflowAlreadyStartedError:
+                    workflow.logger.info(
+                        "validate-laser-labels-%d already running; "
+                        "skipping duplicate dispatch",
+                        dive_id,
+                    )
+
+        async with ExceptionGroupErrorLogging(workflow.logger):
+            async with asyncio.TaskGroup() as tg:
+                for dive_id in complete_dive_ids:
+                    tg.create_task(__validate_dive(dive_id))

--- a/services/fishsense-api-workflow-worker/tests/test_sync_label_studio_laser_labels_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_sync_label_studio_laser_labels_workflow.py
@@ -13,16 +13,36 @@ from __future__ import annotations
 import asyncio
 import uuid
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import List
 
 import pytest
-from temporalio import activity
+from temporalio import activity, workflow
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
 from fishsense_api_workflow_worker.workflows.sync_label_studio_laser_labels_workflow import (
     SyncLabelStudioLaserLabelsWorkflow,
 )
+
+
+# Stand-in for the data-worker child workflow. Lives on a separate task
+# queue so the sync workflow's `task_queue=DATA_PROCESSING_TASK_QUEUE`
+# dispatch is exercised end-to-end (instead of silently degrading to
+# "child runs on the same queue").
+DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
+
+
+@workflow.defn(name="ValidateLaserLabelsForDiveWorkflow")
+class _StubValidateChildWorkflow:
+    # pylint: disable=too-few-public-methods
+    @workflow.run
+    async def run(self, dive_id: int) -> int:
+        return await workflow.execute_activity(
+            "validate_laser_labels_for_dive_activity",
+            args=(dive_id,),
+            schedule_to_close_timeout=timedelta(minutes=5),
+        )
 
 
 @dataclass
@@ -50,12 +70,22 @@ async def test_workflow_invokes_users_then_project_ids_then_one_sync_per_project
             _Call("sync_laser_labels_for_label_studio_project_activity", (project_id,))
         )
 
+    @activity.defn(name="get_dives_with_complete_laser_labeling_activity")
+    async def stub_get_complete_dives() -> List[int]:
+        calls.append(_Call("get_dives_with_complete_laser_labeling_activity", ()))
+        return []
+
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue="test-laser-sync",
             workflows=[SyncLabelStudioLaserLabelsWorkflow],
-            activities=[stub_sync_users, stub_get_ids, stub_sync_project],
+            activities=[
+                stub_sync_users,
+                stub_get_ids,
+                stub_sync_project,
+                stub_get_complete_dives,
+            ],
         ):
             await env.client.execute_workflow(
                 SyncLabelStudioLaserLabelsWorkflow.run,
@@ -71,6 +101,12 @@ async def test_workflow_invokes_users_then_project_ids_then_one_sync_per_project
     ]
     assert len(project_calls) == 3
     assert {c.args[0] for c in project_calls} == {101, 202, 303}
+
+    # Validation step runs after the sync — confirm it's invoked even
+    # when no dives are complete.
+    assert any(
+        c.name == "get_dives_with_complete_laser_labeling_activity" for c in calls
+    )
 
 
 @pytest.mark.asyncio
@@ -89,12 +125,21 @@ async def test_workflow_with_no_projects_does_not_invoke_per_project_sync():
     async def stub_sync_project(project_id: int) -> None:
         sync_calls.append(project_id)
 
+    @activity.defn(name="get_dives_with_complete_laser_labeling_activity")
+    async def stub_get_complete_dives() -> List[int]:
+        return []
+
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue="test-laser-sync-empty",
             workflows=[SyncLabelStudioLaserLabelsWorkflow],
-            activities=[stub_sync_users, stub_get_ids, stub_sync_project],
+            activities=[
+                stub_sync_users,
+                stub_get_ids,
+                stub_sync_project,
+                stub_get_complete_dives,
+            ],
         ):
             await env.client.execute_workflow(
                 SyncLabelStudioLaserLabelsWorkflow.run,
@@ -103,6 +148,62 @@ async def test_workflow_with_no_projects_does_not_invoke_per_project_sync():
             )
 
     assert not sync_calls
+
+
+@pytest.mark.asyncio
+async def test_workflow_dispatches_validation_child_per_complete_dive():
+    """Each dive returned by get_dives_with_complete_laser_labeling_activity
+    must be dispatched to ValidateLaserLabelsForDiveWorkflow on the
+    data-worker task queue."""
+    validated: List[int] = []
+
+    @activity.defn(name="sync_users_label_studio_activity")
+    async def stub_sync_users() -> None:
+        return None
+
+    @activity.defn(name="get_laser_label_studio_project_ids_activity")
+    async def stub_get_ids() -> List[int]:
+        return []
+
+    @activity.defn(name="sync_laser_labels_for_label_studio_project_activity")
+    async def stub_sync_project(_: int) -> None:
+        return None
+
+    @activity.defn(name="get_dives_with_complete_laser_labeling_activity")
+    async def stub_get_complete_dives() -> List[int]:
+        return [10, 20, 30]
+
+    @activity.defn(name="validate_laser_labels_for_dive_activity")
+    async def stub_validate(dive_id: int) -> int:
+        validated.append(dive_id)
+        return 0
+
+    queue_parent = "test-laser-sync-validate-parent"
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=queue_parent,
+            workflows=[SyncLabelStudioLaserLabelsWorkflow],
+            activities=[
+                stub_sync_users,
+                stub_get_ids,
+                stub_sync_project,
+                stub_get_complete_dives,
+            ],
+        ):
+            async with Worker(
+                env.client,
+                task_queue=DATA_PROCESSING_TASK_QUEUE,
+                workflows=[_StubValidateChildWorkflow],
+                activities=[stub_validate],
+            ):
+                await env.client.execute_workflow(
+                    SyncLabelStudioLaserLabelsWorkflow.run,
+                    id=f"test-laser-sync-validate-{uuid.uuid4()}",
+                    task_queue=queue_parent,
+                )
+
+    assert sorted(validated) == [10, 20, 30]
 
 
 @pytest.mark.asyncio
@@ -135,12 +236,21 @@ async def test_per_project_activity_caps_concurrency_at_workflow_level():
         finally:
             in_flight -= 1
 
+    @activity.defn(name="get_dives_with_complete_laser_labeling_activity")
+    async def stub_get_complete_dives() -> List[int]:
+        return []
+
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue="test-laser-sync-conc",
             workflows=[SyncLabelStudioLaserLabelsWorkflow],
-            activities=[stub_sync_users, stub_get_ids, stub_sync_project],
+            activities=[
+                stub_sync_users,
+                stub_get_ids,
+                stub_sync_project,
+                stub_get_complete_dives,
+            ],
             max_concurrent_activities=50,
         ):
             wf_task = asyncio.create_task(

--- a/services/fishsense-api/src/fishsense_api/controllers/label_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/label_controller.py
@@ -6,6 +6,7 @@ from typing import List
 
 from fastapi import Depends, HTTPException
 from fastapi.encoders import jsonable_encoder
+from sqlalchemy import alias
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -279,6 +280,61 @@ async def get_laser_label_studio_project_ids(
             | (LaserLabel.completed.is_(None))  # pylint: disable=no-member
         )
     return list((await session.exec(query.distinct())).all())
+
+
+@app.get("/api/v1/labels/laser/dives-with-complete-labeling")
+async def get_dives_with_complete_laser_labeling(
+    session: AsyncSession = Depends(get_async_session),
+) -> List[int]:
+    """Dive IDs whose laser labeling is fully complete.
+
+    A dive qualifies iff every non-superseded `LaserLabel` for one of
+    its images has `completed=True` AND at least one such label exists.
+    Dives with zero non-superseded laser labels (no labeling activity at
+    all) are excluded — there's nothing to validate.
+
+    Backs the laser label-validation pass that runs after each laser
+    sync: validating against an in-progress dive's labels is wasted
+    effort because the line fit changes as more positives arrive.
+
+    Implemented as `(dive has at least one completed non-superseded
+    laser label) AND NOT (dive has any incomplete non-superseded laser
+    label)` — `NOT EXISTS` is portable across the prod Postgres and
+    the in-memory sqlite the integration tests use; `bool_and` would
+    work on Postgres only.
+
+    NOTE: must precede the `/api/v1/labels/laser/{image_id}` route —
+    Starlette's default path converter treats `{image_id}` as `[^/]+`,
+    so registration order is what disambiguates the literal segment.
+    """
+    logger.debug("Retrieving dive IDs with complete laser labeling")
+    incomplete = alias(LaserLabel.__table__, name="incomplete_laser_label")
+    incomplete_image = alias(Image.__table__, name="incomplete_image")
+    has_incomplete = (
+        select(incomplete.c.id)
+        .select_from(
+            incomplete.join(
+                incomplete_image, incomplete.c.image_id == incomplete_image.c.id
+            )
+        )
+        .where(incomplete_image.c.dive_id == Image.dive_id)
+        .where(incomplete.c.superseded == False)
+        .where(
+            (incomplete.c.completed == False)
+            | (incomplete.c.completed.is_(None))  # pylint: disable=no-member
+        )
+        .exists()
+    )
+    query = (
+        select(Image.dive_id)
+        .join(LaserLabel, LaserLabel.image_id == Image.id)
+        .where(LaserLabel.superseded == False)
+        .where(LaserLabel.completed == True)
+        .where(Image.dive_id != None)
+        .where(~has_incomplete)
+        .distinct()
+    )
+    return list((await session.exec(query)).all())
 
 
 @app.get("/api/v1/labels/laser/{image_id}")

--- a/services/fishsense-api/tests/test_dives_with_complete_laser_labeling_endpoint.py
+++ b/services/fishsense-api/tests/test_dives_with_complete_laser_labeling_endpoint.py
@@ -1,0 +1,203 @@
+"""SQL behavior of `GET /api/v1/labels/laser/dives-with-complete-labeling`.
+
+Pins the predicate: a dive qualifies iff every non-superseded LaserLabel
+for one of its images has `completed=True` AND at least one such label
+exists. Mirrors the in-memory-sqlite fixture style of
+test_select_next_dive_endpoints.py — testing query composition, not
+referential integrity.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+def _dive(dive_id: int):
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+
+    return Dive(
+        id=dive_id,
+        path=f"/dev/null/{dive_id}",
+        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        priority=Priority.HIGH,
+    )
+
+
+def _image(image_id: int, dive_id: int):
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    return Image(
+        id=image_id,
+        path=f"/dev/null/img-{image_id}",
+        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        checksum=f"img-{image_id:032d}"[:32],
+        dive_id=dive_id,
+    )
+
+
+def _laser_label(
+    label_id: int,
+    image_id: int,
+    *,
+    completed: bool | None,
+    superseded: bool = False,
+    project_id: int | None = 42,
+):
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    return LaserLabel(
+        id=label_id,
+        image_id=image_id,
+        completed=completed,
+        superseded=superseded,
+        label_studio_project_id=project_id,
+    )
+
+
+async def _call(session):
+    from fishsense_api.controllers.label_controller import (  # pylint: disable=import-outside-toplevel
+        get_dives_with_complete_laser_labeling,
+    )
+
+    return await get_dives_with_complete_laser_labeling(session=session)
+
+
+async def test_dive_with_only_completed_labels_qualifies(session):
+    session.add_all([_dive(1)])
+    await session.flush()
+    session.add_all([_image(11, 1), _image(12, 1)])
+    await session.flush()
+    session.add_all(
+        [
+            _laser_label(101, 11, completed=True),
+            _laser_label(102, 12, completed=True),
+        ]
+    )
+    await session.flush()
+
+    assert sorted(await _call(session)) == [1]
+
+
+async def test_dive_with_any_incomplete_label_excluded(session):
+    session.add_all([_dive(1)])
+    await session.flush()
+    session.add_all([_image(11, 1), _image(12, 1)])
+    await session.flush()
+    session.add_all(
+        [
+            _laser_label(101, 11, completed=True),
+            _laser_label(102, 12, completed=False),
+        ]
+    )
+    await session.flush()
+
+    assert await _call(session) == []
+
+
+async def test_dive_with_null_completed_label_excluded(session):
+    """`completed IS NULL` is treated as 'incomplete' to match the
+    discovery-side predicate `(completed = false OR IS NULL)`."""
+    session.add_all([_dive(1)])
+    await session.flush()
+    session.add_all([_image(11, 1), _image(12, 1)])
+    await session.flush()
+    session.add_all(
+        [
+            _laser_label(101, 11, completed=True),
+            _laser_label(102, 12, completed=None),
+        ]
+    )
+    await session.flush()
+
+    assert await _call(session) == []
+
+
+async def test_superseded_incomplete_label_does_not_block(session):
+    """Once a label is superseded it shouldn't count against the
+    completeness check — that's what the column is for."""
+    session.add_all([_dive(1)])
+    await session.flush()
+    session.add_all([_image(11, 1), _image(12, 1)])
+    await session.flush()
+    session.add_all(
+        [
+            _laser_label(101, 11, completed=True, project_id=42),
+            _laser_label(102, 12, completed=True, project_id=42),
+            # Older incomplete row in a different project, now superseded.
+            # Different project_id so the (image_id, project_id) UNIQUE
+            # constraint doesn't trip on the in-memory sqlite fixture.
+            _laser_label(103, 11, completed=False, superseded=True, project_id=99),
+        ]
+    )
+    await session.flush()
+
+    assert sorted(await _call(session)) == [1]
+
+
+async def test_dive_with_zero_labels_excluded(session):
+    """A dive with no laser labels at all has nothing to validate."""
+    session.add_all([_dive(1)])
+    await session.flush()
+    session.add_all([_image(11, 1)])
+    await session.flush()
+
+    assert await _call(session) == []
+
+
+async def test_only_superseded_labels_excluded(session):
+    """All labels superseded → no non-superseded population to
+    validate → dive is excluded."""
+    session.add_all([_dive(1)])
+    await session.flush()
+    session.add_all([_image(11, 1)])
+    await session.flush()
+    session.add_all(
+        [
+            _laser_label(101, 11, completed=True, superseded=True),
+        ]
+    )
+    await session.flush()
+
+    assert await _call(session) == []
+
+
+async def test_mixed_dives_only_complete_returned(session):
+    session.add_all([_dive(1), _dive(2), _dive(3)])
+    await session.flush()
+    session.add_all(
+        [_image(11, 1), _image(21, 2), _image(22, 2), _image(31, 3)]
+    )
+    await session.flush()
+    session.add_all(
+        [
+            # Dive 1: complete.
+            _laser_label(101, 11, completed=True),
+            # Dive 2: one complete, one incomplete -> excluded.
+            _laser_label(201, 21, completed=True),
+            _laser_label(202, 22, completed=False),
+            # Dive 3: complete.
+            _laser_label(301, 31, completed=True),
+        ]
+    )
+    await session.flush()
+
+    assert sorted(await _call(session)) == [1, 3]

--- a/services/fishsense-api/tests/test_label_route_disambiguation.py
+++ b/services/fishsense-api/tests/test_label_route_disambiguation.py
@@ -66,6 +66,10 @@ def _resolve(app, path: str) -> str | None:
             "/api/v1/labels/dive-slate/label-studio-project-ids",
             "get_dive_slate_label_studio_project_ids",
         ),
+        (
+            "/api/v1/labels/laser/dives-with-complete-labeling",
+            "get_dives_with_complete_laser_labeling",
+        ),
         ("/api/v1/labels/laser/123", "get_laser_label"),
         ("/api/v1/labels/headtail/45", "get_headtail_label"),
         ("/api/v1/labels/species/67", "get_species_label"),

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/validate_laser_labels_for_dive_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/validate_laser_labels_for_dive_activity.py
@@ -1,0 +1,136 @@
+"""Per-dive laser-label validation (observe-only).
+
+Fetches the dive's non-superseded `LaserLabel`s from fishsense-api,
+fits a RANSAC line through the positives, and logs any labels whose
+perpendicular distance exceeds the per-dive outlier threshold. The
+laser rig is fixed across a dive, so all positive laser observations
+should be colinear in image space — outliers are likely mislabeled.
+
+Phase 1 (this commit): structured logging only. No `superseded`
+writes. Once the threshold is calibrated against real prod label
+distributions, a follow-up commit flips the writeback on. See the
+"Open follow-ups" entry in the repo-root CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import numpy as np
+from fishsense_api_sdk.models.laser_label import LaserLabel
+from temporalio import activity
+
+from fishsense_data_processing_workflow_worker.activities.utils import get_fs_client
+from fishsense_data_processing_workflow_worker.laser_label_validation.line_fit import (
+    MIN_POINTS_FOR_LINE,
+    fit_dive_line,
+    flag_outliers,
+)
+
+__all__ = ["validate_laser_labels_for_dive_activity"]
+
+
+def _positive_xy(labels: List[LaserLabel]) -> tuple[np.ndarray, List[LaserLabel]]:
+    """Pull the positive (x, y) labels and the matching label objects.
+
+    A "positive" is a laser-localization label with both coordinates set.
+    Sentinel rows seeded by populate (no laser visible) and skipped
+    annotations land here as null x/y and are excluded.
+    """
+    positives = [
+        label for label in labels if label.x is not None and label.y is not None
+    ]
+    if not positives:
+        return np.empty((0, 2), dtype=float), []
+    xy = np.array(
+        [(float(label.x), float(label.y)) for label in positives], dtype=float
+    )
+    return xy, positives
+
+
+@activity.defn
+async def validate_laser_labels_for_dive_activity(dive_id: int) -> int:
+    """Run RANSAC line-fit validation for `dive_id`. Returns the number
+    of labels flagged as outliers (0 when the line isn't confident or
+    there aren't enough positives to fit).
+
+    Observe-only: results are logged via `activity.logger`; no
+    `superseded` writes happen.
+    """
+    async with get_fs_client() as fs:
+        labels = await fs.labels.get_laser_labels(dive_id) or []
+
+    if not labels:
+        activity.logger.info(
+            "dive_id=%d has no laser labels; skipping validation", dive_id
+        )
+        return 0
+
+    xy, positives = _positive_xy(labels)
+    if xy.shape[0] < MIN_POINTS_FOR_LINE:
+        activity.logger.info(
+            "dive_id=%d has %d positive laser labels (<%d); "
+            "skipping line fit",
+            dive_id,
+            xy.shape[0],
+            MIN_POINTS_FOR_LINE,
+        )
+        return 0
+
+    fit = fit_dive_line(xy)
+    if fit is None:
+        activity.logger.info(
+            "dive_id=%d: line fit returned None despite %d positives "
+            "(unexpected; check inputs)",
+            dive_id,
+            xy.shape[0],
+        )
+        return 0
+
+    activity.logger.info(
+        "dive_id=%d line fit: n=%d inliers=%d (%.0f%%) "
+        "residual_std=%.2fpx label_noise_mad=%.2fpx "
+        "line_confidence=%.1f confident=%s",
+        dive_id,
+        fit.n_points,
+        fit.inlier_count,
+        100.0 * fit.inlier_fraction,
+        fit.residual_std,
+        fit.label_noise_mad,
+        fit.line_confidence,
+        fit.is_confident,
+    )
+
+    outlier_mask = flag_outliers(xy, fit)
+    n_outliers = int(outlier_mask.sum())
+    if n_outliers == 0:
+        activity.logger.info("dive_id=%d: no outlier laser labels", dive_id)
+        return 0
+
+    perp = fit.perpendicular_distance(xy[:, 0], xy[:, 1])
+    for i, is_outlier in enumerate(outlier_mask):
+        if not is_outlier:
+            continue
+        label = positives[i]
+        activity.logger.info(
+            "dive_id=%d OUTLIER laser_label_id=%s image_id=%s "
+            "x=%.1f y=%.1f perp=%.2fpx label_studio_task_id=%s "
+            "label_studio_project_id=%s "
+            "(would set superseded=True if writeback were enabled)",
+            dive_id,
+            label.id,
+            label.image_id,
+            float(label.x),
+            float(label.y),
+            float(perp[i]),
+            label.label_studio_task_id,
+            label.label_studio_project_id,
+        )
+
+    activity.logger.info(
+        "dive_id=%d flagged %d/%d positive laser labels as outliers",
+        dive_id,
+        n_outliers,
+        xy.shape[0],
+    )
+    return n_outliers

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/laser_label_validation/__init__.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/laser_label_validation/__init__.py
@@ -1,0 +1,4 @@
+"""Laser-label validation primitives.
+
+Vendored from the standalone laser-detector repo (see ``line_fit.py``).
+"""

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/laser_label_validation/line_fit.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/laser_label_validation/line_fit.py
@@ -61,7 +61,7 @@ DEFAULT_OUTLIER_SIGMA = 3.0
 
 
 @dataclass
-class LineFit:
+class LineFit:  # pylint: disable=too-many-instance-attributes
     """A normalized line ``a*x + b*y + c = 0`` plus quality metrics."""
 
     a: float

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/laser_label_validation/line_fit.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/laser_label_validation/line_fit.py
@@ -1,0 +1,226 @@
+"""Per-dive RANSAC line fit on positive laser labels.
+
+VENDORED — DO NOT EDIT IN ISOLATION. Source of truth:
+    https://github.com/UCSD-E4E/2026-05-02_laser_detector
+    src/laser_detector/preprocessing/line_fit.py @ 3d5d2e8 (2026-05-02)
+
+The laser-detector repo is in early development ("nothing trained yet").
+We duplicated this module instead of taking a git dep so prod isn't
+coupled to a moving research repo. Replace the duplicate with a real
+import once the laser-detector publishes a stable release; see the
+"Open follow-ups" section of the repo-root CLAUDE.md.
+
+Two surface differences from the upstream module:
+
+* Upstream operates on polars DataFrames as part of its batch pipeline;
+  the public API here takes a numpy array of (x, y) positives plus a
+  thin convenience that returns outlier indices, so the caller (an
+  activity that already has a ``LaserLabel`` list from the SDK) doesn't
+  pull polars in.
+* The polars helpers ``fit_lines_per_dive`` and ``flag_label_outliers``
+  are dropped — the per-dive RANSAC / outlier kernel is the only piece
+  the validation activity needs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+# Minimum positive labels required to attempt a line fit. A degenerate fit
+# (2 points) always succeeds; we want enough redundancy for RANSAC to mean
+# something.
+MIN_POINTS_FOR_LINE = 5
+
+# RANSAC inlier tolerance in pixels (perpendicular distance). 4K frames + a
+# 3 px laser blob → ~4 px is a generous-but-not-loose tolerance for label
+# noise. Tunable; logged so we can revisit.
+RANSAC_INLIER_TOL_PX = 4.0
+
+# Max RANSAC iterations.
+RANSAC_MAX_ITERS = 200
+
+# Confidence threshold below which we say the line is ambiguous and the prior
+# should not be applied. Eigenvalue ratio (along-line spread / perp spread).
+LINE_CONFIDENCE_THRESHOLD = 5.0
+
+# MAD → consistent estimator of σ for normally distributed residuals.
+MAD_TO_SIGMA = 1.4826
+
+# Floor on the MAD-derived σ used by ``flag_outliers``. On very small dives
+# whose RANSAC inliers happen to be sub-pixel-tight, MAD collapses to ~0 and
+# every label gets flagged. Labels can't reasonably be more precise than ~1 px
+# at native 4K resolution, so any threshold below this is non-physical.
+LABEL_NOISE_MAD_FLOOR_PX = 1.0
+
+# Default σ multiple used by ``flag_outliers``. 3σ leaves a ~0.3% false-flag
+# rate under Gaussian noise, which on a typical-size dive (~100 positives) is
+# well under one expected false flag.
+DEFAULT_OUTLIER_SIGMA = 3.0
+
+
+@dataclass
+class LineFit:
+    """A normalized line ``a*x + b*y + c = 0`` plus quality metrics."""
+
+    a: float
+    b: float
+    c: float
+    n_points: int
+    inlier_count: int
+    inlier_fraction: float
+    residual_std: float  # perp-distance std among inliers, in px (RANSAC tightness)
+    label_noise_mad: float  # 1.4826 * MAD over ALL positive labels' perp distance, in px
+    line_confidence: float  # along-line spread / perp spread (covariance eigenratio)
+
+    @property
+    def is_confident(self) -> bool:
+        return self.line_confidence >= LINE_CONFIDENCE_THRESHOLD
+
+    def perpendicular_distance(self, x: np.ndarray, y: np.ndarray) -> np.ndarray:
+        """Perpendicular distance from each (x,y) to this line, in pixels."""
+        return np.abs(self.a * x + self.b * y + self.c)
+
+
+def _fit_line_total_least_squares(xy: np.ndarray) -> tuple[float, float, float]:
+    """Fit a 2D line via SVD on centered points (total least squares).
+
+    Returns normalized ``(a, b, c)`` for ``a*x + b*y + c = 0``.
+    """
+    centroid = xy.mean(axis=0)
+    centered = xy - centroid
+    # SVD: smallest singular vector is the normal to the best-fit line
+    _, _, vt = np.linalg.svd(centered, full_matrices=False)
+    normal = vt[-1]
+    a, b = float(normal[0]), float(normal[1])
+    norm = float(np.hypot(a, b))
+    if norm == 0.0:
+        return 1.0, 0.0, 0.0
+    a, b = a / norm, b / norm
+    c = float(-(a * centroid[0] + b * centroid[1]))
+    return a, b, c
+
+
+def _ransac_line(
+    xy: np.ndarray,
+    tol_px: float,
+    max_iters: int,
+    rng: np.random.Generator,
+) -> tuple[float, float, float, np.ndarray]:
+    """RANSAC line fit. Returns ``(a, b, c, inlier_mask)``."""
+    n = xy.shape[0]
+    best_inliers: np.ndarray | None = None
+    best_count = -1
+
+    for _ in range(max_iters):
+        idx = rng.choice(n, size=2, replace=False)
+        p0, p1 = xy[idx[0]], xy[idx[1]]
+        dx, dy = p1 - p0
+        norm = float(np.hypot(dx, dy))
+        if norm == 0.0:
+            continue
+        a, b = -dy / norm, dx / norm
+        c = -(a * p0[0] + b * p0[1])
+        dist = np.abs(a * xy[:, 0] + b * xy[:, 1] + c)
+        inliers = dist < tol_px
+        count = int(inliers.sum())
+        if count > best_count:
+            best_count = count
+            best_inliers = inliers
+
+    if best_inliers is None or best_count < 2:
+        a, b, c = _fit_line_total_least_squares(xy)
+        return a, b, c, np.ones(n, dtype=bool)
+
+    a, b, c = _fit_line_total_least_squares(xy[best_inliers])
+    dist = np.abs(a * xy[:, 0] + b * xy[:, 1] + c)
+    inliers = dist < tol_px
+    return a, b, c, inliers
+
+
+def _line_confidence(xy: np.ndarray, a: float, b: float) -> float:
+    """Ratio of along-line variance to perpendicular variance.
+
+    A high ratio means the points are spread out along the line (well-determined
+    direction). A low ratio means they cluster, leaving the line direction
+    ambiguous.
+    """
+    centered = xy - xy.mean(axis=0)
+    along = np.array([-b, a])
+    perp = np.array([a, b])
+    var_along = float(np.var(centered @ along))
+    var_perp = float(np.var(centered @ perp))
+    if var_perp <= 1e-9:
+        return float("inf")
+    return var_along / var_perp
+
+
+def fit_dive_line(
+    xy: np.ndarray,
+    *,
+    tol_px: float = RANSAC_INLIER_TOL_PX,
+    max_iters: int = RANSAC_MAX_ITERS,
+    rng: np.random.Generator | None = None,
+) -> LineFit | None:
+    """Fit a line to one dive's positive labels.
+
+    Returns ``None`` when fewer than ``MIN_POINTS_FOR_LINE`` positives are
+    available — RANSAC on 2-4 points is degenerate.
+    """
+    if xy.shape[0] < MIN_POINTS_FOR_LINE:
+        return None
+    rng = rng or np.random.default_rng(0)
+    a, b, c, inliers = _ransac_line(xy, tol_px=tol_px, max_iters=max_iters, rng=rng)
+    inlier_xy = xy[inliers]
+    n = xy.shape[0]
+    inlier_count = int(inliers.sum())
+
+    dist_inliers = np.abs(a * inlier_xy[:, 0] + b * inlier_xy[:, 1] + c)
+    residual_std = float(np.std(dist_inliers))
+    confidence = _line_confidence(inlier_xy, a, b)
+
+    # MAD on ALL positive labels — the population the outlier flag will be
+    # applied against. ``residual_std`` is bounded by the RANSAC tolerance and
+    # so under-states true label-noise scale; MAD is robust to the gross
+    # outliers in the tail.
+    dist_all = np.abs(a * xy[:, 0] + b * xy[:, 1] + c)
+    label_noise_mad = float(
+        MAD_TO_SIGMA * np.median(np.abs(dist_all - np.median(dist_all)))
+    )
+
+    return LineFit(
+        a=a,
+        b=b,
+        c=c,
+        n_points=n,
+        inlier_count=inlier_count,
+        inlier_fraction=inlier_count / n,
+        residual_std=residual_std,
+        label_noise_mad=label_noise_mad,
+        line_confidence=confidence,
+    )
+
+
+def flag_outliers(
+    xy: np.ndarray,
+    fit: LineFit,
+    *,
+    sigma: float = DEFAULT_OUTLIER_SIGMA,
+    mad_floor_px: float = LABEL_NOISE_MAD_FLOOR_PX,
+) -> np.ndarray:
+    """Boolean mask marking labels whose perpendicular distance to ``fit``
+    exceeds ``sigma * max(label_noise_mad, mad_floor_px)``.
+
+    Returns an all-False mask when ``fit`` is not confident — callers
+    should not act on outlier flags from a low-confidence line.
+
+    The MAD floor handles small-N dives where MAD collapses to sub-pixel
+    values and would otherwise flag every label.
+    """
+    if not fit.is_confident:
+        return np.zeros(xy.shape[0], dtype=bool)
+    effective_mad = max(fit.label_noise_mad, mad_floor_px)
+    threshold = sigma * effective_mad
+    perp = fit.perpendicular_distance(xy[:, 0], xy[:, 1])
+    return perp > threshold

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
@@ -27,6 +27,9 @@ from fishsense_data_processing_workflow_worker.activities.preprocess_laser_image
 from fishsense_data_processing_workflow_worker.activities.preprocess_slate_image import (
     preprocess_slate_image,
 )
+from fishsense_data_processing_workflow_worker.activities.validate_laser_labels_for_dive_activity import (  # noqa: E501  pylint: disable=line-too-long
+    validate_laser_labels_for_dive_activity,
+)
 from fishsense_data_processing_workflow_worker.config import configure_logging, settings
 from fishsense_data_processing_workflow_worker.workflows.dive_frame_clustering_workflow import (
     DiveFrameClusteringWorkflow,
@@ -48,6 +51,9 @@ from fishsense_data_processing_workflow_worker.workflows.preprocess_laser_images
 )
 from fishsense_data_processing_workflow_worker.workflows.preprocess_slate_images_workflow import (
     PreprocessSlateImagesWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.validate_laser_labels_for_dive_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    ValidateLaserLabelsForDiveWorkflow,
 )
 
 TASK_QUEUE_NAME = "fishsense_data_processing_queue"
@@ -81,6 +87,7 @@ async def main():
                 PreprocessHeadtailImagesWorkflow,
                 PreprocessLaserImagesWorkflow,
                 PreprocessSlateImagesWorkflow,
+                ValidateLaserLabelsForDiveWorkflow,
             ],
             activity_executor=executor,
             activities=[
@@ -91,6 +98,7 @@ async def main():
                 preprocess_headtail_image,
                 preprocess_laser_image,
                 preprocess_slate_image,
+                validate_laser_labels_for_dive_activity,
             ],
         )
 

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/validate_laser_labels_for_dive_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/validate_laser_labels_for_dive_workflow.py
@@ -1,0 +1,34 @@
+"""Workflow that runs RANSAC line-fit validation for one dive's laser labels.
+
+Thin wrapper around `validate_laser_labels_for_dive_activity`. Dispatched
+as a child workflow by `SyncLabelStudioLaserLabelsWorkflow` (api-worker)
+once a dive's laser labeling has fully completed.
+
+Per the cross-worker convention in CLAUDE.md, the api-worker decides
+*which* dives to validate (it owns the schedule + has the complete-dive
+SDK call) and the data-worker does the math (it has numpy + the future
+image-based-validation deps already wired in). Phase 1 is observe-only;
+no `superseded` writes happen yet.
+"""
+
+from datetime import timedelta
+
+from temporalio import workflow
+
+
+@workflow.defn
+class ValidateLaserLabelsForDiveWorkflow:
+    # pylint: disable=too-few-public-methods
+    """On-demand wrapper around `validate_laser_labels_for_dive_activity`.
+
+    Returns the number of labels flagged as outliers (0 when the line
+    isn't confident, no positives, etc.). Phase 1 logs flags only.
+    """
+
+    @workflow.run
+    async def run(self, dive_id: int) -> int:
+        return await workflow.execute_activity(
+            "validate_laser_labels_for_dive_activity",
+            args=(dive_id,),
+            schedule_to_close_timeout=timedelta(minutes=5),
+        )

--- a/services/fishsense-data-processing-workflow-worker/tests/test_laser_label_validation_line_fit.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_laser_label_validation_line_fit.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from fishsense_data_processing_workflow_worker.laser_label_validation.line_fit import (  # noqa: E501
+from fishsense_data_processing_workflow_worker.laser_label_validation.line_fit import (  # noqa: E501  pylint: disable=line-too-long
     LABEL_NOISE_MAD_FLOOR_PX,
     MIN_POINTS_FOR_LINE,
     fit_dive_line,

--- a/services/fishsense-data-processing-workflow-worker/tests/test_laser_label_validation_line_fit.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_laser_label_validation_line_fit.py
@@ -1,0 +1,97 @@
+"""Unit tests for the vendored RANSAC line-fit kernel.
+
+Pinning the public surface (`fit_dive_line`, `flag_outliers`) so the
+duplicate copy doesn't silently drift from the upstream laser-detector
+repo without our notice.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from fishsense_data_processing_workflow_worker.laser_label_validation.line_fit import (  # noqa: E501
+    LABEL_NOISE_MAD_FLOOR_PX,
+    MIN_POINTS_FOR_LINE,
+    fit_dive_line,
+    flag_outliers,
+)
+
+
+def _line_points(
+    n: int,
+    *,
+    slope: float = 0.5,
+    intercept: float = 100.0,
+    noise: float = 0.0,
+    seed: int = 0,
+) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    xs = np.linspace(0.0, 1000.0, n)
+    ys = slope * xs + intercept
+    if noise:
+        ys = ys + rng.normal(0.0, noise, size=n)
+    return np.column_stack([xs, ys])
+
+
+def test_fit_returns_none_below_minimum_positives():
+    xy = _line_points(MIN_POINTS_FOR_LINE - 1)
+    assert fit_dive_line(xy) is None
+
+
+def test_fit_recovers_clean_line_with_high_confidence():
+    xy = _line_points(50, slope=0.3, intercept=200.0, noise=0.0)
+    fit = fit_dive_line(xy, rng=np.random.default_rng(0))
+    assert fit is not None
+    # All points are colinear → all should be inliers and residuals tiny.
+    assert fit.inlier_count == 50
+    assert fit.inlier_fraction == pytest.approx(1.0)
+    assert fit.residual_std < 1e-6
+    # Spread along the line is large; perp variance is ~0 → confidence is huge.
+    assert fit.is_confident
+
+
+def test_fit_marks_low_confidence_when_points_cluster():
+    rng = np.random.default_rng(1)
+    # Tight cluster: along-line spread comparable to perpendicular spread.
+    xy = rng.normal(loc=[500.0, 500.0], scale=[2.0, 2.0], size=(20, 2))
+    fit = fit_dive_line(xy, rng=np.random.default_rng(0))
+    assert fit is not None
+    assert not fit.is_confident
+
+
+def test_flag_outliers_catches_off_line_label():
+    xy = _line_points(40, noise=0.5, seed=2)
+    # Inject one obvious outlier: ~50px off the line.
+    xy[10] = xy[10] + np.array([0.0, 50.0])
+    fit = fit_dive_line(xy, rng=np.random.default_rng(0))
+    assert fit is not None
+    assert fit.is_confident
+    mask = flag_outliers(xy, fit)
+    assert mask[10]
+    # No clean point should be flagged. Allow up to one false positive
+    # to absorb very-tight Gaussian tails.
+    assert mask.sum() <= 2
+
+
+def test_flag_outliers_returns_all_false_for_low_confidence_fit():
+    rng = np.random.default_rng(3)
+    xy = rng.normal(loc=[500.0, 500.0], scale=[2.0, 2.0], size=(20, 2))
+    fit = fit_dive_line(xy, rng=np.random.default_rng(0))
+    assert fit is not None
+    assert not fit.is_confident
+    assert not flag_outliers(xy, fit).any()
+
+
+def test_mad_floor_prevents_mass_flagging_when_inliers_are_subpixel_tight():
+    """On a tiny noise-free dive every label was getting flagged before
+    the floor was added — perpendicular MAD collapses to ~0 and the
+    `3σ` threshold becomes sub-pixel."""
+    xy = _line_points(MIN_POINTS_FOR_LINE + 2, noise=0.0)
+    # Bump one point by exactly the floor — should be on the borderline,
+    # not flagged.
+    xy[2] = xy[2] + np.array([0.0, LABEL_NOISE_MAD_FLOOR_PX * 2.0])
+    fit = fit_dive_line(xy, rng=np.random.default_rng(0))
+    assert fit is not None
+    if fit.is_confident:
+        assert flag_outliers(xy, fit).sum() <= 1

--- a/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_activity.py
@@ -1,0 +1,143 @@
+"""Unit tests for validate_laser_labels_for_dive_activity (observe-only).
+
+Pins the activity's contract: returns the count of flagged outliers,
+emits structured log lines for each, and never mutates the SDK side
+(no `put_laser_label` calls — Phase 1 is observe-only).
+"""
+
+from __future__ import annotations
+
+from typing import List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from temporalio.testing import ActivityEnvironment
+
+from fishsense_api_sdk.models.laser_label import LaserLabel
+from fishsense_data_processing_workflow_worker.activities import (
+    validate_laser_labels_for_dive_activity as sut,
+)
+
+
+def _label(
+    label_id: int,
+    image_id: int,
+    x: float | None,
+    y: float | None,
+    *,
+    completed: bool = True,
+    superseded: bool = False,
+) -> LaserLabel:
+    return LaserLabel(
+        id=label_id,
+        label_studio_task_id=10_000 + label_id,
+        label_studio_project_id=42,
+        x=x,
+        y=y,
+        label="kp-1",
+        updated_at=None,
+        superseded=superseded,
+        completed=completed,
+        label_studio_json=None,
+        image_id=image_id,
+        user_id=None,
+    )
+
+
+def _make_fs(labels: List[LaserLabel]):
+    fs = MagicMock()
+    fs.__aenter__ = AsyncMock(return_value=fs)
+    fs.__aexit__ = AsyncMock(return_value=None)
+    fs.labels = MagicMock()
+    fs.labels.get_laser_labels = AsyncMock(return_value=labels)
+    fs.labels.put_laser_label = AsyncMock(
+        side_effect=AssertionError(
+            "Phase 1 must not write back to fishsense-api"
+        )
+    )
+    return fs
+
+
+def _colinear_labels(n: int, *, image_id_start: int = 1000) -> List[LaserLabel]:
+    """n positives on the line y = 0.4*x + 100 with 1px Gaussian noise."""
+    import numpy as np
+
+    rng = np.random.default_rng(0)
+    xs = np.linspace(50.0, 1500.0, n)
+    ys = 0.4 * xs + 100.0 + rng.normal(0.0, 1.0, size=n)
+    return [
+        _label(label_id=i + 1, image_id=image_id_start + i, x=float(x), y=float(y))
+        for i, (x, y) in enumerate(zip(xs, ys))
+    ]
+
+
+@pytest.mark.asyncio
+async def test_returns_zero_when_no_labels(monkeypatch):
+    fs = _make_fs(labels=[])
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    env = ActivityEnvironment()
+    result = await env.run(sut.validate_laser_labels_for_dive_activity, 99)
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_returns_zero_below_minimum_positives(monkeypatch):
+    # 4 positives with x/y set, 5 sentinel-null rows. Below MIN_POINTS_FOR_LINE.
+    labels = _colinear_labels(4) + [
+        _label(label_id=900 + i, image_id=2000 + i, x=None, y=None)
+        for i in range(5)
+    ]
+    fs = _make_fs(labels)
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    env = ActivityEnvironment()
+    result = await env.run(sut.validate_laser_labels_for_dive_activity, 99)
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_clean_dive_flags_no_outliers(monkeypatch):
+    fs = _make_fs(labels=_colinear_labels(40))
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    env = ActivityEnvironment()
+    result = await env.run(sut.validate_laser_labels_for_dive_activity, 99)
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_outlier_label_is_flagged_and_reported(monkeypatch, caplog):
+    labels = _colinear_labels(40)
+    # Bump label index 5 ~50 px off the line — well above 3σ for σ≈1px.
+    labels[5].y = labels[5].y + 50.0  # type: ignore[operator]
+    fs = _make_fs(labels)
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    env = ActivityEnvironment()
+    with caplog.at_level("INFO"):
+        result = await env.run(sut.validate_laser_labels_for_dive_activity, 99)
+
+    assert result >= 1
+    # The OUTLIER log line must mention this specific laser_label_id so an
+    # operator scanning logs can find the row.
+    assert any(
+        "OUTLIER" in rec.message and f"laser_label_id={labels[5].id}" in rec.message
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_does_not_call_put_laser_label(monkeypatch):
+    """Phase 1 invariant: observe-only. The mocked put_laser_label
+    raises AssertionError if invoked, so getting through this test
+    proves the activity didn't try to write."""
+    labels = _colinear_labels(30)
+    labels[2].y = labels[2].y + 80.0  # type: ignore[operator]
+    fs = _make_fs(labels)
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    env = ActivityEnvironment()
+    await env.run(sut.validate_laser_labels_for_dive_activity, 99)
+
+    fs.labels.put_laser_label.assert_not_called()

--- a/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_activity.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import List
 from unittest.mock import AsyncMock, MagicMock
 
+import numpy as np
 import pytest
 from temporalio.testing import ActivityEnvironment
 
@@ -60,8 +61,6 @@ def _make_fs(labels: List[LaserLabel]):
 
 def _colinear_labels(n: int, *, image_id_start: int = 1000) -> List[LaserLabel]:
     """n positives on the line y = 0.4*x + 100 with 1px Gaussian noise."""
-    import numpy as np
-
     rng = np.random.default_rng(0)
     xs = np.linspace(50.0, 1500.0, n)
     ys = 0.4 * xs + 100.0 + rng.normal(0.0, 1.0, size=n)

--- a/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_workflow.py
@@ -1,0 +1,47 @@
+"""Workflow contract test for ValidateLaserLabelsForDiveWorkflow.
+
+Pins that the workflow forwards `dive_id` to the activity and returns
+its result unchanged — mirrors the shape of
+test_perform_laser_calibration_workflow.py.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import List
+
+import pytest
+from temporalio import activity
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from fishsense_data_processing_workflow_worker.workflows.validate_laser_labels_for_dive_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    ValidateLaserLabelsForDiveWorkflow,
+)
+
+
+@pytest.mark.asyncio
+async def test_workflow_invokes_activity_and_returns_outlier_count():
+    calls: List[int] = []
+
+    @activity.defn(name="validate_laser_labels_for_dive_activity")
+    async def stub_activity(dive_id: int) -> int:
+        calls.append(dive_id)
+        return 3
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-validate-laser",
+            workflows=[ValidateLaserLabelsForDiveWorkflow],
+            activities=[stub_activity],
+        ):
+            result = await env.client.execute_workflow(
+                ValidateLaserLabelsForDiveWorkflow.run,
+                123,
+                id=f"test-validate-laser-{uuid.uuid4()}",
+                task_queue="test-validate-laser",
+            )
+
+    assert calls == [123]
+    assert result == 3


### PR DESCRIPTION
## Summary

- After each laser-label sync, fan out a per-dive RANSAC line-fit validation child workflow on the data-worker for every dive whose laser labeling is fully complete (every non-superseded `LaserLabel` has `completed=True`).
- The child fits a line through positive labels (the laser rig is fixed → all observations should be colinear), flags labels >3σ off the line, and **logs** them. **No `superseded` writes happen yet** — Phase 1 is observe-only so the threshold can be calibrated against real prod label distributions before mass-flagging.
- Cross-worker placement (api-worker brains, data-worker math) follows the established stage-13/14 pattern. Sets up Phase 2+ where the heuristic line fit is replaced by an actual ML detector that needs image bytes from the file-exchange.

## Where the math comes from

The line-fit kernel is duplicated from [`UCSD-E4E/2026-05-02_laser_detector` @ 3d5d2e8](https://github.com/UCSD-E4E/2026-05-02_laser_detector/blob/3d5d2e8/src/laser_detector/preprocessing/line_fit.py) into `services/fishsense-data-processing-workflow-worker/src/.../laser_label_validation/line_fit.py` because that repo is in early development ("nothing trained yet") and isn't published. The vendored module has a header comment pointing at the source. CLAUDE.md tracks the dedup as an open follow-up.

## What's not in this PR (deliberately)

- **Writeback.** No `put_laser_label(..., superseded=True)` calls. The activity test pins this invariant — `put_laser_label` is mocked to raise `AssertionError` if invoked.
- **Threshold tuning.** Defaults are the laser-detector author's starting values (3σ, 4 px RANSAC tol, `LINE_CONFIDENCE_THRESHOLD=5.0`, `LABEL_NOISE_MAD_FLOOR_PX=1.0`). Both follow-ups are tracked in the new "Laser-label validation (Phase 1: observe-only)" section of CLAUDE.md.
- **`uv.lock` bump.** Pre-existing dirty-state in the working tree, unrelated to this work — left out so the diff stays focused.

## Test plan

- [x] `pytest` in `services/fishsense-api` — 90 passed (7 new endpoint tests + 1 new route-disambiguation entry)
- [x] `pytest` in `services/fishsense-api-workflow-worker` — 157 passed (1 new sync-workflow test that proves the validation child gets dispatched per complete dive on `fishsense_data_processing_queue`)
- [x] `pytest` in `services/fishsense-data-processing-workflow-worker` (non-integration) — 79 passed (6 line-fit unit + 5 activity unit + 1 workflow contract = 12 new)
- [ ] After merge / deploy: tail data-worker logs for ~1 week. For each `OUTLIER` line, cross-reference `label_studio_project_id` + `label_studio_task_id` against the LS task and confirm the flagged label is genuinely wrong.
- [ ] If false-flag rate is acceptable, ship Phase 2 (flip on `superseded=True` writeback). If not, raise `DEFAULT_OUTLIER_SIGMA` or `LABEL_NOISE_MAD_FLOOR_PX` based on what the logs show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)