### PR TITLE
fix(web): copy OIDC user identity onto JWT + session in auth callbacks

### DIFF
--- a/apps/fishsense-lite-web/lib/auth-callbacks.test.ts
+++ b/apps/fishsense-lite-web/lib/auth-callbacks.test.ts
@@ -22,6 +22,19 @@ describe("jwtCallback", () => {
     expect(result.groups).toEqual(["fishsense-admins", "labelers"]);
   });
 
+  it("copies user identity (name/email/sub/picture) onto token on sign-in", async () => {
+    const result = await jwtCallback({
+      token: {},
+      account: { access_token: "at-1" } as never,
+      profile: {} as never,
+      user: { id: "u-42", name: "Alice", email: "alice@e.com", image: "https://x/y.png" } as never,
+    });
+    expect(result.sub).toBe("u-42");
+    expect(result.name).toBe("Alice");
+    expect(result.email).toBe("alice@e.com");
+    expect(result.picture).toBe("https://x/y.png");
+  });
+
   it("defaults groups to [] when profile has none", async () => {
     const result = await jwtCallback({
       token: { ...baseToken },
@@ -44,12 +57,23 @@ describe("jwtCallback", () => {
 });
 
 describe("sessionCallback", () => {
-  it("surfaces accessToken and groups from token onto session", async () => {
+  it("surfaces accessToken, identity, and groups from token onto session", async () => {
     const result = await sessionCallback({
-      session: { user: { name: "User One", email: "u@e.com" }, expires: "2099-01-01" } as never,
-      token: { ...baseToken, accessToken: "at-9", groups: ["g1"] } as never,
+      session: { user: {}, expires: "2099-01-01" } as never,
+      token: {
+        sub: "u-1",
+        name: "User One",
+        email: "u@e.com",
+        picture: "https://x/y.png",
+        accessToken: "at-9",
+        groups: ["g1"],
+      } as never,
     });
     expect(result.accessToken).toBe("at-9");
+    expect(result.user.id).toBe("u-1");
+    expect(result.user.name).toBe("User One");
+    expect(result.user.email).toBe("u@e.com");
+    expect(result.user.image).toBe("https://x/y.png");
     expect(result.user.groups).toEqual(["g1"]);
   });
 

--- a/apps/fishsense-lite-web/lib/auth-callbacks.ts
+++ b/apps/fishsense-lite-web/lib/auth-callbacks.ts
@@ -1,4 +1,4 @@
-import type { Account, Profile, Session } from "next-auth";
+import type { Account, Profile, Session, User } from "next-auth";
 import type { JWT } from "next-auth/jwt";
 
 interface AuthentikProfileLike extends Profile {
@@ -9,14 +9,26 @@ interface JwtCallbackArgs {
   token: JWT;
   account?: Account | null;
   profile?: AuthentikProfileLike;
+  user?: User;
 }
 
-export async function jwtCallback({ token, account, profile }: JwtCallbackArgs): Promise<JWT> {
+export async function jwtCallback({
+  token,
+  account,
+  profile,
+  user,
+}: JwtCallbackArgs): Promise<JWT> {
   if (account) {
     if (typeof account.access_token === "string") {
       token.accessToken = account.access_token;
     }
     token.groups = Array.isArray(profile?.groups) ? profile.groups : [];
+    if (user) {
+      if (typeof user.id === "string") token.sub = user.id;
+      if (typeof user.name === "string") token.name = user.name;
+      if (typeof user.email === "string") token.email = user.email;
+      if (typeof user.image === "string") token.picture = user.image;
+    }
   }
   return token;
 }
@@ -30,6 +42,10 @@ export async function sessionCallback({ session, token }: SessionCallbackArgs): 
   if (typeof token.accessToken === "string") {
     session.accessToken = token.accessToken;
   }
+  if (typeof token.sub === "string") session.user.id = token.sub;
+  if (typeof token.name === "string") session.user.name = token.name;
+  if (typeof token.email === "string") session.user.email = token.email;
+  if (typeof token.picture === "string") session.user.image = token.picture;
   session.user.groups = Array.isArray(token.groups) ? token.groups : [];
   return session;
 }

--- a/apps/fishsense-lite-web/types/next-auth.d.ts
+++ b/apps/fishsense-lite-web/types/next-auth.d.ts
@@ -5,6 +5,7 @@ declare module "next-auth" {
   interface Session {
     accessToken?: string;
     user: {
+      id?: string;
       groups: string[];
     } & DefaultSession["user"];
   }


### PR DESCRIPTION
## Summary

After the auth feature in #135 merged, the `/portal` page rendered name/email/groups as em-dashes ("—") for a successfully signed-in user. Root cause: providing a custom `jwt` callback replaces NextAuth's default callback, which is what would have copied the OIDC `User` fields (`sub`/`name`/`email`/`image`) onto the token. Without that copy, the session ended up with empty `user.name` / `user.email`.

This fix:

- Updates `jwtCallback` to merge `user` identity (`sub`, `name`, `email`, `picture`) into the token on initial sign-in.
- Defensively mirrors those fields from `token` to `session.user` inside `sessionCallback` (works regardless of NextAuth's internal default behavior).
- Adds `session.user.id` to the type augmentation in `types/next-auth.d.ts`.

Once deployed, an existing signed-in user must sign out and back in once to reissue their JWT cookie with the new fields.

## Test plan

- [x] `vitest run` — 33 tests pass (added one new jwt-callback test for user identity, expanded the session-callback assertion).
- [x] `tsc --noEmit` — clean.
- [ ] Manual: after deploy, sign out → sign in → `/portal` shows real name + email (and groups, if Authentik is configured to expose them).

## Notes

If `/portal` still shows "—" after a fresh sign-in, the Authentik provider likely isn't sending the relevant claims. Check that the provider has scopes `openid profile email` (and `groups` if not already in `profile`) and that the OIDC `id_token` carries `name` / `email` claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)