### PR TITLE
fix(web): restore /portal middleware export and document AUTH_* envs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -545,7 +545,12 @@ Orchestrator:
    existing prod state. Populate `web_volumes/.env` (untracked) per
    the canonical shape in `deploy/web_volumes/.env.example` —
    fishsense-lite-web reads it via `env_file:` and throws on first request
-   if any of the five keys are missing.
+   if any of the nine keys are missing — five for the public landing
+   page (FISHSENSE_API_*, LABEL_STUDIO_*) plus four for the Authentik
+   OIDC gate on `/portal/*` (AUTH_SECRET, AUTH_AUTHENTIK_ID,
+   AUTH_AUTHENTIK_SECRET, AUTH_AUTHENTIK_ISSUER). Landing stays up
+   when AUTH_* are missing because middleware only runs on
+   `/portal/:path*`; `/portal` itself 500s.
 
 Data-worker:
 1. Register a runner with `--labels fishsense-data-worker`.

--- a/apps/fishsense-lite-web/middleware.ts
+++ b/apps/fishsense-lite-web/middleware.ts
@@ -5,7 +5,7 @@ import { auth } from "@/auth";
 // distinguish "user never signed in" from "cookie present but
 // decryption failed." Remove once /portal is reliably populating
 // session.user.
-export const middleware = auth((req) => {
+export default auth((req) => {
   const session = req.auth;
   console.log("[middleware] /portal request", {
     pathname: req.nextUrl.pathname,

--- a/deploy/web_volumes/.env.example
+++ b/deploy/web_volumes/.env.example
@@ -4,8 +4,12 @@
 # alongside this example on the orchestrator deploy host. The file is
 # loaded by the `fishsense-web` compose service (deploy/compose.yml).
 #
-# All five variables are required; the Next.js server throws on first
-# request access if any are missing.
+# All nine variables are required; the Next.js server throws on first
+# request access if any are missing. The five FISHSENSE_/LABEL_STUDIO_
+# keys back the public landing page; the four AUTH_* keys back the
+# Authentik OIDC sign-in that gates /portal/*. Missing AUTH_* keys
+# surface as a 500 on /portal (landing stays up because middleware
+# only runs on /portal/:path*).
 
 # Internal docker-network URL for fishsense-api. Bypasses the public
 # Traefik route + authentik middleware so HTTP basic auth is honored.
@@ -24,3 +28,19 @@ LABEL_STUDIO_URL=https://labeler.e4e.ucsd.edu
 # Service-account API key from Label Studio (Account & Settings -> Access
 # Token). Same key the api-workflow-worker uses for sync.
 LABEL_STUDIO_API_KEY=
+
+# JWT / cookie signing secret for next-auth. Must be a stable random
+# value (>=32 bytes); rotating it invalidates every active session.
+# Generate with: `openssl rand -base64 48`.
+AUTH_SECRET=
+
+# Authentik OIDC application credentials. Create a Provider + Application
+# in Authentik for fishsense-lite-web with redirect URI
+# https://fishsense.e4e.ucsd.edu/api/auth/callback/authentik and copy
+# the Client ID / Client Secret into the two vars below.
+AUTH_AUTHENTIK_ID=
+AUTH_AUTHENTIK_SECRET=
+
+# OIDC issuer URL (Authentik Provider -> "OpenID Configuration Issuer").
+# Typically https://<authentik-host>/application/o/<application-slug>/
+AUTH_AUTHENTIK_ISSUER=


### PR DESCRIPTION
## Summary

Two fixes for the `/portal` 500 reported on prod:

- **[middleware.ts](apps/fishsense-lite-web/middleware.ts)** — switched from `export const middleware = auth(...)` to `export default auth(...)`. The named-const form is not recognized by Next.js's middleware loader in this build (next-auth v5 beta), producing `The Middleware "/middleware" must export a `middleware` or a `default` function` at request time. `export default` is the canonical Auth.js v5 pattern.
- **[deploy/web_volumes/.env.example](deploy/web_volumes/.env.example) + [CLAUDE.md](CLAUDE.md)** — the example file was added in the original web service commit and never updated when commit `b9d30da` (the OIDC gate) added four new required env vars to [lib/env.ts](apps/fishsense-lite-web/lib/env.ts). The example still said "All five variables are required," so the orchestrator's untracked `.env` was provisioned without `AUTH_SECRET` / `AUTH_AUTHENTIK_ID` / `AUTH_AUTHENTIK_SECRET` / `AUTH_AUTHENTIK_ISSUER`. Hitting `/portal` invokes the NextAuth config function which reads these via env.ts's `required()` helper and throws -> SSR 500. Documented the four new keys with generation/setup notes and updated the matching CLAUDE.md operator-bootstrap note (five keys -> nine keys).

The landing page stays up because `middleware`'s `matcher` is `/portal/:path*` and `app/page.tsx` doesn't import `@/auth`, so missing `AUTH_*` only affects the gated route.

## Operator action (required after merge + deploy)

The `.env` on the orchestrator host still needs the four new keys before `/portal` will work. On `<DEPLOY_DIR>/deploy/web_volumes/.env`:

1. In Authentik, create an OIDC Provider + Application for fishsense-lite-web with redirect URI `https://fishsense.e4e.ucsd.edu/api/auth/callback/authentik`.
2. Append:
   - `AUTH_SECRET=$(openssl rand -base64 48)`
   - `AUTH_AUTHENTIK_ID=<client id>`
   - `AUTH_AUTHENTIK_SECRET=<client secret>`
   - `AUTH_AUTHENTIK_ISSUER=https://<authentik-host>/application/o/<slug>/`
3. `docker compose up -d fishsense-lite-web` to pick up the new env_file values.

## Test plan

- [ ] CI build succeeds for `apps/fishsense-lite-web` (verifies the middleware default-export shape compiles cleanly under next-auth v5 beta).
- [ ] After auto-deploy lands on prod and the operator action above is complete, `GET https://fishsense.e4e.ucsd.edu/portal` redirects through Authentik instead of returning 500.
- [ ] Container logs show the `[middleware]` and `[auth]` debug entries fire on subsequent /portal hits (already in place from commits `b9d30da` / `59360a5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)