### PR TITLE
chore(web): temporary /portal session dump + auth callback log for OIDC debugging

### DIFF
--- a/apps/fishsense-lite-web/app/portal/page.tsx
+++ b/apps/fishsense-lite-web/app/portal/page.tsx
@@ -36,6 +36,15 @@ export default async function PortalPage() {
           <dd>{user?.groups?.length ? user.groups.join(", ") : "—"}</dd>
         </dl>
       </section>
+
+      <section className="mt-6 rounded-lg border border-amber-300 bg-amber-50 p-6 text-xs dark:border-amber-700 dark:bg-amber-950">
+        <h2 className="mb-2 text-sm font-medium text-amber-900 dark:text-amber-200">
+          Debug: raw session
+        </h2>
+        <pre className="overflow-x-auto whitespace-pre-wrap break-all text-amber-900 dark:text-amber-200">
+          {JSON.stringify(session, null, 2)}
+        </pre>
+      </section>
     </main>
   );
 }

--- a/apps/fishsense-lite-web/lib/auth-callbacks.ts
+++ b/apps/fishsense-lite-web/lib/auth-callbacks.ts
@@ -19,6 +19,14 @@ export async function jwtCallback({
   user,
 }: JwtCallbackArgs): Promise<JWT> {
   if (account) {
+    // Temporary diagnostic for the empty /portal user-info problem.
+    // Remove once the OIDC profile shape is confirmed in prod logs.
+    console.log("[auth] jwtCallback initial sign-in", {
+      account: { provider: account.provider, type: account.type, hasAccessToken: typeof account.access_token === "string" },
+      user,
+      profileKeys: profile ? Object.keys(profile) : null,
+      profile,
+    });
     if (typeof account.access_token === "string") {
       token.accessToken = account.access_token;
     }


### PR DESCRIPTION
## Summary

The user-identity fix in #148 deployed but `/portal` still renders **Name / Email / Groups** as em-dashes for a successfully signed-in user. Adding temporary diagnostics so we can see what's actually in the session and what the OIDC provider sent us:

1. `/portal` renders the raw session JSON in an amber debug box (visible to the signed-in user).
2. `jwtCallback` logs the initial sign-in `account` / `user` / `profile` shapes to stdout — readable via `docker logs fishsense-lite-web` on the orchestrator host.

## How to use

After this deploys (and signing out + back in to trigger a fresh sign-in):

1. Hit `/portal`. Note what the **Debug: raw session** box shows.
2. On the orchestrator host: `docker logs fishsense-lite-web 2>&1 | grep '\[auth\]'` and grab the line.
3. Share both with the next debugging step.

Likely diagnoses:

- `profile.name` / `profile.email` undefined → Authentik provider's scope/claim mappings need adjustment (most likely `openid profile email` not on the provider).
- `profile.groups` undefined → groups scope mapping not added (separate, expected for now).
- `user` undefined in callback → next-auth provider's profile callback isn't running or returning what we expect; needs a custom provider override.
- Everything populated but session still empty → bug in our callback, fix path is clear from there.

## Plan

This PR is intentionally temporary. Once we identify the root cause from prod logs / debug box output, we'll:

1. Cut a follow-up PR with the actual fix (Authentik config doc, custom profile callback, etc.).
2. Cut a small revert PR removing the debug box and the log line.

Both PRs land on top of this one.

## Test plan

- [x] `next build` clean.
- [x] `vitest run` — 33 tests pass (the new console.log fires during test runs but doesn't affect results).
- [x] `tsc --noEmit` clean.
- [ ] Manual after deploy: sign out, sign in, hit `/portal`, capture both the debug box and `docker logs` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)