### PR TITLE
feat(headtail): cascade stage 5.1 from valid laser labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ but not scheduled (see notes below). Per-stage cohort:
 |---|---|
 | 0.1 | HIGH-priority + at least one image without ANY `LaserLabel` row (in any project) |
 | 2   | HIGH-priority + has PREDICTION clusters + at least one image without ANY `SpeciesLabel` row |
-| 5.1 | HIGH-priority + at least one `SpeciesLabel.top_three_photos_of_group=True` whose image carries no `HeadTailLabel` row at all |
+| 5.1 | HIGH-priority + at least one image with a *valid* `LaserLabel` (`completed=True`, `superseded=False`, `x`/`y` both set) whose image carries no non-sentinel `HeadTailLabel` row |
 | 9   | HIGH-priority + `dive_slate_id` set + at least one `SpeciesLabel.content_of_image='Slate, Laser on slate'` whose image carries no `DiveSlateLabel` row at all |
 | 13  | HIGH-priority + `dive_slate_id` set + no `LaserExtrinsics` + ≥2 completed `DiveSlateLabel` rows (matches the data-worker activity's `MIN_LASER_POINTS=2` precondition) |
 | 14  | HIGH-priority + has `LaserExtrinsics` + has LABEL_STUDIO clusters with at least one `fish_id is None` |
@@ -209,6 +209,20 @@ every parent firing). Resolver activities mirror the same predicate:
 `resolve_laser/headtail/slate_preprocess_inputs_activity` filter
 images on "no label row" so the dispatched per-image work matches
 what the cohort selector promised.
+
+**Stage 5.1 source flip (2026-05-04).** Head/tail used to cascade
+from `SpeciesLabel.top_three_photos_of_group=True`, which forced
+labelers through stages 1 → 2 → 4 (cluster → preprocess dive →
+species top-3 selection) before any head/tail work could start. As
+of 2026-05-04 it cascades from valid laser labels instead: head/tail
+preprocess + populate fire as soon as laser labelers + the
+validator have signed off on an image (`completed=True`,
+`superseded=False`, `x`/`y` both populated — same gate
+`perform_laser_calibration_activity` and the validator's
+`_positive_xy` already use). Practical consequences: head/tail can
+run in parallel with stages 1/2/4; head/tail tasks are created for
+*every* laser-valid image, not just the species pass's top-3 per
+group, so the labeler queue is larger.
 
 Stage 1 (clustering) does NOT yet have a parent — its data-worker
 workflow returns clusters but doesn't write them back to the DB, so

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_headtail_label_studio_project_activity.py
@@ -1,19 +1,21 @@
 """Activity to populate the headtail-labeling LS project for a dive.
 
-Ports stage 5.3 of `populate_label_studio_project.ipynb`. The notebook
-swept all HIGH-priority canonical dives in one pass; this version
-takes a single `dive_id` to match how the operator labels day-to-day
-(dive 0.3 -> 4 -> 5.3 -> 11 sequentially per dive). The all-dive
-sweep can be added as a higher-level workflow that fans out across
-canonical dives if/when batch operation is needed.
+Source flipped on 2026-05-04 from species top-3 → valid laser labels.
+A laser label is "valid" when `completed=True`, `superseded=False`,
+and both `x` and `y` are populated — same gate
+`perform_laser_calibration_activity` and the validator's
+`_positive_xy` already use as "usable laser." Cascading from lasers
+lets head/tail labeling kick off as soon as laser labelers (and the
+validator) sign off, instead of waiting for the species pass to flag
+top-3 measurable angles.
 
-Per the notebook, this stage filters source images two ways:
-  1. Only species labels with `top_three_photos_of_group == True` are
-     candidates — that flag is set by the species labeler in stage 4
-     and selects the best three angles per fish-grouping for
-     length measurement.
-  2. Of those, only images without a *completed* headtail label get
-     a fresh LS task.
+Per-image filter:
+  1. Image must carry a valid laser label (gate above).
+  2. Image must NOT have a non-sentinel HeadTailLabel row already —
+     the existing `id is None or project_id is None` distinction is
+     handled implicitly by `_select_target_images` (drops rows with
+     `completed=True` only; the "no row at all" idempotency comes
+     from the cohort selector).
 
 After importing tasks the activity also marks any pre-existing
 incomplete headtail labels for the dive as `superseded=True`, so the
@@ -25,7 +27,7 @@ from typing import List
 
 from fishsense_api_sdk.models.headtail_label import HeadTailLabel
 from fishsense_api_sdk.models.image import Image
-from fishsense_api_sdk.models.species_label import SpeciesLabel
+from fishsense_api_sdk.models.laser_label import LaserLabel
 from temporalio import activity
 
 from fishsense_api_workflow_worker.activities.populate_utils import (
@@ -37,14 +39,24 @@ from fishsense_api_workflow_worker.activities.utils import get_fs_client
 HEADTAIL_FOLDER = "headtail_jpeg"
 
 
+def _is_valid_laser(label: LaserLabel) -> bool:
+    """Same predicate the API SQL uses for the cohort gate."""
+    return bool(
+        label.completed
+        and not label.superseded
+        and label.x is not None
+        and label.y is not None
+    )
+
+
 def _select_target_images(
-    species_labels: List[SpeciesLabel],
+    laser_labels: List[LaserLabel],
     images_by_id: dict[int, Image],
     existing_headtail_labels: List[HeadTailLabel],
 ) -> List[Image]:
     """Pick the images that need a fresh headtail LS task.
 
-    Source: species labels marked `top_three_photos_of_group=True`.
+    Source: laser labels passing `_is_valid_laser`.
     Filter: drop any image whose existing headtail label is already
     completed (so re-running is a no-op for finished work).
     """
@@ -52,8 +64,8 @@ def _select_target_images(
         label.image_id for label in existing_headtail_labels if label.completed
     }
     selected: List[Image] = []
-    for label in species_labels:
-        if not label.top_three_photos_of_group:
+    for label in laser_labels:
+        if not _is_valid_laser(label):
             continue
         if label.image_id in completed_ids:
             continue
@@ -84,14 +96,12 @@ async def populate_headtail_label_studio_project_activity(
     Returns the number of tasks imported.
     """
     async with get_fs_client() as fs:
-        species_labels = await fs.labels.get_species_labels(dive_id) or []
+        laser_labels = await fs.labels.get_laser_labels(dive_id) or []
         existing_headtail = await fs.labels.get_headtail_labels(dive_id) or []
 
-        # Hydrate Image rows by id for the species labels we care about.
+        # Hydrate Image rows by id for the laser-valid candidates.
         target_image_ids = {
-            label.image_id
-            for label in species_labels
-            if label.top_three_photos_of_group
+            label.image_id for label in laser_labels if _is_valid_laser(label)
         }
         images_by_id: dict[int, Image] = {}
         for image_id in target_image_ids:
@@ -100,7 +110,7 @@ async def populate_headtail_label_studio_project_activity(
                 images_by_id[image.id] = image
 
         targets = _select_target_images(
-            species_labels, images_by_id, existing_headtail
+            laser_labels, images_by_id, existing_headtail
         )
 
         new_count = 0
@@ -133,7 +143,7 @@ async def populate_headtail_label_studio_project_activity(
             )
         else:
             activity.logger.info(
-                "Dive %d has no top-three species images needing headtail "
+                "Dive %d has no laser-valid images needing headtail "
                 "labels; skipping task import",
                 dive_id,
             )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_headtail_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_headtail_preprocess_inputs_activity.py
@@ -2,10 +2,10 @@
 
 Returns a fully-populated `PreprocessHeadtailImagesInput` ready to
 hand to the data-worker's child workflow. Image set is filtered to
-species labels with `top_three_photos_of_group=True` whose image has
-no HeadTailLabel row at all — once populate seeds a (possibly
-incomplete) row, the headtail JPEG is on the file-exchange and we
-don't regenerate it. Matches the API selector predicate.
+images carrying a *valid* LaserLabel (completed=True, superseded=False,
+both x/y populated) whose image has no non-sentinel HeadTailLabel
+row. Matches the API selector predicate (cohort flipped from species
+top-3 → valid lasers on 2026-05-04).
 """
 
 from __future__ import annotations
@@ -14,6 +14,16 @@ from fishsense_shared import PreprocessHeadtailImagesInput
 from temporalio import activity
 
 from fishsense_api_workflow_worker.activities.utils import get_fs_client
+
+
+def _is_valid_laser(label) -> bool:
+    """Same predicate the API SQL uses for the cohort gate."""
+    return bool(
+        label.completed
+        and not label.superseded
+        and label.x is not None
+        and label.y is not None
+    )
 
 
 @activity.defn
@@ -33,7 +43,7 @@ async def resolve_headtail_preprocess_inputs_activity(
                 f"camera_id={dive.camera_id} has no intrinsics"
             )
 
-        species_labels = await fs.labels.get_species_labels(dive_id) or []
+        laser_labels = await fs.labels.get_laser_labels(dive_id) or []
         existing_headtail = await fs.labels.get_headtail_labels(dive_id) or []
         # Skip sentinel rows (project_id IS NULL) — see API selector
         # docstring for rationale.
@@ -45,9 +55,8 @@ async def resolve_headtail_preprocess_inputs_activity(
 
         target_image_ids = [
             label.image_id
-            for label in species_labels
-            if label.top_three_photos_of_group
-            and label.image_id not in labeled_ids
+            for label in laser_labels
+            if _is_valid_laser(label) and label.image_id not in labeled_ids
         ]
 
         images = await fs.images.get(dive_id=dive_id) or []

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_headtail_preprocessing_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_headtail_preprocessing_activity.py
@@ -1,9 +1,9 @@
 """Activity to pick the next HIGH-priority dive that needs stage 5.1
 head/tail preprocessing.
 
-Cohort: HIGH priority + has at least one species label with
-`top_three_photos_of_group=True` whose head/tail label is missing or
-not yet completed (matches
+Cohort: HIGH priority + has at least one image carrying a *valid*
+LaserLabel (completed=True, superseded=False, both x/y populated)
+whose head/tail label is missing (matches
 `populate_headtail_label_studio_project_activity`'s predicate).
 
 The selector is a single SDK call; the SQL predicate lives in the

--- a/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
@@ -1,10 +1,10 @@
 """Unit tests for populate_headtail_label_studio_project_activity.
 
 Two correctness invariants particular to stage 5.3:
-  * Only species labels with `top_three_photos_of_group=True` are
-    candidates — that flag is the species labeler's hand-pick of
-    measurable angles. Pushing every species-labeled image would
-    flood the headtail project.
+  * Only images carrying a *valid* LaserLabel (completed=True,
+    superseded=False, both x/y populated) are candidates — laser
+    labeling + the validator have signed off on these. Anything
+    weaker isn't usable downstream.
   * The `superseded` cleanup pass marks pre-existing incomplete
     headtail rows as obsolete after a re-import, so downstream
     measurement reads only the freshest row per image.
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from typing import List
+from typing import List, Optional
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -22,7 +22,7 @@ from temporalio.testing import ActivityEnvironment
 
 from fishsense_api_sdk.models.headtail_label import HeadTailLabel
 from fishsense_api_sdk.models.image import Image
-from fishsense_api_sdk.models.species_label import SpeciesLabel
+from fishsense_api_sdk.models.laser_label import LaserLabel
 from fishsense_api_workflow_worker.activities import (
     populate_headtail_label_studio_project_activity as sut,
     populate_utils as sut_utils,
@@ -41,24 +41,24 @@ def _image(image_id: int, checksum: str) -> Image:
     )
 
 
-def _species_label(image_id: int, *, top_three: bool) -> SpeciesLabel:
-    return SpeciesLabel(
-        id=image_id * 100,
+def _laser(
+    image_id: int,
+    *,
+    completed: bool = True,
+    superseded: bool = False,
+    x: Optional[float] = 100.0,
+    y: Optional[float] = 200.0,
+) -> LaserLabel:
+    return LaserLabel(
+        id=image_id * 7,
         label_studio_task_id=image_id * 10,
-        label_studio_project_id=70,
-        image_url=None,
+        label_studio_project_id=43,
+        x=x,
+        y=y,
+        label="laser",
         updated_at=None,
-        completed=True,
-        grouping=None,
-        top_three_photos_of_group=top_three,
-        slate_upside_down=None,
-        laser_x=None,
-        laser_y=None,
-        laser_label=None,
-        content_of_image=None,
-        fish_measurable_category=None,
-        fish_angle_category=None,
-        fish_curved_category=None,
+        superseded=superseded,
+        completed=completed,
         label_studio_json={},
         image_id=image_id,
         user_id=None,
@@ -89,16 +89,26 @@ def _headtail_label(
     )
 
 
-def test_select_targets_filters_by_top_three_and_drops_completed():
-    species = [
-        _species_label(1, top_three=True),
-        _species_label(2, top_three=False),
-        _species_label(3, top_three=True),
+def test_select_targets_filters_by_valid_laser_and_drops_completed():
+    laser = [
+        _laser(1),                             # valid + completed headtail -> drop
+        _laser(2, completed=False),            # incomplete laser -> drop
+        _laser(3),                             # valid + no headtail -> keep
+        _laser(4, superseded=True),            # superseded laser -> drop
+        _laser(5, x=None),                     # null x -> drop
+        _laser(6, y=None),                     # null y -> drop
     ]
-    images_by_id = {1: _image(1, "a"), 3: _image(3, "c")}
+    images_by_id = {
+        1: _image(1, "a"),
+        2: _image(2, "b"),
+        3: _image(3, "c"),
+        4: _image(4, "d"),
+        5: _image(5, "e"),
+        6: _image(6, "f"),
+    }
     existing = [_headtail_label(1, completed=True)]
 
-    selected = sut._select_target_images(species, images_by_id, existing)  # pylint: disable=protected-access
+    selected = sut._select_target_images(laser, images_by_id, existing)  # pylint: disable=protected-access
 
     assert [img.id for img in selected] == [3]
 
@@ -123,7 +133,7 @@ def test_build_task_emits_dual_image_and_img_keys(monkeypatch):
 
 
 def _make_fs_client(
-    species_labels: List[SpeciesLabel],
+    laser_labels: List[LaserLabel],
     existing_headtail: List[HeadTailLabel],
     images_by_id: dict,
 ):
@@ -138,7 +148,7 @@ def _make_fs_client(
     fs.images.get = AsyncMock(side_effect=_get_image)
 
     fs.labels = MagicMock()
-    fs.labels.get_species_labels = AsyncMock(return_value=species_labels)
+    fs.labels.get_laser_labels = AsyncMock(return_value=laser_labels)
     fs.labels.get_headtail_labels = AsyncMock(return_value=existing_headtail)
     fs.labels.put_headtail_label = AsyncMock()
     return fs
@@ -160,11 +170,11 @@ async def test_imports_targets_and_supersedes_incomplete_old_rows(monkeypatch):
     superseded. Image 3 is fresh -> get a new task. Image 4 has an
     incomplete old row but no `id` -> superseded skipped (can't
     update without an id) but the new task still goes through."""
-    species = [
-        _species_label(1, top_three=True),
-        _species_label(2, top_three=True),
-        _species_label(3, top_three=True),
-        _species_label(4, top_three=True),
+    laser = [
+        _laser(1),
+        _laser(2),
+        _laser(3),
+        _laser(4),
     ]
     images_by_id = {
         1: _image(1, "a"),
@@ -178,7 +188,7 @@ async def test_imports_targets_and_supersedes_incomplete_old_rows(monkeypatch):
         _headtail_label(4, completed=False, has_id=False),
     ]
 
-    fs = _make_fs_client(species, existing, images_by_id)
+    fs = _make_fs_client(laser, existing, images_by_id)
     ls = _make_ls_client(returned_task_ids=[3001, 3002, 3003])
 
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
@@ -199,15 +209,15 @@ async def test_imports_targets_and_supersedes_incomplete_old_rows(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_no_top_three_targets_skips_import_but_still_supersedes(monkeypatch):
-    """Edge: dive has incomplete old rows but no top_three species
-    flagged. Don't push tasks, but DO supersede the stale rows so
-    they don't linger as canonical."""
-    species = [_species_label(1, top_three=False)]
+async def test_no_valid_laser_targets_skips_import_but_still_supersedes(monkeypatch):
+    """Edge: dive has incomplete old rows but no laser-valid images.
+    Don't push tasks, but DO supersede the stale rows so they don't
+    linger as canonical."""
+    laser = [_laser(1, completed=False)]
     images_by_id = {1: _image(1, "a")}
     existing = [_headtail_label(1, completed=False, has_id=True)]
 
-    fs = _make_fs_client(species, existing, images_by_id)
+    fs = _make_fs_client(laser, existing, images_by_id)
     ls = _make_ls_client(returned_task_ids=[])
 
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_headtail_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_headtail_preprocess_inputs_activity.py
@@ -1,5 +1,11 @@
 # pylint: disable=unused-argument
-"""Unit tests for resolve_headtail_preprocess_inputs_activity."""
+"""Unit tests for resolve_headtail_preprocess_inputs_activity.
+
+The headtail cohort cascades from valid laser labels (completed, not
+superseded, both x/y populated). This resolver mirrors the API SQL
+predicate so the per-image work matches what the cohort selector
+promised.
+"""
 
 from __future__ import annotations
 
@@ -15,7 +21,7 @@ from fishsense_api_sdk.models.camera_intrinsics import CameraIntrinsics
 from fishsense_api_sdk.models.dive import Dive
 from fishsense_api_sdk.models.headtail_label import HeadTailLabel
 from fishsense_api_sdk.models.image import Image
-from fishsense_api_sdk.models.species_label import SpeciesLabel
+from fishsense_api_sdk.models.laser_label import LaserLabel
 from fishsense_api_workflow_worker.activities import (
     resolve_headtail_preprocess_inputs_activity as sut,
 )
@@ -50,24 +56,24 @@ def _image(image_id: int, checksum: str) -> Image:
     )
 
 
-def _species(image_id: int, *, top_three: bool) -> SpeciesLabel:
-    return SpeciesLabel(
-        id=None,
+def _laser(
+    image_id: int,
+    *,
+    completed: bool = True,
+    superseded: bool = False,
+    x: Optional[float] = 100.0,
+    y: Optional[float] = 200.0,
+) -> LaserLabel:
+    return LaserLabel(
+        id=image_id * 7,
         label_studio_task_id=image_id * 10,
-        label_studio_project_id=70,
-        image_url=None,
+        label_studio_project_id=43,
+        x=x,
+        y=y,
+        label="laser",
         updated_at=None,
-        completed=True,
-        grouping=None,
-        top_three_photos_of_group=top_three,
-        slate_upside_down=None,
-        laser_x=None,
-        laser_y=None,
-        laser_label=None,
-        content_of_image=None,
-        fish_measurable_category=None,
-        fish_angle_category=None,
-        fish_curved_category=None,
+        superseded=superseded,
+        completed=completed,
         label_studio_json={},
         image_id=image_id,
         user_id=None,
@@ -109,7 +115,7 @@ def _make_fs(
     dive: Optional[Dive],
     intrinsics: Optional[CameraIntrinsics],
     images: List[Image],
-    species: List[SpeciesLabel],
+    laser: List[LaserLabel],
     headtail: List[HeadTailLabel],
 ):
     fs = MagicMock()
@@ -126,13 +132,13 @@ def _make_fs(
     fs.images.get = AsyncMock(return_value=images)
 
     fs.labels = MagicMock()
-    fs.labels.get_species_labels = AsyncMock(return_value=species)
+    fs.labels.get_laser_labels = AsyncMock(return_value=laser)
     fs.labels.get_headtail_labels = AsyncMock(return_value=headtail)
     return fs
 
 
 @pytest.mark.asyncio
-async def test_returns_only_top_three_without_any_headtail(monkeypatch):
+async def test_returns_only_valid_laser_without_any_real_headtail(monkeypatch):
     fs = _make_fs(
         dive=_dive(),
         intrinsics=_intrinsics(),
@@ -142,11 +148,11 @@ async def test_returns_only_top_three_without_any_headtail(monkeypatch):
             _image(3, "ccc"),
             _image(4, "ddd"),
         ],
-        species=[
-            _species(1, top_three=True),
-            _species(2, top_three=False),
-            _species(3, top_three=True),
-            _species(4, top_three=True),
+        laser=[
+            _laser(1),  # valid + has completed headtail -> dropped
+            _laser(2, completed=False),  # incomplete laser -> dropped
+            _laser(3),  # valid + no headtail -> kept
+            _laser(4),  # valid + incomplete real headtail -> dropped
         ],
         headtail=[
             _headtail(1, completed=True),
@@ -159,11 +165,6 @@ async def test_returns_only_top_three_without_any_headtail(monkeypatch):
         sut.resolve_headtail_preprocess_inputs_activity, 42
     )
 
-    # 1: top-three but headtail row exists (completed) -> dropped.
-    # 2: not top-three -> dropped.
-    # 3: top-three + no headtail row -> kept.
-    # 4: top-three + headtail row exists (incomplete) -> dropped (any
-    #    row excludes — matches API selector predicate).
     assert result.image_checksums == ["ccc"]
     assert result.dive_id == 42
     assert result.camera_matrix == _K.tolist()
@@ -174,17 +175,14 @@ async def test_returns_only_top_three_without_any_headtail(monkeypatch):
 async def test_image_with_only_null_project_sentinel_treated_as_unlabeled(
     monkeypatch,
 ):
-    """NULL-`project_id` HeadTailLabel rows are legacy sentinels — the
-    resolver must ignore them when deciding whether a top-three image
-    needs preprocessing. Matches the API selector predicate."""
+    """NULL-`project_id` HeadTailLabel rows are legacy sentinels —
+    they must NOT exclude a laser-cascaded image. Matches the API
+    selector predicate."""
     fs = _make_fs(
         dive=_dive(),
         intrinsics=_intrinsics(),
         images=[_image(1, "aaa"), _image(2, "bbb")],
-        species=[
-            _species(1, top_three=True),
-            _species(2, top_three=True),
-        ],
+        laser=[_laser(1), _laser(2)],
         headtail=[
             _headtail(1, completed=False, project_id=None),
             _headtail(2, completed=False, project_id=71),
@@ -202,12 +200,41 @@ async def test_image_with_only_null_project_sentinel_treated_as_unlabeled(
 
 
 @pytest.mark.asyncio
-async def test_empty_when_no_top_three(monkeypatch):
+async def test_drops_lasers_that_are_incomplete_superseded_or_null_xy(
+    monkeypatch,
+):
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_intrinsics(),
+        images=[
+            _image(1, "aaa"),
+            _image(2, "bbb"),
+            _image(3, "ccc"),
+            _image(4, "ddd"),
+        ],
+        laser=[
+            _laser(1, completed=False),
+            _laser(2, superseded=True),
+            _laser(3, x=None),
+            _laser(4, y=None),
+        ],
+        headtail=[],
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.resolve_headtail_preprocess_inputs_activity, 42
+    )
+    assert result.image_checksums == []
+
+
+@pytest.mark.asyncio
+async def test_empty_when_no_laser_labels(monkeypatch):
     fs = _make_fs(
         dive=_dive(),
         intrinsics=_intrinsics(),
         images=[_image(1, "aaa")],
-        species=[_species(1, top_three=False)],
+        laser=[],
         headtail=[],
     )
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
@@ -224,15 +251,15 @@ async def test_raises_when_dive_missing_or_camera_missing_or_intrinsics_missing(
     cases = [
         (_make_fs(
             dive=None, intrinsics=_intrinsics(),
-            images=[], species=[], headtail=[],
+            images=[], laser=[], headtail=[],
         ), "not found"),
         (_make_fs(
             dive=_dive(camera_id=None), intrinsics=_intrinsics(),
-            images=[], species=[], headtail=[],
+            images=[], laser=[], headtail=[],
         ), "no camera_id"),
         (_make_fs(
             dive=_dive(), intrinsics=None,
-            images=[], species=[], headtail=[],
+            images=[], laser=[], headtail=[],
         ), "no intrinsics"),
     ]
     for fs, match in cases:

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -161,18 +161,30 @@ async def select_next_for_dive_image_preprocessing(
 async def select_next_for_headtail_preprocessing(
     session: AsyncSession = Depends(get_async_session),
 ) -> int | None:
-    """Stage 5.1: HIGH-priority + has at least one
-    SpeciesLabel.top_three_photos_of_group=True whose image carries no
-    non-sentinel HeadTailLabel row.
+    """Stage 5.1: HIGH-priority + has at least one image carrying a
+    *valid* LaserLabel (completed, not superseded, both x/y populated)
+    whose image carries no non-sentinel HeadTailLabel row.
 
-    "Non-sentinel" = `project_id IS NOT NULL`. See the laser cohort
-    docstring for the rationale.
+    Cascade source flipped from species top-3 → valid laser labels on
+    2026-05-04 so head/tail labeling fans out as soon as laser
+    labelers (and the validator) sign off, without waiting for the
+    species pass. "Valid" matches the predicate already used by
+    `perform_laser_calibration_activity` and
+    `validate_laser_labels_for_dive_activity._positive_xy`:
+    null x/y are sentinel/no-laser rows, superseded comes from
+    validation, completed comes from the labeler.
+
+    "Non-sentinel" headtail = `project_id IS NOT NULL`. See the laser
+    cohort docstring for the rationale.
     """
-    has_top_three_image_without_real_headtail = (
-        select(SpeciesLabel.id)
-        .join(Image, Image.id == SpeciesLabel.image_id)
+    has_valid_laser_image_without_real_headtail = (
+        select(LaserLabel.id)
+        .join(Image, Image.id == LaserLabel.image_id)
         .where(Image.dive_id == Dive.id)
-        .where(SpeciesLabel.top_three_photos_of_group == True)
+        .where(LaserLabel.completed == True)
+        .where(LaserLabel.superseded == False)
+        .where(LaserLabel.x != None)
+        .where(LaserLabel.y != None)
         .where(
             ~select(HeadTailLabel.id)
             .where(HeadTailLabel.image_id == Image.id)
@@ -184,7 +196,7 @@ async def select_next_for_headtail_preprocessing(
     query = (
         select(Dive.id)
         .where(Dive.priority == Priority.HIGH)
-        .where(has_top_three_image_without_real_headtail)
+        .where(has_valid_laser_image_without_real_headtail)
         .order_by(Dive.id)
         .limit(1)
     )

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -592,29 +592,45 @@ async def test_dive_image_preprocessing_returns_none_when_only_label_studio_clus
 
 
 # ---------- stage 5.1: headtail-preprocessing ----------
+#
+# Cohort cascades from valid laser labels: any image with a "valid"
+# laser label (completed=True, superseded=False, x/y both set —
+# matches what perform_laser_calibration and validate_laser_labels
+# treat as usable) drops into the headtail pipeline as soon as it
+# lacks a non-sentinel HeadTailLabel row. Species labeling is no
+# longer in the path; head/tail can run in parallel with stages 1/2/4.
 
 
-async def test_headtail_preprocessing_requires_top_three_without_any_headtail(
+async def test_headtail_preprocessing_requires_valid_laser_without_any_headtail(
     session,
 ):
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         select_next_for_headtail_preprocessing,
     )
     from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
 
-    # dive 1: top_three=True but headtail row exists -> excluded.
-    # dive 2: top_three=True, no headtail row -> picked.
-    # dive 3: only top_three=False -> excluded.
+    # dive 1: valid laser + headtail row exists -> excluded.
+    # dive 2: valid laser, no headtail row -> picked.
+    # dive 3: laser row is null x/y (no-laser sentinel) -> excluded.
     session.add_all([_dive(1), _dive(2), _dive(3)])
     await session.flush()
     session.add_all([_image(11, 1), _image(21, 2), _image(31, 3)])
     await session.flush()
     session.add_all(
         [
-            SpeciesLabel(image_id=11, top_three_photos_of_group=True),
-            SpeciesLabel(image_id=21, top_three_photos_of_group=True),
-            SpeciesLabel(image_id=31, top_three_photos_of_group=False),
+            LaserLabel(
+                image_id=11, completed=True, superseded=False,
+                x=100.0, y=200.0, label_studio_project_id=43,
+            ),
+            LaserLabel(
+                image_id=21, completed=True, superseded=False,
+                x=110.0, y=210.0, label_studio_project_id=43,
+            ),
+            LaserLabel(
+                image_id=31, completed=True, superseded=False,
+                x=None, y=None, label_studio_project_id=43,
+            ),
         ]
     )
     session.add(
@@ -629,18 +645,23 @@ async def test_headtail_preprocessing_excludes_dive_with_only_incomplete_headtai
     session,
 ):
     """Once populate seeds an incomplete HeadTailLabel (with a real
-    project_id) for every top-three image, the dive drops out of the
-    cohort."""
+    project_id) for every laser-cascaded image, the dive drops out of
+    the cohort."""
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         select_next_for_headtail_preprocessing,
     )
     from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
 
     session.add(_dive(1))
     await session.flush()
     session.add(_image(11, 1))
-    session.add(SpeciesLabel(image_id=11, top_three_photos_of_group=True))
+    session.add(
+        LaserLabel(
+            image_id=11, completed=True, superseded=False,
+            x=100.0, y=200.0, label_studio_project_id=43,
+        )
+    )
     session.add(
         HeadTailLabel(
             image_id=11, completed=False, label_studio_project_id=71
@@ -659,12 +680,17 @@ async def test_headtail_preprocessing_excludes_dive_when_sentinel_coexists_with_
         select_next_for_headtail_preprocessing,
     )
     from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
 
     session.add(_dive(1))
     await session.flush()
     session.add(_image(11, 1))
-    session.add(SpeciesLabel(image_id=11, top_three_photos_of_group=True))
+    session.add(
+        LaserLabel(
+            image_id=11, completed=True, superseded=False,
+            x=100.0, y=200.0, label_studio_project_id=43,
+        )
+    )
     session.add_all(
         [
             HeadTailLabel(
@@ -688,12 +714,17 @@ async def test_headtail_preprocessing_ignores_null_project_sentinels(session):
         select_next_for_headtail_preprocessing,
     )
     from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
 
     session.add(_dive(1))
     await session.flush()
     session.add(_image(11, 1))
-    session.add(SpeciesLabel(image_id=11, top_three_photos_of_group=True))
+    session.add(
+        LaserLabel(
+            image_id=11, completed=True, superseded=False,
+            x=100.0, y=200.0, label_studio_project_id=43,
+        )
+    )
     session.add(
         HeadTailLabel(
             image_id=11, completed=False, label_studio_project_id=None
@@ -704,16 +735,60 @@ async def test_headtail_preprocessing_ignores_null_project_sentinels(session):
     assert await select_next_for_headtail_preprocessing(session=session) == 1
 
 
-async def test_headtail_preprocessing_returns_none_when_no_top_three(session):
+async def test_headtail_preprocessing_excludes_incomplete_or_superseded_or_null_xy_lasers(
+    session,
+):
+    """A laser label only counts if completed AND not superseded AND
+    has both x and y populated. Anything weaker is not a "valid
+    label" per the gate."""
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         select_next_for_headtail_preprocessing,
     )
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    # dive 1: laser is not completed.
+    # dive 2: laser is superseded.
+    # dive 3: laser is missing x.
+    # dive 4: laser is missing y.
+    session.add_all([_dive(1), _dive(2), _dive(3), _dive(4)])
+    await session.flush()
+    session.add_all(
+        [_image(11, 1), _image(21, 2), _image(31, 3), _image(41, 4)]
+    )
+    await session.flush()
+    session.add_all(
+        [
+            LaserLabel(
+                image_id=11, completed=False, superseded=False,
+                x=100.0, y=200.0, label_studio_project_id=43,
+            ),
+            LaserLabel(
+                image_id=21, completed=True, superseded=True,
+                x=100.0, y=200.0, label_studio_project_id=43,
+            ),
+            LaserLabel(
+                image_id=31, completed=True, superseded=False,
+                x=None, y=200.0, label_studio_project_id=43,
+            ),
+            LaserLabel(
+                image_id=41, completed=True, superseded=False,
+                x=100.0, y=None, label_studio_project_id=43,
+            ),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_headtail_preprocessing(session=session) is None
+
+
+async def test_headtail_preprocessing_returns_none_when_no_laser_labels(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_headtail_preprocessing,
+    )
 
     session.add(_dive(1))
     await session.flush()
     session.add(_image(11, 1))
-    session.add(SpeciesLabel(image_id=11, top_three_photos_of_group=False))
     await session.flush()
 
     assert await select_next_for_headtail_preprocessing(session=session) is None


### PR DESCRIPTION
## Summary

- Stage 5.1 head/tail preprocess + populate now cascade from valid `LaserLabel` rows (`completed=True`, `superseded=False`, both `x`/`y` set) instead of `SpeciesLabel.top_three_photos_of_group=True`. Same gate `perform_laser_calibration_activity` and the validator's `_positive_xy` already use as "usable laser."
- Head/tail can run in parallel with stages 1/2/4 (cluster → preprocess dive → species). Previously head/tail was blocked until species labelers finished the top-3 selection.
- Cohort SQL, resolver activity, populate activity, and selector docstring all updated in lockstep so the predicate stays consistent end-to-end.

## Behavior changes
- **Pipeline order**: head/tail labeling can begin as soon as laser labelers + the validator sign off on an image, no longer requires species pass.
- **Labeler queue size**: every laser-valid image gets a head/tail task, not just the species pass's top-3 per fish-grouping. If this turns out to flood labelers in prod, the conversation to have is whether to add a top-N gate downstream of the laser cascade.

## Test plan
- [x] `uv run --package fishsense-api pytest services/fishsense-api/tests/` (91 passed)
- [x] `uv run --package fishsense-api-workflow-worker pytest services/fishsense-api-workflow-worker/tests/` (158 passed)
- [x] TDD: tests written first for the new SQL predicate (6), resolver (5), and populate (4); watched fail for the right reason, then made green.
- [ ] Smoke-test on prod once deployed: trigger `PreprocessHeadtailImagesParentWorkflow` against a dive with valid laser labels and no head/tail rows, verify expected images get head/tail tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)