### PR TITLE
chore(deps): bump synology-filestation to 0.1.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,11 @@ fishsense-shared = { workspace = true }
 # exceptions on DSM JSON-error responses (esp. SidNotFound for code 119)
 # and writes downloads atomically (`<local>.part` + rename), eliminating
 # the silent JSON-corruption failure mode that wedged stage 2 on
-# 2026-05-07. Wheel is cp39-abi3 + manylinux_2_34, compatible with
-# python:3.13-slim-trixie. Bump the URL when picking up a new release.
-synology-filestation = { url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.1.17/synology_filestation-0.1.17-cp39-abi3-manylinux_2_34_x86_64.whl" }
+# 2026-05-07. Wheel is cp310-abi3 + manylinux_2_34, compatible with
+# python:3.13-slim-trixie via the stable ABI. Bump the URL when picking
+# up a new release; v0.1.18 raised the project's requires-python to
+# >=3.10, so the platform tag flipped from cp39-abi3 to cp310-abi3.
+synology-filestation = { url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.1.19/synology_filestation-0.1.19-cp310-abi3-manylinux_2_34_x86_64.whl" }
 
 # Workspace-wide pylint configuration. Lives at the repo root so every
 # package picks up the same rules; pylint walks up the directory tree

--- a/uv.lock
+++ b/uv.lock
@@ -722,7 +722,7 @@ dev = [
 
 [[package]]
 name = "fishsense-api-workflow-worker"
-version = "1.35.1"
+version = "1.35.3"
 source = { editable = "services/fishsense-api-workflow-worker" }
 dependencies = [
     { name = "dynaconf" },
@@ -759,7 +759,7 @@ requires-dist = [
     { name = "platformdirs", specifier = ">=4.3.8" },
     { name = "pyaml", specifier = ">=25.7.0" },
     { name = "pymupdf", specifier = ">=1.24.0" },
-    { name = "synology-filestation", url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.1.17/synology_filestation-0.1.17-cp39-abi3-manylinux_2_34_x86_64.whl" },
+    { name = "synology-filestation", url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.1.19/synology_filestation-0.1.19-cp310-abi3-manylinux_2_34_x86_64.whl" },
     { name = "temporalio", specifier = ">=1.15.0" },
     { name = "validators", specifier = ">=0.35.0" },
 ]
@@ -777,7 +777,7 @@ dev = [
 
 [[package]]
 name = "fishsense-backup-worker"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "services/fishsense-backup-worker" }
 dependencies = [
     { name = "dynaconf" },
@@ -802,7 +802,7 @@ requires-dist = [
     { name = "fishsense-shared", editable = "libs/fishsense-shared" },
     { name = "platformdirs", specifier = ">=4.3.8" },
     { name = "pydantic", specifier = ">=2.11.9" },
-    { name = "synology-filestation", url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.1.17/synology_filestation-0.1.17-cp39-abi3-manylinux_2_34_x86_64.whl" },
+    { name = "synology-filestation", url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.1.19/synology_filestation-0.1.19-cp310-abi3-manylinux_2_34_x86_64.whl" },
     { name = "temporalio", specifier = ">=1.17.0" },
     { name = "validators", specifier = ">=0.35.0" },
 ]
@@ -995,7 +995,7 @@ dev = [
 
 [[package]]
 name = "fishsense-shared"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "libs/fishsense-shared" }
 dependencies = [
     { name = "dynaconf" },
@@ -3019,14 +3019,14 @@ wheels = [
 
 [[package]]
 name = "synology-filestation"
-version = "0.1.17"
-source = { url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.1.17/synology_filestation-0.1.17-cp39-abi3-manylinux_2_34_x86_64.whl" }
+version = "0.1.19"
+source = { url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.1.19/synology_filestation-0.1.19-cp310-abi3-manylinux_2_34_x86_64.whl" }
 wheels = [
-    { url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.1.17/synology_filestation-0.1.17-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:27d0c39222e5a2ef6a93a5d42fc297052ff22d28c60f8759a86413600f6283b5" },
+    { url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.1.19/synology_filestation-0.1.19-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f951fc7bbbdf4b692b4c2c164fdaee975a1bda524c48ba6944798095268bf104" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "fsspec", marker = "extra == 'fsspec'", specifier = ">=2023.10" }]
+requires-dist = [{ name = "fsspec", marker = "extra == 'fsspec'", specifier = ">=2026.4.0" }]
 provides-extras = ["fsspec"]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps the workspace's `synology-filestation` URL pin from `v0.1.17` to `v0.1.19`. v0.1.18 raised the upstream project's `requires-python` to `>=3.10`, which flipped the wheel platform tag from `cp39-abi3` to `cp310-abi3`; both the URL and the filename change accordingly. The `cp310-abi3` wheel remains compatible with `python:3.13-slim-trixie` via the stable ABI. v0.1.19 was a chore version-sync release with no behavior changes.
- Updates the comment in [pyproject.toml](pyproject.toml) so the rationale for the `cp310` tag (vs `cp39`) is captured for the next bumper.
- `uv lock` also resyncs three workspace package versions — `origin/main` had drifted (pyproject.toml at the bumped versions, uv.lock at the older ones after the most recent release-please runs):
  - `fishsense-api-workflow-worker`: 1.35.1 → 1.35.3
  - `fishsense-backup-worker`: 0.3.0 → 0.3.1
  - `fishsense-shared`: 0.4.0 → 0.4.1

## Test plan
- [x] `./check.sh all` clean (lint + every package's unit + integration suites). Both consumers (`fishsense-api-workflow-worker` and `fishsense-backup-worker`) import `synology-filestation` symbols at module load, so a wheel-format incompatibility would surface as an `ImportError` during test collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)