### PR TITLE
feat(workers): heartbeat activity loops for progress visibility

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_dive_slate_label_studio_project_activity.py
@@ -80,6 +80,7 @@ async def populate_dive_slate_label_studio_project_activity(
             image = await fs.images.get(image_id=image_id)
             if image is not None:
                 images.append(image)
+            activity.heartbeat()
 
         if not images:
             return 0

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_headtail_label_studio_project_activity.py
@@ -108,6 +108,7 @@ async def populate_headtail_label_studio_project_activity(
             image = await fs.images.get(image_id=image_id)
             if image is not None:
                 images_by_id[image.id] = image
+            activity.heartbeat()
 
         targets = _select_target_images(
             laser_labels, images_by_id, existing_headtail

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_users_label_studio_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_users_label_studio_activity.py
@@ -63,3 +63,5 @@ async def sync_users_label_studio_activity():
                         new_fs_user.id = fs_user.id
 
                         tg.create_task(fs.users.put(new_fs_user))
+
+                    activity.heartbeat()

--- a/services/fishsense-backup-worker/src/fishsense_backup_worker/activities/_heartbeat.py
+++ b/services/fishsense-backup-worker/src/fishsense_backup_worker/activities/_heartbeat.py
@@ -1,0 +1,51 @@
+"""Heartbeat helpers for backup-worker activities.
+
+The backup activities both wrap a long-running blocking call
+(`pg_dump` subprocess, `synology-api` NAS list+delete) inside
+`asyncio.to_thread`. Because the work doesn't yield to the event
+loop, the activity body can't pump heartbeats inline — instead we
+spawn a background pump task that fires `activity.heartbeat()` on a
+fixed cadence while the blocking work runs, mirroring the api-worker
+pattern in `activities/utils.py::_list_ls_tasks_with_heartbeat`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+from temporalio import activity
+
+DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 30.0
+
+
+@asynccontextmanager
+async def heartbeat_pump(
+    interval_seconds: float = DEFAULT_HEARTBEAT_INTERVAL_SECONDS,
+) -> AsyncIterator[None]:
+    """Run `activity.heartbeat()` on a ticker for the duration of the
+    `async with` block.
+
+    The pump is cancelled cleanly on exit; it can't outlive the
+    activity body and won't suppress exceptions raised inside the
+    block.
+    """
+
+    async def _pump() -> None:
+        try:
+            while True:
+                await asyncio.sleep(interval_seconds)
+                activity.heartbeat()
+        except asyncio.CancelledError:
+            return
+
+    pump = asyncio.create_task(_pump())
+    try:
+        yield
+    finally:
+        pump.cancel()
+        try:
+            await pump
+        except asyncio.CancelledError:
+            pass

--- a/services/fishsense-backup-worker/src/fishsense_backup_worker/activities/pg_dump_database.py
+++ b/services/fishsense-backup-worker/src/fishsense_backup_worker/activities/pg_dump_database.py
@@ -23,6 +23,7 @@ from datetime import datetime, timezone
 
 from temporalio import activity
 
+from fishsense_backup_worker.activities._heartbeat import heartbeat_pump
 from fishsense_backup_worker.backup_naming import backup_filename
 from fishsense_backup_worker.config import settings
 from fishsense_backup_worker.nas import NasBackupClient
@@ -83,10 +84,11 @@ async def pg_dump_database(payload) -> None:  # type: ignore[no-untyped-def]
         payload.nas_root_path,
     )
 
-    await asyncio.to_thread(
-        _dump_and_upload,
-        db_name=payload.db_name,
-        nas_root_path=payload.nas_root_path,
-    )
+    async with heartbeat_pump():
+        await asyncio.to_thread(
+            _dump_and_upload,
+            db_name=payload.db_name,
+            nas_root_path=payload.nas_root_path,
+        )
 
     activity.logger.info("pg_dump_database done db=%s", payload.db_name)

--- a/services/fishsense-backup-worker/src/fishsense_backup_worker/activities/prune_database_backups.py
+++ b/services/fishsense-backup-worker/src/fishsense_backup_worker/activities/prune_database_backups.py
@@ -8,6 +8,7 @@ from typing import List
 
 from temporalio import activity
 
+from fishsense_backup_worker.activities._heartbeat import heartbeat_pump
 from fishsense_backup_worker.backup_naming import filenames_to_prune
 from fishsense_backup_worker.config import settings
 from fishsense_backup_worker.nas import NasBackupClient
@@ -54,12 +55,13 @@ async def prune_database_backups(payload) -> None:  # type: ignore[no-untyped-de
         payload.keep,
     )
 
-    pruned = await asyncio.to_thread(
-        _prune,
-        db_name=payload.db_name,
-        nas_root_path=payload.nas_root_path,
-        keep=payload.keep,
-    )
+    async with heartbeat_pump():
+        pruned = await asyncio.to_thread(
+            _prune,
+            db_name=payload.db_name,
+            nas_root_path=payload.nas_root_path,
+            keep=payload.keep,
+        )
 
     activity.logger.info(
         "prune_database_backups done db=%s pruned_count=%d",

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/perform_laser_calibration_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/perform_laser_calibration_activity.py
@@ -82,15 +82,18 @@ async def _gather_laser_points(
     laser_points: list[np.ndarray] = []
     for label in dive_slate_labels:
         if label.image_id is None:
+            activity.heartbeat()
             continue
         laser_label = await fs.labels.get_laser_label(image_id=label.image_id)
         if laser_label is None or laser_label.x is None or laser_label.y is None:
+            activity.heartbeat()
             continue
         point = _laser_point_in_camera_space(
             label, laser_label, slate, camera_intrinsics
         )
         if point is not None:
             laser_points.append(point)
+        activity.heartbeat()
     return laser_points
 
 


### PR DESCRIPTION
## Summary

- Adds `activity.heartbeat()` to activity loops that weren't already pumping, so per-item progress shows up in the Temporal UI on long-running activities.
- Four `populate_*_label_studio_project` and four `sync_*_labels_for_label_studio_project` activities are unchanged — they already heartbeat through `import_tasks_and_record_labels` (populate_utils.py) and `sync_label_studio_project` / `_list_ls_tasks_with_heartbeat` (utils.py).
- New `heartbeat_pump` async-context helper in the backup worker wraps the long blocking `asyncio.to_thread` calls in `pg_dump_database` and `prune_database_backups` with a 30s ticker, mirroring the existing api-worker `_list_ls_tasks_with_heartbeat` pattern.

### Activities instrumented

- `populate_dive_slate_label_studio_project_activity` — per-image hydration loop
- `populate_headtail_label_studio_project_activity` — per-image hydration loop
- `sync_users_label_studio_activity` — per-user reconcile loop
- `perform_laser_calibration_activity` — per-label `_gather_laser_points` loop
- `pg_dump_database` — `heartbeat_pump` around `pg_dump` subprocess + NAS upload
- `prune_database_backups` — `heartbeat_pump` around NAS list + delete

### Intentionally skipped

Single-shot activities where heartbeating adds noise without progress to report: 8 `select_next_high_priority_dive_for_*`, 4 `get_*_label_studio_project_ids`, 4 `resolve_*_preprocess_inputs`, 4 `create_*_label_studio_project`, the 4 per-image `preprocess_*_image`, `cluster_dive_frames`, `stage_slate_pdf`, `write_dashboard_config`, `get_label_studio_projects`, `get_dives_with_complete_laser_labeling`.

### Note on backup workflow

`backup_databases_workflow` doesn't currently set `heartbeat_timeout`, so heartbeats will show progress in the UI but won't enforce liveness. Adding `heartbeat_timeout=timedelta(minutes=2)` on the activity calls is a separate decision — happy to do that in a follow-up if desired.

## Test plan

- [x] `pytest services/fishsense-backup-worker/tests/` — 26 passed
- [x] `pytest services/fishsense-api-workflow-worker/tests/` — 155 passed
- [x] `pytest services/fishsense-data-processing-workflow-worker/tests/ -m "not integration"` — 85 passed
- [ ] Observe heartbeat events in the Temporal UI on the next scheduled run of each touched activity (e.g. the daily backup workflow, the next stage-13 calibration firing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)