### PR TITLE
fix(backup-worker): replace synology-api with synology-filestation

### DIFF
--- a/services/fishsense-backup-worker/pyproject.toml
+++ b/services/fishsense-backup-worker/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "fishsense-shared",
     "platformdirs>=4.3.8",
     "pydantic>=2.11.9",
-    "synology-api>=0.8.1",
+    "synology-filestation",
     "temporalio>=1.17.0",
     "validators>=0.35.0",
 ]

--- a/services/fishsense-backup-worker/src/fishsense_backup_worker/nas.py
+++ b/services/fishsense-backup-worker/src/fishsense_backup_worker/nas.py
@@ -1,37 +1,35 @@
-"""Thin wrapper around synology-api FileStation for the backup paths
-this worker writes to.
+"""FileStation-backed NAS client for the backup worker.
 
-Hides the URL parsing + login dance + the awkward upload/list/delete
-shape behind three methods this worker actually uses. Every method is
-sync (synology-api is sync) — call from inside `asyncio.to_thread` if
-running from an async activity.
+Backed by the `synology-filestation` Rust client (PyO3 wheel from
+`UCSD-E4E/synology-filestation`). Replaces the previous `synology-api`
+PyPI package — see the api-worker's `nas.py` for the 2026-05-07 stage
+2 incident that drove the swap. The backup worker uses a narrow
+slice of the FileStation surface (upload, list, delete), but the
+underlying-library footguns that wedged stage 2 (silent JSON-error
+returns, no atomic-rename) applied here too — fixing both at once.
+
+Operations:
+  * `upload(dest_dir, src_file_path)` — push a fresh `pg_dump` to NAS.
+  * `list_filenames(folder_path)` — enumerate existing backups for a DB.
+  * `delete(file_path)` — remove a single old backup during pruning.
+
+Sync only — call from `asyncio.to_thread` if running from an async
+activity (matches the previous client's contract).
 """
 
+from __future__ import annotations
+
 import logging
-from contextlib import contextmanager
+import os
 from typing import List
 from urllib.parse import urlparse
 
-from synology_api.base_api import BaseApi
-from synology_api.exceptions import FileStationError
-from synology_api.filestation import FileStation
+from synology_filestation import (
+    AlreadyExists,
+    Client,
+)
 
 _log = logging.getLogger(__name__)
-
-
-@contextmanager
-def _surface_filestation_error(op: str):
-    """synology-api's FileStationError stores the human-readable message
-    on `error_message` but never passes it to Exception.__init__, so
-    `str(e)` is empty and Temporal failure events show just the class
-    name. Catch and re-raise as a regular Exception that carries the
-    code + decoded message + the operation that failed."""
-    try:
-        yield
-    except FileStationError as e:
-        msg = getattr(e, "error_message", "") or repr(e)
-        _log.error("nas %s failed: %s", op, msg)
-        raise RuntimeError(f"FileStation {op} failed: {msg}") from e
 
 
 class NasBackupClient:
@@ -48,47 +46,30 @@ class NasBackupClient:
             raise ValueError(
                 f"NAS url must include hostname + port; got {nas_url!r}"
             )
-        # synology-api 0.8.x caches `Authentication` on a class-level
-        # attribute (`BaseApi.shared_session`) and every subsequent
-        # `FileStation()` constructor reuses it instead of logging in
-        # fresh. After DSM's idle session timeout (default ~30 min)
-        # the SID server-side is gone but the worker keeps sending
-        # it, surfacing as "Invalid session / SID not found" on the
-        # very next FileStation call. Reset before construction so
-        # each client gets a real login. See the 2026-05-03 backup
-        # worker incident.
-        BaseApi.shared_session = None
-        self._fs = FileStation(
+        # `auto_relogin=True` (default) makes the client transparently
+        # re-authenticate on SID-expired (DSM code 119) — the property
+        # that fixes the 30-min idle-timeout pattern that bit the
+        # 2026-05-03 backup-worker incident and the 2026-05-07 api-worker
+        # stage 2 incident.
+        self._fs = Client.login(
             parsed.hostname,
             parsed.port,
             username,
             password,
-            secure=True,
-            cert_verify=False,
+            https=True,
         )
 
     def upload(self, *, dest_dir: str, src_file_path: str) -> None:
         """Upload `src_file_path` into NAS folder `dest_dir`. Creates
-        `dest_dir` (idempotently) before the upload — synology-api's
-        `upload_file(create_parents=True)` does NOT actually create
-        missing parents in practice, the upload silently no-ops and
-        returns a non-success tuple. Existing files at the same name
+        `dest_dir` (idempotently) before the upload — the new client
+        honors `_create_parents=True` in `upload`, but historical prod
+        backup paths have at least one layout where the parent of the
+        target dir doesn't exist, so the explicit `_ensure_dir` step
+        stays as belt-and-suspenders. Existing files at the same name
         are overwritten."""
         _log.info("nas upload start dest=%s src=%s", dest_dir, src_file_path)
         self._ensure_dir(dest_dir)
-        with _surface_filestation_error(f"upload {src_file_path} -> {dest_dir}"):
-            result = self._fs.upload_file(
-                dest_dir, src_file_path, overwrite=True
-            )
-        # synology-api returns (status_code, json) on app-level failure
-        # and a plain dict (or success-shaped json) on success. Anything
-        # tuple-shaped is a failure we'd otherwise swallow.
-        if isinstance(result, tuple):
-            status, body = result
-            raise RuntimeError(
-                f"FileStation upload {src_file_path} -> {dest_dir} failed: "
-                f"http_status={status} body={body!r}"
-            )
+        self._fs.upload(src_file_path, dest_dir, overwrite=True)
         _log.info("nas upload done dest=%s", dest_dir)
 
     def _ensure_dir(self, dest_dir: str) -> None:
@@ -100,32 +81,26 @@ class NasBackupClient:
             # `dest_dir` is the share root itself — nothing to create.
             return
         try:
-            self._fs.create_folder(
-                folder_path=parent, name=name, force_parent=True
-            )
-        except FileStationError as e:
-            msg = getattr(e, "error_message", "") or ""
-            if "already exists" in msg.lower():
-                return
-            _log.error("nas ensure_dir %s failed: %s", dest_dir, msg)
-            raise RuntimeError(
-                f"FileStation create_folder {dest_dir} failed: {msg}"
-            ) from e
+            self._fs.create_folder(parent, name, _force_parent=True)
+        except AlreadyExists:
+            return
 
     def list_filenames(self, *, folder_path: str) -> List[str]:
         """Return just the bare filenames in `folder_path` (no paths,
-        no metadata)."""
-        with _surface_filestation_error(f"list {folder_path}"):
-            listing = self._fs.get_file_list(folder_path)
-        # synology-api returns a dict like {"data": {"files": [{"name": ...}, ...]}}
-        # — pluck the names defensively in case the shape changes between versions.
-        files = (
-            listing.get("data", {}).get("files", []) if isinstance(listing, dict) else []
-        )
-        return [f["name"] for f in files if isinstance(f, dict) and "name" in f]
+        no metadata). The Rust client's `list_dir` returns dicts with
+        full paths in `path`; strip to basename so the prune activity's
+        `backup_naming.filenames_to_prune` (which string-matches on
+        filenames) gets the shape it expects."""
+        entries = self._fs.list_dir(folder_path)
+        names = []
+        for entry in entries:
+            full_path = entry.get("path") if isinstance(entry, dict) else None
+            if not full_path:
+                continue
+            names.append(os.path.basename(full_path))
+        return names
 
     def delete(self, *, file_path: str) -> None:
         """Delete a single file at the given absolute NAS path."""
         _log.info("nas delete %s", file_path)
-        with _surface_filestation_error(f"delete {file_path}"):
-            self._fs.delete_blocking_function(file_path)
+        self._fs.delete(file_path)

--- a/services/fishsense-backup-worker/src/fishsense_backup_worker/nas.py
+++ b/services/fishsense-backup-worker/src/fishsense_backup_worker/nas.py
@@ -62,7 +62,7 @@ class NasBackupClient:
     def upload(self, *, dest_dir: str, src_file_path: str) -> None:
         """Upload `src_file_path` into NAS folder `dest_dir`. Creates
         `dest_dir` (idempotently) before the upload — the new client
-        honors `_create_parents=True` in `upload`, but historical prod
+        creates parents by default in `upload`, but historical prod
         backup paths have at least one layout where the parent of the
         target dir doesn't exist, so the explicit `_ensure_dir` step
         stays as belt-and-suspenders. Existing files at the same name

--- a/services/fishsense-backup-worker/tests/test_nas_backup_client.py
+++ b/services/fishsense-backup-worker/tests/test_nas_backup_client.py
@@ -73,7 +73,7 @@ def test_upload_propagates_underlying_failure(monkeypatch):
         password="p",
     )
 
-    with pytest.raises(Exception):
+    with pytest.raises(SidNotFound):
         client.upload(dest_dir="/foo/bar", src_file_path="/tmp/x.dump")
 
 
@@ -94,7 +94,7 @@ def test_delete_propagates_underlying_failure(monkeypatch):
         password="p",
     )
 
-    with pytest.raises(Exception):
+    with pytest.raises(NoSuchFile):
         client.delete(file_path="/foo/bar/missing.dump")
 
 
@@ -124,7 +124,7 @@ def test_ensure_dir_treats_already_exists_as_success(monkeypatch):
 
 
 def test_list_filenames_returns_basenames(monkeypatch):
-    """`list_dir` returns dicts with full paths in `name`; the wrapper
+    """`list_dir` returns dicts with full paths in `path`; the wrapper
     must strip them down to bare basenames so the prune activity's
     string-matching logic works (`backup_naming.filenames_to_prune`
     operates on filenames, not absolute paths).

--- a/services/fishsense-backup-worker/tests/test_nas_backup_client.py
+++ b/services/fishsense-backup-worker/tests/test_nas_backup_client.py
@@ -1,14 +1,13 @@
 # pylint: disable=protected-access
 """Unit tests for NasBackupClient.
 
-Pins the regression for the 2026-05-03 backup-worker incident:
-synology-api 0.8.x caches `Authentication` on
-`BaseApi.shared_session` (class-level), so successive
-`FileStation()` constructors reuse the same in-memory SID across
-activity attempts. After DSM idle-times-out the session, every
-subsequent call returns "Invalid session / SID not found".
-NasBackupClient.__init__ must reset that class attribute before
-constructing FileStation so each client gets a real login.
+Pins the behavioral contract on the methods this worker uses
+(`upload`, `list_filenames`, `delete`) independent of the underlying
+NAS client implementation. The migration from synology-api to
+synology-filestation (driven by the 2026-05-07 stage 2 incident in
+the api-worker — see that worker's `nas.py` docstring) preserves
+this surface; these tests are the regression guard if a future swap
+ever breaks it.
 """
 
 from __future__ import annotations
@@ -16,75 +15,135 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-from synology_api.base_api import BaseApi
+from synology_filestation import (
+    AlreadyExists,
+    NoSuchFile,
+    SidNotFound,
+)
 
 
-def test_init_resets_shared_session_before_constructing_filestation(monkeypatch):
-    """Regression: a stale `BaseApi.shared_session` from a previous
-    activity attempt must be cleared so the new FileStation()
-    constructor logs in fresh, rather than reusing an SID DSM has
-    already idle-timed-out.
+def test_external_shape_preserved_for_activity_call_sites(monkeypatch):
+    """Contract test for the public method shape of `NasBackupClient`.
+
+    `pg_dump_database` and `prune_database_backups` call into this
+    class using these exact keyword arguments. A future refactor that
+    renames a method or drops a kwarg can't be caught at import time
+    (call sites use `getattr` via `asyncio.to_thread`), so pin the
+    shape here.
     """
     from fishsense_backup_worker import nas as sut  # pylint: disable=import-outside-toplevel
 
-    # Pretend a previous activity attempt left a session on the class.
-    BaseApi.shared_session = MagicMock(name="stale-prior-session")
+    fake = MagicMock(name="synology_filestation.Client")
+    fake.list_dir.return_value = []
+    monkeypatch.setattr(sut.Client, "login", lambda *a, **kw: fake)
 
-    seen_shared_session: list = []
-
-    def fake_filestation(*_args, **_kwargs):
-        # Capture what `BaseApi.shared_session` looks like at the
-        # moment FileStation() runs — that's the contract we care
-        # about. By the real synology-api lib's logic this is what
-        # determines whether login() runs or the stale session is
-        # reused.
-        seen_shared_session.append(BaseApi.shared_session)
-        return MagicMock(name="fs-client")
-
-    monkeypatch.setattr(sut, "FileStation", fake_filestation)
-
-    sut.NasBackupClient(
+    client = sut.NasBackupClient(
         nas_url="https://nas.example.com:6021",
         username="u",
         password="p",
     )
 
-    assert seen_shared_session == [None], (
-        "FileStation was constructed while BaseApi.shared_session was "
-        f"still set to {seen_shared_session[0]!r}; the stale session "
-        "would be reused and DSM would reject calls after idle timeout."
-    )
+    # Asserting the calls don't raise TypeError is sufficient — we
+    # don't care what the underlying client does, only that our
+    # wrapper exposes these names with these kwarg names.
+    client.upload(dest_dir="/foo/bar", src_file_path="/tmp/x.dump")
+    client.list_filenames(folder_path="/foo/bar")
+    client.delete(file_path="/foo/bar/old.dump")
 
 
-def test_init_resets_shared_session_on_each_construction(monkeypatch):
-    """Same contract repeated across constructions — every new client
-    gets a clean class state, regardless of what the previous one
-    left behind."""
+def test_upload_propagates_underlying_failure(monkeypatch):
+    """Behavioral invariant: an underlying upload failure must surface
+    to the caller.
+
+    The 2026-05-07 stage 2 incident in the api-worker was caused by
+    silent error-swallowing in synology-api's `get_file`. A symmetric
+    failure mode would exist here if the wrapper ever started
+    swallowing typed exceptions from `Client.upload`. Pin the
+    contract so it can't.
+    """
     from fishsense_backup_worker import nas as sut  # pylint: disable=import-outside-toplevel
 
-    seen_shared_session: list = []
+    fake = MagicMock(name="synology_filestation.Client")
+    fake.upload.side_effect = SidNotFound("session expired")
+    monkeypatch.setattr(sut.Client, "login", lambda *a, **kw: fake)
 
-    def fake_filestation(*_args, **_kwargs):
-        seen_shared_session.append(BaseApi.shared_session)
-        # Simulate the real lib's behavior: when FileStation logs in,
-        # it stores its Authentication on the class attribute.
-        BaseApi.shared_session = MagicMock(name="fresh-session")
-        return MagicMock(name="fs-client")
+    client = sut.NasBackupClient(
+        nas_url="https://nas.example.com:6021",
+        username="u",
+        password="p",
+    )
 
-    monkeypatch.setattr(sut, "FileStation", fake_filestation)
-
-    for _ in range(3):
-        sut.NasBackupClient(
-            nas_url="https://nas.example.com:6021", username="u", password="p"
-        )
-
-    assert seen_shared_session == [None, None, None]
+    with pytest.raises(Exception):
+        client.upload(dest_dir="/foo/bar", src_file_path="/tmp/x.dump")
 
 
-@pytest.fixture(autouse=True)
-def _restore_shared_session():
-    """Tests touch a module-global on synology-api; restore between runs
-    so an unrelated test that imports this module isn't affected."""
-    saved = BaseApi.shared_session
-    yield
-    BaseApi.shared_session = saved
+def test_delete_propagates_underlying_failure(monkeypatch):
+    """Same invariant for `delete` — the prune activity relies on
+    deletion failures bubbling up so retention violations don't
+    silently no-op.
+    """
+    from fishsense_backup_worker import nas as sut  # pylint: disable=import-outside-toplevel
+
+    fake = MagicMock(name="synology_filestation.Client")
+    fake.delete.side_effect = NoSuchFile("file not found")
+    monkeypatch.setattr(sut.Client, "login", lambda *a, **kw: fake)
+
+    client = sut.NasBackupClient(
+        nas_url="https://nas.example.com:6021",
+        username="u",
+        password="p",
+    )
+
+    with pytest.raises(Exception):
+        client.delete(file_path="/foo/bar/missing.dump")
+
+
+def test_ensure_dir_treats_already_exists_as_success(monkeypatch):
+    """`upload` calls `_ensure_dir` to create the destination folder
+    before uploading. The new `synology_filestation.Client` raises
+    typed `AlreadyExists` when the folder is already present; the
+    wrapper must treat that as success rather than propagate (the
+    folder-already-exists case is the common steady-state path).
+    """
+    from fishsense_backup_worker import nas as sut  # pylint: disable=import-outside-toplevel
+
+    fake = MagicMock(name="synology_filestation.Client")
+    fake.create_folder.side_effect = AlreadyExists("folder exists")
+    fake.upload.return_value = None  # success
+    monkeypatch.setattr(sut.Client, "login", lambda *a, **kw: fake)
+
+    client = sut.NasBackupClient(
+        nas_url="https://nas.example.com:6021",
+        username="u",
+        password="p",
+    )
+
+    # Should not raise — AlreadyExists during dir creation is a no-op.
+    client.upload(dest_dir="/foo/bar", src_file_path="/tmp/x.dump")
+    fake.upload.assert_called_once()
+
+
+def test_list_filenames_returns_basenames(monkeypatch):
+    """`list_dir` returns dicts with full paths in `name`; the wrapper
+    must strip them down to bare basenames so the prune activity's
+    string-matching logic works (`backup_naming.filenames_to_prune`
+    operates on filenames, not absolute paths).
+    """
+    from fishsense_backup_worker import nas as sut  # pylint: disable=import-outside-toplevel
+
+    fake = MagicMock(name="synology_filestation.Client")
+    fake.list_dir.return_value = [
+        {"path": "/backups/fishsense/2026-05-01.dump", "isdir": False, "size": 1024},
+        {"path": "/backups/fishsense/2026-05-02.dump", "isdir": False, "size": 1024},
+        {"path": "/backups/fishsense/old", "isdir": True, "size": 0},
+    ]
+    monkeypatch.setattr(sut.Client, "login", lambda *a, **kw: fake)
+
+    client = sut.NasBackupClient(
+        nas_url="https://nas.example.com:6021",
+        username="u",
+        password="p",
+    )
+
+    names = client.list_filenames(folder_path="/backups/fishsense")
+    assert names == ["2026-05-01.dump", "2026-05-02.dump", "old"]

--- a/uv.lock
+++ b/uv.lock
@@ -784,7 +784,7 @@ dependencies = [
     { name = "fishsense-shared" },
     { name = "platformdirs" },
     { name = "pydantic" },
-    { name = "synology-api" },
+    { name = "synology-filestation" },
     { name = "temporalio" },
     { name = "validators" },
 ]
@@ -802,7 +802,7 @@ requires-dist = [
     { name = "fishsense-shared", editable = "libs/fishsense-shared" },
     { name = "platformdirs", specifier = ">=4.3.8" },
     { name = "pydantic", specifier = ">=2.11.9" },
-    { name = "synology-api", specifier = ">=0.8.1" },
+    { name = "synology-filestation", url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.1.17/synology_filestation-0.1.17-cp39-abi3-manylinux_2_34_x86_64.whl" },
     { name = "temporalio", specifier = ">=1.17.0" },
     { name = "validators", specifier = ">=0.35.0" },
 ]


### PR DESCRIPTION
## Summary

- Mirrors #164 for the backup-worker: replaces `synology-api` with `synology-filestation` in `NasBackupClient`.
- Same motivation as #164 (silent JSON-error returns + no atomic-rename in the previous client; typed exceptions + transparent SID re-auth in the new one).
- Public method shape unchanged — `pg_dump_database` and `prune_database_backups` activities keep working without modification.

## Stacked on #164

This PR's base is `feat/api-worker-migrate-to-synology-filestation`, not `main`. The workspace `pyproject.toml` change adding the `synology-filestation` URL source landed in #164, so this PR's diff against #164 is just the backup-worker source/test/pyproject + the lockfile delta switching backup-worker's dep from `synology-api` to `synology-filestation`.

After #164 merges, GitHub will auto-retarget this PR to `main` and the diff will collapse to just the backup-worker files + lockfile delta.

## Test plan

- [x] `uv run pytest` (backup-worker): 29 passed.
- [x] Five new tests in `test_nas_backup_client.py` cover external shape, error propagation on `upload` + `delete`, `AlreadyExists` handling, and `list_filenames` basename extraction.
- [ ] Image build on `services/fishsense-backup-worker/Dockerfile` succeeds (handled by `build.yml`).
- [ ] Post-deploy: nightly `fishsense-daily-db-backup` schedule fires cleanly. No-op if it does — the new client is API-compatible at the wrapper boundary.

## Notes

- `NasBackupClient.list_filenames` now extracts basenames from `Client.list_dir`'s dict entries (the new client returns a flat list of dicts with full paths in `path`; synology-api returned a nested `{"data": {"files": [...]}}` shape with bare names). The wrapper preserves the basename-only return contract that `backup_naming.filenames_to_prune` expects.
- The `BaseApi.shared_session` reset workaround is removed — `Client.login(auto_relogin=True)` handles DSM SID expiry transparently, which was the property the workaround approximated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)