### PR TITLE
docs(web): document AUTH_URL to fix 0.0.0.0:3000 post-sign-in redirect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -545,12 +545,17 @@ Orchestrator:
    existing prod state. Populate `web_volumes/.env` (untracked) per
    the canonical shape in `deploy/web_volumes/.env.example` —
    fishsense-lite-web reads it via `env_file:` and throws on first request
-   if any of the nine keys are missing — five for the public landing
-   page (FISHSENSE_API_*, LABEL_STUDIO_*) plus four for the Authentik
-   OIDC gate on `/portal/*` (AUTH_SECRET, AUTH_AUTHENTIK_ID,
-   AUTH_AUTHENTIK_SECRET, AUTH_AUTHENTIK_ISSUER). Landing stays up
-   when AUTH_* are missing because middleware only runs on
-   `/portal/:path*`; `/portal` itself 500s.
+   if any of the nine required keys are missing — five for the public
+   landing page (FISHSENSE_API_*, LABEL_STUDIO_*) plus four for the
+   Authentik OIDC gate on `/portal` (AUTH_SECRET, AUTH_AUTHENTIK_ID,
+   AUTH_AUTHENTIK_SECRET, AUTH_AUTHENTIK_ISSUER). Landing stays up when
+   AUTH_* are missing because the gate lives in app/portal/page.tsx,
+   not on the landing route; `/portal` itself 500s. A tenth key,
+   `AUTH_URL=https://fishsense.e4e.ucsd.edu`, is technically optional
+   but strongly recommended — without it next-auth derives URLs from
+   request headers, and the OAuth post-sign-in redirect lands at
+   `http://0.0.0.0:3000/...` (the container's internal listen address)
+   instead of the public hostname.
 
 Data-worker:
 1. Register a runner with `--labels fishsense-data-worker`.

--- a/apps/fishsense-lite-web/README.md
+++ b/apps/fishsense-lite-web/README.md
@@ -138,12 +138,18 @@ narrow exception; extract logic into a unit and cover it there.
 - `fishsense.e4e.ucsd.edu` (this app) is **not** behind the
   Authentik forward-auth Traefik middleware that fronts
   `orchestrator.fishsense.e4e.ucsd.edu` (fishsense-api, qcomm static
-  server). Auth is app-owned and only gates `/portal/*`; the landing
-  must stay public.
+  server). Auth is app-owned and only gates `/portal` (the SSR check
+  lives in `app/portal/page.tsx`); the landing must stay public.
 - SSR fetches use the in-cluster URL `http://fishsense-api:8000` to
   bypass the public Traefik route + Authentik middleware that 302s
   basic-auth. Don't switch this to the public hostname.
-- `AUTH_URL` is **not** required: NextAuth v5 + `trustHost: true`
-  derives the base URL from the inbound `Host`/`X-Forwarded-Host`
-  header (Traefik supplies these). If you ever see callback URLs
-  built against `localhost`, that's the knob to revisit.
+- `AUTH_URL` is **strongly recommended** in any non-localhost deploy.
+  NextAuth v5 + `trustHost: true` is *supposed* to derive the base
+  URL from the inbound `Host`/`X-Forwarded-Host` header, but in
+  practice the providers/picker route and the OAuth post-sign-in
+  redirect can still end up built against the container's internal
+  listen address (`http://0.0.0.0:3000/...`) — which 500s the OAuth
+  callback and sends the browser somewhere unreachable. Set
+  `AUTH_URL=https://fishsense.e4e.ucsd.edu` to bypass header
+  detection entirely. See `deploy/web_volumes/.env.example` and the
+  orchestrator-bootstrap section of the repo's `CLAUDE.md`.

--- a/deploy/compose.local.yml
+++ b/deploy/compose.local.yml
@@ -224,6 +224,13 @@ services:
       AUTH_AUTHENTIK_ID: local-test-client-id
       AUTH_AUTHENTIK_SECRET: local-test-client-secret
       AUTH_AUTHENTIK_ISSUER: http://localhost:9999/local-test-issuer
+      # Pin the canonical URL so next-auth doesn't fall back to deriving
+      # it from the request's listen address (http://0.0.0.0:3000/...),
+      # which would point browsers from the host at an unreachable URL
+      # after sign-in. Prod sets the public hostname here; for the local
+      # stack the container's published port on the host is the right
+      # value.
+      AUTH_URL: http://localhost:3000
     ports:
       - "3000:3000"
     networks:

--- a/deploy/web_volumes/.env.example
+++ b/deploy/web_volumes/.env.example
@@ -1,15 +1,15 @@
-# fishsense-web environment file.
+# fishsense-lite-web environment file.
 #
 # Populate the real `./web_volumes/.env` (untracked, gitignored via *.env)
 # alongside this example on the orchestrator deploy host. The file is
-# loaded by the `fishsense-web` compose service (deploy/compose.yml).
+# loaded by the `fishsense-lite-web` compose service (deploy/compose.yml).
 #
-# Nine variables are required; the Next.js server throws on first
-# request access if any are missing. The five FISHSENSE_/LABEL_STUDIO_
-# keys back the public landing page; the four AUTH_* keys back the
-# Authentik OIDC sign-in that gates /portal. Missing AUTH_* keys
-# surface as a 500 on /portal (landing stays up because the gate is
-# in app/portal/page.tsx, not the landing route).
+# Nine variables are required; the Next.js server throws on the first
+# request that touches one of them if it's unset. The five
+# FISHSENSE_/LABEL_STUDIO_ keys back the public landing page; the four
+# AUTH_* keys back the Authentik OIDC sign-in that gates /portal.
+# Missing AUTH_* keys surface as a 500 on /portal (landing stays up
+# because the gate is in app/portal/page.tsx, not the landing route).
 #
 # AUTH_URL is also strongly recommended in any non-localhost deploy
 # (see the AUTH_URL block at the bottom of this file): without it,

--- a/deploy/web_volumes/.env.example
+++ b/deploy/web_volumes/.env.example
@@ -4,12 +4,20 @@
 # alongside this example on the orchestrator deploy host. The file is
 # loaded by the `fishsense-web` compose service (deploy/compose.yml).
 #
-# All nine variables are required; the Next.js server throws on first
+# Nine variables are required; the Next.js server throws on first
 # request access if any are missing. The five FISHSENSE_/LABEL_STUDIO_
 # keys back the public landing page; the four AUTH_* keys back the
-# Authentik OIDC sign-in that gates /portal/*. Missing AUTH_* keys
-# surface as a 500 on /portal (landing stays up because middleware
-# only runs on /portal/:path*).
+# Authentik OIDC sign-in that gates /portal. Missing AUTH_* keys
+# surface as a 500 on /portal (landing stays up because the gate is
+# in app/portal/page.tsx, not the landing route).
+#
+# AUTH_URL is also strongly recommended in any non-localhost deploy
+# (see the AUTH_URL block at the bottom of this file): without it,
+# next-auth derives the public URL from request headers, and any
+# proxy that doesn't forward X-Forwarded-Host / X-Forwarded-Proto
+# correctly produces sign-in URLs that point at the container's
+# internal listen address (http://0.0.0.0:3000/...) and break the
+# OAuth callback.
 
 # Internal docker-network URL for fishsense-api. Bypasses the public
 # Traefik route + authentik middleware so HTTP basic auth is honored.
@@ -44,3 +52,13 @@ AUTH_AUTHENTIK_SECRET=
 # OIDC issuer URL (Authentik Provider -> "OpenID Configuration Issuer").
 # Typically https://<authentik-host>/application/o/<application-slug>/
 AUTH_AUTHENTIK_ISSUER=
+
+# Public URL of fishsense-lite-web. Optional but strongly recommended
+# behind a reverse proxy: when unset, next-auth falls back to deriving
+# the URL from request headers, and the picker page + OAuth post-
+# sign-in redirect end up pointing at the container's internal listen
+# address (http://0.0.0.0:3000/...) instead of the public hostname,
+# which produces "can't connect to 0.0.0.0:3000" in the user's browser
+# after a successful Authentik sign-in. Setting AUTH_URL bypasses
+# header detection and pins every URL next-auth constructs.
+AUTH_URL=https://fishsense.e4e.ucsd.edu


### PR DESCRIPTION
## Summary

After the middleware-removal PRs landed, completing the Authentik sign-in lands the user at `http://0.0.0.0:3000/portal` (the container's internal listen address) instead of `https://fishsense.e4e.ucsd.edu/portal`, producing a connection-refused error in the browser.

Root cause — `next-auth` falls back to deriving the public URL from request headers when `AUTH_URL` is unset. Behind a reverse proxy that doesn't forward `X-Forwarded-Host` / `X-Forwarded-Proto` in the shape `next-auth` expects, the host derivation produces the container's listen address. `trustHost: true` is set in [auth.ts](apps/fishsense-lite-web/auth.ts) and supposed to handle this, but in practice the providers / picker routes still emit `0.0.0.0:3000` URLs (verified locally — `/api/auth/providers` returns `signinUrl: "http://0.0.0.0:3000/..."` when hit through the container's listen address).

`AUTH_URL=https://fishsense.e4e.ucsd.edu` bypasses header detection entirely and pins every URL `next-auth` constructs.

## Changes

This PR is docs / config only — no app code changes. The actual fix in prod is the operator action below.

- [deploy/web_volumes/.env.example](deploy/web_volumes/.env.example) — adds `AUTH_URL` block at the bottom with the prod URL as the example value, plus a callout in the header preamble.
- [deploy/compose.local.yml](deploy/compose.local.yml) — pins `AUTH_URL=http://localhost:3000` on the `fishsense-lite-web` service so the local stack matches prod shape (the integration tests don't run a real OAuth flow today, so this is shape-parity rather than a test fix; #190 will make this load-bearing).
- [CLAUDE.md](CLAUDE.md) — adds a tenth-key note to the orchestrator-bootstrap section explaining `AUTH_URL` is technically optional but strongly recommended.

## Operator action (immediate fix on prod)

No rebuild needed; `env_file` is read at container start, so a restart picks it up:

```
echo 'AUTH_URL=https://fishsense.e4e.ucsd.edu' \
  >> <DEPLOY_DIR>/deploy/web_volumes/.env
docker compose up -d fishsense-lite-web
```

After that, the post-sign-in redirect should land on `https://fishsense.e4e.ucsd.edu/portal` rather than `http://0.0.0.0:3000/portal`.

## Test plan

- [ ] After applying the operator action, complete an Authentik sign-in from `https://fishsense.e4e.ucsd.edu/portal` and confirm the post-sign-in redirect lands on `https://fishsense.e4e.ucsd.edu/portal` (not `0.0.0.0:3000`).
- [ ] After this PR auto-deploys, the next deploy host bootstrapped from the updated `.env.example` will have `AUTH_URL` set out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)