### PR TITLE
Cap per-dive LS project titles at LS's 50-char limit

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
@@ -79,13 +79,25 @@ async def create_or_get_label_studio_project(
     return project.id
 
 
+# LS rejects `Project.title` over 50 characters with a 400. The
+# longest stage suffix ("Laser Calibration Labeling") is 26 chars, so
+# many real dive names blow the budget. `build_per_dive_title` keeps
+# titles within this cap by falling back to the `Dive {id}` form when
+# the dive's own name doesn't fit — that form is always under 50 chars
+# for any reasonable dive_id and uniquely identifies the dive.
+LS_PROJECT_TITLE_MAX = 50
+
+
 async def build_per_dive_title(dive_id: int, suffix: str) -> str:
     """Build a per-dive LS project title in the form
     `"{dive.name} - {suffix}"`. Used by the four create-LS-project
     activities so each dive ends up with its own project rather than
     sharing one canonical project per stage.
 
-    Falls back to `f"Dive {dive_id}"` when the dive has no `name`.
+    Falls back to `f"Dive {dive_id}"` when the dive has no `name` or
+    when `dive.name` would push the full title past LS's 50-char cap.
+    The fallback is keyed by `dive_id` rather than truncated name so
+    two long-named dives can't collide on the same truncated title.
     """
     async with get_fs_client() as fs:
         dive = await fs.dives.get(dive_id=dive_id)
@@ -95,7 +107,10 @@ async def build_per_dive_title(dive_id: int, suffix: str) -> str:
             "no such dive found via the API"
         )
     dive_label = dive.name or f"Dive {dive_id}"
-    return f"{dive_label} - {suffix}"
+    title = f"{dive_label} - {suffix}"
+    if len(title) > LS_PROJECT_TITLE_MAX:
+        title = f"Dive {dive_id} - {suffix}"
+    return title
 
 
 async def import_tasks_and_record_labels(

--- a/services/fishsense-api-workflow-worker/tests/test_create_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_create_laser_label_studio_project_activity.py
@@ -144,3 +144,33 @@ async def test_falls_back_to_dive_id_when_name_missing(monkeypatch):
         title=expected_title,
         label_config="<View/>",
     )
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_dive_id_when_name_too_long(monkeypatch):
+    """LS caps `Project.title` at 50 chars. When a real dive's name
+    plus the stage suffix would exceed the cap, `build_per_dive_title`
+    must fall back to the `f"Dive {dive_id}"` form rather than
+    truncating — truncation could collide two long-named dives."""
+    long_name = "2024-08-21 Florida Keys reef survey dive 03 (cohort A)"
+    assert len(long_name) > sut_utils.LS_PROJECT_TITLE_MAX
+    _patch_dive_lookup(monkeypatch, dive_name=long_name)
+    expected_title = "Dive 393 - Laser Calibration Labeling"
+    monkeypatch.setattr(sut, "LASER_LABELING_CONFIG_XML", "<View/>")
+
+    ls = _make_ls(
+        list_result=[],
+        create_result=SimpleNamespace(id=303, title=expected_title),
+    )
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+
+    result = await ActivityEnvironment().run(
+        sut.create_laser_label_studio_project_activity, 393
+    )
+
+    assert result == 303
+    assert len(expected_title) <= sut_utils.LS_PROJECT_TITLE_MAX
+    ls.projects.create.assert_called_once_with(
+        title=expected_title,
+        label_config="<View/>",
+    )

--- a/services/fishsense-api-workflow-worker/tests/test_label_studio_integration.py
+++ b/services/fishsense-api-workflow-worker/tests/test_label_studio_integration.py
@@ -108,7 +108,12 @@ async def test_create_activity_creates_then_returns_existing_on_rerun(monkeypatc
     returns the same ID. This is the contract that lets us re-run the
     Create workflow without accumulating duplicate projects."""
     dive_id = 393
-    dive_name = f"fs-create-rerun-{uuid.uuid4().hex[:8]}"
+    # LS caps `Project.title` at 50 chars. The per-dive title is
+    # `f"{dive_name} - Laser Calibration Labeling"` (29 chars of fixed
+    # suffix), so dive_name must stay <= 21 chars or LS rejects with a
+    # 400. Same constraint applies to all three integration tests
+    # below — keep prefixes short.
+    dive_name = f"rerun-{uuid.uuid4().hex[:8]}"
     _patch_dive_lookup(monkeypatch, dive_id=dive_id, dive_name=dive_name)
     monkeypatch.setattr(create_sut, "LASER_LABELING_CONFIG_XML", _MIN_LASER_XML)
     title = _expected_title(dive_name)
@@ -139,7 +144,7 @@ async def test_create_activity_raises_when_xml_constant_empty(monkeypatch):
     """Empty XML must raise rather than silently make an unlabel-able
     project, even when LS is reachable."""
     dive_id = 393
-    dive_name = f"fs-empty-xml-{uuid.uuid4().hex[:8]}"
+    dive_name = f"empty-{uuid.uuid4().hex[:8]}"
     _patch_dive_lookup(monkeypatch, dive_id=dive_id, dive_name=dive_name)
     monkeypatch.setattr(create_sut, "LASER_LABELING_CONFIG_XML", "")
 
@@ -304,7 +309,7 @@ async def test_populate_workflow_creates_then_imports_tasks_against_real_ls(
     imported on the first invocation, without any pre-seeding.
     """
     dive_id = 42
-    dive_name = f"fs-int-flow-{uuid.uuid4().hex[:8]}"
+    dive_name = f"flow-{uuid.uuid4().hex[:8]}"
     _patch_dive_lookup(monkeypatch, dive_id=dive_id, dive_name=dive_name)
     monkeypatch.setattr(create_sut, "LASER_LABELING_CONFIG_XML", _MIN_LASER_XML)
     title = _expected_title(dive_name)


### PR DESCRIPTION
## Summary
- LS rejects `Project.title` over 50 chars with a 400 — caught by the integration test's 53-char title `"fs-create-rerun-XXXXXXXX - Laser Calibration Labeling"` (failure: https://github.com/UCSD-E4E/fishsense-lite/actions/runs/25352975694/job/74336360739).
- `build_per_dive_title` now falls back to the `f"Dive {dive_id}"` shape when `dive.name` would push the full title past 50 chars. Truncation was rejected because two long-named dives could collide on the same prefix.
- Integration test dive_name prefixes trimmed (`fs-<purpose>-` → `<purpose>-`) so the constructed titles stay well under the cap.
- New unit test pins the long-name fallback so future changes to suffix length or dive-name shape can't silently regress this.

## Test plan
- [x] `uv run --package fishsense-api-workflow-worker python -m pytest services/fishsense-api-workflow-worker/tests/test_create_laser_label_studio_project_activity.py services/fishsense-api-workflow-worker/tests/test_populate_label_studio_project_workflows.py` → 13 passed (4 of which are the per-dive title path, including the new long-name fallback case).
- [x] `uv run pylint` clean on touched files.
- [ ] Integration suite re-runs against the local devcontainer LS instance after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)