### PR TITLE
chore(deploy): bump fishsense-lite-web to v0.2.0

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -25,7 +25,7 @@ services:
     restart: on-failure:15
 
   fishsense-lite-web:
-    image: ghcr.io/ucsd-e4e/fishsense-lite-web:main
+    image: ghcr.io/ucsd-e4e/fishsense-lite-web:v0.2.0
     restart: on-failure:15
     env_file:
       # Untracked, populated on the host. Required keys:


### PR DESCRIPTION
One-time hand-bump that flips the pin from `:main` (the first-deploy seed) to a versioned tag.

## Why no auto-deploy PR was opened by promote.yml

`promote.yml`'s auto-bump regex requires a `:v[0-9]+\.[0-9]+\.[0-9]+`-shaped pin to match. The `:main` seed didn't match, so the v0.2.0 release (promoted from `sha-b1d34f9` by run 25358190738) skipped the bump step with `no compose pin found for fishsense-lite-web`. Image was promoted to `:v0.2.0` + `:latest` successfully — only the compose-pin update + auto-deploy PR were skipped.

After this PR lands, future `fishsense-lite-web` releases will auto-bump through the standard promote → auto-deploy chain like every other service.

## Branch naming

Branch is `auto-deploy/fishsense-lite-web-v0.2.0` so [deploy.yml](.github/workflows/deploy.yml) fires when this PR merges (orchestrator-host route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)