### PR TITLE
feat(web): gate /portal/* with Authentik OIDC via Auth.js v5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ need a failing test before the implementation lands.
 |---|---|---|
 | `services/fishsense-api/` | FastAPI app (DB CRUD, label endpoints) | — |
 | `services/fishsense-api-workflow-worker/` | api-side Temporal worker: hourly Label Studio sync (laser/headtail/dive-slate/species), on-demand Create/Populate × {Laser,Species,HeadTail,DiveSlate} LS project workflows, hourly preprocess parents for stages 0.1 / 2 / 5.1 / 9 (select + resolve; dispatch child to data-worker) | `fishsense_api_queue` |
-| `apps/fishsense-lite-web/` | Next.js 15 (App Router) + React + TS landing page at `fishsense.e4e.ucsd.edu`. SSR fetches LS project IDs from fishsense-api, resolves names from Label Studio, renders categorized link cards. Replaces the prior mafl dashboard + its hourly config-writer workflow. Will grow into a full web app. | — |
+| `apps/fishsense-lite-web/` | Next.js 15 (App Router) + React + TS landing page at `fishsense.e4e.ucsd.edu`. SSR fetches LS project IDs from fishsense-api, resolves names from Label Studio, renders categorized link cards. Auth.js (next-auth v5) with Authentik OIDC gates `/portal/*`; landing stays public. Replaces the prior mafl dashboard + its hourly config-writer workflow. Will grow into a full web app. | — |
 | `services/fishsense-data-processing-workflow-worker/` | image preprocessing (rectify/overlay/JPEG), laser calibration, fish measurement | `fishsense_data_processing_queue` |
 | `services/fishsense-backup-worker/` | nightly Postgres → NAS backups + retention | `fishsense_backup_queue` |
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Services (each is a workspace member with its own Dockerfile under
 - `services/fishsense-backup-worker/` — Temporal worker for nightly
   Postgres → NAS backups + retention pruning
 
+Apps (Node/Next.js workspace, separate from the Python services):
+
+- `apps/fishsense-lite-web/` — Next.js 15 (App Router) + React + TS web
+  app at `fishsense.e4e.ucsd.edu`. Public landing page (SSR LS-project
+  link cards). Authenticated `/portal/*` gated by Auth.js (next-auth v5)
+  with Authentik OIDC; app-owned JWT session. Configure with the four
+  `AUTH_*` env vars in `web_volumes/.env` (see `.env.example`).
+
 Libraries (workspace members, not published separately):
 
 - `libs/fishsense-shared/` — shared Dynaconf / TLS / logging helpers

--- a/apps/fishsense-lite-web/.env.example
+++ b/apps/fishsense-lite-web/.env.example
@@ -4,3 +4,13 @@ FISHSENSE_API_PASSWORD=
 
 LABEL_STUDIO_URL=https://labeler.e4e.ucsd.edu
 LABEL_STUDIO_API_KEY=
+
+# OAuth via Authentik (gates /portal/*; landing page stays public).
+# AUTH_SECRET: generate with `openssl rand -base64 32`. Used to sign session JWTs.
+AUTH_SECRET=
+# Authentik OIDC provider client credentials.
+AUTH_AUTHENTIK_ID=
+AUTH_AUTHENTIK_SECRET=
+# Issuer URL — include the application slug, no trailing slash, e.g.
+# https://auth.e4e.ucsd.edu/application/o/fishsense-lite-web
+AUTH_AUTHENTIK_ISSUER=

--- a/apps/fishsense-lite-web/app/api/auth/[...nextauth]/route.ts
+++ b/apps/fishsense-lite-web/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/auth";
+
+export const { GET, POST } = handlers;

--- a/apps/fishsense-lite-web/app/page.tsx
+++ b/apps/fishsense-lite-web/app/page.tsx
@@ -15,8 +15,14 @@ export default async function HomePage() {
 
   return (
     <main className="mx-auto max-w-6xl px-6 py-12">
-      <header className="mb-10">
+      <header className="mb-10 flex items-center justify-between gap-4">
         <h1 className="text-4xl font-semibold tracking-tight">E4E FishSense</h1>
+        <a
+          href="/portal"
+          className="rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
+        >
+          Sign in
+        </a>
       </header>
       <div className="space-y-10">
         {sections.map((section) => (

--- a/apps/fishsense-lite-web/app/portal/page.tsx
+++ b/apps/fishsense-lite-web/app/portal/page.tsx
@@ -1,0 +1,41 @@
+import { auth, signOut } from "@/auth";
+
+export const dynamic = "force-dynamic";
+
+export default async function PortalPage() {
+  const session = await auth();
+  const user = session?.user;
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-12">
+      <header className="mb-8 flex items-center justify-between">
+        <h1 className="text-3xl font-semibold tracking-tight">Portal</h1>
+        <form
+          action={async () => {
+            "use server";
+            await signOut({ redirectTo: "/" });
+          }}
+        >
+          <button
+            type="submit"
+            className="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium shadow-sm transition hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800"
+          >
+            Sign out
+          </button>
+        </form>
+      </header>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <h2 className="text-lg font-medium">Signed in as</h2>
+        <dl className="mt-3 grid grid-cols-[max-content_1fr] gap-x-4 gap-y-2 text-sm">
+          <dt className="text-slate-500">Name</dt>
+          <dd>{user?.name ?? "—"}</dd>
+          <dt className="text-slate-500">Email</dt>
+          <dd>{user?.email ?? "—"}</dd>
+          <dt className="text-slate-500">Groups</dt>
+          <dd>{user?.groups?.length ? user.groups.join(", ") : "—"}</dd>
+        </dl>
+      </section>
+    </main>
+  );
+}

--- a/apps/fishsense-lite-web/auth.ts
+++ b/apps/fishsense-lite-web/auth.ts
@@ -1,0 +1,21 @@
+import NextAuth from "next-auth";
+import Authentik from "next-auth/providers/authentik";
+import { jwtCallback, sessionCallback } from "@/lib/auth-callbacks";
+import { env } from "@/lib/env";
+
+export const { auth, handlers, signIn, signOut } = NextAuth({
+  secret: env.authSecret,
+  trustHost: true,
+  session: { strategy: "jwt" },
+  providers: [
+    Authentik({
+      clientId: env.authAuthentikId,
+      clientSecret: env.authAuthentikSecret,
+      issuer: env.authAuthentikIssuer,
+    }),
+  ],
+  callbacks: {
+    jwt: jwtCallback,
+    session: sessionCallback,
+  },
+});

--- a/apps/fishsense-lite-web/auth.ts
+++ b/apps/fishsense-lite-web/auth.ts
@@ -3,7 +3,10 @@ import Authentik from "next-auth/providers/authentik";
 import { jwtCallback, sessionCallback } from "@/lib/auth-callbacks";
 import { env } from "@/lib/env";
 
-export const { auth, handlers, signIn, signOut } = NextAuth({
+// Function-form config: env is read per-request, not at module load.
+// `next build` imports this module to collect page data without AUTH_*
+// env vars set, so reading env eagerly here would fail the build.
+export const { auth, handlers, signIn, signOut } = NextAuth(() => ({
   secret: env.authSecret,
   trustHost: true,
   session: { strategy: "jwt" },
@@ -18,4 +21,4 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
     jwt: jwtCallback,
     session: sessionCallback,
   },
-});
+}));

--- a/apps/fishsense-lite-web/lib/auth-callbacks.test.ts
+++ b/apps/fishsense-lite-web/lib/auth-callbacks.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { jwtCallback, sessionCallback } from "./auth-callbacks";
+
+const baseToken = { sub: "u1", name: "User One", email: "u@e.com" };
+
+describe("jwtCallback", () => {
+  it("copies access_token from account on initial sign-in", async () => {
+    const result = await jwtCallback({
+      token: { ...baseToken },
+      account: { access_token: "at-123", provider: "authentik" } as never,
+      profile: { groups: ["a", "b"] } as never,
+    });
+    expect(result.accessToken).toBe("at-123");
+  });
+
+  it("copies groups from profile on initial sign-in", async () => {
+    const result = await jwtCallback({
+      token: { ...baseToken },
+      account: { access_token: "at-1" } as never,
+      profile: { groups: ["fishsense-admins", "labelers"] } as never,
+    });
+    expect(result.groups).toEqual(["fishsense-admins", "labelers"]);
+  });
+
+  it("defaults groups to [] when profile has none", async () => {
+    const result = await jwtCallback({
+      token: { ...baseToken },
+      account: { access_token: "at-1" } as never,
+      profile: {} as never,
+    });
+    expect(result.groups).toEqual([]);
+  });
+
+  it("returns token unchanged on subsequent calls (no account)", async () => {
+    const existing = { ...baseToken, accessToken: "at-prev", groups: ["x"] };
+    const result = await jwtCallback({
+      token: existing,
+      account: null,
+      profile: undefined,
+    });
+    expect(result.accessToken).toBe("at-prev");
+    expect(result.groups).toEqual(["x"]);
+  });
+});
+
+describe("sessionCallback", () => {
+  it("surfaces accessToken and groups from token onto session", async () => {
+    const result = await sessionCallback({
+      session: { user: { name: "User One", email: "u@e.com" }, expires: "2099-01-01" } as never,
+      token: { ...baseToken, accessToken: "at-9", groups: ["g1"] } as never,
+    });
+    expect(result.accessToken).toBe("at-9");
+    expect(result.user.groups).toEqual(["g1"]);
+  });
+
+  it("defaults groups to [] when token has none", async () => {
+    const result = await sessionCallback({
+      session: { user: { name: "U", email: "u@e.com" }, expires: "2099-01-01" } as never,
+      token: { ...baseToken } as never,
+    });
+    expect(result.user.groups).toEqual([]);
+    expect(result.accessToken).toBeUndefined();
+  });
+});

--- a/apps/fishsense-lite-web/lib/auth-callbacks.ts
+++ b/apps/fishsense-lite-web/lib/auth-callbacks.ts
@@ -1,0 +1,35 @@
+import type { Account, Profile, Session } from "next-auth";
+import type { JWT } from "next-auth/jwt";
+
+interface AuthentikProfileLike extends Profile {
+  groups?: string[];
+}
+
+interface JwtCallbackArgs {
+  token: JWT;
+  account?: Account | null;
+  profile?: AuthentikProfileLike;
+}
+
+export async function jwtCallback({ token, account, profile }: JwtCallbackArgs): Promise<JWT> {
+  if (account) {
+    if (typeof account.access_token === "string") {
+      token.accessToken = account.access_token;
+    }
+    token.groups = Array.isArray(profile?.groups) ? profile.groups : [];
+  }
+  return token;
+}
+
+interface SessionCallbackArgs {
+  session: Session;
+  token: JWT;
+}
+
+export async function sessionCallback({ session, token }: SessionCallbackArgs): Promise<Session> {
+  if (typeof token.accessToken === "string") {
+    session.accessToken = token.accessToken;
+  }
+  session.user.groups = Array.isArray(token.groups) ? token.groups : [];
+  return session;
+}

--- a/apps/fishsense-lite-web/lib/env.test.ts
+++ b/apps/fishsense-lite-web/lib/env.test.ts
@@ -28,12 +28,25 @@ describe("env proxy", () => {
     vi.stubEnv("FISHSENSE_API_PASSWORD", "p");
     vi.stubEnv("LABEL_STUDIO_URL", "http://ls");
     vi.stubEnv("LABEL_STUDIO_API_KEY", "k");
+    vi.stubEnv("AUTH_SECRET", "s");
+    vi.stubEnv("AUTH_AUTHENTIK_ID", "cid");
+    vi.stubEnv("AUTH_AUTHENTIK_SECRET", "csec");
+    vi.stubEnv("AUTH_AUTHENTIK_ISSUER", "https://auth.example/application/o/slug");
 
     expect(env.fishsenseApiUrl).toBe("http://api");
     expect(env.fishsenseApiUsername).toBe("u");
     expect(env.fishsenseApiPassword).toBe("p");
     expect(env.labelStudioUrl).toBe("http://ls");
     expect(env.labelStudioApiKey).toBe("k");
+    expect(env.authSecret).toBe("s");
+    expect(env.authAuthentikId).toBe("cid");
+    expect(env.authAuthentikSecret).toBe("csec");
+    expect(env.authAuthentikIssuer).toBe("https://auth.example/application/o/slug");
+  });
+
+  it("throws on access when AUTH_AUTHENTIK_ISSUER is missing", () => {
+    vi.stubEnv("AUTH_AUTHENTIK_ISSUER", "");
+    expect(() => env.authAuthentikIssuer).toThrow(/AUTH_AUTHENTIK_ISSUER/);
   });
 
   it("throws on access when an env var is missing", () => {

--- a/apps/fishsense-lite-web/lib/env.ts
+++ b/apps/fishsense-lite-web/lib/env.ts
@@ -12,6 +12,10 @@ const ENV_VARS = {
   fishsenseApiPassword: "FISHSENSE_API_PASSWORD",
   labelStudioUrl: "LABEL_STUDIO_URL",
   labelStudioApiKey: "LABEL_STUDIO_API_KEY",
+  authSecret: "AUTH_SECRET",
+  authAuthentikId: "AUTH_AUTHENTIK_ID",
+  authAuthentikSecret: "AUTH_AUTHENTIK_SECRET",
+  authAuthentikIssuer: "AUTH_AUTHENTIK_ISSUER",
 } as const;
 
 type EnvKey = keyof typeof ENV_VARS;

--- a/apps/fishsense-lite-web/middleware.ts
+++ b/apps/fishsense-lite-web/middleware.ts
@@ -1,0 +1,5 @@
+export { auth as middleware } from "@/auth";
+
+export const config = {
+  matcher: ["/portal/:path*"],
+};

--- a/apps/fishsense-lite-web/next-env.d.ts
+++ b/apps/fishsense-lite-web/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/fishsense-lite-web/package-lock.json
+++ b/apps/fishsense-lite-web/package-lock.json
@@ -1,14 +1,15 @@
 {
-  "name": "@fishsense/web",
+  "name": "@fishsense/lite-web",
   "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@fishsense/web",
+      "name": "@fishsense/lite-web",
       "version": "0.2.0",
       "dependencies": {
         "next": "15.5.15",
+        "next-auth": "^5.0.0-beta.31",
         "react": "19.0.0",
         "react-dom": "19.0.0"
       },
@@ -36,6 +37,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/core": {
@@ -1428,6 +1458,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -5092,6 +5131,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5448,6 +5496,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
+      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.2"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -5530,6 +5605,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/object-assign": {
@@ -5980,6 +6064,25 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/apps/fishsense-lite-web/package.json
+++ b/apps/fishsense-lite-web/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "next": "15.5.15",
+    "next-auth": "^5.0.0-beta.31",
     "react": "19.0.0",
     "react-dom": "19.0.0"
   },

--- a/apps/fishsense-lite-web/types/next-auth.d.ts
+++ b/apps/fishsense-lite-web/types/next-auth.d.ts
@@ -1,0 +1,18 @@
+import type { DefaultSession } from "next-auth";
+import "next-auth/jwt";
+
+declare module "next-auth" {
+  interface Session {
+    accessToken?: string;
+    user: {
+      groups: string[];
+    } & DefaultSession["user"];
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    accessToken?: string;
+    groups?: string[];
+  }
+}

--- a/apps/fishsense-lite-web/vitest.config.ts
+++ b/apps/fishsense-lite-web/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
   test: {
     environment: "node",
     include: ["lib/**/*.test.ts"],

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -7,7 +7,7 @@ orchestrator host, and prod data-worker host.
 
 | File | Purpose |
 |---|---|
-| `compose.yml` | Top-level prod orchestrator stack. `include:`s the four siblings below + defines `postgres`, `qcomm-static-file-server`, `fishsense-lite-web`. Pulls `prometheus_network` and `traefik_proxy` as external networks. |
+| `compose.yml` | Top-level prod orchestrator stack. `include:`s the four siblings below + defines `postgres`, `qcomm-static-file-server`, `fishsense-lite-web` (public landing + Authentik-OIDC-gated `/portal/*`). Pulls `prometheus_network` and `traefik_proxy` as external networks. |
 | `compose.orchestrator.yml` | `fishsense-api` + nginx `static_file_server` (file-exchange DAV). Behind Traefik + `authentik@docker` middleware. |
 | `compose.temporal.yml` | Temporal cluster (history, frontend, matching, worker, UI). |
 | `compose.workers.yml` | `fishsense-*` workers running on the orchestrator host: `fishsense-api-workflow-worker`, `fishsense-backup-worker`. (Workers consume Temporal but aren't part of the cluster.) |
@@ -94,8 +94,11 @@ without its mTLS certs.
    - `worker_volumes/backup_worker/config/.secrets.toml` — same shape
      for `fishsense-backup-worker` (paired `settings.toml` tracked).
    - `worker_volumes/backup_worker/logs/` — log volume.
-   - `web_volumes/.env` — `fishsense-lite-web` runtime env file (5
-     required keys; see `web_volumes/.env.example` for the shape).
+   - `web_volumes/.env` — `fishsense-lite-web` runtime env file (9
+     required keys: 5 for fishsense-api / Label Studio access + 4
+     `AUTH_*` for Authentik OIDC gating of `/portal/*`. Generate
+     `AUTH_SECRET` with `openssl rand -base64 32`. See
+     `apps/fishsense-lite-web/.env.example` for the canonical shape).
    - `superset_volumes/`, `qcomm_static_file_server_volumes/`,
      `static_file_server_volumes/`, `fishsense_api_volumes/` — see the
      respective compose files for the bind-mount paths.
@@ -321,7 +324,8 @@ Orchestrator host (one runner: `fishsense-prod`):
 compose.yml
 ├── postgres (PG 16, password file via docker secret)
 ├── qcomm-static-file-server (Traefik + authentik)
-├── fishsense-lite-web (homepage at fishsense.e4e.ucsd.edu)
+├── fishsense-lite-web (homepage + /portal at fishsense.e4e.ucsd.edu;
+│     /portal/* auth via Authentik OIDC, app-owned NextAuth session)
 ├── include: compose.orchestrator.yml
 │     ├── fishsense-api
 │     └── static_file_server (nginx DAV — the /api/v1/exchange/ routes)

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -30,7 +30,8 @@ services:
     env_file:
       # Untracked, populated on the host. Required keys:
       #   FISHSENSE_API_URL, FISHSENSE_API_USERNAME, FISHSENSE_API_PASSWORD,
-      #   LABEL_STUDIO_URL, LABEL_STUDIO_API_KEY
+      #   LABEL_STUDIO_URL, LABEL_STUDIO_API_KEY,
+      #   AUTH_SECRET, AUTH_AUTHENTIK_ID, AUTH_AUTHENTIK_SECRET, AUTH_AUTHENTIK_ISSUER
       # See apps/fishsense-lite-web/.env.example for the canonical shape.
       - ./web_volumes/.env
     labels:


### PR DESCRIPTION
## Summary

- Adds app-owned OAuth login to `apps/fishsense-lite-web` using Auth.js (next-auth v5) with Authentik as the OIDC provider, so a logged-in portal can grow alongside the existing public landing page.
- Gates only `/portal/*` via `middleware.ts`; the landing page (`/`) stays public and decoupled from `AUTH_*` env vars so it keeps rendering even before the OIDC client is configured.
- JWT session callbacks plumb `access_token` and Authentik `groups` onto the session — group-based authorization is a one-line check away when needed.
- Sign-in surfaced on the landing as a plain `<a href="/portal">Sign in</a>`; middleware redirects unauthenticated visitors to Authentik. `/portal` shows name/email/groups + a sign-out form.
- Required env additions: `AUTH_SECRET`, `AUTH_AUTHENTIK_ID`, `AUTH_AUTHENTIK_SECRET`, `AUTH_AUTHENTIK_ISSUER` (issuer should include the application slug, no trailing slash).
- Documented in `apps/fishsense-lite-web/.env.example`, `deploy/compose.yml` env_file comment, top-level `README.md` (new `apps/` section), `deploy/README.md` (host bootstrap key count + compose layout note), and `CLAUDE.md` service map.

## Pre-merge ops checklist (must happen before deploying)

- [ ] In Authentik: create OAuth2/OpenID **Provider** (signing key + scopes `openid profile email`) and **Application** (slug `fishsense-lite-web`). Redirect URI: `https://fishsense.e4e.ucsd.edu/api/auth/callback/authentik`.
- [ ] On the orchestrator host, append the four `AUTH_*` keys to `web_volumes/.env` (generate `AUTH_SECRET` with `openssl rand -base64 32`).
- [ ] After deploy, restart `fishsense-lite-web` so it picks up the new env file.

## Test plan

- [x] `vitest run` — 32 tests pass (env: 7, auth-callbacks: 6, plus existing 19).
- [x] `tsc --noEmit` — clean (module augmentation in `types/next-auth.d.ts` types `session.accessToken` + `session.user.groups`).
- [x] `next lint` — clean.
- [x] `next build` — `/`, `/api/auth/[...nextauth]`, `/portal`, and middleware (87.4 kB) all emit. Pre-existing `jose` Edge-runtime warnings about `CompressionStream` / `DecompressionStream` are inert for default HS-signed JWT sessions.
- [ ] **Manual**: with `AUTH_*` env populated against the real Authentik tenant, click "Sign in" on the landing → redirected to Authentik → return to `/portal` → name/email/groups render → "Sign out" returns to the landing.
- [ ] **Manual**: visiting `/portal` while signed out redirects to Authentik (no app crash, no env reads on `/`).

## Follow-ups (not in this PR)

- Group-based authorization: hook into `callbacks.authorized` in `auth.ts` or check `session.user.groups` server-side in `app/portal/*`. Plumbing already done.
- User-scoped fishsense-api calls: today SSR uses a shared service-account basic auth that gets 302'd by Authentik when called from outside the docker network. With OAuth tokens now in `session.accessToken`, we can later call fishsense-api with `Authorization: Bearer <token>` once Authentik is configured to accept its own tokens at the API (already noted as "option 4" in CLAUDE.md's authentik-fronts-the-API section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)