### PR TITLE
fix(api): unblock auto-migrate on prod (alembic runtime dep + idempotent migration)

### DIFF
--- a/services/fishsense-api/src/fishsense_api/alembic/versions/299428e39cb9_add_label_studio_sync_cursor.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/299428e39cb9_add_label_studio_sync_cursor.py
@@ -21,7 +21,17 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    """Upgrade schema."""
+    """Upgrade schema.
+
+    Idempotent against `SQLModel.metadata.create_all`: the FastAPI
+    lifespan runs `create_all` before alembic upgrade, so on a
+    fresh-bootstrap deploy this table already exists by the time the
+    migration runs. Skip the DDL when the table is present.
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table('labelstudiosynccursor'):
+        return
     op.create_table(
         'labelstudiosynccursor',
         sa.Column('id', sa.Integer(), nullable=False),

--- a/services/fishsense-api/tests/test_label_studio_sync_cursor_migration.py
+++ b/services/fishsense-api/tests/test_label_studio_sync_cursor_migration.py
@@ -1,0 +1,72 @@
+"""Regression tests for the labelstudiosynccursor migration idempotency.
+
+The FastAPI lifespan runs `SQLModel.metadata.create_all` *before*
+`run_alembic_upgrade`. On a fresh-bootstrap deploy this means the
+`labelstudiosynccursor` table already exists by the time the alembic
+migration runs. The migration must skip its `create_table` op rather
+than fail with `DuplicateTableError`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _load_migration_module():
+    """Migration filenames start with a digit, so importlib.util is needed."""
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "fishsense_api"
+        / "alembic"
+        / "versions"
+        / "299428e39cb9_add_label_studio_sync_cursor.py"
+    )
+    spec = importlib.util.spec_from_file_location("ls_sync_cursor_migration", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def migration():
+    return _load_migration_module()
+
+
+def test_upgrade_skips_when_table_already_exists(migration, monkeypatch):
+    """create_all already made the table — upgrade must be a no-op."""
+    fake_inspector = MagicMock()
+    fake_inspector.has_table.return_value = True
+
+    fake_op = MagicMock()
+    fake_op.get_bind.return_value = "bind"
+
+    monkeypatch.setattr(migration, "op", fake_op)
+    monkeypatch.setattr(migration.sa, "inspect", lambda _bind: fake_inspector)
+
+    migration.upgrade()
+
+    fake_inspector.has_table.assert_called_once_with("labelstudiosynccursor")
+    fake_op.create_table.assert_not_called()
+    fake_op.create_index.assert_not_called()
+
+
+def test_upgrade_creates_when_table_absent(migration, monkeypatch):
+    """If the table somehow doesn't exist, the migration must still build it."""
+    fake_inspector = MagicMock()
+    fake_inspector.has_table.return_value = False
+
+    fake_op = MagicMock()
+    fake_op.get_bind.return_value = "bind"
+
+    monkeypatch.setattr(migration, "op", fake_op)
+    monkeypatch.setattr(migration.sa, "inspect", lambda _bind: fake_inspector)
+
+    migration.upgrade()
+
+    fake_op.create_table.assert_called_once()
+    assert fake_op.create_index.call_count == 2


### PR DESCRIPTION
## Summary

Three fixes that together let the auto-migrate-on-startup feature land on prod without crash-looping fishsense-api:

- **`alembic` is a runtime dep, not dev** — the FastAPI lifespan calls `run_alembic_upgrade`, but the runtime image ships `uv sync --no-dev`, so `from alembic import command` blew up at import time and the container never served traffic.
- **`labelstudiosynccursor` migration is idempotent vs `create_all`** — the lifespan runs `SQLModel.metadata.create_all` *before* `run_alembic_upgrade`, so the table already exists by the time `op.create_table` runs and crashes with `DuplicateTableError`. Guarded with `inspector.has_table` + early-return. Plus regression tests covering both the skip-when-exists and create-when-absent paths.
- **`compose.local.yml` builds fishsense-api from source** — was pinned to `v1.27.0` (the broken image). Local stack and integration CI now exercise whatever's on the branch, so this class of crash-on-startup bug is caught before promotion.

The DNS-resolution failures observed on the api-workflow-worker were a downstream symptom: when fishsense-api crash-loops, docker DNS can't resolve its hostname.

## Test plan

- [x] `uv run pytest services/fishsense-api/tests/test_label_studio_sync_cursor_migration.py` — both regression tests pass
- [ ] After merge + promote: `docker compose up fishsense-api` on the orchestrator host completes lifespan startup without `DuplicateTableError`
- [ ] api-workflow-worker activities (e.g. `select_next_high_priority_dive_for_headtail_preprocessing_activity`) succeed instead of failing on DNS resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)