### PR TITLE
fix(data-worker): use start_to_close on per-image preprocess activities

### DIFF
--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/preprocess_dive_images_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/preprocess_dive_images_workflow.py
@@ -58,7 +58,7 @@ class PreprocessDiveImagesWorkflow:
                             camera_matrix=payload.camera_matrix,
                             distortion_coefficients=payload.distortion_coefficients,
                         ),
-                        schedule_to_close_timeout=timedelta(minutes=5),
+                        start_to_close_timeout=timedelta(minutes=5),
                     )
                     for i, checksum in enumerate(cluster)
                 ]

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/preprocess_headtail_images_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/preprocess_headtail_images_workflow.py
@@ -49,7 +49,7 @@ class PreprocessHeadtailImagesWorkflow:
                         camera_matrix=payload.camera_matrix,
                         distortion_coefficients=payload.distortion_coefficients,
                     ),
-                    schedule_to_close_timeout=timedelta(minutes=5),
+                    start_to_close_timeout=timedelta(minutes=5),
                 )
                 for checksum in payload.image_checksums
             ]

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/preprocess_laser_images_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/preprocess_laser_images_workflow.py
@@ -55,7 +55,7 @@ class PreprocessLaserImagesWorkflow:
                         camera_matrix=payload.camera_matrix,
                         distortion_coefficients=payload.distortion_coefficients,
                     ),
-                    schedule_to_close_timeout=timedelta(minutes=5),
+                    start_to_close_timeout=timedelta(minutes=5),
                 )
                 for checksum in payload.image_checksums
             ]

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/preprocess_slate_images_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/preprocess_slate_images_workflow.py
@@ -59,7 +59,7 @@ class PreprocessSlateImagesWorkflow:
                         camera_matrix=payload.camera_matrix,
                         distortion_coefficients=payload.distortion_coefficients,
                     ),
-                    schedule_to_close_timeout=timedelta(minutes=5),
+                    start_to_close_timeout=timedelta(minutes=5),
                 )
                 for checksum in payload.image_checksums
             ]

--- a/services/fishsense-data-processing-workflow-worker/tests/test_preprocess_dive_images_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_preprocess_dive_images_workflow.py
@@ -89,7 +89,7 @@ async def test_workflow_uses_start_to_close_not_schedule_to_close():
     timeouts: List[Tuple[Optional[timedelta], Optional[timedelta]]] = []
 
     @activity.defn(name="preprocess_dive_image")
-    async def stub_preprocess_dive_image(payload: PreprocessDiveImageInput) -> None:
+    async def stub_preprocess_dive_image(payload: PreprocessDiveImageInput) -> None:  # pylint: disable=unused-argument
         info = activity.info()
         timeouts.append((info.start_to_close_timeout, info.schedule_to_close_timeout))
 

--- a/services/fishsense-data-processing-workflow-worker/tests/test_preprocess_dive_images_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_preprocess_dive_images_workflow.py
@@ -8,7 +8,8 @@ without doing any real image work.
 """
 
 import uuid
-from typing import List
+from datetime import timedelta
+from typing import List, Optional, Tuple
 
 import pytest
 from temporalio import activity
@@ -79,6 +80,43 @@ async def test_workflow_fans_out_one_activity_per_image_with_correct_indices():
     for c in calls:
         assert c.camera_matrix == _K
         assert c.distortion_coefficients == _D
+
+
+@pytest.mark.asyncio
+async def test_workflow_uses_start_to_close_not_schedule_to_close():
+    """See PreprocessHeadtailImagesWorkflow's matching test — same fan-out
+    shape, same prod failure mode."""
+    timeouts: List[Tuple[Optional[timedelta], Optional[timedelta]]] = []
+
+    @activity.defn(name="preprocess_dive_image")
+    async def stub_preprocess_dive_image(payload: PreprocessDiveImageInput) -> None:
+        info = activity.info()
+        timeouts.append((info.start_to_close_timeout, info.schedule_to_close_timeout))
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-stage2-timeouts",
+            workflows=[PreprocessDiveImagesWorkflow],
+            activities=[stub_preprocess_dive_image],
+        ):
+            await env.client.execute_workflow(
+                PreprocessDiveImagesWorkflow.run,
+                PreprocessDiveImagesInput(
+                    dive_id=383,
+                    clusters=[["a"]],
+                    camera_matrix=_K,
+                    distortion_coefficients=_D,
+                ),
+                id=f"test-stage2-timeouts-{uuid.uuid4()}",
+                task_queue="test-stage2-timeouts",
+            )
+
+    assert len(timeouts) == 1
+    start_to_close, schedule_to_close = timeouts[0]
+    assert start_to_close is not None and start_to_close > timedelta(0)
+    if schedule_to_close is not None and schedule_to_close > timedelta(0):
+        assert schedule_to_close > start_to_close
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-data-processing-workflow-worker/tests/test_preprocess_headtail_images_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_preprocess_headtail_images_workflow.py
@@ -1,7 +1,8 @@
 """Workflow contract test for PreprocessHeadtailImagesWorkflow."""
 
 import uuid
-from typing import List
+from datetime import timedelta
+from typing import List, Optional, Tuple
 
 import pytest
 from temporalio import activity
@@ -51,6 +52,55 @@ async def test_workflow_fans_out_one_activity_per_image_with_correct_args():
         assert c.output_folder == "preprocess_headtail_jpeg"
         assert c.camera_matrix == _K
         assert c.distortion_coefficients == _D
+
+
+@pytest.mark.asyncio
+async def test_workflow_uses_start_to_close_not_schedule_to_close():
+    """Per-image preprocess activities must be timed by execution duration,
+    not queue+execution. With fan-out across many images on a small worker
+    pool, schedule_to_close_timeout would tick down while activities sit in
+    the task queue waiting for an executor slot — the dive-76 head/tail run
+    failed exactly this way in prod (activity scheduled at event 16, started
+    at event 352, hit the 5-minute schedule_to_close before completing).
+    """
+    timeouts: List[Tuple[Optional[timedelta], Optional[timedelta]]] = []
+
+    @activity.defn(name="preprocess_headtail_image")
+    async def stub(payload: PreprocessHeadtailImageInput) -> None:
+        info = activity.info()
+        timeouts.append((info.start_to_close_timeout, info.schedule_to_close_timeout))
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-stage51-timeouts",
+            workflows=[PreprocessHeadtailImagesWorkflow],
+            activities=[stub],
+        ):
+            await env.client.execute_workflow(
+                PreprocessHeadtailImagesWorkflow.run,
+                PreprocessHeadtailImagesInput(
+                    dive_id=383,
+                    image_checksums=["a"],
+                    camera_matrix=_K,
+                    distortion_coefficients=_D,
+                ),
+                id=f"test-stage51-timeouts-{uuid.uuid4()}",
+                task_queue="test-stage51-timeouts",
+            )
+
+    assert len(timeouts) == 1
+    start_to_close, schedule_to_close = timeouts[0]
+    assert start_to_close is not None and start_to_close > timedelta(0), (
+        "per-image activity must set start_to_close_timeout — execution "
+        "budget per image, not queue+execution"
+    )
+    if schedule_to_close is not None and schedule_to_close > timedelta(0):
+        assert schedule_to_close > start_to_close, (
+            "schedule_to_close (queue+execution) must not be the binding "
+            "constraint on per-image execution; it should be looser than "
+            "start_to_close, since fan-out wait time is unbounded"
+        )
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-data-processing-workflow-worker/tests/test_preprocess_headtail_images_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_preprocess_headtail_images_workflow.py
@@ -66,7 +66,7 @@ async def test_workflow_uses_start_to_close_not_schedule_to_close():
     timeouts: List[Tuple[Optional[timedelta], Optional[timedelta]]] = []
 
     @activity.defn(name="preprocess_headtail_image")
-    async def stub(payload: PreprocessHeadtailImageInput) -> None:
+    async def stub(payload: PreprocessHeadtailImageInput) -> None:  # pylint: disable=unused-argument
         info = activity.info()
         timeouts.append((info.start_to_close_timeout, info.schedule_to_close_timeout))
 

--- a/services/fishsense-data-processing-workflow-worker/tests/test_preprocess_laser_images_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_preprocess_laser_images_workflow.py
@@ -75,7 +75,7 @@ async def test_workflow_uses_start_to_close_not_schedule_to_close():
     timeouts: List[Tuple[Optional[timedelta], Optional[timedelta]]] = []
 
     @activity.defn(name="preprocess_laser_image")
-    async def stub_preprocess_laser_image(payload: PreprocessLaserImageInput) -> None:
+    async def stub_preprocess_laser_image(payload: PreprocessLaserImageInput) -> None:  # pylint: disable=unused-argument
         info = activity.info()
         timeouts.append((info.start_to_close_timeout, info.schedule_to_close_timeout))
 

--- a/services/fishsense-data-processing-workflow-worker/tests/test_preprocess_laser_images_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_preprocess_laser_images_workflow.py
@@ -6,7 +6,8 @@ here — only on the workflow's fanout shape and per-image arg propagation.
 """
 
 import uuid
-from typing import List
+from datetime import timedelta
+from typing import List, Optional, Tuple
 
 import pytest
 from temporalio import activity
@@ -64,6 +65,45 @@ async def test_workflow_fans_out_one_activity_per_image_with_correct_args():
         assert c.camera_matrix == _K
         assert c.distortion_coefficients == _D
         assert c.output_folder == "preprocess_jpeg"
+
+
+@pytest.mark.asyncio
+async def test_workflow_uses_start_to_close_not_schedule_to_close():
+    """See PreprocessHeadtailImagesWorkflow's matching test — same fan-out
+    shape, same prod failure mode (queue wait > schedule_to_close on dives
+    with image counts >> data-worker pool size)."""
+    timeouts: List[Tuple[Optional[timedelta], Optional[timedelta]]] = []
+
+    @activity.defn(name="preprocess_laser_image")
+    async def stub_preprocess_laser_image(payload: PreprocessLaserImageInput) -> None:
+        info = activity.info()
+        timeouts.append((info.start_to_close_timeout, info.schedule_to_close_timeout))
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-stage01-timeouts",
+            workflows=[PreprocessLaserImagesWorkflow],
+            activities=[stub_preprocess_laser_image],
+        ):
+            await env.client.execute_workflow(
+                PreprocessLaserImagesWorkflow.run,
+                PreprocessLaserImagesInput(
+                    dive_id=440,
+                    image_checksums=["a"],
+                    camera_matrix=_K,
+                    distortion_coefficients=_D,
+                    bbox=list(_BBOX),
+                ),
+                id=f"test-stage01-timeouts-{uuid.uuid4()}",
+                task_queue="test-stage01-timeouts",
+            )
+
+    assert len(timeouts) == 1
+    start_to_close, schedule_to_close = timeouts[0]
+    assert start_to_close is not None and start_to_close > timedelta(0)
+    if schedule_to_close is not None and schedule_to_close > timedelta(0):
+        assert schedule_to_close > start_to_close
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-data-processing-workflow-worker/tests/test_preprocess_slate_images_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_preprocess_slate_images_workflow.py
@@ -1,7 +1,8 @@
 """Workflow contract test for PreprocessSlateImagesWorkflow."""
 
 import uuid
-from typing import List
+from datetime import timedelta
+from typing import List, Optional, Tuple
 
 import pytest
 from temporalio import activity
@@ -58,6 +59,46 @@ async def test_workflow_fans_out_one_activity_per_image_with_correct_args():
         assert [tuple(p) for p in c.reference_points] == _REF_POINTS
         assert c.camera_matrix == _K
         assert c.distortion_coefficients == _D
+
+
+@pytest.mark.asyncio
+async def test_workflow_uses_start_to_close_not_schedule_to_close():
+    """See PreprocessHeadtailImagesWorkflow's matching test — same fan-out
+    shape, same prod failure mode."""
+    timeouts: List[Tuple[Optional[timedelta], Optional[timedelta]]] = []
+
+    @activity.defn(name="preprocess_slate_image")
+    async def stub(payload: PreprocessSlateImageInput) -> None:
+        info = activity.info()
+        timeouts.append((info.start_to_close_timeout, info.schedule_to_close_timeout))
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-stage9-timeouts",
+            workflows=[PreprocessSlateImagesWorkflow],
+            activities=[stub],
+        ):
+            await env.client.execute_workflow(
+                PreprocessSlateImagesWorkflow.run,
+                PreprocessSlateImagesInput(
+                    dive_id=383,
+                    image_checksums=["a"],
+                    slate_id=10,
+                    slate_dpi=300,
+                    reference_points=_REF_POINTS,
+                    camera_matrix=_K,
+                    distortion_coefficients=_D,
+                ),
+                id=f"test-stage9-timeouts-{uuid.uuid4()}",
+                task_queue="test-stage9-timeouts",
+            )
+
+    assert len(timeouts) == 1
+    start_to_close, schedule_to_close = timeouts[0]
+    assert start_to_close is not None and start_to_close > timedelta(0)
+    if schedule_to_close is not None and schedule_to_close > timedelta(0):
+        assert schedule_to_close > start_to_close
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-data-processing-workflow-worker/tests/test_preprocess_slate_images_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_preprocess_slate_images_workflow.py
@@ -68,7 +68,7 @@ async def test_workflow_uses_start_to_close_not_schedule_to_close():
     timeouts: List[Tuple[Optional[timedelta], Optional[timedelta]]] = []
 
     @activity.defn(name="preprocess_slate_image")
-    async def stub(payload: PreprocessSlateImageInput) -> None:
+    async def stub(payload: PreprocessSlateImageInput) -> None:  # pylint: disable=unused-argument
         info = activity.info()
         timeouts.append((info.start_to_close_timeout, info.schedule_to_close_timeout))
 


### PR DESCRIPTION
## Summary

- The four preprocess fan-out workflows (laser/dive/headtail/slate) used `schedule_to_close_timeout=5min`, which clocks **queue wait + execution**. With 8 concurrent activity slots and `asyncio.gather` scheduling every per-image activity at t=0, late-queued activities on large dives burned through the 5-minute budget before ever starting.
- Switching each to `start_to_close_timeout=5min` gives every activity a real per-execution budget regardless of queue depth. Recovery is automatic — the parent uses `id_reuse_policy=ALLOW_DUPLICATE_FAILED_ONLY`, so the next hourly firing re-dispatches the failed child cleanly.
- Added a `test_workflow_uses_start_to_close_not_schedule_to_close` contract test to all four workflow test files. Each captures `activity.info()` and asserts `start_to_close` is set and (when non-zero) `schedule_to_close > start_to_close`. Verified the test fails against the prior code before applying the fix.

### Concrete trigger

Dive 76 stage 5.1 (`PreprocessHeadtailImagesWorkflow`):
- `preprocess_headtail_image` activity 12 scheduled at event 16, started at event 352
- Hit `TIMEOUT_TYPE_SCHEDULE_TO_CLOSE` non-retryable
- Child workflow `preprocess-headtail-76` failed → parent failed

## Test plan

- [x] New contract tests verified to fail on the old code
- [x] All four contract tests pass after the fix
- [x] Full data-worker non-integration suite: 89 passed, 9 deselected (integration-only)
- [ ] Confirm next hourly stage 5.1 firing on dive 76 succeeds end-to-end after deploy

## Out of scope

`uv.lock` had unrelated drift (`fishsense-api-workflow-worker` 1.32.1 → 1.33.0 catch-up to a previous pyproject bump). Left out of this PR; can be synced separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)