### PR TITLE
feat(web): order Head/Tail before Species on dashboard

### DIFF
--- a/apps/fishsense-lite-web/lib/sections.test.ts
+++ b/apps/fishsense-lite-web/lib/sections.test.ts
@@ -37,7 +37,7 @@ describe("buildSections", () => {
     ]);
   });
 
-  it("emits sections in the canonical order: Laser, Species, Head/Tail, Slate, Results, Administration", () => {
+  it("emits sections in the canonical order: Laser, Head/Tail, Species, Slate, Results, Administration", () => {
     const sections = buildSections(
       {
         laser: [{ id: 1, title: "L" }],
@@ -52,8 +52,8 @@ describe("buildSections", () => {
     );
     expect(sections.map((s) => s.title)).toEqual([
       "Laser Labeling",
-      "Species Labeling",
       "Head/Tail Labeling",
+      "Species Labeling",
       "Slate Labeling",
       "Results",
       "Administration",

--- a/apps/fishsense-lite-web/lib/sections.ts
+++ b/apps/fishsense-lite-web/lib/sections.ts
@@ -14,8 +14,8 @@ export type Section = {
 
 const LABELING_KINDS: { key: keyof ActiveProjects; title: string }[] = [
   { key: "laser", title: "Laser Labeling" },
-  { key: "species", title: "Species Labeling" },
   { key: "headtail", title: "Head/Tail Labeling" },
+  { key: "species", title: "Species Labeling" },
   { key: "slate", title: "Slate Labeling" },
 ];
 


### PR DESCRIPTION
## Summary
- Reorders the labeling sections on the landing page so Head/Tail Labeling appears immediately after Laser Labeling, ahead of Species Labeling.

## Why
Stage 5.1 head/tail now cascades from valid laser labels in parallel with stage 2 species (per the 2026-05-04 cohort flip), so labelers typically pick up head/tail tasks alongside or before species. The dashboard order should match.

## Release impact
`feat(web):` touching `apps/fishsense-lite-web/` — release-please will roll this into the next fishsense-lite-web release bump.

## Test plan
- [x] `lib/sections.test.ts` updated to assert the new canonical order.
- [ ] CI runs vitest + typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)