### PR TITLE
feat(api): dive_pipeline_status view for Superset dashboards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,44 @@ run in parallel with stages 1/2/4; head/tail tasks are created for
 *every* laser-valid image, not just the species pass's top-3 per
 group, so the labeler queue is larger.
 
+## `dive_pipeline_status` view
+
+Postgres view that exposes a wide row per dive with one boolean
+column per pipeline stage. Created by alembic migration
+`60e82ad5dac7_add_dive_pipeline_status_view`; SQL canonicalized in
+[fishsense_api.views](services/fishsense-api/src/fishsense_api/views.py).
+Backs Superset dashboards reading the fishsense Postgres connection.
+
+| Column | True iff |
+|---|---|
+| `dive_id`, `priority`, `dive_slate_id` | identity / dimensions |
+| `laser_preprocessed` | every image in the dive has at least one `LaserLabel` row (any project, any state) |
+| `laser_labeling_complete` | ≥1 completed-non-superseded `LaserLabel` AND zero incomplete-non-superseded |
+| `headtail_preprocessed` | every image carrying a *valid* laser label (completed, not superseded, x/y both set) has a non-sentinel `HeadTailLabel` row |
+| `headtail_labeling_complete` | ≥1 completed-non-superseded `HeadTailLabel` AND zero incomplete-non-superseded |
+| `has_prediction_clusters` | dive has at least one PREDICTION `DiveFrameCluster` (stage 1 ran and persisted) |
+| `dive_images_preprocessed` | `has_prediction_clusters` AND every image has a non-sentinel `SpeciesLabel` row |
+| `species_labeling_complete` | ≥1 completed `SpeciesLabel` AND zero incomplete (no `superseded` column on this model) |
+| `slate_applicable` | `dive_slate_id IS NOT NULL` |
+| `slate_preprocessed` | every image with `SpeciesLabel.content_of_image='Slate, Laser on slate'` has a non-sentinel `DiveSlateLabel` row |
+| `slate_labeling_complete` | ≥1 completed `DiveSlateLabel` AND zero incomplete |
+| `calibrated` | dive has a `LaserExtrinsics` row |
+| `measured` | ≥1 LABEL_STUDIO `DiveFrameCluster` AND zero LABEL_STUDIO clusters with `fish_id IS NULL` |
+
+**"Complete" semantics throughout** mirror
+`get_dives_with_complete_laser_labeling`: vacuous truth (zero rows of
+a kind) reads as `False`, not `True`. A dive with no laser labels at
+all is *not* "laser_labeling_complete" — there's nothing to validate.
+Same for the other `*_labeling_complete` and `measured` flags.
+
+**Edits** to predicates: change the SQL in `views.py` (single source
+of truth — both alembic migration and tests use it), then write a new
+alembic revision that drops + recreates the view (Postgres `CREATE OR
+REPLACE VIEW` is restrictive about column-shape changes; the
+drop/recreate pattern is simpler and the view has no dependents). Add
+a test for the new behavior in `test_dive_pipeline_status_view.py`
+before changing the SQL.
+
 Stage 1 (clustering) does NOT yet have a parent — its data-worker
 workflow returns clusters but doesn't write them back to the DB, so
 adding a parent requires deciding whether the parent persists the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,17 @@ drop/recreate pattern is simpler and the view has no dependents). Add
 a test for the new behavior in `test_dive_pipeline_status_view.py`
 before changing the SQL.
 
+**Auto-migrate on startup.** `fishsense_api.server.lifespan` runs
+`SQLModel.metadata.create_all` first (fresh-env bootstrap — the
+alembic baseline is `alter_column`-only and assumes tables already
+exist), then `run_alembic_upgrade` (catches up to head, including
+non-table artifacts like this view). Both are idempotent against an
+existing prod schema; the second is what creates the view on the
+deploy that ships its migration. `alembic.ini` does NOT ship in the
+runtime image (`uv sync --no-editable` only installs the package
+source); `run_alembic_upgrade` builds the Config programmatically with
+`script_location` pointed at `<package>/alembic`.
+
 Stage 1 (clustering) does NOT yet have a parent — its data-worker
 workflow returns clusters but doesn't write them back to the DB, so
 adding a parent requires deciding whether the parent persists the

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/60e82ad5dac7_add_dive_pipeline_status_view.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/60e82ad5dac7_add_dive_pipeline_status_view.py
@@ -1,0 +1,40 @@
+"""add dive_pipeline_status view
+
+Revision ID: 60e82ad5dac7
+Revises: 299428e39cb9
+Create Date: 2026-05-04
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from fishsense_api.views import (
+    DIVE_PIPELINE_STATUS_VIEW_SQL,
+    DROP_DIVE_PIPELINE_STATUS_VIEW_SQL,
+)
+
+
+# revision identifiers, used by Alembic.
+revision: str = '60e82ad5dac7'
+down_revision: Union[str, Sequence[str], None] = '299428e39cb9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create the read-only dive_pipeline_status view.
+
+    Backs Superset dashboards against the fishsense Postgres DB. The
+    view derives one boolean column per pipeline stage from the
+    underlying tables — no writeback path, no drift. SQL lives in
+    `fishsense_api.views` so this migration and the test fixture
+    apply the same definition.
+    """
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)
+
+
+def downgrade() -> None:
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)

--- a/services/fishsense-api/src/fishsense_api/database.py
+++ b/services/fishsense-api/src/fishsense_api/database.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator
+from pathlib import Path
 
+from alembic import command as alembic_command
+from alembic.config import Config as AlembicConfig
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
@@ -55,6 +58,32 @@ class Database:
     async def dispose(self) -> None:
         """Dispose of the database engine."""
         await self.engine.dispose()
+
+
+def run_alembic_upgrade() -> None:
+    """Apply pending alembic migrations up to the latest revision.
+
+    Invoked from the FastAPI lifespan so a deploy that ships a new
+    migration (e.g. the `dive_pipeline_status` view) doesn't require
+    a manual operator step.
+
+    The Config is built programmatically because `alembic.ini` does
+    NOT ship inside the wheel — `uv sync --no-editable` only installs
+    the package source under `site-packages/fishsense_api/`. Locating
+    `script_location` relative to this module's path keeps the
+    migration scripts findable regardless of the runtime's CWD.
+
+    Sync API; callers should offload to a worker thread
+    (`asyncio.to_thread`) to avoid blocking the event loop, since
+    `command.upgrade` opens its own engine and runs DDL synchronously
+    via the async-engine bridge in `alembic/env.py`.
+    """
+    cfg = AlembicConfig()
+    cfg.set_main_option(
+        "script_location",
+        str(Path(__file__).resolve().parent / "alembic"),
+    )
+    alembic_command.upgrade(cfg, "head")
 
 
 _session_factory: sessionmaker | None = None  # pylint: disable=invalid-name

--- a/services/fishsense-api/src/fishsense_api/server.py
+++ b/services/fishsense-api/src/fishsense_api/server.py
@@ -1,29 +1,39 @@
 """FishSense API Server"""
 
+import asyncio
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
 from fishsense_api.__version__ import __version__
-from fishsense_api.database import setup_database
+from fishsense_api.database import run_alembic_upgrade, setup_database
 
 
 @asynccontextmanager
 async def lifespan(_: FastAPI):
     """Generate the database lifespan.
 
-    Args:
-        app (FastAPI): FastAPI application instance.
+    Order is intentional:
+      1. `init_database` (`SQLModel.metadata.create_all`) — bootstraps
+         tables on a fresh environment. The alembic baseline migration
+         only contains `alter_column` ops, so it assumes tables already
+         exist; running alembic against an empty DB would fail without
+         this prior step. No-op against an existing prod schema.
+      2. `run_alembic_upgrade` — applies any pending migrations
+         (including non-table artifacts like the `dive_pipeline_status`
+         view that aren't part of `SQLModel.metadata`). Sync API,
+         offloaded via `asyncio.to_thread` so DDL doesn't block the
+         event loop.
     """
     database = setup_database()
 
-    # Startup events (e.g., create tables)
     async with database.engine.begin() as conn:
         await database.init_database(conn)
 
+    await asyncio.to_thread(run_alembic_upgrade)
+
     yield
 
-    # Shutdown events (e.g., dispose engine)
     await database.dispose()
 
 

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -1,0 +1,225 @@
+"""SQL view definitions exposed alongside the SQLModel tables.
+
+Views are not part of `SQLModel.metadata`; they are created out-of-band
+by alembic in prod and by the test fixtures in CI. This module owns
+the canonical SQL string so both code paths apply the same definition.
+
+The shape lives here (not in `models/`) because views are derived
+artifacts, not entities — there's no row-level CRUD against them.
+Superset reads them directly via the `fishsense` Postgres connection.
+
+Portability note: the SQL is plain ANSI/SQL-92 with `EXISTS` / `NOT
+EXISTS` subqueries. Both the prod Postgres and the in-memory sqlite
+the test fixture uses parse it identically. No `bool_and` /
+`COUNT(...) FILTER` (Postgres-only) — adding those would force the
+test suite to spin up a real Postgres.
+"""
+
+from __future__ import annotations
+
+DIVE_PIPELINE_STATUS_VIEW_NAME = "dive_pipeline_status"
+
+# Slate-content marker mirrors `dive_controller.SLATE_CONTENT_MARKER`.
+# Kept inline rather than imported to avoid `views.py` pulling controller
+# imports during alembic migration runs (alembic env loads `views` to
+# get this string before the FastAPI app is initialized).
+_SLATE_CONTENT_MARKER = "Slate, Laser on slate"
+
+# "Complete" everywhere = ≥1 completed-non-superseded row AND zero
+# incomplete-non-superseded rows. Mirrors
+# `get_dives_with_complete_laser_labeling`'s semantics so a dive with
+# zero labels of a kind doesn't vacuously read as complete.
+DIVE_PIPELINE_STATUS_VIEW_SQL = f"""
+CREATE VIEW {DIVE_PIPELINE_STATUS_VIEW_NAME} AS
+SELECT
+    d.id AS dive_id,
+    d.priority,
+    d.dive_slate_id,
+
+    -- Stage 0.1: every image in the dive has at least one LaserLabel
+    -- row (any project, any state). The cohort selector is the
+    -- inverse of this predicate.
+    (EXISTS (SELECT 1 FROM image i WHERE i.dive_id = d.id)
+     AND NOT EXISTS (
+         SELECT 1 FROM image i
+         WHERE i.dive_id = d.id
+           AND NOT EXISTS (
+               SELECT 1 FROM laserlabel ll WHERE ll.image_id = i.id
+           )
+     )) AS laser_preprocessed,
+
+    -- Laser labeling: ≥1 completed-non-superseded AND zero
+    -- incomplete-non-superseded.
+    (EXISTS (
+         SELECT 1 FROM laserlabel ll
+         JOIN image i ON i.id = ll.image_id
+         WHERE i.dive_id = d.id
+           AND ll.superseded = FALSE
+           AND ll.completed = TRUE
+     )
+     AND NOT EXISTS (
+         SELECT 1 FROM laserlabel ll
+         JOIN image i ON i.id = ll.image_id
+         WHERE i.dive_id = d.id
+           AND ll.superseded = FALSE
+           AND (ll.completed = FALSE OR ll.completed IS NULL)
+     )) AS laser_labeling_complete,
+
+    -- Stage 5.1: every image carrying a *valid* laser label
+    -- (completed, not superseded, x/y both set) has a non-sentinel
+    -- HeadTailLabel row. ≥1 such image must exist (otherwise the
+    -- predicate would be vacuously true for dives with no laser work
+    -- yet).
+    (EXISTS (
+         SELECT 1 FROM laserlabel ll
+         JOIN image i ON i.id = ll.image_id
+         WHERE i.dive_id = d.id
+           AND ll.completed = TRUE
+           AND ll.superseded = FALSE
+           AND ll.x IS NOT NULL
+           AND ll.y IS NOT NULL
+     )
+     AND NOT EXISTS (
+         SELECT 1 FROM laserlabel ll
+         JOIN image i ON i.id = ll.image_id
+         WHERE i.dive_id = d.id
+           AND ll.completed = TRUE
+           AND ll.superseded = FALSE
+           AND ll.x IS NOT NULL
+           AND ll.y IS NOT NULL
+           AND NOT EXISTS (
+               SELECT 1 FROM headtaillabel htl
+               WHERE htl.image_id = i.id
+                 AND htl.label_studio_project_id IS NOT NULL
+           )
+     )) AS headtail_preprocessed,
+
+    -- Headtail labeling: ≥1 completed-non-superseded AND zero
+    -- incomplete-non-superseded.
+    (EXISTS (
+         SELECT 1 FROM headtaillabel htl
+         JOIN image i ON i.id = htl.image_id
+         WHERE i.dive_id = d.id
+           AND htl.superseded = FALSE
+           AND htl.completed = TRUE
+     )
+     AND NOT EXISTS (
+         SELECT 1 FROM headtaillabel htl
+         JOIN image i ON i.id = htl.image_id
+         WHERE i.dive_id = d.id
+           AND htl.superseded = FALSE
+           AND (htl.completed = FALSE OR htl.completed IS NULL)
+     )) AS headtail_labeling_complete,
+
+    -- Stage 1: ≥1 PREDICTION cluster present (stage-1 clustering ran
+    -- and persisted output). The data-worker stage 1 workflow does not
+    -- yet write back, so this is currently false dive-wide; the column
+    -- still exists so dashboards don't have to rebuild when stage 1
+    -- starts persisting.
+    EXISTS (
+        SELECT 1 FROM diveframecluster dfc
+        WHERE dfc.dive_id = d.id
+          AND dfc.data_source = 'PREDICTION'
+    ) AS has_prediction_clusters,
+
+    -- Stage 2: has PREDICTION clusters AND every image carries a
+    -- non-sentinel SpeciesLabel row.
+    (EXISTS (
+         SELECT 1 FROM diveframecluster dfc
+         WHERE dfc.dive_id = d.id
+           AND dfc.data_source = 'PREDICTION'
+     )
+     AND EXISTS (SELECT 1 FROM image i WHERE i.dive_id = d.id)
+     AND NOT EXISTS (
+         SELECT 1 FROM image i
+         WHERE i.dive_id = d.id
+           AND NOT EXISTS (
+               SELECT 1 FROM specieslabel sl
+               WHERE sl.image_id = i.id
+                 AND sl.label_studio_project_id IS NOT NULL
+           )
+     )) AS dive_images_preprocessed,
+
+    -- Species labeling: ≥1 completed AND zero incomplete. (No
+    -- superseded column on SpeciesLabel — the model doesn't carry
+    -- one; the existing cohort selectors don't filter on it either.)
+    (EXISTS (
+         SELECT 1 FROM specieslabel sl
+         JOIN image i ON i.id = sl.image_id
+         WHERE i.dive_id = d.id
+           AND sl.completed = TRUE
+     )
+     AND NOT EXISTS (
+         SELECT 1 FROM specieslabel sl
+         JOIN image i ON i.id = sl.image_id
+         WHERE i.dive_id = d.id
+           AND (sl.completed = FALSE OR sl.completed IS NULL)
+     )) AS species_labeling_complete,
+
+    -- Slate path applies only when dive has an associated slate.
+    (d.dive_slate_id IS NOT NULL) AS slate_applicable,
+
+    -- Stage 9: every image whose SpeciesLabel marks it as containing a
+    -- slate-with-laser has a non-sentinel DiveSlateLabel row. ≥1 such
+    -- image must exist.
+    (d.dive_slate_id IS NOT NULL
+     AND EXISTS (
+         SELECT 1 FROM specieslabel sl
+         JOIN image i ON i.id = sl.image_id
+         WHERE i.dive_id = d.id
+           AND sl.content_of_image = '{_SLATE_CONTENT_MARKER}'
+     )
+     AND NOT EXISTS (
+         SELECT 1 FROM specieslabel sl
+         JOIN image i ON i.id = sl.image_id
+         WHERE i.dive_id = d.id
+           AND sl.content_of_image = '{_SLATE_CONTENT_MARKER}'
+           AND NOT EXISTS (
+               SELECT 1 FROM diveslatelabel dsl
+               WHERE dsl.image_id = i.id
+                 AND dsl.label_studio_project_id IS NOT NULL
+           )
+     )) AS slate_preprocessed,
+
+    -- Slate labeling: ≥1 completed AND zero incomplete. (No
+    -- superseded column on DiveSlateLabel — same as species.)
+    (EXISTS (
+         SELECT 1 FROM diveslatelabel dsl
+         JOIN image i ON i.id = dsl.image_id
+         WHERE i.dive_id = d.id
+           AND dsl.completed = TRUE
+     )
+     AND NOT EXISTS (
+         SELECT 1 FROM diveslatelabel dsl
+         JOIN image i ON i.id = dsl.image_id
+         WHERE i.dive_id = d.id
+           AND (dsl.completed = FALSE OR dsl.completed IS NULL)
+     )) AS slate_labeling_complete,
+
+    -- Stage 13: dive has a LaserExtrinsics row.
+    EXISTS (
+        SELECT 1 FROM laserextrinsics le
+        WHERE le.dive_id = d.id
+    ) AS calibrated,
+
+    -- Stage 14: ≥1 LABEL_STUDIO cluster AND zero LABEL_STUDIO clusters
+    -- with fish_id NULL (every cluster bound to a fish via stage-14
+    -- measurement).
+    (EXISTS (
+         SELECT 1 FROM diveframecluster dfc
+         WHERE dfc.dive_id = d.id
+           AND dfc.data_source = 'LABEL_STUDIO'
+     )
+     AND NOT EXISTS (
+         SELECT 1 FROM diveframecluster dfc
+         WHERE dfc.dive_id = d.id
+           AND dfc.data_source = 'LABEL_STUDIO'
+           AND dfc.fish_id IS NULL
+     )) AS measured
+
+FROM dive d
+"""
+
+DROP_DIVE_PIPELINE_STATUS_VIEW_SQL = (
+    f"DROP VIEW IF EXISTS {DIVE_PIPELINE_STATUS_VIEW_NAME}"
+)

--- a/services/fishsense-api/tests/test_alembic_upgrade.py
+++ b/services/fishsense-api/tests/test_alembic_upgrade.py
@@ -1,0 +1,93 @@
+"""Tests for the auto-migrate on startup behavior.
+
+The FastAPI lifespan applies pending alembic migrations before
+serving traffic so a deploy that ships a new migration (e.g. the
+`dive_pipeline_status` view) doesn't require a manual operator step.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fishsense_api import database
+
+
+def test_run_alembic_upgrade_invokes_command_upgrade_to_head():
+    """The function must end up calling `alembic.command.upgrade(cfg,
+    "head")`. The Config's `script_location` must point at the
+    package's alembic directory so the migration scripts are found
+    inside the installed wheel (where alembic.ini does NOT ship)."""
+    fake_command = MagicMock()
+    fake_config_cls = MagicMock()
+    fake_cfg = MagicMock()
+    fake_config_cls.return_value = fake_cfg
+
+    with patch.object(database, "alembic_command", fake_command), patch.object(
+        database, "AlembicConfig", fake_config_cls
+    ):
+        database.run_alembic_upgrade()
+
+    fake_command.upgrade.assert_called_once_with(fake_cfg, "head")
+    set_calls = fake_cfg.set_main_option.call_args_list
+    script_location_call = next(
+        c for c in set_calls if c.args[0] == "script_location"
+    )
+    expected = str(
+        Path(database.__file__).resolve().parent / "alembic"
+    )
+    assert script_location_call.args[1] == expected
+
+
+@pytest.mark.asyncio
+async def test_lifespan_runs_alembic_upgrade_after_setup(monkeypatch):
+    """Wired-up regression: the FastAPI lifespan must invoke the
+    upgrade so the deployed image catches up the schema on its own."""
+    from fishsense_api import server  # pylint: disable=import-outside-toplevel
+
+    fake_db = MagicMock()
+    fake_engine_begin = MagicMock()
+    fake_engine_begin.__aenter__ = MagicMock(
+        return_value=__import__("asyncio").get_event_loop().create_future()
+    )
+    # Simpler: stub setup_database + dispose + init_database to no-ops, and
+    # assert the upgrade-runner was awaited before yield.
+    fake_db.engine.begin = MagicMock(return_value=_AsyncCM())
+    fake_db.dispose = _AsyncNoop()
+
+    upgrade_calls = []
+
+    async def fake_to_thread(fn, *_args, **_kwargs):
+        upgrade_calls.append(fn)
+
+    monkeypatch.setattr(server, "setup_database", lambda: fake_db)
+    monkeypatch.setattr(server.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(
+        server, "run_alembic_upgrade", lambda: "called"
+    )
+    fake_db.init_database = _AsyncNoop()
+
+    async with server.lifespan(None):
+        pass
+
+    assert server.run_alembic_upgrade in upgrade_calls, (
+        "lifespan must call asyncio.to_thread(run_alembic_upgrade)"
+    )
+
+
+class _AsyncCM:
+    async def __aenter__(self):
+        return None
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _AsyncNoop:
+    def __call__(self, *args, **kwargs):
+        async def _coro():
+            return None
+
+        return _coro()

--- a/services/fishsense-api/tests/test_dive_pipeline_status_view.py
+++ b/services/fishsense-api/tests/test_dive_pipeline_status_view.py
@@ -1,0 +1,693 @@
+# pylint: disable=too-many-lines
+"""Tests for the `dive_pipeline_status` view.
+
+Each stage flag has at least one True case and at least one False
+case, including the vacuous-zero-rows edge ("zero labels of a kind"
+must read as not-complete, mirroring the
+`get_dives_with_complete_laser_labeling` semantics). Edge cases that
+historically tripped operators get their own tests:
+
+  * Dive with zero images — every flag should be False (not vacuously
+    True).
+  * Dive without `dive_slate_id` — slate_* flags should all be False
+    regardless of labels.
+  * Sentinel HeadTail/DiveSlate rows (project_id NULL) should not
+    count as "preprocessed" — matches the cohort selectors' filter.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from fishsense_api.views import (
+    DIVE_PIPELINE_STATUS_VIEW_NAME,
+    DIVE_PIPELINE_STATUS_VIEW_SQL,
+    DROP_DIVE_PIPELINE_STATUS_VIEW_SQL,
+)
+
+
+@pytest.fixture
+async def session():
+    """In-memory sqlite + the view created on top via raw SQL."""
+    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+        await conn.execute(text(DIVE_PIPELINE_STATUS_VIEW_SQL))
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    async with engine.begin() as conn:
+        await conn.execute(text(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL))
+    await engine.dispose()
+
+
+def _dive(dive_id: int, *, priority: str = "HIGH", dive_slate_id=None):
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+
+    return Dive(
+        id=dive_id,
+        path=f"/dev/null/{dive_id}",
+        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        priority=Priority[priority],
+        dive_slate_id=dive_slate_id,
+    )
+
+
+def _image(image_id: int, dive_id: int):
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    return Image(
+        id=image_id,
+        path=f"/dev/null/img-{image_id}",
+        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        checksum=f"img-{image_id:032d}"[:32],
+        dive_id=dive_id,
+    )
+
+
+_BOOL_FLAG_COLUMNS = (
+    "laser_preprocessed",
+    "laser_labeling_complete",
+    "headtail_preprocessed",
+    "headtail_labeling_complete",
+    "has_prediction_clusters",
+    "dive_images_preprocessed",
+    "species_labeling_complete",
+    "slate_applicable",
+    "slate_preprocessed",
+    "slate_labeling_complete",
+    "calibrated",
+    "measured",
+)
+
+
+async def _row(session, dive_id: int) -> dict:
+    """Fetch the view row for a dive as a dict for easy assertion.
+
+    Boolean flags get coerced to `bool` so `is True` / `is False`
+    works against both Postgres (native bool) and sqlite (0/1 int)."""
+    result = await session.exec(
+        text(
+            f"SELECT * FROM {DIVE_PIPELINE_STATUS_VIEW_NAME} "
+            f"WHERE dive_id = :dive_id"
+        ).bindparams(dive_id=dive_id)
+    )
+    row = dict(result.mappings().one())
+    for col in _BOOL_FLAG_COLUMNS:
+        row[col] = bool(row[col])
+    return row
+
+
+# ---------- baseline / identity ----------
+
+
+async def test_empty_dive_emits_a_row_with_every_flag_false(session):
+    """Edge: dive with zero images. Every flag must be False, not
+    vacuously True via empty subqueries."""
+    session.add(_dive(1))
+    await session.flush()
+
+    row = await _row(session, 1)
+    flag_columns = [
+        "laser_preprocessed",
+        "laser_labeling_complete",
+        "headtail_preprocessed",
+        "headtail_labeling_complete",
+        "has_prediction_clusters",
+        "dive_images_preprocessed",
+        "species_labeling_complete",
+        "slate_applicable",
+        "slate_preprocessed",
+        "slate_labeling_complete",
+        "calibrated",
+        "measured",
+    ]
+    for col in flag_columns:
+        assert not row[col], f"{col} should be False for an empty dive"
+
+
+async def test_identity_columns_pass_through(session):
+    session.add(_dive(7, priority="LOW", dive_slate_id=42))
+    await session.flush()
+
+    row = await _row(session, 7)
+    assert row["dive_id"] == 7
+    # priority enum stored as enum-name string by sqlmodel.
+    assert row["priority"] == "LOW"
+    assert row["dive_slate_id"] == 42
+
+
+# ---------- laser_preprocessed (stage 0.1) ----------
+
+
+async def test_laser_preprocessed_true_when_every_image_has_laser_row(session):
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add_all([_image(11, 1), _image(12, 1)])
+    await session.flush()
+    session.add_all(
+        [
+            LaserLabel(image_id=11, completed=False),
+            LaserLabel(image_id=12, completed=False),
+        ]
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["laser_preprocessed"] is True
+
+
+async def test_laser_preprocessed_false_when_one_image_lacks_label(session):
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add_all([_image(11, 1), _image(12, 1)])
+    await session.flush()
+    session.add(LaserLabel(image_id=11, completed=False))
+    await session.flush()
+
+    assert (await _row(session, 1))["laser_preprocessed"] is False
+
+
+# ---------- laser_labeling_complete ----------
+
+
+async def test_laser_labeling_complete_true_when_all_completed_and_none_incomplete(
+    session,
+):
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add_all([_image(11, 1), _image(12, 1)])
+    await session.flush()
+    session.add_all(
+        [
+            LaserLabel(image_id=11, completed=True, superseded=False),
+            LaserLabel(image_id=12, completed=True, superseded=False),
+        ]
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["laser_labeling_complete"] is True
+
+
+async def test_laser_labeling_complete_false_when_zero_labels(session):
+    """Vacuous-truth guard: zero labels must NOT read as complete."""
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+
+    assert (await _row(session, 1))["laser_labeling_complete"] is False
+
+
+async def test_laser_labeling_complete_false_when_any_incomplete(session):
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add_all([_image(11, 1), _image(12, 1)])
+    await session.flush()
+    session.add_all(
+        [
+            LaserLabel(image_id=11, completed=True, superseded=False),
+            LaserLabel(image_id=12, completed=False, superseded=False),
+        ]
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["laser_labeling_complete"] is False
+
+
+async def test_laser_labeling_complete_ignores_superseded_incomplete(session):
+    """Superseded incomplete rows are dead; they must not block
+    completion. Mirrors the laser-validate flow's behavior."""
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add_all(
+        [
+            LaserLabel(image_id=11, completed=True, superseded=False),
+            LaserLabel(image_id=11, completed=False, superseded=True),
+        ]
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["laser_labeling_complete"] is True
+
+
+# ---------- headtail_preprocessed (stage 5.1) ----------
+
+
+async def test_headtail_preprocessed_true_when_every_valid_laser_image_has_headtail(
+    session,
+):
+    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add(
+        LaserLabel(
+            image_id=11, completed=True, superseded=False,
+            x=100.0, y=200.0,
+        )
+    )
+    session.add(
+        HeadTailLabel(image_id=11, completed=False, label_studio_project_id=71)
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["headtail_preprocessed"] is True
+
+
+async def test_headtail_preprocessed_false_when_no_valid_laser_images(session):
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    # Laser is incomplete -> no valid lasers in the dive -> nothing to
+    # preprocess yet.
+    session.add(LaserLabel(image_id=11, completed=False, x=100.0, y=200.0))
+    await session.flush()
+
+    assert (await _row(session, 1))["headtail_preprocessed"] is False
+
+
+async def test_headtail_preprocessed_false_when_valid_laser_image_lacks_headtail(
+    session,
+):
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add(
+        LaserLabel(
+            image_id=11, completed=True, superseded=False,
+            x=100.0, y=200.0,
+        )
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["headtail_preprocessed"] is False
+
+
+async def test_headtail_preprocessed_ignores_sentinel_headtail_rows(session):
+    """A sentinel HeadTailLabel (label_studio_project_id NULL) does
+    NOT count as preprocessed — matches the cohort selector."""
+    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add(
+        LaserLabel(
+            image_id=11, completed=True, superseded=False,
+            x=100.0, y=200.0,
+        )
+    )
+    session.add(
+        HeadTailLabel(
+            image_id=11, completed=False, label_studio_project_id=None
+        )
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["headtail_preprocessed"] is False
+
+
+# ---------- headtail_labeling_complete ----------
+
+
+async def test_headtail_labeling_complete_true_when_all_completed_and_none_incomplete(
+    session,
+):
+    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add(
+        HeadTailLabel(
+            image_id=11, completed=True, superseded=False,
+            label_studio_project_id=71,
+        )
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["headtail_labeling_complete"] is True
+
+
+async def test_headtail_labeling_complete_false_when_any_incomplete(session):
+    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add_all([_image(11, 1), _image(12, 1)])
+    await session.flush()
+    session.add_all(
+        [
+            HeadTailLabel(
+                image_id=11, completed=True, superseded=False,
+                label_studio_project_id=71,
+            ),
+            HeadTailLabel(
+                image_id=12, completed=False, superseded=False,
+                label_studio_project_id=71,
+            ),
+        ]
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["headtail_labeling_complete"] is False
+
+
+async def test_headtail_labeling_complete_false_when_zero_labels(session):
+    session.add(_dive(1))
+    await session.flush()
+
+    assert (await _row(session, 1))["headtail_labeling_complete"] is False
+
+
+# ---------- has_prediction_clusters / dive_images_preprocessed (stage 2) ----------
+
+
+async def test_has_prediction_clusters_reflects_data_source(session):
+    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster  # pylint: disable=import-outside-toplevel
+
+    session.add_all([_dive(1), _dive(2)])
+    await session.flush()
+    session.add(
+        DiveFrameCluster(
+            dive_id=1, data_source="PREDICTION", index=0,
+        )
+    )
+    session.add(
+        DiveFrameCluster(
+            dive_id=2, data_source="LABEL_STUDIO", index=0,
+        )
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["has_prediction_clusters"] is True
+    # dive 2 only has LABEL_STUDIO clusters -> stage 1 hasn't run.
+    assert (await _row(session, 2))["has_prediction_clusters"] is False
+
+
+async def test_dive_images_preprocessed_requires_clusters_and_species_rows(session):
+    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add_all([_image(11, 1), _image(12, 1)])
+    await session.flush()
+    session.add(
+        DiveFrameCluster(
+            dive_id=1, data_source="PREDICTION", index=0,
+        )
+    )
+    session.add_all(
+        [
+            SpeciesLabel(image_id=11, label_studio_project_id=70),
+            SpeciesLabel(image_id=12, label_studio_project_id=70),
+        ]
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["dive_images_preprocessed"] is True
+
+
+async def test_dive_images_preprocessed_false_without_prediction_cluster(session):
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add(SpeciesLabel(image_id=11, label_studio_project_id=70))
+    await session.flush()
+
+    assert (await _row(session, 1))["dive_images_preprocessed"] is False
+
+
+async def test_dive_images_preprocessed_false_when_image_lacks_species_row(session):
+    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add_all([_image(11, 1), _image(12, 1)])
+    await session.flush()
+    session.add(
+        DiveFrameCluster(
+            dive_id=1, data_source="PREDICTION", index=0,
+        )
+    )
+    session.add(SpeciesLabel(image_id=11, label_studio_project_id=70))
+    await session.flush()
+
+    assert (await _row(session, 1))["dive_images_preprocessed"] is False
+
+
+# ---------- species_labeling_complete ----------
+
+
+async def test_species_labeling_complete_true_when_all_completed(session):
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add(
+        SpeciesLabel(
+            image_id=11, completed=True, superseded=False,
+            label_studio_project_id=70,
+        )
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["species_labeling_complete"] is True
+
+
+async def test_species_labeling_complete_false_when_any_incomplete(session):
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add_all([_image(11, 1), _image(12, 1)])
+    await session.flush()
+    session.add_all(
+        [
+            SpeciesLabel(
+                image_id=11, completed=True, superseded=False,
+                label_studio_project_id=70,
+            ),
+            SpeciesLabel(
+                image_id=12, completed=False, superseded=False,
+                label_studio_project_id=70,
+            ),
+        ]
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["species_labeling_complete"] is False
+
+
+# ---------- slate_applicable / slate_preprocessed / slate_labeling_complete ----------
+
+
+async def test_slate_applicable_tracks_dive_slate_id(session):
+    session.add_all([_dive(1, dive_slate_id=42), _dive(2, dive_slate_id=None)])
+    await session.flush()
+
+    assert (await _row(session, 1))["slate_applicable"] is True
+    assert (await _row(session, 2))["slate_applicable"] is False
+
+
+async def test_slate_preprocessed_true_when_marked_images_have_slate_rows(session):
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1, dive_slate_id=42))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add(
+        SpeciesLabel(
+            image_id=11, label_studio_project_id=70,
+            content_of_image="Slate, Laser on slate",
+        )
+    )
+    session.add(
+        DiveSlateLabel(image_id=11, label_studio_project_id=66)
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["slate_preprocessed"] is True
+
+
+async def test_slate_preprocessed_false_when_no_slate_marked_images(session):
+    """No species label says 'Slate, Laser on slate' -> there's
+    nothing to preprocess yet -> False, not vacuously True."""
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1, dive_slate_id=42))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add(
+        SpeciesLabel(
+            image_id=11, label_studio_project_id=70,
+            content_of_image="Fish",
+        )
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["slate_preprocessed"] is False
+
+
+async def test_slate_preprocessed_false_when_dive_lacks_slate_id(session):
+    """Even if labels exist, no dive_slate_id means slate path doesn't
+    apply to this dive at all."""
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1, dive_slate_id=None))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add(
+        SpeciesLabel(
+            image_id=11, label_studio_project_id=70,
+            content_of_image="Slate, Laser on slate",
+        )
+    )
+    session.add(DiveSlateLabel(image_id=11, label_studio_project_id=66))
+    await session.flush()
+
+    assert (await _row(session, 1))["slate_preprocessed"] is False
+
+
+async def test_slate_labeling_complete_true_when_all_completed(session):
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1, dive_slate_id=42))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add(
+        DiveSlateLabel(
+            image_id=11, completed=True, superseded=False,
+            label_studio_project_id=66,
+        )
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["slate_labeling_complete"] is True
+
+
+# ---------- calibrated (stage 13) ----------
+
+
+async def test_calibrated_true_when_laser_extrinsics_row_exists(session):
+    from fishsense_api.models.laser_extrinsics import LaserExtrinsics  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(LaserExtrinsics(dive_id=1, camera_id=1))
+    await session.flush()
+
+    assert (await _row(session, 1))["calibrated"] is True
+
+
+async def test_calibrated_false_when_no_laser_extrinsics(session):
+    session.add(_dive(1))
+    await session.flush()
+
+    assert (await _row(session, 1))["calibrated"] is False
+
+
+# ---------- measured (stage 14) ----------
+
+
+async def test_measured_true_when_every_label_studio_cluster_has_fish_id(session):
+    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add_all(
+        [
+            DiveFrameCluster(
+                dive_id=1, data_source="LABEL_STUDIO", index=0, fish_id=100,
+            ),
+            DiveFrameCluster(
+                dive_id=1, data_source="LABEL_STUDIO", index=1, fish_id=101,
+            ),
+        ]
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["measured"] is True
+
+
+async def test_measured_false_when_any_label_studio_cluster_unbound(session):
+    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add_all(
+        [
+            DiveFrameCluster(
+                dive_id=1, data_source="LABEL_STUDIO", index=0, fish_id=100,
+            ),
+            DiveFrameCluster(
+                dive_id=1, data_source="LABEL_STUDIO", index=1, fish_id=None,
+            ),
+        ]
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["measured"] is False
+
+
+async def test_measured_false_when_no_label_studio_clusters(session):
+    """Vacuous-truth guard: zero LABEL_STUDIO clusters -> not measured."""
+    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    # PREDICTION-only cluster; no LABEL_STUDIO ones.
+    session.add(
+        DiveFrameCluster(
+            dive_id=1, data_source="PREDICTION", index=0,
+        )
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["measured"] is False


### PR DESCRIPTION
## Summary

- Postgres view exposing one boolean column per pipeline stage per dive — useful for Superset dashboards and ad-hoc operator triage.
- No writeback path. Booleans are derived from the same predicates the cohort selectors already encode, so they can't drift from underlying tables.
- View SQL lives in [services/fishsense-api/src/fishsense_api/views.py](services/fishsense-api/src/fishsense_api/views.py); alembic migration `60e82ad5dac7` and test fixture both apply the same string.
- **Second commit** wires `alembic upgrade head` into the FastAPI lifespan so the new migration applies automatically on the first start of the deployed image — no manual operator step. See "Auto-migrate on startup" below.

## Columns

| Column | True iff |
|---|---|
| `laser_preprocessed` | every image has at least one `LaserLabel` row |
| `laser_labeling_complete` | ≥1 completed-non-superseded `LaserLabel` AND zero incomplete-non-superseded |
| `headtail_preprocessed` | every image with a *valid* laser label has a non-sentinel `HeadTailLabel` row |
| `headtail_labeling_complete` | ≥1 completed-non-superseded `HeadTailLabel` AND zero incomplete-non-superseded |
| `has_prediction_clusters` | dive has at least one PREDICTION `DiveFrameCluster` |
| `dive_images_preprocessed` | `has_prediction_clusters` AND every image has a non-sentinel `SpeciesLabel` row |
| `species_labeling_complete` | ≥1 completed `SpeciesLabel` AND zero incomplete |
| `slate_applicable` | `dive_slate_id IS NOT NULL` |
| `slate_preprocessed` | every image with `SpeciesLabel.content_of_image='Slate, Laser on slate'` has a non-sentinel `DiveSlateLabel` row |
| `slate_labeling_complete` | ≥1 completed `DiveSlateLabel` AND zero incomplete |
| `calibrated` | dive has a `LaserExtrinsics` row |
| `measured` | ≥1 LABEL_STUDIO `DiveFrameCluster` AND zero LABEL_STUDIO clusters with `fish_id IS NULL` |

Plus identity columns `dive_id`, `priority`, `dive_slate_id`.

## Semantics

"Complete" everywhere mirrors `get_dives_with_complete_laser_labeling`: vacuous truth (zero rows of a kind) → `False`, not `True`. So a dive with no laser labels at all is not vacuously "laser_labeling_complete" — there's nothing to validate. Same for the other `*_complete` and `measured` flags.

## Auto-migrate on startup

`fishsense_api.server.lifespan` now runs in this order before serving traffic:

1. `SQLModel.metadata.create_all` — fresh-env bootstrap (the alembic baseline is `alter_column`-only and assumes tables already exist; running alembic against an empty DB would fail without this prior step). No-op against an existing prod schema.
2. `run_alembic_upgrade` — programmatic `alembic upgrade head`, catches up to the latest migration including non-table artifacts like the new view.

`alembic.ini` does NOT ship in the runtime image (`uv sync --no-editable` only installs the package source under `site-packages/fishsense_api/`). `run_alembic_upgrade` builds the alembic Config programmatically and points `script_location` at `<package>/alembic`, which is part of the installed wheel. Sync API offloaded to `asyncio.to_thread` so DDL doesn't block the event loop.

## Test plan
- [x] `uv run --package fishsense-api pytest services/fishsense-api/tests/` → 124 passed (91 prior + 31 new view + 2 new auto-migrate)
- [x] TDD: 31 view tests + 2 auto-migrate tests written first; pylint 10/10 on touched files
- [ ] After deploy: confirm `dive_pipeline_status` is queryable as a Superset dataset under the fishsense connection (no manual alembic upgrade needed — the deploy applies it on container start)

## Future work
- The view is regular (not materialized). If Superset queries get slow at scale, convert to materialized + scheduled REFRESH.
- A `GET /api/v1/dives/{id}/pipeline-status` endpoint could read the view if non-Superset consumers want it; not building until there's a caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)