### PR TITLE
chore(web): widen /portal auth diagnostic to fire on every request

### DIFF
--- a/apps/fishsense-lite-web/auth.ts
+++ b/apps/fishsense-lite-web/auth.ts
@@ -9,6 +9,10 @@ import { env } from "@/lib/env";
 export const { auth, handlers, signIn, signOut } = NextAuth(() => ({
   secret: env.authSecret,
   trustHost: true,
+  // Temporary diagnostic — surfaces internal NextAuth events
+  // (cookie decode failures, OAuth callback flow, jwt encode/decode)
+  // to stdout. Remove once the /portal session-null issue is resolved.
+  debug: true,
   session: { strategy: "jwt" },
   providers: [
     Authentik({

--- a/apps/fishsense-lite-web/lib/auth-callbacks.ts
+++ b/apps/fishsense-lite-web/lib/auth-callbacks.ts
@@ -18,15 +18,24 @@ export async function jwtCallback({
   profile,
   user,
 }: JwtCallbackArgs): Promise<JWT> {
+  // Temporary diagnostic for the empty /portal user-info problem.
+  // Logs every invocation (initial sign-in *and* subsequent SSR
+  // calls) so we can see whether the callback runs at all, and what
+  // shape the token / profile is in. Remove once /portal is reliably
+  // populating session.user.
+  console.log("[auth] jwtCallback", {
+    hasAccount: !!account,
+    accountProvider: account?.provider,
+    accountType: account?.type,
+    profileKeys: profile ? Object.keys(profile) : null,
+    profile,
+    user,
+    tokenSub: token.sub,
+    tokenName: token.name,
+    tokenEmail: token.email,
+    tokenGroupsCount: Array.isArray(token.groups) ? token.groups.length : null,
+  });
   if (account) {
-    // Temporary diagnostic for the empty /portal user-info problem.
-    // Remove once the OIDC profile shape is confirmed in prod logs.
-    console.log("[auth] jwtCallback initial sign-in", {
-      account: { provider: account.provider, type: account.type, hasAccessToken: typeof account.access_token === "string" },
-      user,
-      profileKeys: profile ? Object.keys(profile) : null,
-      profile,
-    });
     if (typeof account.access_token === "string") {
       token.accessToken = account.access_token;
     }
@@ -47,6 +56,14 @@ interface SessionCallbackArgs {
 }
 
 export async function sessionCallback({ session, token }: SessionCallbackArgs): Promise<Session> {
+  // Temporary diagnostic — see jwtCallback comment above.
+  console.log("[auth] sessionCallback", {
+    tokenSub: token.sub,
+    tokenName: token.name,
+    tokenEmail: token.email,
+    tokenGroupsCount: Array.isArray(token.groups) ? token.groups.length : null,
+    hasAccessToken: typeof token.accessToken === "string",
+  });
   if (typeof token.accessToken === "string") {
     session.accessToken = token.accessToken;
   }

--- a/apps/fishsense-lite-web/middleware.ts
+++ b/apps/fishsense-lite-web/middleware.ts
@@ -1,4 +1,25 @@
-export { auth as middleware } from "@/auth";
+import { auth } from "@/auth";
+
+// Temporary diagnostic wrapper around the auth middleware. Logs every
+// /portal request with whether `req.auth` carries a session, so we can
+// distinguish "user never signed in" from "cookie present but
+// decryption failed." Remove once /portal is reliably populating
+// session.user.
+export const middleware = auth((req) => {
+  const session = req.auth;
+  console.log("[middleware] /portal request", {
+    pathname: req.nextUrl.pathname,
+    hasAuth: !!session,
+    user: session?.user
+      ? {
+          name: session.user.name,
+          email: session.user.email,
+          groups: session.user.groups,
+        }
+      : null,
+    cookieNames: req.cookies.getAll().map((c) => c.name),
+  });
+});
 
 export const config = {
   matcher: ["/portal/:path*"],


### PR DESCRIPTION
## Summary

We're on web v0.5.0 and /portal renders \`Debug: raw session: null\` with no console logs landing anywhere. The existing diagnostic in \`jwtCallback\` is gated on \`if (account)\`, so it only fires on the initial sign-in — when there's no valid JWT cookie yet, neither callback runs at all and the log line never appears.

This PR widens the diagnostic so we can actually see what's happening:

- **middleware.ts**: wrap with \`auth((req) => ...)\` and log every /portal request — pathname, whether \`req.auth\` carries a session, user shape, and cookie names present. Fires regardless of session state.
- **auth-callbacks.ts**: drop the \`if (account)\` gate on the \`jwtCallback\` log so it fires on every call; add a sibling log in \`sessionCallback\`. These fire only when there's a token to decode, so combined with the middleware log we can place the failure precisely (\"never signed in\" vs \"cookie present but decode failed\" vs \"both callbacks ran but session.user is empty\").
- **auth.ts**: enable NextAuth's built-in \`debug: true\` so OAuth callback flow, cookie decryption errors, and jwt encode/decode events also land in stdout.

## Release impact
\`chore(web):\` — no release-please bump.

## Test plan
- [ ] CI: vitest + typecheck (existing auth-callbacks tests don't assert on console output, so they should still pass).
- [ ] Manual: hit /portal, check container logs for \`[middleware]\`, \`[auth] jwtCallback\`, \`[auth] sessionCallback\`, and \`[next-auth][debug]\` lines. The pattern of which logs fire (or don't) tells us where the auth chain is breaking.

## Cleanup
All three logs are explicitly marked temporary in the diffs — remove once /portal reliably populates \`session.user\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)