### PR TITLE
feat(web): show app version in footer

### DIFF
--- a/apps/fishsense-lite-web/app/layout.tsx
+++ b/apps/fishsense-lite-web/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import pkg from "../package.json";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -9,8 +10,11 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen bg-slate-50 text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100">
-        {children}
+      <body className="flex min-h-screen flex-col bg-slate-50 text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100">
+        <div className="flex-1">{children}</div>
+        <footer className="border-t border-slate-200 px-6 py-3 text-xs text-slate-500 dark:border-slate-800 dark:text-slate-400">
+          fishsense-lite-web v{pkg.version}
+        </footer>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

Adds a small footer to the root layout that displays the running app version (read from `apps/fishsense-lite-web/package.json`).

Mainly a deploy-debugging aid: at a glance you can confirm which release is actually serving when verifying that a fix has rolled out. release-please bumps the package version on each release, so once an `auto-deploy/fishsense-lite-web-vX.Y.Z` PR merges, the deployed footer should reflect the new version.

## Test plan

- [x] `next build` — clean.
- [x] `vitest run` — 33 tests pass (no test changes; footer is purely visual).
- [x] `tsc --noEmit` — clean.
- [ ] Manual: load `/` and `/portal`, footer reads `fishsense-lite-web v<version>`.

## Notes

If a finer-grained signal is needed later (e.g. distinguishing two builds at the same version), we can add a git SHA via a Dockerfile `ARG` + a CI build-arg passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)