### PR TITLE
feat(web): add server error boundary that logs the failure

### DIFF
--- a/apps/fishsense-lite-web/app/error.tsx
+++ b/apps/fishsense-lite-web/app/error.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Next.js App Router error boundary. Catches uncaught errors thrown by
+// SSR (e.g. fishsense-api / Label Studio fetch failures bubbling out of
+// HomePage) and any client-side exceptions in the same segment. The
+// digest field is set by Next on server-side errors and matches the
+// `[Error: ... digest=...]` line Next.js writes to stderr — logging it
+// here lets operators correlate a user-facing error page with the
+// server log entry.
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[error-boundary] rendering fallback", {
+      message: error.message,
+      digest: error.digest,
+    });
+  }, [error]);
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-16 text-center">
+      <h1 className="text-3xl font-semibold tracking-tight">
+        Something went wrong
+      </h1>
+      <p className="mt-4 text-slate-600 dark:text-slate-400">
+        The page failed to load. This is usually transient — try again, and if
+        it persists, check that fishsense-api and Label Studio are reachable.
+      </p>
+      {error.digest ? (
+        <p className="mt-2 text-xs text-slate-500">
+          Error reference: <code>{error.digest}</code>
+        </p>
+      ) : null}
+      <button
+        type="button"
+        onClick={reset}
+        className="mt-8 rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
+      >
+        Try again
+      </button>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `app/error.tsx`, the Next.js App Router error boundary the app was missing. Catches SSR failures (e.g. fishsense-api / Label Studio fetch errors bubbling out of `HomePage`) and renders a friendly fallback with a Try again button instead of Next.js's default 500 page.
- The boundary logs `error.message` + `error.digest` via `console.error`, so operators can match the user-visible fallback to the server log entry Next.js emits with the same digest.
- Pairs with the fetch-side logging from #156: lib log says *which* fetch failed, boundary log says *which request hit the fallback*, joined by digest.

## Release impact
This is a `feat(web):` commit touching `apps/fishsense-lite-web/`, so on merge release-please will bump fishsense-lite-web 0.4.0 → 0.5.0 and open a release PR.

## Test plan
- [ ] `npm run typecheck` passes (couldn't run locally — no Node in this devcontainer; CI will exercise it).
- [ ] `npm test` passes (no existing tests under `app/`; vitest is configured to scan `lib/**/*.test.ts` only, so this file isn't unit-tested).
- [ ] Manual: trigger an SSR failure (point `FISHSENSE_API_URL` at a non-existent host, load `/`) and confirm the fallback renders + the digest appears in browser console + matches the Next.js server log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)