### PR TITLE
fix(api): move alembic to runtime deps (HOTFIX for v1.27.0 startup crash)

### DIFF
--- a/deploy/compose.local.yml
+++ b/deploy/compose.local.yml
@@ -89,13 +89,24 @@ services:
       - fishsense_local
 
   fishsense-api:
-    # Using the pinned prod image because the in-repo Dockerfile is broken in
-    # the monorepo layout — it COPYs services/fishsense-api/uv.lock, but the
-    # lockfile only exists at the repo root post-migration. Switching to a
-    # local `build:` here also requires fixing services/fishsense-api/Dockerfile
-    # (and .github/workflows/docker.yml) to use a workspace-aware build.
-    # Tracked as a follow-up; not needed for data-worker TDD work.
-    image: ghcr.io/ucsd-e4e/fishsense-api:v1.27.0
+    # Build from source rather than pulling a pinned prod image. This
+    # is the local stack — used by integration.yml + dev — and we want
+    # it to exercise whatever fishsense-api source is currently on the
+    # branch, not a previously-published image that may be broken.
+    #
+    # Concrete failure mode this avoids: integration tests on a PR that
+    # depends on a fishsense-api source change would otherwise pull the
+    # last-released image, which doesn't have the change. v1.27.0 made
+    # this acute — the published image crash-loops on `import alembic`
+    # because alembic was misclassified as a dev dep, so every PR's
+    # backup-worker pg_dump integration test fails on an empty DB.
+    #
+    # The Dockerfile is monorepo-aware (build context = repo root,
+    # `-f services/fishsense-api/Dockerfile`), so the `context: ..` +
+    # `dockerfile: services/fishsense-api/Dockerfile` shape works.
+    build:
+      context: ..
+      dockerfile: services/fishsense-api/Dockerfile
     restart: on-failure:15
     depends_on:
       postgres:

--- a/services/fishsense-api/pyproject.toml
+++ b/services/fishsense-api/pyproject.toml
@@ -5,6 +5,13 @@ description = "This is the FishSense API server."
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    # alembic is a *runtime* dep — the FastAPI lifespan calls
+    # `run_alembic_upgrade` on startup so deploys auto-apply pending
+    # migrations. Kept in dev too (developers run alembic CLI), but
+    # the runtime image is built with `uv sync --no-dev`, so it must
+    # appear here or `from alembic import command` blows up at import
+    # time and the container crashes before serving traffic.
+    "alembic>=1.16.5",
     "asyncpg>=0.30.0",
     "dynaconf>=3.2.11",
     "fastapi>=0.119.0",
@@ -23,7 +30,6 @@ fishsense-api-sdk = { workspace = true }
 [dependency-groups]
 dev = [
     "aiosqlite>=0.20.0",
-    "alembic>=1.16.5",
     "black>=25.9.0",
     "pylint>=4.0.2",
     "pytest>=8.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -643,6 +643,7 @@ name = "fishsense-api"
 version = "1.27.0"
 source = { editable = "services/fishsense-api" }
 dependencies = [
+    { name = "alembic" },
     { name = "asyncpg" },
     { name = "dynaconf" },
     { name = "fastapi" },
@@ -657,7 +658,6 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "aiosqlite" },
-    { name = "alembic" },
     { name = "black" },
     { name = "datamodel-code-generator" },
     { name = "fishsense-api-sdk" },
@@ -668,6 +668,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.16.5" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "fastapi", specifier = ">=0.119.0" },
@@ -682,7 +683,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
-    { name = "alembic", specifier = ">=1.16.5" },
     { name = "black", specifier = ">=25.9.0" },
     { name = "datamodel-code-generator", specifier = "==0.26.1" },
     { name = "fishsense-api-sdk", editable = "libs/fishsense-api-sdk" },


### PR DESCRIPTION
## Hotfix for prod outage on fishsense-api v1.27.0

PR #103 added \`from alembic import command\` at the top of \`fishsense_api.database\`, which runs at module-load time. alembic was declared only in \`[dependency-groups.dev]\`, but the runtime Dockerfile uses \`uv sync --no-dev --no-editable\`, so the shipped v1.27.0 image has no alembic installed.

Result: the api container crashes on startup with \`ModuleNotFoundError: No module named 'alembic'\` before serving any traffic. Auto-deploy of v1.27.0 ran successfully ~30 min ago, so prod is currently broken.

## How it surfaced

Integration test on PR #106 (the release-please PR) failed in backup-worker's pg_dump integration test:

\`\`\`
AssertionError: dump file is missing or suspiciously small: ... assert (True and 896 > 1024)
\`\`\`

The 896-byte dump is pg_dump's TOC-only output for an empty database: api never finished starting, never ran create_all + alembic upgrade, so the fishsense database has no schema.

## Fix

Move \`alembic>=1.16.5\` from \`[dependency-groups.dev]\` to \`[project.dependencies]\` in \`services/fishsense-api/pyproject.toml\`. Removed from the dev group since runtime install covers dev too.

## Test plan
- [x] \`uv lock\` resolves cleanly
- [x] \`pytest services/fishsense-api/tests/\` 124/124 still passes
- [ ] Integration suite (gated by \`integration-tests\` label) — should pass since the api will actually start now
- [ ] Post-merge: release-please cuts v1.27.1, promote retags, auto-deploy redeploys → orchestrator's fishsense-api comes back up

## Follow-up to consider

Add a CI step that runs \`uv sync --no-dev --package fishsense-api\` and tries to import \`fishsense_api\`, so a future dev/runtime dep drift fails fast in CI rather than at deploy time. Not in this PR — fix first, harden later.

Generated with Claude Code