### PR TITLE
chore: tighten operational logging across services and web

### DIFF
--- a/apps/fishsense-lite-web/lib/fishsense-api.ts
+++ b/apps/fishsense-lite-web/lib/fishsense-api.ts
@@ -22,6 +22,10 @@ async function getProjectIds(kind: LabelKind, revalidate: number): Promise<numbe
   });
 
   if (!response.ok) {
+    console.error(
+      `[fishsense-api] ${kind} project IDs fetch failed`,
+      { url, status: response.status, statusText: response.statusText },
+    );
     throw new Error(
       `fishsense-api ${kind} project IDs failed: ${response.status} ${response.statusText}`,
     );

--- a/apps/fishsense-lite-web/lib/label-studio.ts
+++ b/apps/fishsense-lite-web/lib/label-studio.ts
@@ -9,12 +9,17 @@ export async function getProject(
   id: number,
   revalidate: number,
 ): Promise<LabelStudioProject> {
-  const response = await fetch(`${env.labelStudioUrl}/api/projects/${id}`, {
+  const url = `${env.labelStudioUrl}/api/projects/${id}`;
+  const response = await fetch(url, {
     headers: { Authorization: `Token ${env.labelStudioApiKey}` },
     next: { revalidate },
   });
 
   if (!response.ok) {
+    console.error(
+      `[label-studio] project ${id} fetch failed`,
+      { url, status: response.status, statusText: response.statusText },
+    );
     throw new Error(
       `Label Studio project ${id} fetch failed: ${response.status} ${response.statusText}`,
     );

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/create_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/create_dive_slate_label_studio_project_activity.py
@@ -49,10 +49,20 @@ async def create_dive_slate_label_studio_project_activity(dive_id: int) -> int:
     re-running for the same dive returns the existing project's ID
     rather than creating a duplicate. Match is by title.
     """
+    activity.logger.info(
+        "create dive-slate LS project dive_id=%d", dive_id
+    )
     title = await build_per_dive_title(
         dive_id, DIVE_SLATE_PROJECT_TITLE_SUFFIX
     )
-    return await create_or_get_label_studio_project(
+    project_id = await create_or_get_label_studio_project(
         project_title=title,
         labeling_config_xml=DIVE_SLATE_LABELING_CONFIG_XML,
     )
+    activity.logger.info(
+        "create dive-slate LS project dive_id=%d project_id=%d title=%r",
+        dive_id,
+        project_id,
+        title,
+    )
+    return project_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/create_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/create_headtail_label_studio_project_activity.py
@@ -32,8 +32,18 @@ async def create_headtail_label_studio_project_activity(dive_id: int) -> int:
     re-running for the same dive returns the existing project's ID
     rather than creating a duplicate. Match is by title.
     """
+    activity.logger.info(
+        "create headtail LS project dive_id=%d", dive_id
+    )
     title = await build_per_dive_title(dive_id, HEADTAIL_PROJECT_TITLE_SUFFIX)
-    return await create_or_get_label_studio_project(
+    project_id = await create_or_get_label_studio_project(
         project_title=title,
         labeling_config_xml=HEADTAIL_LABELING_CONFIG_XML,
     )
+    activity.logger.info(
+        "create headtail LS project dive_id=%d project_id=%d title=%r",
+        dive_id,
+        project_id,
+        title,
+    )
+    return project_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/create_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/create_laser_label_studio_project_activity.py
@@ -33,8 +33,18 @@ async def create_laser_label_studio_project_activity(dive_id: int) -> int:
     — re-running for the same dive returns the existing project's ID
     rather than creating a duplicate. Match is by title.
     """
+    activity.logger.info(
+        "create laser LS project dive_id=%d", dive_id
+    )
     title = await build_per_dive_title(dive_id, LASER_PROJECT_TITLE_SUFFIX)
-    return await create_or_get_label_studio_project(
+    project_id = await create_or_get_label_studio_project(
         project_title=title,
         labeling_config_xml=LASER_LABELING_CONFIG_XML,
     )
+    activity.logger.info(
+        "create laser LS project dive_id=%d project_id=%d title=%r",
+        dive_id,
+        project_id,
+        title,
+    )
+    return project_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/create_species_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/create_species_label_studio_project_activity.py
@@ -127,8 +127,18 @@ async def create_species_label_studio_project_activity(dive_id: int) -> int:
     re-running for the same dive returns the existing project's ID
     rather than creating a duplicate. Match is by title.
     """
+    activity.logger.info(
+        "create species LS project dive_id=%d", dive_id
+    )
     title = await build_per_dive_title(dive_id, SPECIES_PROJECT_TITLE_SUFFIX)
-    return await create_or_get_label_studio_project(
+    project_id = await create_or_get_label_studio_project(
         project_title=title,
         labeling_config_xml=SPECIES_LABELING_CONFIG_XML,
     )
+    activity.logger.info(
+        "create species LS project dive_id=%d project_id=%d title=%r",
+        dive_id,
+        project_id,
+        title,
+    )
+    return project_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_dive_frame_clustering_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_dive_frame_clustering_inputs_activity.py
@@ -18,17 +18,24 @@ from fishsense_api_workflow_worker.activities.utils import get_fs_client
 async def resolve_dive_frame_clustering_inputs_activity(
     dive_id: int,
 ) -> ClusterDiveFramesInput:
+    activity.logger.info(
+        "resolving clustering inputs dive_id=%d", dive_id
+    )
     async with get_fs_client() as fs:
         images = await fs.images.get(dive_id=dive_id) or []
 
-    return ClusterDiveFramesInput(
-        dive_id=dive_id,
-        images=[
-            ClusterDiveFrameImage(
-                image_id=image.id,
-                taken_datetime=image.taken_datetime,
-            )
-            for image in images
-            if image.id is not None
-        ],
+    cluster_images = [
+        ClusterDiveFrameImage(
+            image_id=image.id,
+            taken_datetime=image.taken_datetime,
+        )
+        for image in images
+        if image.id is not None
+    ]
+    activity.logger.info(
+        "resolved clustering inputs dive_id=%d images=%d cluster_inputs=%d",
+        dive_id,
+        len(images),
+        len(cluster_images),
     )
+    return ClusterDiveFramesInput(dive_id=dive_id, images=cluster_images)

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_headtail_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_headtail_preprocess_inputs_activity.py
@@ -30,6 +30,9 @@ def _is_valid_laser(label) -> bool:
 async def resolve_headtail_preprocess_inputs_activity(
     dive_id: int,
 ) -> PreprocessHeadtailImagesInput:
+    activity.logger.info(
+        "resolving headtail preprocess inputs dive_id=%d", dive_id
+    )
     async with get_fs_client() as fs:
         dive = await fs.dives.get(dive_id=dive_id)
         if dive is None:
@@ -67,6 +70,13 @@ async def resolve_headtail_preprocess_inputs_activity(
             if image_id in checksum_by_id
         ]
 
+        activity.logger.info(
+            "resolved headtail preprocess inputs dive_id=%d "
+            "valid_laser_targets=%d image_checksums=%d",
+            dive_id,
+            len(target_image_ids),
+            len(image_checksums),
+        )
         return PreprocessHeadtailImagesInput(
             dive_id=dive_id,
             image_checksums=image_checksums,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_preprocess_inputs_activity.py
@@ -53,6 +53,7 @@ def _select_unlabeled_images(
 async def resolve_laser_preprocess_inputs_activity(
     dive_id: int,
 ) -> PreprocessLaserImagesInput:
+    activity.logger.info("resolving laser preprocess inputs dive_id=%d", dive_id)
     async with get_fs_client() as fs:
         dive = await fs.dives.get(dive_id=dive_id)
         if dive is None:
@@ -70,6 +71,12 @@ async def resolve_laser_preprocess_inputs_activity(
         existing_labels = await fs.labels.get_laser_labels(dive_id) or []
         unlabeled = _select_unlabeled_images(images, existing_labels)
 
+        activity.logger.info(
+            "resolved laser preprocess inputs dive_id=%d images=%d unlabeled=%d",
+            dive_id,
+            len(images),
+            len(unlabeled),
+        )
         return PreprocessLaserImagesInput(
             dive_id=dive_id,
             image_checksums=[image.checksum for image in unlabeled],

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_slate_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_slate_preprocess_inputs_activity.py
@@ -26,6 +26,9 @@ SLATE_CONTENT_MARKER = "Slate, Laser on slate"
 async def resolve_slate_preprocess_inputs_activity(
     dive_id: int,
 ) -> PreprocessSlateImagesInput:
+    activity.logger.info(
+        "resolving slate preprocess inputs dive_id=%d", dive_id
+    )
     async with get_fs_client() as fs:
         dive = await fs.dives.get(dive_id=dive_id)
         if dive is None:
@@ -81,6 +84,14 @@ async def resolve_slate_preprocess_inputs_activity(
             if image_id in checksum_by_id
         ]
 
+        activity.logger.info(
+            "resolved slate preprocess inputs dive_id=%d slate_id=%d "
+            "slate_targets=%d image_checksums=%d",
+            dive_id,
+            slate.id,
+            len(target_image_ids),
+            len(image_checksums),
+        )
         return PreprocessSlateImagesInput(
             dive_id=dive_id,
             image_checksums=image_checksums,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_species_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_species_preprocess_inputs_activity.py
@@ -43,6 +43,9 @@ def _is_valid_laser(label: LaserLabel) -> bool:
 async def resolve_species_preprocess_inputs_activity(
     dive_id: int,
 ) -> PreprocessSpeciesImagesInput:
+    activity.logger.info(
+        "resolving species preprocess inputs dive_id=%d", dive_id
+    )
     async with get_fs_client() as fs:
         dive = await fs.dives.get(dive_id=dive_id)
         if dive is None:
@@ -89,6 +92,14 @@ async def resolve_species_preprocess_inputs_activity(
             if cluster_checksums:
                 clusters.append(cluster_checksums)
 
+        activity.logger.info(
+            "resolved species preprocess inputs dive_id=%d "
+            "prediction_clusters=%d non_empty_clusters=%d total_checksums=%d",
+            dive_id,
+            len(prediction_clusters),
+            len(clusters),
+            sum(len(c) for c in clusters),
+        )
         return PreprocessSpeciesImagesInput(
             dive_id=dive_id,
             clusters=clusters,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/utils.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/utils.py
@@ -119,10 +119,21 @@ async def sync_label_studio_project(
     """
     ls = get_ls_client()
 
+    activity.logger.info(
+        "sync_label_studio_project starting kind=%s project_id=%d",
+        kind,
+        project_id,
+    )
+
     try:
         _ = await asyncio.to_thread(ls.projects.get, project_id)
     except ApiError as e:
-        activity.logger.warning(f"Error fetching project {project_id}: {e}")
+        activity.logger.warning(
+            "sync_label_studio_project missing kind=%s project_id=%d error=%s",
+            kind,
+            project_id,
+            e,
+        )
         return
 
     tasks = await _list_ls_tasks_with_heartbeat(ls, project_id)
@@ -144,9 +155,24 @@ async def sync_label_studio_project(
 
         if not eligible_tasks:
             activity.logger.info(
-                "No new tasks for project %d (cursor=%s)", project_id, cursor_ts
+                "sync_label_studio_project no new tasks kind=%s project_id=%d "
+                "total_tasks=%d cursor=%s",
+                kind,
+                project_id,
+                len(tasks),
+                cursor_ts,
             )
             return
+
+        activity.logger.info(
+            "sync_label_studio_project running kind=%s project_id=%d "
+            "total_tasks=%d eligible_tasks=%d cursor=%s",
+            kind,
+            project_id,
+            len(tasks),
+            len(eligible_tasks),
+            cursor_ts,
+        )
 
         async def _run(task: Any) -> None:
             async with sem:
@@ -173,3 +199,10 @@ async def sync_label_studio_project(
                 last_synced_at=max_seen,
             )
             await fs.labels.put_sync_cursor(kind, project_id, new_cursor)
+            activity.logger.info(
+                "sync_label_studio_project cursor advanced kind=%s "
+                "project_id=%d cursor=%s",
+                kind,
+                project_id,
+                max_seen,
+            )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -250,7 +250,9 @@ async def schedule_workflow(
 async def schedule_workflows(client: Client):
     """Schedule workflows for the worker."""
 
-    async with ExceptionGroupErrorLogging(logging.getLogger()):
+    log = logging.getLogger(__name__)
+    log.info("registering Temporal schedules")
+    async with ExceptionGroupErrorLogging(log):
         async with asyncio.TaskGroup() as tg:
             tg.create_task(
                 schedule_workflow(
@@ -368,6 +370,7 @@ async def schedule_workflows(client: Client):
                     overlap=ScheduleOverlapPolicy.SKIP,
                 )
             )
+    log.info("Temporal schedules registered")
 
 
 async def main():
@@ -378,6 +381,12 @@ async def main():
 
     tls_config = build_tls_config(settings.temporal)
 
+    log.info(
+        "connecting to Temporal host=%s:%d tls=%s",
+        settings.temporal.host,
+        settings.temporal.port,
+        bool(tls_config),
+    )
     client = await Client.connect(
         f"{settings.temporal.host}:{settings.temporal.port}", tls=tls_config
     )

--- a/services/fishsense-api/src/fishsense_api/database.py
+++ b/services/fishsense-api/src/fishsense_api/database.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
@@ -35,6 +36,8 @@ from fishsense_api.models.measurement import Measurement
 from fishsense_api.models.species import Species
 from fishsense_api.models.species_label import SpeciesLabel
 from fishsense_api.models.user import User
+
+_log = logging.getLogger(__name__)
 
 
 class Database:
@@ -120,8 +123,13 @@ def run_alembic_upgrade() -> None:
     )
 
     if asyncio.run(_has_alembic_version_table()):
+        _log.info("alembic_version present; running upgrade head")
         alembic_command.upgrade(cfg, "head")
+        _log.info("alembic upgrade complete")
     else:
+        _log.info(
+            "alembic_version missing; stamping head (fresh DB after create_all)"
+        )
         alembic_command.stamp(cfg, "head")
 
 
@@ -156,6 +164,7 @@ async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
         try:
             yield session
             await session.commit()
-        except:
+        except Exception:
+            _log.exception("session rolled back due to unhandled exception")
             await session.rollback()
             raise

--- a/services/fishsense-api/src/fishsense_api/server.py
+++ b/services/fishsense-api/src/fishsense_api/server.py
@@ -1,12 +1,15 @@
 """FishSense API Server"""
 
 import asyncio
+import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
 from fishsense_api.__version__ import __version__
 from fishsense_api.database import run_alembic_upgrade, setup_database
+
+_log = logging.getLogger(__name__)
 
 
 @asynccontextmanager
@@ -25,15 +28,20 @@ async def lifespan(_: FastAPI):
          offloaded via `asyncio.to_thread` so DDL doesn't block the
          event loop.
     """
+    _log.info("fishsense-api starting (version=%s)", __version__)
     database = setup_database()
 
+    _log.info("running SQLModel.metadata.create_all")
     async with database.engine.begin() as conn:
         await database.init_database(conn)
 
+    _log.info("running alembic upgrade")
     await asyncio.to_thread(run_alembic_upgrade)
+    _log.info("fishsense-api startup complete")
 
     yield
 
+    _log.info("fishsense-api shutting down")
     await database.dispose()
 
 

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
@@ -71,6 +71,12 @@ async def main():
 
     tls_config = build_tls_config(settings.temporal)
 
+    log.info(
+        "connecting to Temporal host=%s:%d tls=%s",
+        settings.temporal.host,
+        settings.temporal.port,
+        bool(tls_config),
+    )
     client = await Client.connect(
         f"{settings.temporal.host}:{settings.temporal.port}", tls=tls_config
     )


### PR DESCRIPTION
## Summary

Audit pass to close concrete observability gaps so operators can trace per-dive activity flow and integration failures from container logs without re-running with debug enabled.

**api-workflow-worker**
- `resolve_*` activities (laser, headtail, slate, species, clustering): entry log with `dive_id`, exit log with resolved image / cluster / checksum counts.
- `create_*_label_studio_project` activities (laser, species, headtail, dive_slate): entry with `dive_id`, exit with the resolved `project_id` and per-dive title.
- Shared `sync_label_studio_project` helper: structured `starting` / `running` / `no new tasks` / `missing project` / `cursor advanced` lines keyed on `kind` + `project_id`.
- `worker.py`: logs the Temporal connection target and brackets `schedule_workflows` with start/complete lines.

**fishsense-api**
- Lifespan logs `create_all`, `alembic upgrade head` vs `stamp head`, and shutdown.
- `get_async_session`: replaces bare `except:` with `_log.exception(...)` before rollback so silent failures become observable.

**data-processing-workflow-worker**
- `worker.py`: logs Temporal connection target on startup.

**fishsense-lite-web**
- `lib/fishsense-api.ts` + `lib/label-studio.ts`: `console.error` with `{ url, status, statusText }` before throwing on non-OK fetches so homepage 500s have an attributable line in container logs.

## Test plan
- [x] `pytest` — 412 unit tests pass across fishsense-api (143), fishsense-api-workflow-worker (181), and fishsense-data-processing-workflow-worker (88).
- [x] `pylint` 10.00/10 on the changed Python files.
- [ ] Web app `npm run typecheck` + `vitest` — couldn't run locally (no Node in devcontainer); the change is two added `console.error` calls before existing throws and no test mocks `console`. CI will exercise this.
- [ ] Integration tests (this PR is labeled `integration-tests` so the workflow runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)