### PR TITLE
feat(incus): tenant declaration + deploy pipeline (Incus tenant #1)

### DIFF
--- a/deploy/incus/auto-deploy.yml
+++ b/deploy/incus/auto-deploy.yml
@@ -1,0 +1,26 @@
+# STAGING NOTE: at cutover this file moves to `.github/workflows/auto-deploy.yml`.
+# It only functions from that path — GitHub Actions only reads workflows under
+# .github/workflows/. Kept here during staging alongside the rest of the interior.
+#
+# What it does: on a merged `auto-deploy/*` PR, run on the platform-provided
+# self-hosted runner and trigger the selfupdate unit, which does
+#   nixos-rebuild switch --flake github:UCSD-E4E/fishsense-lite#fishsense
+# converging the instance to the committed flake + compose interior (HANDOFF §3B).
+#
+# The runner is auto-provisioned + auto-registered by the platform because the
+# flake sets `repo = "UCSD-E4E/fishsense-lite"` (ADR 0022) — no runner token to
+# manage. It is opt-in by the `[self-hosted, fishsense]` label (HANDOFF §8):
+# jobs that must stay GitHub-hosted (e.g. the NRP data-worker deploy) use
+# `runs-on: ubuntu-latest` and are NEVER given a bare `runs-on: self-hosted`.
+name: auto-deploy
+
+on:
+  push:
+    branches: ["auto-deploy/**"]
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, fishsense] # the label the platform sets on our runner
+    steps:
+      - name: Converge the instance
+        run: systemctl start fishsense-selfupdate # polkit-authorized on the slot

--- a/deploy/incus/auto-deploy.yml
+++ b/deploy/incus/auto-deploy.yml
@@ -2,8 +2,9 @@
 # It only functions from that path — GitHub Actions only reads workflows under
 # .github/workflows/. Kept here during staging alongside the rest of the interior.
 #
-# What it does: on a merged `auto-deploy/*` PR, run on the platform-provided
-# self-hosted runner and trigger the selfupdate unit, which does
+# What it does: on a **push to an `auto-deploy/*` branch** (the `on:` trigger
+# below — e.g. when a release/promote auto-deploy PR is merged into it), run on
+# the platform-provided self-hosted runner and trigger the selfupdate unit, which does
 #   nixos-rebuild switch --flake github:UCSD-E4E/fishsense-lite#fishsense
 # converging the instance to the committed flake + compose interior (HANDOFF §3B).
 #

--- a/deploy/incus/flake.nix
+++ b/deploy/incus/flake.nix
@@ -1,0 +1,70 @@
+# fishsense-lite deploy target — INTERIOR half of the mkTenant contract (ADR 0020).
+#
+# STAGING NOTE: at cutover this file moves to the REPO ROOT as `flake.nix` (that's
+# where `fishsense-selfupdate` fetches it: `nixos-rebuild switch --flake
+# github:UCSD-E4E/fishsense-lite#fishsense`). It's kept here under deploy/incus/
+# during staging so it doesn't collide with the old orchestrator deploy. The
+# `compose = ` path below is written ROOT-RELATIVE for that final location.
+{
+  description = "fishsense-lite — KRG Incus platform tenant #1";
+
+  inputs = {
+    # Pinned to a merged krg-infra main SHA that includes:
+    #   #431 vault-agent fishsense.vm cert + repo-owns-deploy runner
+    #   #435 ADR 0023 in-slot Temporal client-cert render
+    #   #436 quota 6/12   #437 api.fishsense SANs + external_host rename
+    #   #438 OIDC secrets → tenant KV + §9 app-secret render pattern
+    #   #439 root disk 50 GiB   #440 co-located proxy outpost (Option A)   #443 OIDC writer glob
+    # This rev IS our stable contract (ADR 0020 §5); bump deliberately to pick up
+    # platform-seam changes.
+    krg-infra.url = "github:KastnerRG/krg-infra/2554daa6f026fee17f34827e5bd4e3712dcec3fd?dir=nix";
+    nixpkgs.follows = "krg-infra/nixpkgs";
+  };
+
+  outputs = {
+    self,
+    krg-infra,
+    nixpkgs,
+  }: let
+    system = "x86_64-linux";
+
+    tenant = krg-infra.lib.mkTenant {
+      name = "fishsense"; # Incus project + OpenBao role + runner scope (provisioned)
+      zone = "e4e"; # fronted by the e4e-prod edge (*.e4e.ucsd.edu)
+      hostname = "fishsense.e4e.ucsd.edu"; # apex CNAME (published; edge serves a prod LE cert)
+      sso.group = "FishSense"; # AD group (per-route auth is in our inner traefik — HANDOFF §7)
+      resources = {
+        # Bump from the provisioned 4/8 (krg-nat has 16 vCPU / 98 GiB headroom).
+        # Boundary quota is terraform-owned: krg-infra PR #436 bumps var.tenants.fishsense
+        # + the example flake to match this. ADMIN: `tofu apply` then restart the instance
+        # for the RAM raise to take. This block is the reproducible projection.
+        cpu = 6;
+        ram = "12GiB";
+      };
+      image = "krg-golden"; # slot boots from the hardened template (already applied)
+      compose = ./deploy/incus/compose.yml; # YOUR interior — repo-owns-deploy
+      repo = "UCSD-E4E/fishsense-lite"; # LOAD-BEARING: scopes the auto-provisioned runner (ADR 0022)
+      # In-VM vault-agent renders a `fishsense-worker` Temporal client cert to
+      # /run/tenant/temporal/{tls.crt,tls.key,ca.crt} (ADR 0023 / krg-infra #435).
+      # Required — without it no cert renders and the workers can't reach krg-prod Temporal.
+      temporal = {namespace = "fishsense";};
+    };
+  in {
+    # The Incus slot (booted at 10.100.0.10) converges to THIS config via our runner.
+    # nixosModules.tenant brings the lab baseline (AD-join, firewall, CrowdSec,
+    # monitoring) + Docker + the compose runner + the vault-agent cert renders.
+    nixosConfigurations.fishsense = nixpkgs.lib.nixosSystem {
+      inherit system;
+      modules = [
+        krg-infra.nixosModules.tenant
+        {krg.tenant = tenant;}
+        ./hardware-configuration.nix # captured on-box 2026-07-07; ⚠ instance-specific disk UUIDs (re-capture if the slot is reprovisioned)
+        ./secrets.nix # extends krg.vaultAgent.renders → /run/tenant/secrets/app.env (HANDOFF §9)
+      ];
+    };
+
+    # Reproducible boundary projection (admin copies into terraform/incus):
+    #   nix eval .#krgTenant.terraformTenant --json
+    krgTenant = tenant;
+  };
+}

--- a/deploy/incus/flake.nix
+++ b/deploy/incus/flake.nix
@@ -42,6 +42,9 @@
         ram = "12GiB";
       };
       image = "krg-golden"; # slot boots from the hardened template (already applied)
+      # ROOT-relative path: correct once this flake lives at the repo root (the
+      # activation move — see STAGING NOTE header). NOT evaluated from the staging
+      # location; the runner only builds via `#fishsense` after activation.
       compose = ./deploy/incus/compose.yml; # YOUR interior — repo-owns-deploy
       repo = "UCSD-E4E/fishsense-lite"; # LOAD-BEARING: scopes the auto-provisioned runner (ADR 0022)
       # In-VM vault-agent renders a `fishsense-worker` Temporal client cert to

--- a/deploy/incus/hardware-configuration.nix
+++ b/deploy/incus/hardware-configuration.nix
@@ -1,0 +1,32 @@
+# Captured on-box from the running Incus slot (2026-07-07):
+#   incus exec fishsense --project fishsense -- nixos-generate-config --show-hardware-config
+#
+# ⚠️ The root/boot UUIDs below are specific to THIS instance's disk. If the slot
+# is ever reprovisioned onto a fresh disk they change and boot breaks — re-capture
+# then. The durable long-term fix is a shared golden hardware profile keyed on
+# labels (krg-infra ADR 0022 §4) so no per-instance capture is needed; tracked as
+# a follow-up.
+{
+  config,
+  lib,
+  pkgs,
+  modulesPath,
+  ...
+}: {
+  imports = [(modulesPath + "/profiles/qemu-guest.nix")];
+  boot.initrd.availableKernelModules = ["ahci" "xhci_pci" "virtio_pci" "virtio_scsi" "sd_mod"];
+  boot.initrd.kernelModules = [];
+  boot.kernelModules = ["kvm-intel"];
+  boot.extraModulePackages = [];
+  fileSystems."/" = {
+    device = "/dev/disk/by-uuid/f222513b-ded1-49fa-b591-20ce86a2fe7f";
+    fsType = "ext4";
+  };
+  fileSystems."/boot" = {
+    device = "/dev/disk/by-uuid/12CE-A600";
+    fsType = "vfat";
+    options = ["fmask=0022" "dmask=0022"];
+  };
+  swapDevices = [];
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+}

--- a/deploy/incus/secrets.nix
+++ b/deploy/incus/secrets.nix
@@ -1,0 +1,90 @@
+# App-secret delivery for the fishsense interior (HANDOFF §9).
+#
+# nixosModules.tenant's vault-agent renders only the CERTS (fishsense.vm,
+# temporal). App secrets need their own render, which we add here — the list
+# merges with the platform's. The tenant AppRole reads
+# secret/data/tenants/fishsense/*, so it can render everything under there.
+#
+# One consolidated env file is rendered to a tmpfs path and env_file-mounted
+# into the services that need it (compose.yml). Vars a service doesn't recognize
+# are ignored, so a single file is simplest.
+#
+# ── OpenBao KV layout under secret/tenants/fishsense/ (KV-v2) ───────────────────
+# WE seed (operator — see README):
+#   postgres      { password, backup_password }  # admin pw + the `backup` role's pw
+#   superset      { secret_key, db_password }     # flask secret + the `superset` DB role's pw
+#   web           { auth_secret }              # next-auth cookie/JWT signing
+#   api           { username, password }       # fishsense-api basic-auth service acct
+#   label_studio  { api_key }
+#   object_store  { access_key, secret_key }   # Garage S3
+#   nas           { username, password }        # Synology FileStation
+# PLATFORM writes (tofu — do NOT seed):
+#   oidc/web                 { client_id, client_secret, issuer_url }   (#438)
+#   oidc/analytics           { client_id, client_secret, issuer_url }   (#438)
+#   oidc/proxy-outpost-token { token }   (co-located outpost API token — #440)
+#
+# ⚠️ vault-agent is FAIL-CLOSED (errorOnMissingKey): a referenced path/field that
+# isn't seeded takes the whole stack down rather than starting empty. Seed every
+# path below before the first converge.
+{
+  krg.vaultAgent.renders = [
+    {
+      # Shared secrets, env_file-mounted into postgres, web, superset×4, and both
+      # workers. E4EFS_POSTGRES__PASSWORD here is the ADMIN role (fishsense-api +
+      # container); the backup-worker overrides it with a second env_file below.
+      destination = "/run/tenant/secrets/app.env";
+      contents = ''
+        {{ with secret "secret/data/tenants/fishsense/postgres" }}POSTGRES_PASSWORD={{ .Data.data.password }}
+        E4EFS_POSTGRES__PASSWORD={{ .Data.data.password }}{{ end }}
+        {{/* superset connects as the least-priv `superset` role — DATABASE_PASSWORD is
+             that role's password, NOT admin (superset_config.py DATABASE_USER=superset) */}}
+        {{ with secret "secret/data/tenants/fishsense/superset" }}SUPERSET_SECRET_KEY={{ .Data.data.secret_key }}
+        DATABASE_PASSWORD={{ .Data.data.db_password }}{{ end }}
+
+        {{/* fishsense-lite-web (next-auth + landing) */}}
+        {{ with secret "secret/data/tenants/fishsense/web" }}AUTH_SECRET={{ .Data.data.auth_secret }}{{ end }}
+        {{ with secret "secret/data/tenants/fishsense/api" }}FISHSENSE_API_USERNAME={{ .Data.data.username }}
+        FISHSENSE_API_PASSWORD={{ .Data.data.password }}{{ end }}
+        {{ with secret "secret/data/tenants/fishsense/label_studio" }}LABEL_STUDIO_API_KEY={{ .Data.data.api_key }}{{ end }}
+        {{ with secret "secret/data/tenants/fishsense/oidc/web" }}AUTH_AUTHENTIK_ID={{ .Data.data.client_id }}
+        AUTH_AUTHENTIK_SECRET={{ .Data.data.client_secret }}
+        AUTH_AUTHENTIK_ISSUER={{ .Data.data.issuer_url }}{{ end }}
+
+        {{/* superset OIDC (analytics) — names read by superset_config.py OAUTH_PROVIDERS */}}
+        {{ with secret "secret/data/tenants/fishsense/oidc/analytics" }}AUTHENTIK_KEY={{ .Data.data.client_id }}
+        AUTHENTIK_SECRET={{ .Data.data.client_secret }}
+        AUTHENTIK_ISSUER={{ .Data.data.issuer_url }}{{ end }}
+
+        {{/* api-worker + backup-worker — dynaconf E4EFS_<SECTION>__<KEY> env override */}}
+        {{ with secret "secret/data/tenants/fishsense/api" }}E4EFS_FISHSENSE_API__USERNAME={{ .Data.data.username }}
+        E4EFS_FISHSENSE_API__PASSWORD={{ .Data.data.password }}{{ end }}
+        {{ with secret "secret/data/tenants/fishsense/object_store" }}E4EFS_OBJECT_STORE__ACCESS_KEY={{ .Data.data.access_key }}
+        E4EFS_OBJECT_STORE__SECRET_KEY={{ .Data.data.secret_key }}{{ end }}
+        {{ with secret "secret/data/tenants/fishsense/label_studio" }}E4EFS_LABEL_STUDIO__API_KEY={{ .Data.data.api_key }}{{ end }}
+        {{ with secret "secret/data/tenants/fishsense/nas" }}E4EFS_E4E_NAS__USERNAME={{ .Data.data.username }}
+        E4EFS_E4E_NAS__PASSWORD={{ .Data.data.password }}{{ end }}
+      '';
+    }
+    {
+      # Backup-worker override: it connects to postgres as the least-priv `backup`
+      # role, not admin. Mounted as the SECOND env_file on that service so this
+      # E4EFS_POSTGRES__PASSWORD wins over app.env's admin value.
+      destination = "/run/tenant/secrets/backup-postgres.env";
+      contents = ''
+        {{ with secret "secret/data/tenants/fishsense/postgres" }}E4EFS_POSTGRES__PASSWORD={{ .Data.data.backup_password }}{{ end }}
+      '';
+    }
+    {
+      # Co-located Authentik outpost API token (platform-written by #440, only after
+      # the terraform/authentik apply). SOFT render — errorOnMissingKey=false so an
+      # un-minted token can't fail-close the WHOLE agent (which would also block the
+      # fishsense.vm cert → inner Traefik). Missing token = outpost can't connect
+      # (login fails, loud but localized) while the rest of the stack stays up.
+      destination = "/run/tenant/outpost/token.env";
+      errorOnMissingKey = false;
+      contents = ''
+        {{ with secret "secret/data/tenants/fishsense/oidc/proxy-outpost-token" }}AUTHENTIK_TOKEN={{ .Data.data.token }}{{ end }}
+      '';
+    }
+  ];
+}


### PR DESCRIPTION
## What

The **Nix + CI half** of the fishsense-lite interior for the KRG Incus platform (tenant #1). Staged under `deploy/incus/`; the compose stack it wires to is in a companion PR (`feat/incus-compose-stack`).

- **`flake.nix`** — `mkTenant` declaration: 6 vCPU / 12 GiB, `temporal = { namespace = "fishsense"; }` opt-in, pinned krg-infra rev (incl. #435–#440, #443). Imports `hardware-configuration.nix` + `secrets.nix`.
- **`hardware-configuration.nix`** — captured from the running slot. ⚠️ instance-specific disk UUIDs (re-capture on reprovision).
- **`auto-deploy.yml`** — repo-owns-deploy runner trigger (`runs-on: [self-hosted, fishsense]` → `systemctl start fishsense-selfupdate`). Moves to `.github/workflows/` at cutover.
- **`secrets.nix`** — `krg.vaultAgent.renders`: consolidated `app.env` + a `backup-postgres.env` DB-role override + a **soft** outpost-token render (`errorOnMissingKey=false` so an un-minted token can't fail-close the cert→Traefik chain). OIDC + outpost token are platform-written (HANDOFF §9, krg-infra #438/#440); the rest we seed.

## Notes

- Companion PR (`feat/incus-compose-stack`) adds `compose.yml` (which this flake references) + service config + README. `deploy/incus/` is inert staging until cutover, so main is safe with either PR landing first.
- Full context: the interior README in the companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
