### PR TITLE
feat(laser): supersede flagged laser labels (Phase 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -660,19 +660,35 @@ behavior during a migration window but not the desired steady
 state. Resolve by aligning `<STAGE>_PROJECT_TITLE` in the Create
 activity with whatever the operator wants as canonical.
 
-### Laser-label validation (Phase 1: observe-only)
+### Laser-label validation
 
-`SyncLabelStudioLaserLabelsWorkflow` (api-worker) now dispatches a
+`SyncLabelStudioLaserLabelsWorkflow` (api-worker) dispatches a
 `ValidateLaserLabelsForDiveWorkflow` child on the data-worker for
 each dive whose laser labeling is fully complete (every non-superseded
 `LaserLabel` has `completed=True`). The child fits a per-dive RANSAC
 line through the positives, flags labels >3σ off it (with a 1-px MAD
-floor for tight small-N dives), and **logs** outliers. **No
-`superseded` writes happen yet** — Phase 1 is observe-only so the
-threshold can be calibrated against real prod label distributions
-before mass-flagging.
+floor for tight small-N dives), and **supersedes each flagged label**
+by writing `superseded=True` back through `put_laser_label`.
 
-Two open follow-ups before Phase 2 (writeback):
+Iterative-cleanup property: `get_laser_labels` filters
+`superseded=False` server-side, so a re-run on the same dive sees a
+smaller population, refits the line, and may flag additional
+borderline labels that are now visible as outliers relative to the
+cleaned inlier set. The hourly schedule re-runs against complete
+dives, so this naturally tightens over time. Each per-dive run is
+idempotent at the dive level — a partial failure mid-supersede leaves
+the previously-superseded labels in place, and the next run picks up
+where it left off.
+
+Stage 13 + 14 consequences: laser calibration and fish measurement
+both consume `LaserLabel` rows via the `superseded=False` filter, so
+once a label is superseded it disappears from those pipelines too.
+That's the intended behavior — bad labels should not feed
+calibration. If a calibration was already computed using a
+later-superseded label, the calibration row stays as-is until
+something explicitly recomputes it; there's no automatic invalidation.
+
+Open follow-up:
 
 1. **Replace the vendored copy of `line_fit.py` with a real
    dependency.** The kernel was duplicated from
@@ -684,24 +700,21 @@ Two open follow-ups before Phase 2 (writeback):
    data-processing worker's `pyproject.toml`. The vendored file has a
    header comment pointing at the source.
 
-2. **Calibrate the threshold + flip writeback on.** Phase 1 runs every
-   hour with the laser sync. After ~1 week of observe-only logs:
-   - Sample the OUTLIER log lines and confirm flagged labels are
-     genuinely wrong (cross-reference the LS task URL via
-     `label_studio_project_id` + `label_studio_task_id`).
-   - If the false-flag rate is acceptable, modify
-     `validate_laser_labels_for_dive_activity` to set
-     `superseded=True` on each flagged label via
-     `fs.labels.put_laser_label`, and remove the
-     "would set superseded=True" suffix from the OUTLIER log line.
-   - If the false-flag rate is not acceptable, raise the
-     `DEFAULT_OUTLIER_SIGMA` (currently 3.0) or the
-     `LABEL_NOISE_MAD_FLOOR_PX` (currently 1.0) in the vendored
-     `line_fit.py` based on what the logs show.
+Tuning knobs if the writeback turns out too aggressive (false-positive
+rate too high, watch the OUTLIER log lines):
 
-   Note: stage-13 calibration consumes laser labels via the
-   `superseded=False` filter on `get_laser_labels`, so once writeback
-   is enabled an outlier-flagged label will automatically drop out of
-   subsequent calibration runs. That's the intended behavior, but the
-   first writeback run will retroactively change the input set for any
-   re-calibration — coordinate the deploy.
+- Raise `DEFAULT_OUTLIER_SIGMA` (currently 3.0) — straightforward
+  threshold loosening.
+- Raise `LABEL_NOISE_MAD_FLOOR_PX` (currently 1.0) — protects
+  small-N dives where MAD collapses sub-pixel.
+- Raise `LINE_CONFIDENCE_THRESHOLD` (currently 5.0) — refuses to
+  supersede on dives whose line geometry isn't well-determined.
+  `flag_outliers` already returns all-False for non-confident fits,
+  so the practical effect is "skip more dives entirely."
+
+Reviving a superseded label (e.g., after a labeler re-opens the LS
+task and corrects the position) requires an explicit operator action
+— `get_laser_label_by_label_studio_id` filters out superseded rows so
+the existing sync path won't propagate the correction back to the DB.
+That's the same dead-letter semantic `superseded` has had for every
+other label kind; no new tooling here.

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/validate_laser_labels_for_dive_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/validate_laser_labels_for_dive_activity.py
@@ -1,15 +1,29 @@
-"""Per-dive laser-label validation (observe-only).
+"""Per-dive laser-label validation.
 
 Fetches the dive's non-superseded `LaserLabel`s from fishsense-api,
-fits a RANSAC line through the positives, and logs any labels whose
-perpendicular distance exceeds the per-dive outlier threshold. The
-laser rig is fixed across a dive, so all positive laser observations
-should be colinear in image space — outliers are likely mislabeled.
+fits a RANSAC line through the positives, and supersedes any label
+whose perpendicular distance exceeds the per-dive outlier threshold.
+The laser rig is fixed across a dive, so all positive laser
+observations should be colinear in image space — outliers are
+mislabeled and shouldn't feed downstream stage 13 calibration / stage
+14 measurement.
 
-Phase 1 (this commit): structured logging only. No `superseded`
-writes. Once the threshold is calibrated against real prod label
-distributions, a follow-up commit flips the writeback on. See the
-"Open follow-ups" entry in the repo-root CLAUDE.md.
+Phase 2 (writeback enabled): each flagged label is updated with
+`superseded=True` via `put_laser_label`. The endpoint is an upsert by
+primary key, so re-runs on a dive whose outliers have already been
+superseded are no-ops at the SDK level — `get_laser_labels` filters
+on `superseded=False` server-side, so the second run sees a smaller
+population, refits the line, and may flag additional borderline
+labels that are now visible as outliers relative to the cleaned
+inlier set. That iterative tightening is intentional.
+
+Note on labeler corrections: once a `LaserLabel` row is superseded,
+`get_laser_label_by_label_studio_id` filters it out, so a labeler
+re-opening the same Label Studio task and saving a corrected position
+will NOT propagate back to the DB through the existing sync path.
+This is the same dead-letter semantic that `superseded` has always
+had; reviving a superseded label requires an explicit operator action
+(or a future workflow that diffs LS state against superseded rows).
 """
 
 from __future__ import annotations
@@ -50,17 +64,21 @@ def _positive_xy(labels: List[LaserLabel]) -> tuple[np.ndarray, List[LaserLabel]
 
 @activity.defn
 async def validate_laser_labels_for_dive_activity(dive_id: int) -> int:
-    """Run RANSAC line-fit validation for `dive_id`. Returns the number
-    of labels flagged as outliers (0 when the line isn't confident or
-    there aren't enough positives to fit).
+    """Run RANSAC line-fit validation for `dive_id` and supersede any
+    flagged outliers. Returns the number of labels superseded (0 when
+    the line isn't confident or there aren't enough positives to fit).
 
-    Observe-only: results are logged via `activity.logger`; no
-    `superseded` writes happen.
+    Heartbeats around the SDK fetch + each compute milestone + each
+    supersede write so a stalled call (large dive's `label_studio_json`
+    payload over Traefik, slow PUT, etc.) trips `heartbeat_timeout`
+    instead of grinding to `schedule_to_close_timeout` with no signal
+    of where it hung.
 
-    Heartbeats around the SDK fetch + each compute milestone so a
-    stalled fetch (large dive's `label_studio_json` payload over
-    Traefik) trips `heartbeat_timeout` instead of grinding all the way
-    to `schedule_to_close_timeout` with no signal of where it hung.
+    Failure semantics: if any individual `put_laser_label` raises, the
+    activity raises and Temporal retries the whole activity. The
+    activity is idempotent at the dive level — already-superseded
+    labels are filtered out by `get_laser_labels` server-side, so a
+    retry sees a smaller population and re-runs the line fit cleanly.
     """
     activity.logger.info(
         "dive_id=%d validation starting; fetching laser labels", dive_id
@@ -68,80 +86,82 @@ async def validate_laser_labels_for_dive_activity(dive_id: int) -> int:
     activity.heartbeat()
     async with get_fs_client() as fs:
         labels = await fs.labels.get_laser_labels(dive_id) or []
-    activity.logger.info(
-        "dive_id=%d fetched %d laser label rows", dive_id, len(labels)
-    )
-    activity.heartbeat()
-
-    if not labels:
         activity.logger.info(
-            "dive_id=%d has no laser labels; skipping validation", dive_id
+            "dive_id=%d fetched %d laser label rows", dive_id, len(labels)
         )
-        return 0
+        activity.heartbeat()
 
-    xy, positives = _positive_xy(labels)
-    if xy.shape[0] < MIN_POINTS_FOR_LINE:
+        if not labels:
+            activity.logger.info(
+                "dive_id=%d has no laser labels; skipping validation", dive_id
+            )
+            return 0
+
+        xy, positives = _positive_xy(labels)
+        if xy.shape[0] < MIN_POINTS_FOR_LINE:
+            activity.logger.info(
+                "dive_id=%d has %d positive laser labels (<%d); "
+                "skipping line fit",
+                dive_id,
+                xy.shape[0],
+                MIN_POINTS_FOR_LINE,
+            )
+            return 0
+
+        fit = fit_dive_line(xy)
+        if fit is None:
+            activity.logger.info(
+                "dive_id=%d: line fit returned None despite %d positives "
+                "(unexpected; check inputs)",
+                dive_id,
+                xy.shape[0],
+            )
+            return 0
+
         activity.logger.info(
-            "dive_id=%d has %d positive laser labels (<%d); "
-            "skipping line fit",
+            "dive_id=%d line fit: n=%d inliers=%d (%.0f%%) "
+            "residual_std=%.2fpx label_noise_mad=%.2fpx "
+            "line_confidence=%.1f confident=%s",
             dive_id,
-            xy.shape[0],
-            MIN_POINTS_FOR_LINE,
+            fit.n_points,
+            fit.inlier_count,
+            100.0 * fit.inlier_fraction,
+            fit.residual_std,
+            fit.label_noise_mad,
+            fit.line_confidence,
+            fit.is_confident,
         )
-        return 0
 
-    fit = fit_dive_line(xy)
-    if fit is None:
-        activity.logger.info(
-            "dive_id=%d: line fit returned None despite %d positives "
-            "(unexpected; check inputs)",
-            dive_id,
-            xy.shape[0],
-        )
-        return 0
+        outlier_mask = flag_outliers(xy, fit)
+        n_outliers = int(outlier_mask.sum())
+        if n_outliers == 0:
+            activity.logger.info("dive_id=%d: no outlier laser labels", dive_id)
+            return 0
+
+        perp = fit.perpendicular_distance(xy[:, 0], xy[:, 1])
+        for i, is_outlier in enumerate(outlier_mask):
+            if not is_outlier:
+                continue
+            label = positives[i]
+            activity.logger.info(
+                "dive_id=%d OUTLIER laser_label_id=%s image_id=%s "
+                "x=%.1f y=%.1f perp=%.2fpx label_studio_task_id=%s "
+                "label_studio_project_id=%s -> superseded=True",
+                dive_id,
+                label.id,
+                label.image_id,
+                float(label.x),
+                float(label.y),
+                float(perp[i]),
+                label.label_studio_task_id,
+                label.label_studio_project_id,
+            )
+            label.superseded = True
+            await fs.labels.put_laser_label(label.image_id, label)
+            activity.heartbeat()
 
     activity.logger.info(
-        "dive_id=%d line fit: n=%d inliers=%d (%.0f%%) "
-        "residual_std=%.2fpx label_noise_mad=%.2fpx "
-        "line_confidence=%.1f confident=%s",
-        dive_id,
-        fit.n_points,
-        fit.inlier_count,
-        100.0 * fit.inlier_fraction,
-        fit.residual_std,
-        fit.label_noise_mad,
-        fit.line_confidence,
-        fit.is_confident,
-    )
-
-    outlier_mask = flag_outliers(xy, fit)
-    n_outliers = int(outlier_mask.sum())
-    if n_outliers == 0:
-        activity.logger.info("dive_id=%d: no outlier laser labels", dive_id)
-        return 0
-
-    perp = fit.perpendicular_distance(xy[:, 0], xy[:, 1])
-    for i, is_outlier in enumerate(outlier_mask):
-        if not is_outlier:
-            continue
-        label = positives[i]
-        activity.logger.info(
-            "dive_id=%d OUTLIER laser_label_id=%s image_id=%s "
-            "x=%.1f y=%.1f perp=%.2fpx label_studio_task_id=%s "
-            "label_studio_project_id=%s "
-            "(would set superseded=True if writeback were enabled)",
-            dive_id,
-            label.id,
-            label.image_id,
-            float(label.x),
-            float(label.y),
-            float(perp[i]),
-            label.label_studio_task_id,
-            label.label_studio_project_id,
-        )
-
-    activity.logger.info(
-        "dive_id=%d flagged %d/%d positive laser labels as outliers",
+        "dive_id=%d superseded %d/%d positive laser labels",
         dive_id,
         n_outliers,
         xy.shape[0],

--- a/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_activity.py
@@ -1,8 +1,8 @@
-"""Unit tests for validate_laser_labels_for_dive_activity (observe-only).
+"""Unit tests for validate_laser_labels_for_dive_activity.
 
 Pins the activity's contract: returns the count of flagged outliers,
-emits structured log lines for each, and never mutates the SDK side
-(no `put_laser_label` calls — Phase 1 is observe-only).
+emits a structured OUTLIER log line for each, and calls
+`put_laser_label` with `superseded=True` once per flagged label.
 """
 
 from __future__ import annotations
@@ -51,10 +51,10 @@ def _make_fs(labels: List[LaserLabel]):
     fs.__aexit__ = AsyncMock(return_value=None)
     fs.labels = MagicMock()
     fs.labels.get_laser_labels = AsyncMock(return_value=labels)
+    # put_laser_label echoes the row id back like the real endpoint
+    # (status_code=201, body is the persisted row id).
     fs.labels.put_laser_label = AsyncMock(
-        side_effect=AssertionError(
-            "Phase 1 must not write back to fishsense-api"
-        )
+        side_effect=lambda image_id, label: label.id or 0
     )
     return fs
 
@@ -96,13 +96,16 @@ async def test_returns_zero_below_minimum_positives(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_clean_dive_flags_no_outliers(monkeypatch):
+async def test_clean_dive_flags_no_outliers_and_does_not_write(monkeypatch):
     fs = _make_fs(labels=_colinear_labels(40))
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
 
     env = ActivityEnvironment()
     result = await env.run(sut.validate_laser_labels_for_dive_activity, 99)
     assert result == 0
+    # No outliers → no writes. Pins that the activity doesn't ever
+    # supersede a clean dive's labels.
+    fs.labels.put_laser_label.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -127,16 +130,45 @@ async def test_outlier_label_is_flagged_and_reported(monkeypatch, caplog):
 
 
 @pytest.mark.asyncio
-async def test_does_not_call_put_laser_label(monkeypatch):
-    """Phase 1 invariant: observe-only. The mocked put_laser_label
-    raises AssertionError if invoked, so getting through this test
-    proves the activity didn't try to write."""
-    labels = _colinear_labels(30)
-    labels[2].y = labels[2].y + 80.0  # type: ignore[operator]
+async def test_supersedes_each_flagged_outlier(monkeypatch):
+    """Phase 2 invariant: every flagged outlier gets `superseded=True`
+    written back via `put_laser_label`. Two outliers in this fixture so
+    the assertion catches both an off-by-one and a "wrote only the
+    first" regression."""
+    labels = _colinear_labels(40)
+    labels[3].y = labels[3].y + 60.0  # type: ignore[operator]
+    labels[17].y = labels[17].y - 70.0  # type: ignore[operator]
     fs = _make_fs(labels)
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
 
     env = ActivityEnvironment()
-    await env.run(sut.validate_laser_labels_for_dive_activity, 99)
+    result = await env.run(sut.validate_laser_labels_for_dive_activity, 99)
 
-    fs.labels.put_laser_label.assert_not_called()
+    assert result == 2
+    # One PUT per flagged outlier, each carrying the matching image_id
+    # and a `superseded=True` body.
+    assert fs.labels.put_laser_label.await_count == 2
+    written_image_ids = {
+        call.args[0] for call in fs.labels.put_laser_label.call_args_list
+    }
+    assert written_image_ids == {labels[3].image_id, labels[17].image_id}
+    for call in fs.labels.put_laser_label.call_args_list:
+        _, written_label = call.args
+        assert written_label.superseded is True
+
+
+@pytest.mark.asyncio
+async def test_supersede_failure_propagates(monkeypatch):
+    """If the writeback raises, the activity raises so Temporal retries
+    the whole run rather than silently leaving outliers in place."""
+    labels = _colinear_labels(30)
+    labels[2].y = labels[2].y + 80.0  # type: ignore[operator]
+    fs = _make_fs(labels)
+    fs.labels.put_laser_label = AsyncMock(
+        side_effect=RuntimeError("simulated PUT failure")
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    env = ActivityEnvironment()
+    with pytest.raises(RuntimeError, match="simulated PUT failure"):
+        await env.run(sut.validate_laser_labels_for_dive_activity, 99)


### PR DESCRIPTION
Flips on the writeback step planned in #74. After ~a week of Phase 1 observe-only with no false-flag complaints in the data-worker's `OUTLIER` log lines, `validate_laser_labels_for_dive_activity` now mutates each flagged `LaserLabel` to `superseded=True` and PUTs it back through `fs.labels.put_laser_label`.

## Summary

- **Writeback enabled.** One PUT per flagged outlier, with `activity.heartbeat()` between each so a slow PUT trips `heartbeat_timeout=1m` (configured in #79) instead of `schedule_to_close=15m`.
- **Idempotent at the dive level.** `get_laser_labels` filters `superseded=False` server-side, so a retry of a partially-failed run sees a smaller population, refits the line, and re-flags whatever's left. Successful supersedes from the failed attempt are not undone.
- **Iterative tightening.** Re-running on a previously-cleaned dive may flag additional borderline labels that the first pass left in (the inlier set is smaller and tighter). The hourly schedule re-runs against complete dives, so this converges naturally.

## Stage 13/14 consequences

Both stage-13 calibration and stage-14 measurement consume `LaserLabel` rows via the `superseded=False` filter, so once a label is superseded it disappears from those pipelines too. **A calibration that was already computed against a now-superseded label stays as-is** — there's no automatic invalidation. If you want a re-calibration to incorporate the cleanup, drop the existing `LaserExtrinsics` row and the cohort selector will pick the dive back up.

## Reviving a superseded label

Once a label is superseded, `get_laser_label_by_label_studio_id` filters it out, so a labeler re-opening the LS task and saving a corrected position will NOT propagate back to the DB through the existing sync path. This is the same dead-letter semantic that `superseded` has had for every other label kind — no new tooling here. Reviving requires explicit operator action against the DB.

## Tuning knobs (if false-positive rate is too high)

Watch the OUTLIER log lines, then turn one of these in `services/fishsense-data-processing-workflow-worker/src/.../laser_label_validation/line_fit.py`:

- `DEFAULT_OUTLIER_SIGMA` (currently 3.0) — straightforward threshold loosening.
- `LABEL_NOISE_MAD_FLOOR_PX` (currently 1.0) — protects small-N dives where MAD collapses sub-pixel.
- `LINE_CONFIDENCE_THRESHOLD` (currently 5.0) — refuses to supersede on dives whose line geometry isn't well-determined. Practical effect is "skip more dives entirely."

## Test plan

- [x] `pytest` in `services/fishsense-data-processing-workflow-worker` (non-integration) — 80 passed (3 new/changed tests under `test_validate_laser_labels_for_dive_activity.py` pin the new write contract: clean dive → no PUT, outliers → one PUT each with `superseded=True`, PUT failure propagates so Temporal retries instead of silently dropping outliers).
- [x] `pylint` on the activity + tests — 10/10.
- [ ] After merge + deploy: tail the data-worker logs for the next hourly firing. The OUTLIER log line ends in `-> superseded=True` instead of the Phase-1 "would set superseded=True if writeback were enabled" suffix. Cross-reference one or two against the LS task URL to spot-check the line fit on real dives.
- [ ] Sanity-check `LaserLabel` row counts before/after on a known-noisy dive: `SELECT count(*) FROM laserlabel WHERE superseded = TRUE` should grow by the expected outlier count, not by orders of magnitude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)