### PR TITLE
fix(laser): refuse to supersede when outlier fraction > 50%

### DIFF
--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/validate_laser_labels_for_dive_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/validate_laser_labels_for_dive_activity.py
@@ -47,6 +47,7 @@ __all__ = [
     "validate_laser_labels_for_dive_activity",
     "SUPERSEDE_CONCURRENCY",
     "HEARTBEAT_INTERVAL_SECONDS",
+    "MAX_OUTLIER_FRACTION",
 ]
 
 # Bound on concurrent supersede PUTs per dive. A dive with many flagged
@@ -57,6 +58,16 @@ __all__ = [
 # every outbound HTTP slot when multiple validate workflows run in
 # parallel against different dives.
 SUPERSEDE_CONCURRENCY = 8
+
+# Safety gate: refuse to supersede when more than this fraction of a
+# dive's positive labels would be flagged. At >50% the line fit is
+# more likely to be degenerate (a small accidentally-aligned cluster
+# being picked over the real majority) than the labelers being wrong
+# at that rate. Empirically prod has ~6 dives at 50%+ supersede rate
+# that are almost certainly degenerate fits — refusing to act on them
+# costs us nothing (the labels stay as-is, available for manual
+# review) and prevents propagating the line-fit error to the DB.
+MAX_OUTLIER_FRACTION = 0.5
 
 # Background-pump heartbeat cadence. Comfortably under the workflow's
 # `heartbeat_timeout=1m` so a single missed pump tick still leaves a
@@ -189,6 +200,20 @@ async def validate_laser_labels_for_dive_activity(dive_id: int) -> int:
         n_outliers = int(outlier_mask.sum())
         if n_outliers == 0:
             activity.logger.info("dive_id=%d: no outlier laser labels", dive_id)
+            return 0
+
+        outlier_fraction = n_outliers / xy.shape[0]
+        if outlier_fraction > MAX_OUTLIER_FRACTION:
+            activity.logger.warning(
+                "dive_id=%d would supersede %d/%d positive laser labels "
+                "(%.0f%%, gate=%.0f%%); refusing — line fit is likely "
+                "degenerate. Labels left unchanged for manual review.",
+                dive_id,
+                n_outliers,
+                xy.shape[0],
+                100.0 * outlier_fraction,
+                100.0 * MAX_OUTLIER_FRACTION,
+            )
             return 0
 
         perp = fit.perpendicular_distance(xy[:, 0], xy[:, 1])

--- a/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_activity.py
@@ -425,6 +425,49 @@ async def test_supersede_writes_run_concurrently(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_refuses_to_supersede_when_outlier_fraction_exceeds_safety_gate(
+    monkeypatch, caplog
+):
+    """Safety gate: if the algorithm thinks more than
+    `MAX_OUTLIER_FRACTION` of the dive's positive labels are wrong,
+    refuse to supersede — at that point it's more likely the per-dive
+    line fit is degenerate than that >half the labelers are wrong on
+    the same dive.
+
+    Empirically prod prod showed 51 dives at 30-50% supersede rates and
+    6 dives at 50%+ — those are almost certainly degenerate fits, not
+    bad labelers. Without this gate the activity propagates the line
+    fit's mistake to the DB at scale; with it we log a warning, return
+    0, and leave the dive's labels alone for manual review.
+    """
+    # 30 positives total, 18 mutated to be far off the line — 60%
+    # outlier rate, above the 50% gate.
+    labels = _colinear_labels(30)
+    outlier_idxs = list(range(0, 18))
+    for idx in outlier_idxs:
+        # Alternating sign so the points still scatter around the
+        # original line rather than coordinate-shifting to a new one
+        # (which RANSAC could pick up as a parallel fit).
+        offset = 50.0 if idx % 2 == 0 else -50.0
+        labels[idx].y = labels[idx].y + offset  # type: ignore[operator]
+    fs = _make_fs(labels)
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    env = ActivityEnvironment()
+    with caplog.at_level("WARNING"):
+        result = await env.run(sut.validate_laser_labels_for_dive_activity, 99)
+
+    # The gate refuses to act — return 0, no PUTs.
+    assert result == 0
+    fs.labels.put_laser_label.assert_not_called()
+    # Operator-facing warning so the dive surfaces in log scans.
+    assert any(
+        "refusing" in rec.message.lower() and "dive_id=99" in rec.message
+        for rec in caplog.records
+    ), f"expected a 'refusing' WARNING for dive_id=99, got {[r.message for r in caplog.records]}"
+
+
+@pytest.mark.asyncio
 async def test_supersede_failure_propagates(monkeypatch):
     """If the writeback raises, the activity raises so Temporal retries
     the whole run rather than silently leaving outliers in place."""


### PR DESCRIPTION
## Symptom

Per-dive supersede distribution from prod (after #87 + #90 made the activity actually finish):

| bucket | dives | labels superseded |
|---|---|---|
| 0-5% | 59 | 68 |
| 5-15% | 55 | 1262 |
| 15-30% | 93 | 5131 |
| 30-50% | 51 | 2431 |
| 50%+ | 6 | 665 |

The 6 dives at 50%+ are almost certainly degenerate line fits, not 50%+-wrong labelers — that rate is structurally implausible for crowdsourced labeling. Top offenders include dive 466 at 70% (138/196), dive 24 at 53%, etc.

## Diagnosis

The line fit picks up a small accidentally-aligned cluster of points (RANSAC favors any subset that's tightly colinear within tolerance, even if it's a minority), then flags the real majority as outliers. With Phase 2 enabled the activity propagates that error to the DB at scale.

## Fix

`MAX_OUTLIER_FRACTION=0.5` gate. When the per-dive outlier fraction would exceed 50%, the activity logs a WARNING (`would supersede N/M (X%, gate=50%); refusing — line fit is likely degenerate`) and returns 0 without writing. Labels stay as-is for manual review.

## Scope

- **Forward-looking only.** Existing 9557 superseded rows are unchanged. The 6 high-rate dives need operator SQL revival (`UPDATE laserlabel SET superseded = false WHERE …`) — drafted in conversation, not in this PR because the revival predicate is an operator decision (which dives, scoped to the validate-introduced supersedes only, etc).
- **Doesn't address the 15-30% bucket.** 93 dives contributed ~5k supersedes there. Whether that's "real noise" or "DEFAULT_OUTLIER_SIGMA=3.0 is too tight" needs spot-check-driven tuning, not a hard-coded threshold change. Out of scope for this PR.

## TDD ordering

Per the saved preference: failing test first.

1. Wrote `test_refuses_to_supersede_when_outlier_fraction_exceeds_safety_gate` — 30-positive fixture, 18 mutated 50px off the line (60% outlier rate). Asserts return value is 0, no PUTs called, WARNING log mentions `refusing` + dive_id. Test was committed-thought against the prior code (returned 18, called PUT 18 times) and turned green only after the gate landed.

## Test plan

- [x] `pytest` — 11/11 in the activity test file (10 from main + 1 new), 85/85 in the full non-integration suite.
- [x] `pylint` — 10/10 on the changed activity + test files.
- [ ] After merge + deploy: tail data-worker logs for `WARNING` lines on dives 466, 337, 347, 341, 471, 465, 279, 463, 332, 260 (the top per-dive offenders). Should see the gate firing on the high-rate ones and normal supersede on the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)