### PR TITLE
fix(laser): timeouts + heartbeats on validate activity; .secrets.toml.example for all workers

### DIFF
--- a/deploy/worker_volumes/api_worker/config/.secrets.toml.example
+++ b/deploy/worker_volumes/api_worker/config/.secrets.toml.example
@@ -1,0 +1,37 @@
+# fishsense-api-workflow-worker secrets — TEMPLATE.
+#
+# Copy to `.secrets.toml` (gitignored — `.gitignore` matches that exact
+# filename, not this `.example`) on the orchestrator host and fill in
+# the real values. Dynaconf merges this on top of `settings.toml` at
+# worker startup; required-key set is defined by the validators in
+# services/fishsense-api-workflow-worker/src/.../config.py.
+#
+# Three credential surfaces:
+#
+# * label_studio — admin-scoped API key for the Label Studio instance
+#   at `label_studio.url`. Used by every sync_*_labels and populate_*
+#   activity. Get this from a Label Studio admin user's "Account &
+#   Settings → Access Token" page.
+#
+# * e4e_nas — Synology DSM credentials (FileStation API). Used by
+#   `stage_raw_bytes_for_dive_activity` (download .ORFs) and
+#   `archive_processed_jpegs_to_nas_activity` (upload JPEGs). Needs
+#   read on `e4e_nas.raw_root_path` and write on
+#   `processed_jpegs.nas_root_path`.
+#
+# * fishsense_api — service-account credentials the SDK presents over
+#   HTTP Basic auth to fishsense-api. The api-worker hits fishsense-api
+#   on the internal docker network (`http://fishsense-api:8000`), so
+#   it bypasses the public authentik middleware — basic auth is honored
+#   end-to-end.
+
+[label_studio]
+api_key = "<label-studio-admin-api-key>"
+
+[e4e_nas]
+username = "<dsm-service-account>"
+password = "<dsm-service-account-password>"
+
+[fishsense_api]
+username = "<service-account>"
+password = "<service-account-password>"

--- a/deploy/worker_volumes/backup_worker/config/.secrets.toml.example
+++ b/deploy/worker_volumes/backup_worker/config/.secrets.toml.example
@@ -1,0 +1,28 @@
+# fishsense-backup-worker secrets — TEMPLATE.
+#
+# Copy to `.secrets.toml` (gitignored — `.gitignore` matches that exact
+# filename, not this `.example`) on the orchestrator host and fill in
+# the real values. Dynaconf merges this on top of `settings.toml` at
+# worker startup; required-key set is defined by the validators in
+# services/fishsense-backup-worker/src/.../config.py.
+#
+# Two credential surfaces:
+#
+# * postgres — DB credentials the worker uses for `pg_dump`. The
+#   `postgres.username` ("backup") is in `settings.toml`; only the
+#   password belongs here. Role should have CONNECT + USAGE + SELECT
+#   on every database listed in `backup.databases` (default:
+#   fishsense, superset, temporal_db). The backup worker is the ONLY
+#   service in the repo with Postgres credentials — keep the role
+#   narrow.
+#
+# * e4e_nas — Synology DSM credentials (FileStation API). Used to
+#   upload nightly dumps to `backup.nas_root_path`. Needs write +
+#   delete (for retention pruning) on that path.
+
+[postgres]
+password = "<backup-role-password>"
+
+[e4e_nas]
+username = "<dsm-service-account>"
+password = "<dsm-service-account-password>"

--- a/deploy/worker_volumes/data_worker/config/.secrets.toml.example
+++ b/deploy/worker_volumes/data_worker/config/.secrets.toml.example
@@ -1,0 +1,27 @@
+# fishsense-data-processing-workflow-worker secrets — TEMPLATE.
+#
+# Copy to `.secrets.toml` (gitignored — `.gitignore` matches that exact
+# filename, not this `.example`) on the data-worker host and fill in
+# the real values. Dynaconf merges this on top of `settings.toml` at
+# worker startup; required-key set is defined by the validators in
+# services/fishsense-data-processing-workflow-worker/src/.../config.py.
+#
+# One credential surface:
+#
+# * fishsense_api — service-account credentials the SDK presents over
+#   HTTP Basic auth to fishsense-api. The data-worker is on a separate
+#   host from the orchestrator and hits the public hostname
+#   (`https://orchestrator.fishsense.e4e.ucsd.edu`), so the request
+#   goes through Traefik/authentik. Until the planned authentik
+#   basic-auth-passthrough policy lands (see project memory
+#   `project_data_worker_authentik_todo.md`), the data-worker reaches
+#   fishsense-api via the IPAllowList route and the basic-auth
+#   credentials below are still the SDK's auth header.
+#
+# By design there is no [e4e_nas] block here — the data-worker never
+# touches the NAS. The api-worker stages bytes onto the file-exchange
+# before dispatching child workflows.
+
+[fishsense_api]
+username = "<service-account>"
+password = "<service-account-password>"

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/sync_label_studio_laser_labels_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/sync_label_studio_laser_labels_workflow.py
@@ -88,7 +88,10 @@ class SyncLabelStudioLaserLabelsWorkflow:
                         # blocked by the prior firing's success.
                         id=f"validate-laser-labels-{dive_id}",
                         task_queue=DATA_PROCESSING_TASK_QUEUE,
-                        execution_timeout=timedelta(minutes=10),
+                        # Must be ≥ the child activity's
+                        # schedule_to_close (15m); see
+                        # validate_laser_labels_for_dive_workflow.py.
+                        execution_timeout=timedelta(minutes=20),
                         id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
                     )
                 except WorkflowAlreadyStartedError:

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/validate_laser_labels_for_dive_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/validate_laser_labels_for_dive_activity.py
@@ -56,9 +56,22 @@ async def validate_laser_labels_for_dive_activity(dive_id: int) -> int:
 
     Observe-only: results are logged via `activity.logger`; no
     `superseded` writes happen.
+
+    Heartbeats around the SDK fetch + each compute milestone so a
+    stalled fetch (large dive's `label_studio_json` payload over
+    Traefik) trips `heartbeat_timeout` instead of grinding all the way
+    to `schedule_to_close_timeout` with no signal of where it hung.
     """
+    activity.logger.info(
+        "dive_id=%d validation starting; fetching laser labels", dive_id
+    )
+    activity.heartbeat()
     async with get_fs_client() as fs:
         labels = await fs.labels.get_laser_labels(dive_id) or []
+    activity.logger.info(
+        "dive_id=%d fetched %d laser label rows", dive_id, len(labels)
+    )
+    activity.heartbeat()
 
     if not labels:
         activity.logger.info(

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/validate_laser_labels_for_dive_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/validate_laser_labels_for_dive_workflow.py
@@ -27,8 +27,20 @@ class ValidateLaserLabelsForDiveWorkflow:
 
     @workflow.run
     async def run(self, dive_id: int) -> int:
+        # Three-axis timeout shape:
+        #   * `start_to_close` caps a single attempt — `get_laser_labels`
+        #     on a large dive can return tens of MB of `label_studio_json`
+        #     through Traefik, so 10m gives the SDK 10s-timeout × 3-retry
+        #     ladder room to ride out a slow link without bailing early.
+        #   * `heartbeat_timeout` (1m) fires if the activity stops
+        #     heartbeating mid-fetch — converts a silent hang into a
+        #     diagnosable timeout faster than waiting for start_to_close.
+        #   * `schedule_to_close` (15m) bounds the whole thing including
+        #     any retry the workflow might trigger.
         return await workflow.execute_activity(
             "validate_laser_labels_for_dive_activity",
             args=(dive_id,),
-            schedule_to_close_timeout=timedelta(minutes=5),
+            schedule_to_close_timeout=timedelta(minutes=15),
+            start_to_close_timeout=timedelta(minutes=10),
+            heartbeat_timeout=timedelta(minutes=1),
         )


### PR DESCRIPTION
Two follow-ups from the post-merge ops investigation of #74.

## Summary

**`.secrets.toml.example` for all three workers.** Each worker's deploy config dir gets a checked-in template documenting the credential surface that has to be filled in on the host. Surfaces:
- api-worker: `label_studio.api_key`, `e4e_nas.username/password`, `fishsense_api.username/password`
- data-worker: `fishsense_api.username/password` (no NAS by design)
- backup-worker: `postgres.password`, `e4e_nas.username/password`

Was always implicit — the validators in each worker's `config.py` are the canonical list — but a fresh deploy still required reading the validator tuple to know what to put in the file. The data-worker just hit this gap when the new validate-laser-labels workflow became the first activity to actually call `get_fs_client()` against creds that hadn't been populated, throwing `'DynaBox' object has no attribute 'username'`. `.gitignore` matches `.secrets.toml` exactly, not `.secrets.toml.example` — verified with `git check-ignore`.

**Instrument + bump timeouts on `validate_laser_labels_for_dive_activity`.** A run hit `ScheduleToClose` (5m) without producing any log output, so we couldn't tell whether the SDK fetch or the line fit hung. The SDK has its own 10s httpx timeout × 3-retry ladder (~40s worst case), so 5m timing out implies a slow-but-real response (a large dive's `get_laser_labels` returns one row per image with full `label_studio_json` payloads — easily tens of MB through the public Traefik route from the data-worker host) rather than a hard network failure.

Two changes:
- Activity logs `"starting; fetching"` and `"fetched N rows"` around the SDK call, with `activity.heartbeat()` after each milestone. Next failure tells us where it hung instead of just "timed out."
- Workflow switches from a single `schedule_to_close=5m` to a three-axis shape: `start_to_close=10m` (per-attempt cap that gives the SDK retry ladder room), `heartbeat_timeout=1m` (turns a silent hang mid-fetch into a fast failure), `schedule_to_close=15m` (whole thing including any retry). Parent dispatch's `execution_timeout` bumped 10m → 20m to stay above the new `schedule_to_close`.

## Test plan

- [x] `pytest` in `services/fishsense-data-processing-workflow-worker` — unit + workflow tests for the validate activity still pass (6/6)
- [x] `pytest` in `services/fishsense-api-workflow-worker` — sync workflow tests still pass (4/4)
- [ ] After merge + deploy: trigger `SyncLabelStudioLaserLabelsWorkflow` (or wait for the next hourly firing) and check the data-worker logs for the new `dive_id=N validation starting; fetching laser labels` / `dive_id=N fetched N rows` lines. Three diagnostic outcomes if it fails again:
  - Heartbeat timeout (1m) — silent hang mid-fetch; we know within 60s where it hung
  - `start_to_close` (10m) with `"fetching"` present but no `"fetched"` — fetch genuinely takes >10m, would need server-side pagination on `/api/v1/dives/{dive_id}/labels/laser`
  - Success — wider window absorbs a slow-but-real response, prior failure was just under-budgeted

🤖 Generated with [Claude Code](https://claude.com/claude-code)