### PR TITLE
fix(sdk): return None on 404 from per-dive plural label getters

### DIFF
--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/label_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/label_client.py
@@ -80,6 +80,9 @@ class LabelClient(ClientBase):
             List[DiveSlateLabel] | None: The list of dive slate labels for the specified dive.
         """
         response = await self._get(f"/api/v1/dives/{dive_id}/labels/dive-slate")
+        if response.status_code == 404:
+            self.logger.debug("No dive slate labels found for dive ID %s", dive_id)
+            return None
         response.raise_for_status()
 
         json = response.json()
@@ -164,6 +167,9 @@ class LabelClient(ClientBase):
             List[HeadTailLabel] | None: The list of head-tail labels for the specified dive.
         """
         response = await self._get(f"/api/v1/dives/{dive_id}/labels/headtail")
+        if response.status_code == 404:
+            self.logger.debug("No head-tail labels found for dive ID %s", dive_id)
+            return None
         response.raise_for_status()
 
         json = response.json()
@@ -303,6 +309,9 @@ class LabelClient(ClientBase):
             List[LaserLabel] | None: The list of laser labels for the specified dive.
         """
         response = await self._get(f"/api/v1/dives/{dive_id}/labels/laser")
+        if response.status_code == 404:
+            self.logger.debug("No laser labels found for dive ID %s", dive_id)
+            return None
         response.raise_for_status()
 
         json = response.json()
@@ -422,6 +431,9 @@ class LabelClient(ClientBase):
             List[SpeciesLabel] | None: The list of species labels for the specified dive.
         """
         response = await self._get(f"/api/v1/dives/{dive_id}/labels/species")
+        if response.status_code == 404:
+            self.logger.debug("No species labels found for dive ID %s", dive_id)
+            return None
         response.raise_for_status()
 
         json = response.json()

--- a/libs/fishsense-api-sdk/tests/clients/test_label_client.py
+++ b/libs/fishsense-api-sdk/tests/clients/test_label_client.py
@@ -30,7 +30,7 @@ def _mock_404() -> Mock:
     return response
 
 
-class TestLabelClient:
+class TestLabelClient:  # pylint: disable=too-many-public-methods
     """Test suite for LabelClient class."""
 
     async def test_get_dive_slate_label_returns_none_on_404(self):

--- a/libs/fishsense-api-sdk/tests/clients/test_label_client.py
+++ b/libs/fishsense-api-sdk/tests/clients/test_label_client.py
@@ -86,6 +86,43 @@ class TestLabelClient:
                     await client.get_species_label(label_studio_id=999) is None
                 )
 
+    # 404→None for the per-dive *plural* getters. The API returns 404 with
+    # `Labels not found` when a dive has zero rows of a given label kind
+    # (label_controller.py — `get_*_labels_for_dive`). That is a valid
+    # steady state — e.g. a dive with valid laser labels but no
+    # head/tail rows yet — and must not blow up the workflow that
+    # called the SDK. Regression caught when the stage 5.1 head/tail
+    # cascade fired against dive 58 (no head/tail rows yet) and
+    # `resolve_headtail_preprocess_inputs_activity` 500'd.
+
+    async def test_get_dive_slate_labels_returns_none_on_404(self):
+        client = _make_client()
+        with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = _mock_404()
+            async with client:
+                assert await client.get_dive_slate_labels(999) is None
+
+    async def test_get_headtail_labels_returns_none_on_404(self):
+        client = _make_client()
+        with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = _mock_404()
+            async with client:
+                assert await client.get_headtail_labels(999) is None
+
+    async def test_get_laser_labels_returns_none_on_404(self):
+        client = _make_client()
+        with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = _mock_404()
+            async with client:
+                assert await client.get_laser_labels(999) is None
+
+    async def test_get_species_labels_returns_none_on_404(self):
+        client = _make_client()
+        with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = _mock_404()
+            async with client:
+                assert await client.get_species_labels(999) is None
+
     async def test_get_laser_label_studio_project_ids_hits_collection_endpoint(self):
         client = _make_client()
         response = Mock()


### PR DESCRIPTION
## Summary

- Follow-up to PR #97 (head/tail cascade from valid laser labels). The cascade went live and the first scheduled run of `PreprocessHeadtailImagesParentWorkflow` against dive 58 — which has valid laser labels but no head/tail rows yet — crashed with `HTTPStatusError: 404` from `LabelClient.get_headtail_labels`.
- Root cause: the four `get_<kind>_labels(dive_id)` plural getters (laser, headtail, species, dive-slate) called `raise_for_status()` directly. The API returns `404 Labels not found` when a dive has zero rows of a kind — a valid steady state — but the SDK turned that into a worker-killing exception. The singular siblings (`get_<kind>_label`) already handle 404→None correctly; this aligns the plural ones.
- Same defect would have affected the laser cohort on a truly fresh dive, but populate had always seeded sentinel rows in lockstep, so it never surfaced before the head/tail cascade flipped its source.

## Test plan
- [x] `uv run --package fishsense-api-sdk pytest libs/fishsense-api-sdk/tests/` → 106/106 passed
- [x] `uv run --package fishsense-api-workflow-worker pytest services/fishsense-api-workflow-worker/tests/` → 158/158 passed
- [x] TDD: 4 new failing tests written first (`test_get_<kind>_labels_returns_none_on_404`), watched fail with `AssertionError: raise_for_status must not be called for the 404 case`, then made green.
- [ ] After deploy: re-trigger `preprocess-headtail-images-workflow-schedule` against dive 58 and confirm the activity completes (returns an empty `image_checksums` list iff every laser-valid image already has a head/tail row, otherwise the cohort entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)