### PR TITLE
fix(laser): supersede PUTs run concurrently, capped at 8

### DIFF
--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/validate_laser_labels_for_dive_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/validate_laser_labels_for_dive_activity.py
@@ -28,6 +28,7 @@ had; reviving a superseded label requires an explicit operator action
 
 from __future__ import annotations
 
+import asyncio
 from typing import List
 
 import numpy as np
@@ -41,7 +42,16 @@ from fishsense_data_processing_workflow_worker.laser_label_validation.line_fit i
     flag_outliers,
 )
 
-__all__ = ["validate_laser_labels_for_dive_activity"]
+__all__ = ["validate_laser_labels_for_dive_activity", "SUPERSEDE_CONCURRENCY"]
+
+# Bound on concurrent supersede PUTs per dive. A dive with many flagged
+# outliers was blowing `start_to_close` (10m) on sequential PUTs because
+# the SDK's 10s-timeout × 3-retry ladder per PUT compounds linearly. With
+# a cap of 8, the budget is N/8 × per-PUT cost — comfortable for any
+# realistic outlier count. The cap also keeps a single dive from hogging
+# every outbound HTTP slot when multiple validate workflows run in
+# parallel against different dives.
+SUPERSEDE_CONCURRENCY = 8
 
 
 def _positive_xy(labels: List[LaserLabel]) -> tuple[np.ndarray, List[LaserLabel]]:
@@ -139,6 +149,7 @@ async def validate_laser_labels_for_dive_activity(dive_id: int) -> int:
             return 0
 
         perp = fit.perpendicular_distance(xy[:, 0], xy[:, 1])
+        flagged: list[LaserLabel] = []
         for i, is_outlier in enumerate(outlier_mask):
             if not is_outlier:
                 continue
@@ -157,8 +168,23 @@ async def validate_laser_labels_for_dive_activity(dive_id: int) -> int:
                 label.label_studio_project_id,
             )
             label.superseded = True
-            await fs.labels.put_laser_label(label.image_id, label)
-            activity.heartbeat()
+            flagged.append(label)
+
+        # Concurrent supersede PUTs, capped by SUPERSEDE_CONCURRENCY.
+        # `asyncio.gather` (return_exceptions=False) raises the first
+        # exception bare — matches the existing failure-propagation
+        # contract (TaskGroup would wrap in ExceptionGroup) — and lets
+        # already-in-flight tasks run to completion, so partial
+        # supersede progress survives a single failed PUT and the
+        # next retry of the activity sees the cleaned subset.
+        sem = asyncio.Semaphore(SUPERSEDE_CONCURRENCY)
+
+        async def _supersede(label: LaserLabel) -> None:
+            async with sem:
+                await fs.labels.put_laser_label(label.image_id, label)
+                activity.heartbeat()
+
+        await asyncio.gather(*(_supersede(label) for label in flagged))
 
     activity.logger.info(
         "dive_id=%d superseded %d/%d positive laser labels",

--- a/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_activity.py
@@ -7,6 +7,7 @@ emits a structured OUTLIER log line for each, and calls
 
 from __future__ import annotations
 
+import asyncio
 import re
 from typing import List
 from unittest.mock import AsyncMock, MagicMock
@@ -310,6 +311,68 @@ async def test_inlier_fraction_strictly_improves_after_supersede(
     # point is an inlier).
     assert second_fraction > first_fraction
     assert second_fraction == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_supersede_writes_run_concurrently(monkeypatch):
+    """Phase 2 PUTs must run concurrently (not sequentially). A dive
+    with many flagged outliers was blowing `start_to_close` on
+    sequential PUTs through Traefik — the supersede loop has to
+    parallelize, capped at `SUPERSEDE_CONCURRENCY` so we don't
+    saturate the data-worker's outbound HTTP slots or hammer the API.
+
+    Side_effect is gated on an `asyncio.Event` so the test can
+    observe `peak_in_flight`: with sequential it would be 1; with
+    unbounded it would be `n_outliers`; with the cap it should equal
+    `SUPERSEDE_CONCURRENCY`."""
+    # 16 outliers, twice the cap, so we can observe saturation rather
+    # than just "more than one in flight."
+    n_outliers = 2 * sut.SUPERSEDE_CONCURRENCY
+    labels = _colinear_labels(60)
+    outlier_idxs = list(range(0, n_outliers * 2, 2))[:n_outliers]
+    for idx in outlier_idxs:
+        labels[idx].y = labels[idx].y + 50.0  # type: ignore[operator]
+
+    in_flight = 0
+    peak_in_flight = 0
+    release = asyncio.Event()
+
+    async def gated_put(_image_id: int, label: LaserLabel) -> int:
+        nonlocal in_flight, peak_in_flight
+        in_flight += 1
+        peak_in_flight = max(peak_in_flight, in_flight)
+        try:
+            await release.wait()
+        finally:
+            in_flight -= 1
+        return label.id or 0
+
+    fs = MagicMock()
+    fs.__aenter__ = AsyncMock(return_value=fs)
+    fs.__aexit__ = AsyncMock(return_value=None)
+    fs.labels = MagicMock()
+    fs.labels.get_laser_labels = AsyncMock(return_value=labels)
+    fs.labels.put_laser_label = AsyncMock(side_effect=gated_put)
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    env = ActivityEnvironment()
+    activity_task = asyncio.create_task(
+        env.run(sut.validate_laser_labels_for_dive_activity, 99)
+    )
+    # Let the activity get going and saturate the cap. The PUT
+    # side_effect blocks on `release`, so this sleep is bounded by
+    # how long the line-fit + log-emission takes (sub-second on this
+    # fixture size).
+    await asyncio.sleep(0.5)
+    assert peak_in_flight == sut.SUPERSEDE_CONCURRENCY, (
+        f"peak in flight was {peak_in_flight}, "
+        f"expected exactly {sut.SUPERSEDE_CONCURRENCY}"
+    )
+    release.set()
+    result = await activity_task
+
+    assert result == n_outliers
+    assert fs.labels.put_laser_label.await_count == n_outliers
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Symptom

Prod: `validate_laser_labels_for_dive_activity` tasks timing out under Phase 2.

## Diagnosis

The supersede loop in #83 awaited each `put_laser_label` sequentially, so a dive with N flagged outliers paid `N × per-PUT cost`. With the SDK's 10s-timeout × 3-retry ladder (~36s worst case per PUT) plus any Traefik latency, even modestly populated dives blew the 10m `start_to_close`.

## Fix

Fan the supersede PUTs out concurrently with `asyncio.gather`, gated by `Semaphore(SUPERSEDE_CONCURRENCY=8)`. Budget is now `(N / 8) × per-PUT cost` — comfortable for any realistic outlier count. The cap also keeps a single dive from hogging every outbound HTTP slot when multiple validate workflows run in parallel against different dives.

`asyncio.gather` chosen over `asyncio.TaskGroup` deliberately so the first PUT exception propagates **bare** — TaskGroup wraps in `ExceptionGroup` which would break `test_supersede_failure_propagates`. Already-in-flight tasks run to completion, so partial supersede progress survives a single failed PUT and the next retry of the activity sees the cleaned subset (per the dive-level idempotency property pinned by `test_rerun_after_supersede_is_a_noop`).

## TDD ordering

Per the saved preference: failing test first, refactor second.

1. Wrote `test_supersede_writes_run_concurrently` — gates PUT side-effects on an `asyncio.Event`, runs the activity in a background task, asserts `peak_in_flight == SUPERSEDE_CONCURRENCY`. With the prior sequential implementation, peak=1 → test fails on assertion.
2. Then added `SUPERSEDE_CONCURRENCY=8` constant and refactored the loop. Test now passes with peak=8.

## Test plan

- [x] `pytest` — 9/9 in the activity test file (8 from main + 1 new), 83/83 in the full non-integration suite.
- [x] `pylint` — 10/10 on the changed activity + test files.
- [ ] After merge + deploy: tail data-worker logs for the next firing of a previously-timing-out dive. Should see N parallel `OUTLIER ... -> superseded=True` log lines clustered tightly in time, then `superseded N/M positive laser labels`, all within `start_to_close=10m`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)