### PR TITLE
fix(api-workflow-worker): suppress validation-pass failures in laser sync

### DIFF
--- a/libs/fishsense-shared/src/fishsense_shared/exception_group.py
+++ b/libs/fishsense-shared/src/fishsense_shared/exception_group.py
@@ -11,6 +11,14 @@ classifies the failure as ``WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED
 and the workflow task retries forever instead of failing the run. The default
 stays ``suppress=False`` so activities and worker startup keep their existing
 propagating behavior.
+
+``suppress=True`` only swallows ``Exception`` subclasses (which includes
+``ExceptionGroup`` — the all-``Exception``-subclass flavor of the group).
+Control-flow signals like ``asyncio.CancelledError``, ``KeyboardInterrupt``,
+and ``SystemExit`` are ``BaseException`` subclasses and always propagate; a
+``BaseExceptionGroup`` that contains any of those is likewise not an
+``ExceptionGroup`` and propagates. Without this, swallowing cancellation
+would break Temporal's workflow-cancel semantics.
 """
 
 
@@ -46,4 +54,4 @@ class ExceptionGroupErrorLogging:
                 exc,
                 exc_info=(exc_type, exc, tb),
             )
-        return self.suppress and exc is not None
+        return self.suppress and isinstance(exc, Exception)

--- a/libs/fishsense-shared/src/fishsense_shared/exception_group.py
+++ b/libs/fishsense-shared/src/fishsense_shared/exception_group.py
@@ -3,14 +3,23 @@
 Wrap ``asyncio.TaskGroup()`` with this to make individual task failures visible
 (by default the TaskGroup raises a single ExceptionGroup whose contents only
 appear in the bare exception traceback).
+
+Pass ``suppress=True`` for fire-and-forget workflow blocks. Inside a Temporal
+workflow, the bare ``BaseExceptionGroup`` raised by ``asyncio.TaskGroup`` is
+not a ``temporalio.exceptions.FailureError`` subclass, so letting it propagate
+classifies the failure as ``WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE``
+and the workflow task retries forever instead of failing the run. The default
+stays ``suppress=False`` so activities and worker startup keep their existing
+propagating behavior.
 """
 
 
 class ExceptionGroupErrorLogging:
     """Async context manager to report errors in asyncio TaskGroups."""
 
-    def __init__(self, activity_logger):
+    def __init__(self, activity_logger, *, suppress: bool = False):
         self.activity_logger = activity_logger
+        self.suppress = suppress
 
     async def __aenter__(self):
         return self
@@ -37,4 +46,4 @@ class ExceptionGroupErrorLogging:
                 exc,
                 exc_info=(exc_type, exc, tb),
             )
-        return False
+        return self.suppress and exc is not None

--- a/libs/fishsense-shared/tests/test_exception_group.py
+++ b/libs/fishsense-shared/tests/test_exception_group.py
@@ -1,0 +1,141 @@
+"""Tests for ExceptionGroupErrorLogging.
+
+The helper has two callsite shapes:
+
+1. Activity / startup contexts (``suppress=False``, the default) where
+   any task-group failure should still propagate so Temporal converts
+   it to an activity / startup failure as usual.
+2. Workflow contexts that explicitly want fire-and-forget semantics —
+   e.g. the post-sync validation pass in
+   ``SyncLabelStudioLaserLabelsWorkflow``, which must not roll back a
+   successful sync if a downstream child workflow fails. Without
+   ``suppress=True`` the bare ``BaseExceptionGroup`` raised by
+   ``asyncio.TaskGroup`` is not a ``temporalio.exceptions.FailureError``
+   subclass, so Temporal treats it as
+   ``WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE`` and
+   retries the workflow task forever.
+"""
+
+# pylint: disable=redefined-outer-name
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from fishsense_shared import ExceptionGroupErrorLogging
+
+
+@pytest.fixture
+def caplog_at_error(caplog):
+    caplog.set_level(logging.ERROR)
+    return caplog
+
+
+@pytest.mark.asyncio
+async def test_clean_exit_does_not_log(caplog_at_error):
+    logger = logging.getLogger("test_clean_exit")
+    async with ExceptionGroupErrorLogging(logger):
+        pass
+    assert not caplog_at_error.records
+
+
+@pytest.mark.asyncio
+async def test_propagates_exception_group_by_default(caplog_at_error):
+    logger = logging.getLogger("test_propagate_group")
+
+    group = BaseExceptionGroup(
+        "from taskgroup",
+        [ValueError("a"), RuntimeError("b")],
+    )
+
+    with pytest.raises(BaseExceptionGroup) as exc_info:
+        async with ExceptionGroupErrorLogging(logger):
+            raise group
+
+    assert exc_info.value is group
+    sub_records = [r for r in caplog_at_error.records if "Sub-exception" in r.message]
+    assert len(sub_records) == 2
+
+
+@pytest.mark.asyncio
+async def test_propagates_bare_exception_by_default(caplog_at_error):
+    logger = logging.getLogger("test_propagate_bare")
+
+    with pytest.raises(ValueError):
+        async with ExceptionGroupErrorLogging(logger):
+            raise ValueError("solo")
+
+    assert any("Error in TaskGroup" in r.message for r in caplog_at_error.records)
+
+
+@pytest.mark.asyncio
+async def test_suppresses_exception_group_when_suppress_true(caplog_at_error):
+    logger = logging.getLogger("test_suppress_group")
+
+    group = BaseExceptionGroup(
+        "from taskgroup",
+        [ValueError("a"), RuntimeError("b"), KeyError("c")],
+    )
+
+    async with ExceptionGroupErrorLogging(logger, suppress=True):
+        raise group
+
+    sub_records = [r for r in caplog_at_error.records if "Sub-exception" in r.message]
+    assert len(sub_records) == 3
+
+
+@pytest.mark.asyncio
+async def test_suppresses_bare_exception_when_suppress_true(caplog_at_error):
+    logger = logging.getLogger("test_suppress_bare")
+
+    async with ExceptionGroupErrorLogging(logger, suppress=True):
+        raise ValueError("solo")
+
+    assert any("Error in TaskGroup" in r.message for r in caplog_at_error.records)
+
+
+@pytest.mark.asyncio
+async def test_real_taskgroup_propagates_by_default(caplog_at_error):
+    """Integration check against a real ``asyncio.TaskGroup``: 3 failing
+    children → 3 logged sub-exceptions and the group still propagates so
+    upstream callers can fail loudly when they want to."""
+    logger = logging.getLogger("test_real_taskgroup_propagate")
+
+    async def boom(label: str) -> None:
+        raise RuntimeError(label)
+
+    with pytest.raises(BaseExceptionGroup) as exc_info:
+        async with ExceptionGroupErrorLogging(logger):
+            async with asyncio.TaskGroup() as tg:
+                tg.create_task(boom("a"))
+                tg.create_task(boom("b"))
+                tg.create_task(boom("c"))
+
+    assert len(exc_info.value.exceptions) == 3
+    sub_records = [r for r in caplog_at_error.records if "Sub-exception" in r.message]
+    assert len(sub_records) == 3
+
+
+@pytest.mark.asyncio
+async def test_real_taskgroup_swallowed_when_suppress_true(caplog_at_error):
+    """The validation-pass scenario from the failing workflow event:
+    multiple child workflow dispatches blow up, the helper logs each,
+    and the surrounding workflow continues."""
+    logger = logging.getLogger("test_real_taskgroup_suppress")
+
+    async def boom(label: str) -> None:
+        raise RuntimeError(label)
+
+    after_block_ran = False
+    async with ExceptionGroupErrorLogging(logger, suppress=True):
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(boom("a"))
+            tg.create_task(boom("b"))
+    after_block_ran = True
+
+    assert after_block_ran
+    sub_records = [r for r in caplog_at_error.records if "Sub-exception" in r.message]
+    assert len(sub_records) == 2

--- a/libs/fishsense-shared/tests/test_exception_group.py
+++ b/libs/fishsense-shared/tests/test_exception_group.py
@@ -120,6 +120,47 @@ async def test_real_taskgroup_propagates_by_default(caplog_at_error):
 
 
 @pytest.mark.asyncio
+async def test_suppress_true_does_not_swallow_cancelled_error():
+    """``asyncio.CancelledError`` is a control-flow signal — swallowing
+    it would break Temporal workflow cancellation. ``suppress=True``
+    must only stop ``Exception`` subclasses, never ``BaseException``."""
+    logger = logging.getLogger("test_suppress_cancelled")
+
+    with pytest.raises(asyncio.CancelledError):
+        async with ExceptionGroupErrorLogging(logger, suppress=True):
+            raise asyncio.CancelledError()
+
+
+@pytest.mark.asyncio
+async def test_suppress_true_does_not_swallow_keyboard_interrupt():
+    logger = logging.getLogger("test_suppress_kbd")
+
+    with pytest.raises(KeyboardInterrupt):
+        async with ExceptionGroupErrorLogging(logger, suppress=True):
+            raise KeyboardInterrupt()
+
+
+@pytest.mark.asyncio
+async def test_suppress_true_does_not_swallow_base_exception_group_with_cancellation():
+    """A ``BaseExceptionGroup`` that contains a ``CancelledError`` is
+    not an ``ExceptionGroup`` (which is the all-``Exception`` subclass
+    flavor). Cancellation must still escape so Temporal can drive the
+    workflow's cancel handler."""
+    logger = logging.getLogger("test_suppress_mixed_group")
+
+    mixed = BaseExceptionGroup(
+        "mixed",
+        [ValueError("ordinary failure"), asyncio.CancelledError()],
+    )
+
+    with pytest.raises(BaseExceptionGroup) as exc_info:
+        async with ExceptionGroupErrorLogging(logger, suppress=True):
+            raise mixed
+
+    assert exc_info.value is mixed
+
+
+@pytest.mark.asyncio
 async def test_real_taskgroup_swallowed_when_suppress_true(caplog_at_error):
     """The validation-pass scenario from the failing workflow event:
     multiple child workflow dispatches blow up, the helper logs each,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/sync_label_studio_laser_labels_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/sync_label_studio_laser_labels_workflow.py
@@ -101,7 +101,12 @@ class SyncLabelStudioLaserLabelsWorkflow:
                         dive_id,
                     )
 
-        async with ExceptionGroupErrorLogging(workflow.logger):
+        # suppress=True: validation failures must not roll back a successful
+        # sync. Without it, the BaseExceptionGroup from asyncio.TaskGroup
+        # leaks out of the workflow as a non-FailureError, which Temporal
+        # classifies as WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE
+        # and retries forever.
+        async with ExceptionGroupErrorLogging(workflow.logger, suppress=True):
             async with asyncio.TaskGroup() as tg:
                 for dive_id in complete_dive_ids:
                     tg.create_task(__validate_dive(dive_id))

--- a/services/fishsense-api-workflow-worker/tests/test_sync_label_studio_laser_labels_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_sync_label_studio_laser_labels_workflow.py
@@ -18,6 +18,7 @@ from typing import List
 
 import pytest
 from temporalio import activity, workflow
+from temporalio.exceptions import ApplicationError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
@@ -269,3 +270,73 @@ async def test_per_project_activity_caps_concurrency_at_workflow_level():
     # Workflow-level cap is PROJECT_CONCURRENCY = 4.
     assert peak_in_flight <= 4, f"peak concurrency was {peak_in_flight}, expected <= 4"
     assert len(started) == 20
+
+
+@pytest.mark.asyncio
+async def test_workflow_completes_when_validation_children_fail():
+    """Regression: when every per-dive validation child workflow fails,
+    the parent must still complete successfully.
+
+    Before the fix, asyncio.TaskGroup wrapped the per-dive failures in a
+    bare BaseExceptionGroup. That isn't a temporalio FailureError
+    subclass, so Temporal classified it as
+    WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE and
+    retried the workflow task indefinitely instead of treating the run
+    as a workflow execution failure. The validation pass is wrapped in
+    its own ExceptionGroupErrorLogging block precisely so failures
+    there don't roll back a successful sync, so the parent must finish.
+    """
+
+    @activity.defn(name="sync_users_label_studio_activity")
+    async def stub_sync_users() -> None:
+        return None
+
+    @activity.defn(name="get_laser_label_studio_project_ids_activity")
+    async def stub_get_ids() -> List[int]:
+        return []
+
+    @activity.defn(name="sync_laser_labels_for_label_studio_project_activity")
+    async def stub_sync_project(_: int) -> None:
+        return None
+
+    @activity.defn(name="get_dives_with_complete_laser_labeling_activity")
+    async def stub_get_complete_dives() -> List[int]:
+        return [1, 2, 3]
+
+    @activity.defn(name="validate_laser_labels_for_dive_activity")
+    async def stub_validate_fails(dive_id: int) -> int:
+        raise ApplicationError(
+            f"validation deliberately failed for dive {dive_id}",
+            non_retryable=True,
+        )
+
+    queue_parent = "test-laser-sync-validate-fails-parent"
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=queue_parent,
+            workflows=[SyncLabelStudioLaserLabelsWorkflow],
+            activities=[
+                stub_sync_users,
+                stub_get_ids,
+                stub_sync_project,
+                stub_get_complete_dives,
+            ],
+        ):
+            async with Worker(
+                env.client,
+                task_queue=DATA_PROCESSING_TASK_QUEUE,
+                workflows=[_StubValidateChildWorkflow],
+                activities=[stub_validate_fails],
+            ):
+                # Must NOT raise. With the bug, this would either raise
+                # WorkflowFailureError or hang in the unhandled-failure
+                # retry loop until the test's wall-clock timeout.
+                await asyncio.wait_for(
+                    env.client.execute_workflow(
+                        SyncLabelStudioLaserLabelsWorkflow.run,
+                        id=f"test-laser-sync-validate-fails-{uuid.uuid4()}",
+                        task_queue=queue_parent,
+                    ),
+                    timeout=30.0,
+                )


### PR DESCRIPTION
## Summary
- The post-sync validation `TaskGroup` in `SyncLabelStudioLaserLabelsWorkflow` was leaking a bare `BaseExceptionGroup` whenever any per-dive `ValidateLaserLabelsForDiveWorkflow` child failed. Because `BaseExceptionGroup` is not a `temporalio.exceptions.FailureError` subclass, Temporal classified the parent as `WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE` and retried the workflow task indefinitely instead of completing the run — observed in prod at `eventId: 174` ("unhandled errors in a TaskGroup (9 sub-exceptions)").
- Added a `suppress: bool = False` kwarg to `ExceptionGroupErrorLogging`. Default-off preserves the existing propagating behavior for activities, worker startup, and the sync `TaskGroup` itself (where a failure should still fail the workflow). The validation-pass call site flips it to `True`, matching the existing comment's "shouldn't roll back a successful sync" intent.

## Test plan
- [x] 7 new `fishsense-shared` unit tests for `ExceptionGroupErrorLogging` covering clean exit, default-propagate (group + bare), `suppress=True` (group + bare), and real `asyncio.TaskGroup` integration in both modes.
- [x] New workflow regression test `test_workflow_completes_when_validation_children_fail` in `test_sync_label_studio_laser_labels_workflow.py` — drives the workflow end-to-end against `WorkflowEnvironment.start_time_skipping()` with every `ValidateLaserLabelsForDiveWorkflow` child failing non-retryably; asserts the parent completes without raising.
- [x] `./check.sh all` clean (lint + every package's unit + integration suites).

## Latent issue not addressed here
The four sync `TaskGroup`s (laser/species/headtail/dive-slate at `:60`/`:49`/`:50`/`:50`) have the same shape — if all per-project sync activities failed, the resulting `BaseExceptionGroup` would similarly leak as `WORKFLOW_WORKER_UNHANDLED_FAILURE` instead of as a workflow execution failure. Cleanest follow-up is unwrapping to a `temporalio.exceptions.ApplicationError` so Temporal sees a real workflow execution failure. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)