### PR TITLE
fix(laser): pump heartbeats during slow get_laser_labels

### DIFF
--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/validate_laser_labels_for_dive_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/validate_laser_labels_for_dive_activity.py
@@ -29,7 +29,8 @@ had; reviving a superseded label requires an explicit operator action
 from __future__ import annotations
 
 import asyncio
-from typing import List
+import contextlib
+from typing import AsyncIterator, List
 
 import numpy as np
 from fishsense_api_sdk.models.laser_label import LaserLabel
@@ -42,7 +43,11 @@ from fishsense_data_processing_workflow_worker.laser_label_validation.line_fit i
     flag_outliers,
 )
 
-__all__ = ["validate_laser_labels_for_dive_activity", "SUPERSEDE_CONCURRENCY"]
+__all__ = [
+    "validate_laser_labels_for_dive_activity",
+    "SUPERSEDE_CONCURRENCY",
+    "HEARTBEAT_INTERVAL_SECONDS",
+]
 
 # Bound on concurrent supersede PUTs per dive. A dive with many flagged
 # outliers was blowing `start_to_close` (10m) on sequential PUTs because
@@ -52,6 +57,44 @@ __all__ = ["validate_laser_labels_for_dive_activity", "SUPERSEDE_CONCURRENCY"]
 # every outbound HTTP slot when multiple validate workflows run in
 # parallel against different dives.
 SUPERSEDE_CONCURRENCY = 8
+
+# Background-pump heartbeat cadence. Comfortably under the workflow's
+# `heartbeat_timeout=1m` so a single missed pump tick still leaves a
+# safety margin. The pump is what stops a slow `get_laser_labels`
+# response — httpx applies its `read` timeout per byte-gap rather than
+# to the whole download, so a slowly-streamed multi-MB body can keep
+# reading for minutes without tripping httpx but well past our
+# heartbeat window.
+HEARTBEAT_INTERVAL_SECONDS = 30.0
+
+
+@contextlib.asynccontextmanager
+async def _heartbeat_pump() -> AsyncIterator[None]:
+    """Background task that pumps `activity.heartbeat()` every
+    `HEARTBEAT_INTERVAL_SECONDS` so a single slow await inside the
+    activity body can't trip the workflow's `heartbeat_timeout`.
+
+    The explicit per-call `activity.heartbeat()` lines elsewhere in
+    the activity stay in place — they're cheap and bracket the
+    interesting milestones for diagnostics. The pump exists for the
+    case where one of those awaits is itself slow.
+    """
+
+    async def _pump() -> None:
+        try:
+            while True:
+                await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
+                activity.heartbeat()
+        except asyncio.CancelledError:
+            return
+
+    task = asyncio.create_task(_pump())
+    try:
+        yield
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
 
 
 def _positive_xy(labels: List[LaserLabel]) -> tuple[np.ndarray, List[LaserLabel]]:
@@ -94,7 +137,7 @@ async def validate_laser_labels_for_dive_activity(dive_id: int) -> int:
         "dive_id=%d validation starting; fetching laser labels", dive_id
     )
     activity.heartbeat()
-    async with get_fs_client() as fs:
+    async with _heartbeat_pump(), get_fs_client() as fs:
         labels = await fs.labels.get_laser_labels(dive_id) or []
         activity.logger.info(
             "dive_id=%d fetched %d laser label rows", dive_id, len(labels)

--- a/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_activity.py
@@ -314,6 +314,55 @@ async def test_inlier_fraction_strictly_improves_after_supersede(
 
 
 @pytest.mark.asyncio
+async def test_heartbeats_fire_during_slow_get_laser_labels(monkeypatch):
+    """A dive with thousands of laser labels can produce a
+    `get_laser_labels` response large enough that the streamed read
+    exceeds `heartbeat_timeout=1m` even though the SDK's per-attempt
+    `httpx` `read` timeout is 10s — httpx applies its read timeout per
+    byte-gap, not to the whole download, so a slowly-streamed multi-MB
+    body just keeps reading until done. The activity must pump
+    heartbeats on a fixed interval independent of the await on the GET
+    so `heartbeat_timeout` doesn't fire mid-fetch.
+
+    Test shape: lower the pump interval to 0.05s, mock the GET to
+    sleep 0.3s, count `activity.heartbeat` calls. With a working pump
+    we get ~6 pump-driven calls plus the explicit before/after calls.
+    Without a pump (the prior implementation) only the 2 explicit
+    calls fire — assert >= 4 to leave headroom."""
+    monkeypatch.setattr(sut, "HEARTBEAT_INTERVAL_SECONDS", 0.05)
+
+    heartbeat_calls = 0
+
+    def count_heartbeat(*_args, **_kwargs):
+        nonlocal heartbeat_calls
+        heartbeat_calls += 1
+
+    monkeypatch.setattr(sut.activity, "heartbeat", count_heartbeat)
+
+    slow_get_duration = 0.3
+
+    async def slow_get_laser_labels(_dive_id: int):
+        await asyncio.sleep(slow_get_duration)
+        return []
+
+    fs = MagicMock()
+    fs.__aenter__ = AsyncMock(return_value=fs)
+    fs.__aexit__ = AsyncMock(return_value=None)
+    fs.labels = MagicMock()
+    fs.labels.get_laser_labels = AsyncMock(side_effect=slow_get_laser_labels)
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    env = ActivityEnvironment()
+    await env.run(sut.validate_laser_labels_for_dive_activity, 99)
+
+    assert heartbeat_calls >= 4, (
+        f"expected >= 4 heartbeat calls during a {slow_get_duration}s GET "
+        "with pump interval 0.05s (~6 pump fires + explicit calls); "
+        f"got {heartbeat_calls} — pump is not running"
+    )
+
+
+@pytest.mark.asyncio
 async def test_supersede_writes_run_concurrently(monkeypatch):
     """Phase 2 PUTs must run concurrently (not sequentially). A dive
     with many flagged outliers was blowing `start_to_close` on


### PR DESCRIPTION
## Symptom

Prod (after #87 merged): `validate_laser_labels_for_dive_activity` hit `heartbeat_timeout` (then `schedule_to_close` after retries) on a dive big enough that `get_laser_labels` ran for >60s.

```
{
  "message": "Activity task timed out",
  "cause": {
    "message": "activity ScheduleToClose timeout",
    "cause": {
      "message": "activity Heartbeat timeout",
      "timeoutFailureInfo": { "timeoutType": "TIMEOUT_TYPE_HEARTBEAT" }
    }
  }
}
```

## Diagnosis

The SDK's `httpx` `timeout=10` is a **per-byte-gap** read timeout, not a total-duration cap — a server that streams a multi-MB response slowly stays under the per-byte timeout while running well past our 60s heartbeat budget. The activity heartbeated only at discrete milestones (before fetch, after fetch, post-PUT in the supersede loop), so a slow fetch was a heartbeat-silent window. #87's concurrent-supersede fix solved the post-fetch budget but didn't help the pre-fetch one.

## Fix

`_heartbeat_pump` async context manager spawns a background task that calls `activity.heartbeat()` every `HEARTBEAT_INTERVAL_SECONDS=30s` for the lifetime of the wrapped block, cancelled and joined cleanly on exit. The activity's fs-client + computation block is wrapped in the pump so the cadence is guaranteed regardless of which await we're stuck on.

The explicit per-call `activity.heartbeat()` lines stay in place — they're cheap and bracket the interesting milestones for diagnostics. The pump is the safety net for slow individual awaits.

## TDD ordering

Per the saved preference: failing test first.

1. Wrote `test_heartbeats_fire_during_slow_get_laser_labels` — lowers the pump interval to 0.05s, mocks `get_laser_labels` to sleep 0.3s, counts `activity.heartbeat` calls and asserts ≥4. Pre-pump the count is 2 (only explicit before/after calls); with the pump running the count is ~8. Test was committed-thought against the pre-pump code and turned green only after the implementation.

## Test plan

- [x] `pytest` — 10/10 in the activity test file (9 from main + 1 new), 84/84 in the full non-integration suite.
- [x] `pylint` — 10/10 on the changed activity + test files.
- [ ] After merge + deploy: tail data-worker logs for the next firing of a previously-timing-out big dive. Heartbeats should fire every ~30s in the activity task's worker logs (or be visible via `temporal workflow show` on the run). The activity should complete inside `start_to_close=10m` with a `superseded N/M` line at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)