### PR TITLE
feat(incus): compose interior + service config (Incus tenant #1)

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,17 @@
+# GitGuardian / ggshield configuration.
+# https://docs.gitguardian.com/ggshield-docs/reference/configuration
+version: 2
+
+secret:
+  ignored-paths:
+    # False positive: "Generic High Entropy Secret" (GitGuardian incident
+    # 34643179) on deploy/incus/traefik-dynamic.yml. That file is pure Traefik
+    # routing config — its only credential-adjacent values are cert *file paths*
+    # (/etc/traefik/tls/fishsense.vm.{crt,key}, rendered at runtime by the
+    # in-instance vault-agent, never committed) plus public hostnames, internal
+    # service URLs, and Authentik response-header *names* (X-authentik-jwt, ...).
+    # No secret material lives here by design — the Incus interior keeps every
+    # secret in OpenBao and delivers it via vault-agent renders (deploy/incus/
+    # secrets.nix + env_file mounts), so this path can never legitimately hold
+    # one. Scoped to the single file so real secrets elsewhere are still caught.
+    - deploy/incus/traefik-dynamic.yml

--- a/deploy/incus/README.md
+++ b/deploy/incus/README.md
@@ -1,0 +1,167 @@
+# fishsense-lite interior — KRG Incus platform tenant
+
+This directory is the **repo-owned interior** for fishsense as tenant #1 on the
+KRG Incus platform (ADR 0017 / 0020). The platform runs this compose stack on
+our Incus slot (`10.100.0.10`); a merged `auto-deploy/*` PR converges the
+instance via `fishsense-selfupdate` → `nixos-rebuild switch --flake
+github:UCSD-E4E/fishsense-lite#fishsense`.
+
+Upstream hand-off:
+<https://github.com/KastnerRG/krg-infra/tree/main/docs/handoff/fishsense-lite>
+
+> **Status: skeleton / staging.** Staged under `deploy/incus/` so it does not
+> clobber the running orchestrator-host stack (the sibling `deploy/compose*.yml`)
+> before cutover. At cutover the flake's `mkTenant` `compose = ` points here.
+
+## What runs here
+
+| Service | Route | Auth |
+|---|---|---|
+| `web` (fishsense-lite-web) | `fishsense.e4e.ucsd.edu` | in-app OIDC (`fishsense_oauth`) |
+| `fishsense-api` | `api.fishsense.e4e.ucsd.edu` | forwardAuth → co-located outpost |
+| `superset` (+init/worker/beat + `valkey`) | `analytics.fishsense.e4e.ucsd.edu` | in-app OIDC (`fishsense_analytics`) |
+| `authentik-outpost` (co-located outpost) | `/outpost.goauthentik.io/*` on api | gates the API route |
+| `fishsense-api-workflow-worker` | — | krg-prod Temporal (mTLS) |
+| `fishsense-backup-worker` | — | krg-prod Temporal (mTLS) |
+| `postgres` (`fishsense` + `superset` DBs) | — | vault-agent password |
+| `traefik` (inner edge, `:443`, `fishsense.vm`) | all of the above | — |
+
+**Off-slot (unchanged):** the `fishsense-data-processing-workflow-worker` runs
+on NRP/Kubernetes (`deploy/k8s/data-worker/`); the api-worker scales it via the
+NRP k8s API. Garage object storage lives on the NAS (reached over S3). Both are
+just open-egress destinations from this slot.
+
+> **API hostname rename — cutover consumer.** The API route is
+> `api.fishsense.e4e.ucsd.edu` here (was `orchestrator.` on the old host). The
+> `fishsense_orchestrator` provider `external_host` is already updated platform-side
+> (#437). The one thing still to flip at cutover:
+> `deploy/k8s/data-worker/settings.toml` `[fishsense_api].url`. The in-slot web +
+> api-worker are unaffected (they use the interior `http://fishsense-api:8000`).
+
+## What changed vs the old orchestrator stack
+
+- **Temporal is external** — krg-prod shared cluster, not in-stack. Dropped the
+  `temporal` + `temporal-ui` services, the `workflows.` subdomain, and
+  `temporal_db` / `temporal_visibility_db` from Postgres.
+- **Routing** flips from the shared host Traefik (docker-label provider +
+  letsencrypt + `authentik@docker`) to **our own inner Traefik** with the
+  **file provider** (`traefik-dynamic.yml`), serving the vault-agent
+  `fishsense.vm` cert on `:443`. No per-service `traefik.*` labels.
+- **qcomm docs** static file server dropped (out of tenant scope).
+
+## Temporal (krg-prod)
+
+Endpoint `krg-prod.ucsd.edu:7233` (raw gRPC), namespace `fishsense` (30d
+retention), **mTLS-only**, gRPC server-name override → `workflows.krg.ucsd.edu`,
+verify against the lab CA. Wired in `worker_volumes/*/config/settings.toml`
+`[temporal]`, reading certs from `/run/tenant/temporal/{tls.crt,tls.key,ca.crt}`.
+
+**In-slot: wired by krg-infra PR #435** (ADR 0023). The in-VM vault-agent mints
+a `fishsense-worker` client cert to `/run/tenant/temporal/*` (auto-renewed, same
+pattern as `fishsense.vm`) — **once we opt in via the `flake.nix` `mkTenant`
+`temporal = { namespace = "fishsense" }` field** (no field → no render). The
+compose + settings already target these exact paths, so the in-slot workers
+connect once the pinned flake (with the opt-in) converges on the slot — #435 and
+its OpenBao grant are merged.
+
+**NRP off-prem data-worker: still the manual interim** — an admin hands us a
+30-day PEM trio to load as a k8s Secret (automated krg-deploy → NRP-Secret
+delivery is a follow-up needing an NRP kubeconfig). Namespace isolation is by
+convention, not enforced (krg-infra #434).
+
+**The `backup_worker` settings.toml needs the same `[temporal]` block** — mirror
+the api-worker's.
+
+## Secrets (HANDOFF §9 — vault-agent renders, `secret/tenants/fishsense/*`)
+
+Nothing secret is committed. `nixosModules.tenant` renders only the **certs**;
+[`secrets.nix`](secrets.nix) extends `krg.vaultAgent.renders` to produce one
+consolidated **`/run/tenant/secrets/app.env`**, `env_file`-mounted into the
+services that need it. Vault-agent is **fail-closed** — seed every referenced
+path before the first converge or the stack won't start.
+
+**Vault-agent render targets:**
+
+| Path | Consumer | Source |
+|---|---|---|
+| `/run/tenant/tls/fishsense.vm.{crt,key}` | traefik | platform (#428) |
+| `/run/tenant/temporal/{tls.crt,tls.key,ca.crt}` | both workers | platform (#435, temporal opt-in) |
+| `/run/tenant/secrets/app.env` | postgres, fishsense-api, web, superset×4, both workers | `secrets.nix` |
+| `/run/tenant/secrets/backup-postgres.env` | backup-worker (2nd env_file, overrides DB pw → `backup` role) | `secrets.nix` |
+| `/run/tenant/outpost/token.env` | authentik-outpost (`AUTHENTIK_TOKEN`; **soft** render, `errorOnMissingKey=false`) | `secrets.nix` |
+
+**DB-role model:** the postgres container + fishsense-api use the **admin** `postgres`
+role (`POSTGRES_PASSWORD` / `E4EFS_POSTGRES__PASSWORD` = `postgres.password`); **superset**
+uses its own least-priv `superset` role (`DATABASE_PASSWORD` = `superset.db_password`,
+read-only SELECT on `fishsense`); the **backup-worker** uses the `backup` role
+(`backup_password`, via the override env_file). Three distinct roles.
+
+**OpenBao KV under `secret/tenants/fishsense/` — WE seed:**
+
+| Path | Fields |
+|---|---|
+| `postgres` | `password`, `backup_password` |
+| `superset` | `secret_key`, `db_password` |
+| `web` | `auth_secret` |
+| `api` | `username`, `password` (fishsense-api basic-auth service acct) |
+| `label_studio` | `api_key` |
+| `object_store` | `access_key`, `secret_key` (Garage) |
+| `nas` | `username`, `password` (FileStation) |
+
+**Platform writes (tofu — do NOT seed):** `oidc/web`, `oidc/analytics`
+(`client_id`/`client_secret`/`issuer_url`) (#438), and `oidc/proxy-outpost-token`
+(`token` — the co-located outpost's API token, #440).
+
+**Committed non-secret config** (repo binds, self-contained under `deploy/incus/`):
+`worker_volumes/*/config/settings.toml`, `fishsense_api_volumes/config/settings.toml`,
+`pg_volumes/config/{postgres.conf,pg_hba.conf}`, `superset_volumes/docker/*`
+(incl. `superset_config.py` — OIDC derived from the platform `AUTHENTIK_ISSUER`, not
+hardcoded). `nrp.kubeconfig` is a vault-agent render / operator-placed file.
+
+**DB bootstrap = restore, not init.** Postgres starts from a **prod `pg_dump` restore**
+into the `pgdata` volume (roles + passwords come from the dump); seed OpenBao to match.
+`pg_volumes/scripts/` ships no init SQL on purpose — see its README.
+
+## Status — resolved vs. remaining
+
+**Resolved (baked into these files):**
+- ✅ `flake.nix` — pinned rev `2554daa` (incl. #435–#440, #443), `temporal` opt-in, quota 6/12.
+- ✅ `hardware-configuration.nix` — captured on-box, imported by the flake.
+  (⚠️ instance-specific disk UUIDs; durable fix = label-keyed golden profile, ADR 0022 §4.)
+- ✅ `secrets.nix` — §9 app-secret renders (`app.env` + `backup-postgres.env` + soft `token.env`).
+- ✅ `auto-deploy.yml` — runner trigger, `runs-on: [self-hosted, fishsense]`.
+- ✅ **Option A co-located outpost** (`authentik-outpost`, image `2026.2`) — matches HANDOFF §7.
+  Platform IaC **landed** (#440): dedicated `fishsense_proxy` outpost, token →
+  `oidc/proxy-outpost-token`, soft-rendered (`errorOnMissingKey=false`).
+- ✅ API renamed `orchestrator.` → `api.fishsense.e4e.ucsd.edu`; provider `external_host`
+  updated platform-side (#437) — matches.
+- ✅ Quota 6/12 (#436) + root disk **50 GiB** (#439) landed. Repo public. Data on named volumes.
+
+**Remaining — operator actions (values/creds stay on the box, not in git):**
+1. **Seed OpenBao FIRST, then bootstrap.** vault-agent is fail-closed on the *whole*
+   agent — a single missing secret blocks even the `fishsense.vm` cert render, so the
+   inner Traefik + compose stack won't start (system generation still activates; the
+   switch returns non-zero but is recoverable: seed, re-run the switch). Seed **all**
+   the `WE seed` KV paths above before the admin's first `nixos-rebuild switch`.
+   Do **not** seed `oidc/*` (platform-written; the outpost token renders soft anyway).
+2. **Pin the outpost image** to krg-prod's Authentik server version (currently `2026.2`),
+   and **validate the sign-in round-trip** once the API route is up.
+3. **File CNAMEs** `api.` + `analytics.` → e4e-prod, confirm they resolve, then let
+   #437's SAN re-issue run (staging ACME first, confirm, then off — like the apex).
+4. **Apply the quota/disk raise + restart** the instance (6/12 + 50 GiB now merged, #436/#439).
+5. **NRP data-worker Temporal cert** (the un-automated piece) — on krg-deploy,
+   `bao write pki_int/issue/temporal-client common_name=temporal-worker ttl=720h`,
+   load the PEM trio as k8s Secret `temporal-client`, renew at 30 days. Switch CN to
+   `fishsense-worker` after #435's grant is live.
+
+**Notes (not blockers):**
+- **auto-deploy is a trigger, not a clean CI gate.** `fishsense-selfupdate` is a
+  oneshot that propagates `nixos-rebuild`'s exit, but it stops the runner mid-switch
+  (the Actions job may report cancelled/interrupted) and exit 0 only means `compose up -d`
+  was *issued*, not that containers are healthy. Verify on-box (`systemctl status
+  fishsense-selfupdate`) or add a post-converge HTTP health probe.
+- **Observability — deferred, tracked.** Central tenant metrics are **held** (ours:
+  **#220**, upstream krg-infra **#441** — push-based Alloy → mTLS `remote_write` → central
+  Grafana, fishsense pilot). No alerting exists yet (ours: **#221**, upstream krg-infra
+  **#442**). We expose **no** metrics ports for now; revisit once #441 lands (design any
+  in-stack Prometheus `remote_write`-ready so it federates cleanly).

--- a/deploy/incus/README.md
+++ b/deploy/incus/README.md
@@ -69,14 +69,15 @@ its OpenBao grant are merged.
 delivery is a follow-up needing an NRP kubeconfig). Namespace isolation is by
 convention, not enforced (krg-infra #434).
 
-**The `backup_worker` settings.toml needs the same `[temporal]` block** — mirror
-the api-worker's.
+Both worker `settings.toml` files point `[temporal]` at krg-prod (api-worker and
+backup-worker alike).
 
 ## Secrets (HANDOFF §9 — vault-agent renders, `secret/tenants/fishsense/*`)
 
 Nothing secret is committed. `nixosModules.tenant` renders only the **certs**;
-[`secrets.nix`](secrets.nix) extends `krg.vaultAgent.renders` to produce one
-consolidated **`/run/tenant/secrets/app.env`**, `env_file`-mounted into the
+`secrets.nix` (in the companion pipeline PR — `deploy/incus/secrets.nix`, moved to
+repo-root `secrets.nix` at activation) extends `krg.vaultAgent.renders` to produce
+one consolidated **`/run/tenant/secrets/app.env`**, `env_file`-mounted into the
 services that need it. Vault-agent is **fail-closed** — seed every referenced
 path before the first converge or the stack won't start.
 

--- a/deploy/incus/compose.yml
+++ b/deploy/incus/compose.yml
@@ -1,0 +1,250 @@
+# fishsense-lite INTERIOR — KRG Incus platform tenant #1 (ADR 0017 / 0020).
+#
+# This is the repo-owned deploy that the platform runs on our Incus slot
+# (10.100.0.10). It REPLACES the old orchestrator-host stack (the sibling
+# deploy/compose*.yml files) — staged here under deploy/incus/ so it doesn't
+# clobber the running prod config until cutover. At cutover this becomes the
+# flake's `compose = ./deploy/incus/compose.yml` target.
+#
+# WHAT CHANGED vs the old orchestrator stack (see README.md for the full map):
+#   * Temporal is NO LONGER in-stack — we consume krg-prod's shared cluster
+#     (krg-prod.ucsd.edu:7233, namespace `fishsense`, mTLS). The `temporal`
+#     + `temporal-ui` services and the `workflows.` subdomain are gone.
+#   * Postgres no longer hosts temporal_db / temporal_visibility_db — only
+#     `fishsense` + `superset` remain in-slot.
+#   * Routing flips from the shared host Traefik (docker-label provider +
+#     letsencrypt certresolver + authentik@docker) to OUR OWN inner Traefik
+#     using the FILE provider, serving the vault-agent-minted `fishsense.vm`
+#     cert on :443 (the edge re-encrypts to us and verifies that serverName).
+#     All per-service `traefik.*` labels are gone; routing lives in
+#     traefik-dynamic.yml.
+#   * The qcomm docs static file server is dropped (out of tenant scope).
+#
+# INGRESS CONTRACT (wired admin-side — do not change the shape):
+#   public → e4e-prod edge (prod LE cert, TLS-terminate)
+#          → re-encrypt HTTPS, verify serverName=fishsense.vm vs the fleet CA
+#          → krg-nat:30443 → incus_network_forward → 10.100.0.10:443 (traefik below)
+
+services:
+  # ── inner edge: TLS on :443 with fishsense.vm, route Host → containers ─────────────────
+  traefik:
+    image: traefik:3.7.6
+    restart: unless-stopped
+    command:
+      - --providers.file.filename=/etc/traefik/dynamic.yml
+      - --providers.file.watch=true
+      - --entrypoints.websecure.address=:443
+      # - --api.dashboard=true   # enable only behind an auth'd route if ever wanted
+    ports:
+      - "0.0.0.0:443:443" # the incus_network_forward targets :443 on the instance NIC
+    volumes:
+      - /run/tenant/tls:/etc/traefik/tls:ro          # fishsense.vm.{crt,key} — vault-agent (#428)
+      - ./traefik-dynamic.yml:/etc/traefik/dynamic.yml:ro
+    depends_on: [web, fishsense-api, superset, authentik-outpost]
+    networks: [interior]
+
+  # ── co-located Authentik proxy outpost (gates the API route) — HANDOFF §7 / #440 ───────
+  # Dials OUT to krg-prod Authentik over the API websocket (egress open) and serves
+  # /outpost.goauthentik.io/* LOCALLY — so the api forward-auth sign-in/callback completes
+  # on api.fishsense's own domain (cookie domain correct, no cross-host proxy). The
+  # fishsense_orchestrator provider is registered (platform IaC) on a dedicated
+  # `fishsense_proxy` outpost whose API token is written to
+  # secret/tenants/fishsense/oidc/proxy-outpost-token.
+  authentik-outpost:
+    image: ghcr.io/goauthentik/proxy:2026.2   # keep in step with krg-prod's Authentik server version
+    restart: unless-stopped
+    environment:
+      AUTHENTIK_HOST: https://auth.krg.ucsd.edu
+      AUTHENTIK_INSECURE: "false"
+    env_file:
+      # AUTHENTIK_TOKEN=… — soft vault-agent render (errorOnMissingKey=false; secrets.nix).
+      - /run/tenant/outpost/token.env
+    expose: ["9000"]   # interior only — do NOT publish
+    networks: [interior]
+
+  # ── web portal → fishsense.e4e.ucsd.edu ────────────────────────────────────────────────
+  web:
+    image: ghcr.io/ucsd-e4e/fishsense-lite-web:v0.7.0
+    restart: unless-stopped
+    # Non-secret config inline (committed IaC); secrets from the vault-agent render
+    # (AUTH_SECRET, AUTH_AUTHENTIK_{ID,SECRET,ISSUER}, FISHSENSE_API_{USERNAME,PASSWORD},
+    # LABEL_STUDIO_API_KEY — see secrets.nix). FISHSENSE_API_URL stays the interior
+    # host so SSR bypasses our traefik + the API forwardAuth gate.
+    environment:
+      FISHSENSE_API_URL: http://fishsense-api:8000
+      LABEL_STUDIO_URL: https://labeler.e4e.ucsd.edu
+      AUTH_URL: https://fishsense.e4e.ucsd.edu
+    env_file:
+      - /run/tenant/secrets/app.env
+    expose: ["3000"]
+    networks: [interior]
+
+  # ── API → api.fishsense.e4e.ucsd.edu (forwardAuth-gated) ───────────────────────────────
+  fishsense-api:
+    image: ghcr.io/ucsd-e4e/fishsense-api:v1.28.0
+    restart: unless-stopped
+    # DB password (admin role) as E4EFS_POSTGRES__PASSWORD from the render.
+    env_file:
+      - /run/tenant/secrets/app.env
+    volumes:
+      - ./fishsense_api_volumes/config:/e4efs/config:ro  # committed settings.toml ([postgres] host=postgres)
+    expose: ["8000"]
+    depends_on: [postgres]
+    networks: [interior]
+    # NOTE: plain `docker compose up` ignores `deploy.replicas` (swarm-only).
+    # The old stack declared replicas: 4 but ran 1 under compose. If we ever
+    # need real horizontal scale here, either move to swarm or add explicit
+    # replica hostnames to the traefik-dynamic.yml api service. Traefik points
+    # at the service DNS name `fishsense-api:8000` for now.
+
+  # ── analytics → analytics.fishsense.e4e.ucsd.edu (in-app OIDC) ─────────────────────────
+  superset:
+    image: &superset-image apache/superset:6.0.0
+    container_name: fishsense_superset
+    command: ["/app/docker/docker-bootstrap.sh", "app-gunicorn"]
+    user: "root"
+    restart: unless-stopped
+    env_file:
+      - path: ./superset_volumes/docker/.env   # committed non-secret superset config (repo IaC)
+        required: true
+      - path: /run/tenant/secrets/app.env      # vault-agent render — SUPERSET_SECRET_KEY, SUPERSET_OIDC_* (secrets.nix)
+        required: true
+    volumes: &superset-volumes
+      - ./superset_volumes/docker:/app/docker   # committed bootstrap scripts/config (repo IaC)
+      - superset_home:/app/superset_home        # named volume — persistent, docker-owned
+    expose: ["8088"]
+    depends_on:
+      superset-init:
+        condition: service_completed_successfully
+    networks: [interior]
+
+  superset-init:
+    image: *superset-image
+    container_name: superset_init
+    command: ["/app/docker/docker-init.sh"]
+    user: "root"
+    env_file:
+      - path: ./superset_volumes/docker/.env
+        required: true
+      - path: /run/tenant/secrets/app.env
+        required: true
+    volumes: *superset-volumes
+    depends_on:
+      postgres:
+        condition: service_started
+      valkey:
+        condition: service_started
+    healthcheck:
+      disable: true
+    networks: [interior]
+
+  superset-worker:
+    image: *superset-image
+    container_name: superset_worker
+    command: ["/app/docker/docker-bootstrap.sh", "worker"]
+    user: "root"
+    restart: unless-stopped
+    env_file:
+      - path: ./superset_volumes/docker/.env
+        required: true
+      - path: /run/tenant/secrets/app.env
+        required: true
+    volumes: *superset-volumes
+    depends_on:
+      superset-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "celery -A superset.tasks.celery_app:app inspect ping -d celery@$$HOSTNAME",
+        ]
+    networks: [interior]
+
+  superset-worker-beat:
+    image: *superset-image
+    container_name: superset_worker_beat
+    command: ["/app/docker/docker-bootstrap.sh", "beat"]
+    user: "root"
+    restart: unless-stopped
+    env_file:
+      - path: ./superset_volumes/docker/.env
+        required: true
+      - path: /run/tenant/secrets/app.env
+        required: true
+    volumes: *superset-volumes
+    depends_on:
+      superset-init:
+        condition: service_completed_successfully
+    healthcheck:
+      disable: true
+    networks: [interior]
+
+  # Valkey — the BSD-licensed OSS fork of Redis (post-2024 relicense); a drop-in,
+  # protocol-compatible replacement for superset's cache + celery broker.
+  valkey:
+    image: valkey/valkey:9.1.0
+    container_name: superset_cache
+    restart: unless-stopped
+    volumes:
+      - valkey_data:/data   # named volume — persistent, docker-owned
+    networks: [interior]
+
+  # ── api-side Temporal worker (hourly schedules, LS sync, preprocess parents) ───────────
+  fishsense-api-workflow-worker:
+    image: ghcr.io/ucsd-e4e/fishsense-api-workflow-worker:v1.35.3
+    restart: unless-stopped
+    # Secrets as dynaconf E4EFS_* env overrides from the vault-agent render
+    # (API basic-auth, Garage keys, LS key, NAS creds — see secrets.nix).
+    env_file:
+      - /run/tenant/secrets/app.env
+    volumes:
+      # settings.toml here is non-secret config, [temporal] → krg-prod.
+      - ./worker_volumes/api_worker/config:/e4efs/config:ro
+      - ./worker_volumes/api_worker/logs:/e4efs/logs:rw
+      # krg-prod Temporal mTLS client identity — vault-agent render (temporal opt-in
+      # in flake.nix; krg-infra #435).
+      - /run/tenant/temporal:/run/tenant/temporal:ro
+    networks: [interior]
+
+  # ── nightly Postgres → NAS backups ─────────────────────────────────────────────────────
+  fishsense-backup-worker:
+    image: ghcr.io/ucsd-e4e/fishsense-backup-worker:v0.3.1
+    restart: unless-stopped
+    env_file:
+      - /run/tenant/secrets/app.env            # shared secrets
+      - /run/tenant/secrets/backup-postgres.env # overrides E4EFS_POSTGRES__PASSWORD → `backup` role (last wins)
+    volumes:
+      - ./worker_volumes/backup_worker/config:/e4efs/config:ro
+      - ./worker_volumes/backup_worker/logs:/e4efs/logs:rw
+      - /run/tenant/temporal:/run/tenant/temporal:ro
+    networks: [interior]
+
+  # ── in-slot Postgres: `fishsense` + `superset` DBs only (temporal_db moved to krg-prod) ─
+  postgres:
+    image: postgres:17.10
+    restart: unless-stopped
+    shm_size: 128mb
+    # POSTGRES_PASSWORD comes from the vault-agent render (secret/tenants/fishsense/postgres).
+    env_file:
+      - /run/tenant/secrets/app.env
+    volumes:
+      - pgdata:/var/lib/postgresql/data:rw       # named volume — persistent, docker-owned
+      - ./pg_volumes/config:/etc/postgresql:ro   # committed postgres.conf (repo IaC)
+      - ./pg_volumes/scripts:/docker-entrypoint-initdb.d:ro  # committed initdb scripts (repo IaC)
+    command: --config_file=/etc/postgresql/postgres.conf
+    expose: ["5432"]
+    networks: [interior]
+
+# Persistent data stores as named volumes (docker-created + owned) rather than
+# host binds — survive restarts, nothing to seed, cleanest fit for repo-owns-deploy.
+# Config/secret dirs stay binds: repo-committed IaC (postgres.conf, superset docker,
+# initdb scripts, traefik-dynamic.yml) or vault-agent renders (/run/tenant/*).
+volumes:
+  pgdata:
+  superset_home:
+  valkey_data:
+
+networks:
+  interior:
+    driver: bridge

--- a/deploy/incus/fishsense_api_volumes/config/settings.toml
+++ b/deploy/incus/fishsense_api_volumes/config/settings.toml
@@ -1,0 +1,11 @@
+# fishsense-api — Incus interior settings (non-secret).
+#
+# DIFF vs the old orchestrator settings.toml: [postgres].host points at the
+# in-slot `postgres` compose service instead of the external fabricant-prod DB.
+# The password is injected as E4EFS_POSTGRES__PASSWORD from the vault-agent
+# render (app.env — admin role); see secrets.nix.
+[postgres]
+host = "postgres"
+port = 5432
+username = "postgres"
+database = "fishsense"

--- a/deploy/incus/pg_volumes/config/pg_hba.conf
+++ b/deploy/incus/pg_volumes/config/pg_hba.conf
@@ -1,0 +1,152 @@
+# PostgreSQL Client Authentication Configuration File
+# ===================================================
+#
+# Refer to the "Client Authentication" section in the PostgreSQL
+# documentation for a complete description of this file.  A short
+# synopsis follows.
+#
+# ----------------------
+# Authentication Records
+# ----------------------
+#
+# This file controls: which hosts are allowed to connect, how clients
+# are authenticated, which PostgreSQL user names they can use, which
+# databases they can access.  Records take one of these forms:
+#
+# local         DATABASE  USER  METHOD  [OPTIONS]
+# host          DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostssl       DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnossl     DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostgssenc    DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnogssenc  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+#
+# (The uppercase items must be replaced by actual values.)
+#
+# The first field is the connection type:
+# - "local" is a Unix-domain socket
+# - "host" is a TCP/IP socket (encrypted or not)
+# - "hostssl" is a TCP/IP socket that is SSL-encrypted
+# - "hostnossl" is a TCP/IP socket that is not SSL-encrypted
+# - "hostgssenc" is a TCP/IP socket that is GSSAPI-encrypted
+# - "hostnogssenc" is a TCP/IP socket that is not GSSAPI-encrypted
+#
+# DATABASE can be "all", "sameuser", "samerole", "replication", a
+# database name, a regular expression (if it starts with a slash (/))
+# or a comma-separated list thereof.  The "all" keyword does not match
+# "replication".  Access to replication must be enabled in a separate
+# record (see example below).
+#
+# USER can be "all", a user name, a group name prefixed with "+", a
+# regular expression (if it starts with a slash (/)) or a comma-separated
+# list thereof.  In both the DATABASE and USER fields you can also write
+# a file name prefixed with "@" to include names from a separate file.
+#
+# ADDRESS specifies the set of hosts the record matches.  It can be a
+# host name, or it is made up of an IP address and a CIDR mask that is
+# an integer (between 0 and 32 (IPv4) or 128 (IPv6) inclusive) that
+# specifies the number of significant bits in the mask.  A host name
+# that starts with a dot (.) matches a suffix of the actual host name.
+# Alternatively, you can write an IP address and netmask in separate
+# columns to specify the set of hosts.  Instead of a CIDR-address, you
+# can write "samehost" to match any of the server's own IP addresses,
+# or "samenet" to match any address in any subnet that the server is
+# directly connected to.
+#
+# METHOD can be "trust", "reject", "md5", "password", "scram-sha-256",
+# "gss", "sspi", "ident", "peer", "pam", "ldap", "radius" or "cert".
+# Note that "password" sends passwords in clear text; "md5" or
+# "scram-sha-256" are preferred since they send encrypted passwords.
+#
+# OPTIONS are a set of options for the authentication in the format
+# NAME=VALUE.  The available options depend on the different
+# authentication methods -- refer to the "Client Authentication"
+# section in the documentation for a list of which options are
+# available for which authentication methods.
+#
+# Database and user names containing spaces, commas, quotes and other
+# special characters must be quoted.  Quoting one of the keywords
+# "all", "sameuser", "samerole" or "replication" makes the name lose
+# its special character, and just match a database or username with
+# that name.
+#
+# ---------------
+# Include Records
+# ---------------
+#
+# This file allows the inclusion of external files or directories holding
+# more records, using the following keywords:
+#
+# include           FILE
+# include_if_exists FILE
+# include_dir       DIRECTORY
+#
+# FILE is the file name to include, and DIR is the directory name containing
+# the file(s) to include.  Any file in a directory will be loaded if suffixed
+# with ".conf".  The files of a directory are ordered by name.
+# include_if_exists ignores missing files.  FILE and DIRECTORY can be
+# specified as a relative or an absolute path, and can be double-quoted if
+# they contain spaces.
+#
+# -------------
+# Miscellaneous
+# -------------
+#
+# This file is read on server startup and when the server receives a
+# SIGHUP signal.  If you edit the file on a running system, you have to
+# SIGHUP the server for the changes to take effect, run "pg_ctl reload",
+# or execute "SELECT pg_reload_conf()".
+#
+# ----------------------------------
+# Put your actual configuration here
+# ----------------------------------
+#
+# If you want to allow non-local connections, you need to add more
+# "host" records.  In that case you will also need to make PostgreSQL
+# listen on a non-local interface via the listen_addresses
+# configuration parameter, or via the -i or -h command line switches.
+
+# CAUTION: Configuring the system for local "trust" authentication
+# allows any local user to connect as any PostgreSQL user, including
+# the database superuser.  If you do not trust all your local users,
+# use another authentication method.
+
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     trust
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            trust
+# IPv6 local connections:
+host    all             all             ::1/128                 trust
+# Allow replication connections from localhost, by a user with the
+# replication privilege.
+local   replication     all                                     trust
+host    replication     all             127.0.0.1/32            trust
+host    replication     all             ::1/128                 trust
+
+# host    all             all             all                     scram-sha-256
+host    all             postgres        172.16.0.0/8     scram-sha-256
+host    all             temporal        172.16.0.0/8     scram-sha-256
+host    all             superset        172.16.0.0/10     scram-sha-256
+host    all             backup          172.16.0.0/8     scram-sha-256
+host    all             all        137.110.116.196/24     scram-sha-256
+host    all             all        137.110.160.98/24     scram-sha-256
+
+# UCSD IP Blocks
+host    all             all        100.80.0.0/12         scram-sha-256
+host    all             all        100.96.0.0/13         scram-sha-256
+host    all             all        100.108.0.0/14         scram-sha-256
+host    all             all        128.54.0.0/16         scram-sha-256
+host    all             all        128.199.0.0/16         scram-sha-256
+host    all             all        132.239.0.0/16         scram-sha-256
+host    all             all        132.110.0.0/16         scram-sha-256
+host    all             all        169.228.0.0/16         scram-sha-256
+host    all             all        172.16.0.0/13         scram-sha-256
+host    all             all        100.108.0.0/14         scram-sha-256
+# UCSD VPN IP Blocks
+host    all             all        137.110.0.0/14         scram-sha-256
+host    all             all        137.110.32.0/21         scram-sha-256
+host    all             all        137.110.40.0/23         scram-sha-256
+host    all             all        137.110.42.0/24         scram-sha-256
+host    all             all        137.110.53.0/24         scram-sha-256

--- a/deploy/incus/pg_volumes/config/postgres.conf
+++ b/deploy/incus/pg_volumes/config/postgres.conf
@@ -1,0 +1,822 @@
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+# "#" anywhere on a line.  The complete list of parameter names and allowed
+# values can be found in the PostgreSQL documentation.
+#
+# The commented-out settings shown in this file represent the default values.
+# Re-commenting a setting is NOT sufficient to revert it to the default value;
+# you need to reload the server.
+#
+# This file is read on server startup and when the server receives a SIGHUP
+# signal.  If you edit the file on a running system, you have to SIGHUP the
+# server for the changes to take effect, run "pg_ctl reload", or execute
+# "SELECT pg_reload_conf()".  Some parameters, which are marked below,
+# require a server shutdown and restart to take effect.
+#
+# Any parameter can also be given as a command-line option to the server, e.g.,
+# "postgres -c log_connections=on".  Some parameters can be changed at run time
+# with the "SET" SQL command.
+#
+# Memory units:  B  = bytes            Time units:  us  = microseconds
+#                kB = kilobytes                     ms  = milliseconds
+#                MB = megabytes                     s   = seconds
+#                GB = gigabytes                     min = minutes
+#                TB = terabytes                     h   = hours
+#                                                   d   = days
+
+
+#------------------------------------------------------------------------------
+# FILE LOCATIONS
+#------------------------------------------------------------------------------
+
+# The default values of these variables are driven from the -D command-line
+# option or PGDATA environment variable, represented here as ConfigDir.
+
+#data_directory = 'ConfigDir'           # use data in another directory
+                                        # (change requires restart)
+hba_file = '/etc/postgresql/pg_hba.conf'     # host-based authentication file
+                                        # (change requires restart)
+#ident_file = 'ConfigDir/pg_ident.conf' # ident configuration file
+                                        # (change requires restart)
+
+# If external_pid_file is not explicitly set, no extra PID file is written.
+#external_pid_file = ''                 # write an extra PID file
+                                        # (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+
+# - Connection Settings -
+
+listen_addresses = '*'
+                                        # comma-separated list of addresses;
+                                        # defaults to 'localhost'; use '*' for all
+                                        # (change requires restart)
+port = 5432                            # (change requires restart)
+#max_connections = 100                  # (change requires restart)
+#reserved_connections = 0               # (change requires restart)
+#superuser_reserved_connections = 3     # (change requires restart)
+#unix_socket_directories = '/tmp'       # comma-separated list of directories
+                                        # (change requires restart)
+#unix_socket_group = ''                 # (change requires restart)
+#unix_socket_permissions = 0777         # begin with 0 to use octal notation
+                                        # (change requires restart)
+#bonjour = off                          # advertise server via Bonjour
+                                        # (change requires restart)
+#bonjour_name = ''                      # defaults to the computer name
+                                        # (change requires restart)
+
+# - TCP settings -
+# see "man tcp" for details
+
+#tcp_keepalives_idle = 0                # TCP_KEEPIDLE, in seconds;
+                                        # 0 selects the system default
+#tcp_keepalives_interval = 0            # TCP_KEEPINTVL, in seconds;
+                                        # 0 selects the system default
+#tcp_keepalives_count = 0               # TCP_KEEPCNT;
+                                        # 0 selects the system default
+#tcp_user_timeout = 0                   # TCP_USER_TIMEOUT, in milliseconds;
+                                        # 0 selects the system default
+
+#client_connection_check_interval = 0   # time between checks for client
+                                        # disconnection while running queries;
+                                        # 0 for never
+
+# - Authentication -
+
+#authentication_timeout = 1min          # 1s-600s
+#password_encryption = scram-sha-256    # scram-sha-256 or md5
+#scram_iterations = 4096
+#db_user_namespace = off
+
+# GSSAPI using Kerberos
+#krb_server_keyfile = 'FILE:${sysconfdir}/krb5.keytab'
+#krb_caseins_users = off
+#gss_accept_delegation = off
+
+# - SSL -
+
+# ssl = on
+#ssl_ca_file = ''
+# ssl_cert_file = '/certs/dronelab-nathan-3.ucsd.edu.crt'
+#ssl_crl_file = ''
+#ssl_crl_dir = ''
+# ssl_key_file = '/certs/dronelab-nathan-3.ucsd.edu.key'
+#ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL' # allowed SSL ciphers
+#ssl_prefer_server_ciphers = on
+#ssl_ecdh_curve = 'prime256v1'
+#ssl_min_protocol_version = 'TLSv1.2'
+#ssl_max_protocol_version = ''
+#ssl_dh_params_file = ''
+#ssl_passphrase_command = ''
+#ssl_passphrase_command_supports_reload = off
+
+
+#------------------------------------------------------------------------------
+# RESOURCE USAGE (except WAL)
+#------------------------------------------------------------------------------
+
+# - Memory -
+
+#shared_buffers = 128MB                 # min 128kB
+                                        # (change requires restart)
+#huge_pages = try                       # on, off, or try
+                                        # (change requires restart)
+#huge_page_size = 0                     # zero for system default
+                                        # (change requires restart)
+#temp_buffers = 8MB                     # min 800kB
+#max_prepared_transactions = 0          # zero disables the feature
+                                        # (change requires restart)
+# Caution: it is not advisable to set max_prepared_transactions nonzero unless
+# you actively intend to use prepared transactions.
+#work_mem = 4MB                         # min 64kB
+#hash_mem_multiplier = 2.0              # 1-1000.0 multiplier on hash table work_mem
+#maintenance_work_mem = 64MB            # min 1MB
+#autovacuum_work_mem = -1               # min 1MB, or -1 to use maintenance_work_mem
+#logical_decoding_work_mem = 64MB       # min 64kB
+#max_stack_depth = 2MB                  # min 100kB
+#shared_memory_type = mmap              # the default is the first option
+                                        # supported by the operating system:
+                                        #   mmap
+                                        #   sysv
+                                        #   windows
+                                        # (change requires restart)
+#dynamic_shared_memory_type = posix     # the default is usually the first option
+                                        # supported by the operating system:
+                                        #   posix
+                                        #   sysv
+                                        #   windows
+                                        #   mmap
+                                        # (change requires restart)
+#min_dynamic_shared_memory = 0MB        # (change requires restart)
+#vacuum_buffer_usage_limit = 256kB      # size of vacuum and analyze buffer access strategy ring;
+                                        # 0 to disable vacuum buffer access strategy;
+                                        # range 128kB to 16GB
+
+# - Disk -
+
+#temp_file_limit = -1                   # limits per-process temp file space
+                                        # in kilobytes, or -1 for no limit
+
+# - Kernel Resources -
+
+#max_files_per_process = 1000           # min 64
+                                        # (change requires restart)
+
+# - Cost-Based Vacuum Delay -
+
+#vacuum_cost_delay = 0                  # 0-100 milliseconds (0 disables)
+#vacuum_cost_page_hit = 1               # 0-10000 credits
+#vacuum_cost_page_miss = 2              # 0-10000 credits
+#vacuum_cost_page_dirty = 20            # 0-10000 credits
+#vacuum_cost_limit = 200                # 1-10000 credits
+
+# - Background Writer -
+
+#bgwriter_delay = 200ms                 # 10-10000ms between rounds
+#bgwriter_lru_maxpages = 100            # max buffers written/round, 0 disables
+#bgwriter_lru_multiplier = 2.0          # 0-10.0 multiplier on buffers scanned/round
+#bgwriter_flush_after = 0               # measured in pages, 0 disables
+
+# - Asynchronous Behavior -
+
+#backend_flush_after = 0                # measured in pages, 0 disables
+#effective_io_concurrency = 1           # 1-1000; 0 disables prefetching
+#maintenance_io_concurrency = 10        # 1-1000; 0 disables prefetching
+#max_worker_processes = 8               # (change requires restart)
+#max_parallel_workers_per_gather = 2    # limited by max_parallel_workers
+#max_parallel_maintenance_workers = 2   # limited by max_parallel_workers
+#max_parallel_workers = 8               # number of max_worker_processes that
+                                        # can be used in parallel operations
+#parallel_leader_participation = on
+#old_snapshot_threshold = -1            # 1min-60d; -1 disables; 0 is immediate
+                                        # (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# WRITE-AHEAD LOG
+#------------------------------------------------------------------------------
+
+# - Settings -
+
+#wal_level = replica                    # minimal, replica, or logical
+                                        # (change requires restart)
+#fsync = on                             # flush data to disk for crash safety
+                                        # (turning this off can cause
+                                        # unrecoverable data corruption)
+#synchronous_commit = on                # synchronization level;
+                                        # off, local, remote_write, remote_apply, or on
+#wal_sync_method = fsync                # the default is the first option
+                                        # supported by the operating system:
+                                        #   open_datasync
+                                        #   fdatasync (default on Linux and FreeBSD)
+                                        #   fsync
+                                        #   fsync_writethrough
+                                        #   open_sync
+#full_page_writes = on                  # recover from partial page writes
+#wal_log_hints = off                    # also do full page writes of non-critical updates
+                                        # (change requires restart)
+#wal_compression = off                  # enables compression of full-page writes;
+                                        # off, pglz, lz4, zstd, or on
+#wal_init_zero = on                     # zero-fill new WAL files
+#wal_recycle = on                       # recycle WAL files
+#wal_buffers = -1                       # min 32kB, -1 sets based on shared_buffers
+                                        # (change requires restart)
+#wal_writer_delay = 200ms               # 1-10000 milliseconds
+#wal_writer_flush_after = 1MB           # measured in pages, 0 disables
+#wal_skip_threshold = 2MB
+
+#commit_delay = 0                       # range 0-100000, in microseconds
+#commit_siblings = 5                    # range 1-1000
+
+# - Checkpoints -
+
+#checkpoint_timeout = 5min              # range 30s-1d
+#checkpoint_completion_target = 0.9     # checkpoint target duration, 0.0 - 1.0
+#checkpoint_flush_after = 0             # measured in pages, 0 disables
+#checkpoint_warning = 30s               # 0 disables
+#max_wal_size = 1GB
+#min_wal_size = 80MB
+
+# - Prefetching during recovery -
+
+#recovery_prefetch = try                # prefetch pages referenced in the WAL?
+#wal_decode_buffer_size = 512kB         # lookahead window used for prefetching
+                                        # (change requires restart)
+
+# - Archiving -
+
+#archive_mode = off             # enables archiving; off, on, or always
+                                # (change requires restart)
+#archive_library = ''           # library to use to archive a WAL file
+                                # (empty string indicates archive_command should
+                                # be used)
+#archive_command = ''           # command to use to archive a WAL file
+                                # placeholders: %p = path of file to archive
+                                #               %f = file name only
+                                # e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
+#archive_timeout = 0            # force a WAL file switch after this
+                                # number of seconds; 0 disables
+
+# - Archive Recovery -
+
+# These are only used in recovery mode.
+
+#restore_command = ''           # command to use to restore an archived WAL file
+                                # placeholders: %p = path of file to restore
+                                #               %f = file name only
+                                # e.g. 'cp /mnt/server/archivedir/%f %p'
+#archive_cleanup_command = ''   # command to execute at every restartpoint
+#recovery_end_command = ''      # command to execute at completion of recovery
+
+# - Recovery Target -
+
+# Set these only when performing a targeted recovery.
+
+#recovery_target = ''           # 'immediate' to end recovery as soon as a
+                                # consistent state is reached
+                                # (change requires restart)
+#recovery_target_name = ''      # the named restore point to which recovery will proceed
+                                # (change requires restart)
+#recovery_target_time = ''      # the time stamp up to which recovery will proceed
+                                # (change requires restart)
+#recovery_target_xid = ''       # the transaction ID up to which recovery will proceed
+                                # (change requires restart)
+#recovery_target_lsn = ''       # the WAL LSN up to which recovery will proceed
+                                # (change requires restart)
+#recovery_target_inclusive = on # Specifies whether to stop:
+                                # just after the specified recovery target (on)
+                                # just before the recovery target (off)
+                                # (change requires restart)
+#recovery_target_timeline = 'latest'    # 'current', 'latest', or timeline ID
+                                # (change requires restart)
+#recovery_target_action = 'pause'       # 'pause', 'promote', 'shutdown'
+                                # (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# REPLICATION
+#------------------------------------------------------------------------------
+
+# - Sending Servers -
+
+# Set these on the primary and on any standby that will send replication data.
+
+#max_wal_senders = 10           # max number of walsender processes
+                                # (change requires restart)
+#max_replication_slots = 10     # max number of replication slots
+                                # (change requires restart)
+#wal_keep_size = 0              # in megabytes; 0 disables
+#max_slot_wal_keep_size = -1    # in megabytes; -1 disables
+#wal_sender_timeout = 60s       # in milliseconds; 0 disables
+#track_commit_timestamp = off   # collect timestamp of transaction commit
+                                # (change requires restart)
+
+# - Primary Server -
+
+# These settings are ignored on a standby server.
+
+#synchronous_standby_names = '' # standby servers that provide sync rep
+                                # method to choose sync standbys, number of sync standbys,
+                                # and comma-separated list of application_name
+                                # from standby(s); '*' = all
+
+# - Standby Servers -
+
+# These settings are ignored on a primary server.
+
+#primary_conninfo = ''                  # connection string to sending server
+#primary_slot_name = ''                 # replication slot on sending server
+#hot_standby = on                       # "off" disallows queries during recovery
+                                        # (change requires restart)
+#max_standby_archive_delay = 30s        # max delay before canceling queries
+                                        # when reading WAL from archive;
+                                        # -1 allows indefinite delay
+#max_standby_streaming_delay = 30s      # max delay before canceling queries
+                                        # when reading streaming WAL;
+                                        # -1 allows indefinite delay
+#wal_receiver_create_temp_slot = off    # create temp slot if primary_slot_name
+                                        # is not set
+#wal_receiver_status_interval = 10s     # send replies at least this often
+                                        # 0 disables
+#hot_standby_feedback = off             # send info from standby to prevent
+                                        # query conflicts
+#wal_receiver_timeout = 60s             # time that receiver waits for
+                                        # communication from primary
+                                        # in milliseconds; 0 disables
+#wal_retrieve_retry_interval = 5s       # time to wait before retrying to
+                                        # retrieve WAL after a failed attempt
+#recovery_min_apply_delay = 0           # minimum delay for applying changes during recovery
+
+# - Subscribers -
+
+# These settings are ignored on a publisher.
+
+#max_logical_replication_workers = 4    # taken from max_worker_processes
+                                        # (change requires restart)
+#max_sync_workers_per_subscription = 2  # taken from max_logical_replication_workers
+#max_parallel_apply_workers_per_subscription = 2        # taken from max_logical_replication_workers
+
+
+#------------------------------------------------------------------------------
+# QUERY TUNING
+#------------------------------------------------------------------------------
+
+# - Planner Method Configuration -
+
+#enable_async_append = on
+#enable_bitmapscan = on
+#enable_gathermerge = on
+#enable_hashagg = on
+#enable_hashjoin = on
+#enable_incremental_sort = on
+#enable_indexscan = on
+#enable_indexonlyscan = on
+#enable_material = on
+#enable_memoize = on
+#enable_mergejoin = on
+#enable_nestloop = on
+#enable_parallel_append = on
+#enable_parallel_hash = on
+#enable_partition_pruning = on
+#enable_partitionwise_join = off
+#enable_partitionwise_aggregate = off
+#enable_presorted_aggregate = on
+#enable_seqscan = on
+#enable_sort = on
+#enable_tidscan = on
+
+# - Planner Cost Constants -
+
+#seq_page_cost = 1.0                    # measured on an arbitrary scale
+#random_page_cost = 4.0                 # same scale as above
+#cpu_tuple_cost = 0.01                  # same scale as above
+#cpu_index_tuple_cost = 0.005           # same scale as above
+#cpu_operator_cost = 0.0025             # same scale as above
+#parallel_setup_cost = 1000.0   # same scale as above
+#parallel_tuple_cost = 0.1              # same scale as above
+#min_parallel_table_scan_size = 8MB
+#min_parallel_index_scan_size = 512kB
+#effective_cache_size = 4GB
+
+#jit_above_cost = 100000                # perform JIT compilation if available
+                                        # and query more expensive than this;
+                                        # -1 disables
+#jit_inline_above_cost = 500000         # inline small functions if query is
+                                        # more expensive than this; -1 disables
+#jit_optimize_above_cost = 500000       # use expensive JIT optimizations if
+                                        # query is more expensive than this;
+                                        # -1 disables
+
+# - Genetic Query Optimizer -
+
+#geqo = on
+#geqo_threshold = 12
+#geqo_effort = 5                        # range 1-10
+#geqo_pool_size = 0                     # selects default based on effort
+#geqo_generations = 0                   # selects default based on effort
+#geqo_selection_bias = 2.0              # range 1.5-2.0
+#geqo_seed = 0.0                        # range 0.0-1.0
+
+# - Other Planner Options -
+
+#default_statistics_target = 100        # range 1-10000
+#constraint_exclusion = partition       # on, off, or partition
+#cursor_tuple_fraction = 0.1            # range 0.0-1.0
+#from_collapse_limit = 8
+#jit = on                               # allow JIT compilation
+#join_collapse_limit = 8                # 1 disables collapsing of explicit
+                                        # JOIN clauses
+#plan_cache_mode = auto                 # auto, force_generic_plan or
+                                        # force_custom_plan
+#recursive_worktable_factor = 10.0      # range 0.001-1000000
+
+
+#------------------------------------------------------------------------------
+# REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+# - Where to Log -
+
+#log_destination = 'stderr'             # Valid values are combinations of
+                                        # stderr, csvlog, jsonlog, syslog, and
+                                        # eventlog, depending on platform.
+                                        # csvlog and jsonlog require
+                                        # logging_collector to be on.
+
+# This is used when logging to stderr:
+#logging_collector = off                # Enable capturing of stderr, jsonlog,
+                                        # and csvlog into log files. Required
+                                        # to be on for csvlogs and jsonlogs.
+                                        # (change requires restart)
+
+# These are only used if logging_collector is on:
+#log_directory = 'log'                  # directory where log files are written,
+                                        # can be absolute or relative to PGDATA
+#log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'        # log file name pattern,
+                                        # can include strftime() escapes
+#log_file_mode = 0600                   # creation mode for log files,
+                                        # begin with 0 to use octal notation
+#log_rotation_age = 1d                  # Automatic rotation of logfiles will
+                                        # happen after that time.  0 disables.
+#log_rotation_size = 10MB               # Automatic rotation of logfiles will
+                                        # happen after that much log output.
+                                        # 0 disables.
+#log_truncate_on_rotation = off         # If on, an existing log file with the
+                                        # same name as the new log file will be
+                                        # truncated rather than appended to.
+                                        # But such truncation only occurs on
+                                        # time-driven rotation, not on restarts
+                                        # or size-driven rotation.  Default is
+                                        # off, meaning append to existing files
+                                        # in all cases.
+
+# These are relevant when logging to syslog:
+#syslog_facility = 'LOCAL0'
+#syslog_ident = 'postgres'
+#syslog_sequence_numbers = on
+#syslog_split_messages = on
+
+# This is only relevant when logging to eventlog (Windows):
+# (change requires restart)
+#event_source = 'PostgreSQL'
+
+# - When to Log -
+
+#log_min_messages = warning             # values in order of decreasing detail:
+                                        #   debug5
+                                        #   debug4
+                                        #   debug3
+                                        #   debug2
+                                        #   debug1
+                                        #   info
+                                        #   notice
+                                        #   warning
+                                        #   error
+                                        #   log
+                                        #   fatal
+                                        #   panic
+
+#log_min_error_statement = error        # values in order of decreasing detail:
+                                        #   debug5
+                                        #   debug4
+                                        #   debug3
+                                        #   debug2
+                                        #   debug1
+                                        #   info
+                                        #   notice
+                                        #   warning
+                                        #   error
+                                        #   log
+                                        #   fatal
+                                        #   panic (effectively off)
+
+#log_min_duration_statement = -1        # -1 is disabled, 0 logs all statements
+                                        # and their durations, > 0 logs only
+                                        # statements running at least this number
+                                        # of milliseconds
+
+#log_min_duration_sample = -1           # -1 is disabled, 0 logs a sample of statements
+                                        # and their durations, > 0 logs only a sample of
+                                        # statements running at least this number
+                                        # of milliseconds;
+                                        # sample fraction is determined by log_statement_sample_rate
+
+#log_statement_sample_rate = 1.0        # fraction of logged statements exceeding
+                                        # log_min_duration_sample to be logged;
+                                        # 1.0 logs all such statements, 0.0 never logs
+
+
+#log_transaction_sample_rate = 0.0      # fraction of transactions whose statements
+                                        # are logged regardless of their duration; 1.0 logs all
+                                        # statements from all transactions, 0.0 never logs
+
+#log_startup_progress_interval = 10s    # Time between progress updates for
+                                        # long-running startup operations.
+                                        # 0 disables the feature, > 0 indicates
+                                        # the interval in milliseconds.
+
+# - What to Log -
+
+#debug_print_parse = off
+#debug_print_rewritten = off
+#debug_print_plan = off
+#debug_pretty_print = on
+#log_autovacuum_min_duration = 10min    # log autovacuum activity;
+                                        # -1 disables, 0 logs all actions and
+                                        # their durations, > 0 logs only
+                                        # actions running at least this number
+                                        # of milliseconds.
+#log_checkpoints = on
+#log_connections = off
+#log_disconnections = off
+#log_duration = off
+#log_error_verbosity = default          # terse, default, or verbose messages
+#log_hostname = off
+#log_line_prefix = '%m [%p] '           # special values:
+                                        #   %a = application name
+                                        #   %u = user name
+                                        #   %d = database name
+                                        #   %r = remote host and port
+                                        #   %h = remote host
+                                        #   %b = backend type
+                                        #   %p = process ID
+                                        #   %P = process ID of parallel group leader
+                                        #   %t = timestamp without milliseconds
+                                        #   %m = timestamp with milliseconds
+                                        #   %n = timestamp with milliseconds (as a Unix epoch)
+                                        #   %Q = query ID (0 if none or not computed)
+                                        #   %i = command tag
+                                        #   %e = SQL state
+                                        #   %c = session ID
+                                        #   %l = session line number
+                                        #   %s = session start timestamp
+                                        #   %v = virtual transaction ID
+                                        #   %x = transaction ID (0 if none)
+                                        #   %q = stop here in non-session
+                                        #        processes
+                                        #   %% = '%'
+                                        # e.g. '<%u%%%d> '
+#log_lock_waits = off                   # log lock waits >= deadlock_timeout
+#log_recovery_conflict_waits = off      # log standby recovery conflict waits
+                                        # >= deadlock_timeout
+#log_parameter_max_length = -1          # when logging statements, limit logged
+                                        # bind-parameter values to N bytes;
+                                        # -1 means print in full, 0 disables
+#log_parameter_max_length_on_error = 0  # when logging an error, limit logged
+                                        # bind-parameter values to N bytes;
+                                        # -1 means print in full, 0 disables
+#log_statement = 'none'                 # none, ddl, mod, all
+#log_replication_commands = off
+#log_temp_files = -1                    # log temporary files equal or larger
+                                        # than the specified size in kilobytes;
+                                        # -1 disables, 0 logs all temp files
+#log_timezone = 'GMT'
+
+# - Process Title -
+
+#cluster_name = ''                      # added to process titles if nonempty
+                                        # (change requires restart)
+#update_process_title = on
+
+
+#------------------------------------------------------------------------------
+# STATISTICS
+#------------------------------------------------------------------------------
+
+# - Cumulative Query and Index Statistics -
+
+#track_activities = on
+#track_activity_query_size = 1024       # (change requires restart)
+#track_counts = on
+#track_io_timing = off
+#track_wal_io_timing = off
+#track_functions = none                 # none, pl, all
+#stats_fetch_consistency = cache        # cache, none, snapshot
+
+
+# - Monitoring -
+
+#compute_query_id = auto
+#log_statement_stats = off
+#log_parser_stats = off
+#log_planner_stats = off
+#log_executor_stats = off
+
+
+#------------------------------------------------------------------------------
+# AUTOVACUUM
+#------------------------------------------------------------------------------
+
+#autovacuum = on                        # Enable autovacuum subprocess?  'on'
+                                        # requires track_counts to also be on.
+#autovacuum_max_workers = 3             # max number of autovacuum subprocesses
+                                        # (change requires restart)
+#autovacuum_naptime = 1min              # time between autovacuum runs
+#autovacuum_vacuum_threshold = 50       # min number of row updates before
+                                        # vacuum
+#autovacuum_vacuum_insert_threshold = 1000      # min number of row inserts
+                                        # before vacuum; -1 disables insert
+                                        # vacuums
+#autovacuum_analyze_threshold = 50      # min number of row updates before
+                                        # analyze
+#autovacuum_vacuum_scale_factor = 0.2   # fraction of table size before vacuum
+#autovacuum_vacuum_insert_scale_factor = 0.2    # fraction of inserts over table
+                                        # size before insert vacuum
+#autovacuum_analyze_scale_factor = 0.1  # fraction of table size before analyze
+#autovacuum_freeze_max_age = 200000000  # maximum XID age before forced vacuum
+                                        # (change requires restart)
+#autovacuum_multixact_freeze_max_age = 400000000        # maximum multixact age
+                                        # before forced vacuum
+                                        # (change requires restart)
+#autovacuum_vacuum_cost_delay = 2ms     # default vacuum cost delay for
+                                        # autovacuum, in milliseconds;
+                                        # -1 means use vacuum_cost_delay
+#autovacuum_vacuum_cost_limit = -1      # default vacuum cost limit for
+                                        # autovacuum, -1 means use
+                                        # vacuum_cost_limit
+
+
+#------------------------------------------------------------------------------
+# CLIENT CONNECTION DEFAULTS
+#------------------------------------------------------------------------------
+
+# - Statement Behavior -
+
+#client_min_messages = notice           # values in order of decreasing detail:
+                                        #   debug5
+                                        #   debug4
+                                        #   debug3
+                                        #   debug2
+                                        #   debug1
+                                        #   log
+                                        #   notice
+                                        #   warning
+                                        #   error
+#search_path = '"$user", public'        # schema names
+#row_security = on
+#default_table_access_method = 'heap'
+#default_tablespace = ''                # a tablespace name, '' uses the default
+#default_toast_compression = 'pglz'     # 'pglz' or 'lz4'
+#temp_tablespaces = ''                  # a list of tablespace names, '' uses
+                                        # only default tablespace
+#check_function_bodies = on
+#default_transaction_isolation = 'read committed'
+#default_transaction_read_only = off
+#default_transaction_deferrable = off
+#session_replication_role = 'origin'
+statement_timeout = 30000                  # in milliseconds, 0 is disabled
+#lock_timeout = 0                       # in milliseconds, 0 is disabled
+#idle_in_transaction_session_timeout = 0        # in milliseconds, 0 is disabled
+#idle_session_timeout = 0               # in milliseconds, 0 is disabled
+#vacuum_freeze_table_age = 150000000
+#vacuum_freeze_min_age = 50000000
+#vacuum_failsafe_age = 1600000000
+#vacuum_multixact_freeze_table_age = 150000000
+#vacuum_multixact_freeze_min_age = 5000000
+#vacuum_multixact_failsafe_age = 1600000000
+#bytea_output = 'hex'                   # hex, escape
+#xmlbinary = 'base64'
+#xmloption = 'content'
+#gin_pending_list_limit = 4MB
+#createrole_self_grant = ''             # set and/or inherit
+
+# - Locale and Formatting -
+
+#datestyle = 'iso, mdy'
+#intervalstyle = 'postgres'
+#timezone = 'GMT'
+#timezone_abbreviations = 'Default'     # Select the set of available time zone
+                                        # abbreviations.  Currently, there are
+                                        #   Default
+                                        #   Australia (historical usage)
+                                        #   India
+                                        # You can create your own file in
+                                        # share/timezonesets/.
+#extra_float_digits = 1                 # min -15, max 3; any value >0 actually
+                                        # selects precise output mode
+#client_encoding = sql_ascii            # actually, defaults to database
+                                        # encoding
+
+# These settings are initialized by initdb, but they can be changed.
+#lc_messages = ''                       # locale for system error message
+                                        # strings
+#lc_monetary = 'C'                      # locale for monetary formatting
+#lc_numeric = 'C'                       # locale for number formatting
+#lc_time = 'C'                          # locale for time formatting
+
+#icu_validation_level = warning         # report ICU locale validation
+                                        # errors at the given level
+
+# default configuration for text search
+#default_text_search_config = 'pg_catalog.simple'
+
+# - Shared Library Preloading -
+
+#local_preload_libraries = ''
+#session_preload_libraries = ''
+#shared_preload_libraries = ''  # (change requires restart)
+#jit_provider = 'llvmjit'               # JIT library to use
+
+# - Other Defaults -
+
+#dynamic_library_path = '$libdir'
+#extension_destdir = ''                 # prepend path when loading extensions
+                                        # and shared objects (added by Debian)
+#gin_fuzzy_search_limit = 0
+
+
+#------------------------------------------------------------------------------
+# LOCK MANAGEMENT
+#------------------------------------------------------------------------------
+
+#deadlock_timeout = 1s
+#max_locks_per_transaction = 64         # min 10
+                                        # (change requires restart)
+#max_pred_locks_per_transaction = 64    # min 10
+                                        # (change requires restart)
+#max_pred_locks_per_relation = -2       # negative values mean
+                                        # (max_pred_locks_per_transaction
+                                        #  / -max_pred_locks_per_relation) - 1
+#max_pred_locks_per_page = 2            # min 0
+
+
+#------------------------------------------------------------------------------
+# VERSION AND PLATFORM COMPATIBILITY
+#------------------------------------------------------------------------------
+
+# - Previous PostgreSQL Versions -
+
+#array_nulls = on
+#backslash_quote = safe_encoding        # on, off, or safe_encoding
+#escape_string_warning = on
+#lo_compat_privileges = off
+#quote_all_identifiers = off
+#standard_conforming_strings = on
+#synchronize_seqscans = on
+
+# - Other Platforms and Clients -
+
+#transform_null_equals = off
+
+
+#------------------------------------------------------------------------------
+# ERROR HANDLING
+#------------------------------------------------------------------------------
+
+#exit_on_error = off                    # terminate session on any error?
+#restart_after_crash = on               # reinitialize after backend crash?
+#data_sync_retry = off                  # retry or panic on failure to fsync
+                                        # data?
+                                        # (change requires restart)
+#recovery_init_sync_method = fsync      # fsync, syncfs (Linux 5.8+)
+
+
+#------------------------------------------------------------------------------
+# CONFIG FILE INCLUDES
+#------------------------------------------------------------------------------
+
+# These options allow settings to be loaded from files other than the
+# default postgresql.conf.  Note that these are directives, not variable
+# assignments, so they can usefully be given more than once.
+
+#include_dir = '...'                    # include files ending in '.conf' from
+                                        # a directory, e.g., 'conf.d'
+#include_if_exists = '...'              # include file only if it exists
+#include = '...'                        # include file
+
+
+#------------------------------------------------------------------------------
+# CUSTOMIZED OPTIONS
+#------------------------------------------------------------------------------
+
+# Add settings for extensions here

--- a/deploy/incus/pg_volumes/scripts/README.md
+++ b/deploy/incus/pg_volumes/scripts/README.md
@@ -1,0 +1,35 @@
+# Postgres init scripts — intentionally empty (restore-based bootstrap)
+
+The Incus deploy bootstraps Postgres by **restoring a prod `pg_dump`** into the
+`pgdata` named volume, not by running init SQL. So this directory ships **no
+`*.sql`/`*.sh`** — Postgres' official image only runs `/docker-entrypoint-initdb.d/`
+on a *fresh* data dir anyway, and after a restore the dir is non-empty.
+
+## Cutover procedure (operator)
+
+1. Bring up **only** postgres against a fresh `pgdata` volume, or stop the stack.
+2. Restore the latest prod dump (the nightly `fishsense-backup-worker` output) —
+   this brings the `fishsense` + `superset` databases **and** the DB roles
+   (`postgres` admin, `superset`, `backup`) **with their existing passwords**:
+   ```
+   pg_restore -U postgres -d postgres --clean --create <prod_dump>
+   ```
+   (Skip `temporal_db` / `temporal_visibility` — Temporal is external now, krg-prod.)
+   **This is also the Postgres 16 → 17 major upgrade** — restoring an older dump into
+   the newer server is the supported dump/restore upgrade path. The backup worker's
+   `pg_dump` client is pg17 (Debian trixie), so ongoing dumps of the 17 server are fine.
+3. Seed OpenBao `secret/tenants/fishsense/*` with **those same** role passwords
+   (`postgres.password`, `superset.db_password`, `postgres.backup_password`) so the
+   vault-agent render (`app.env`) matches what the restore created. See
+   [`../../secrets.nix`](../../secrets.nix).
+4. Bring the full stack up.
+
+## Fresh (no-data) env
+
+If you ever stand up an empty instance (dev / DR with no dump), you must create the
+`superset` DB + role (read-only SELECT on `fishsense`) and the `backup` role
+(`pg_read_all_data`) by hand — see the old stack's
+`deploy/pg_volumes/scripts/2025-09-02_create_database.sql` +
+`2026-05-01_create_backup_role.sql` for the exact grants. Passwords must match what
+you seed in OpenBao. This is deliberately not automated here to avoid an empty-DB
+footgun on the restore path.

--- a/deploy/incus/superset_volumes/docker/.env
+++ b/deploy/incus/superset_volumes/docker/.env
@@ -1,0 +1,75 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Allowing python to print() in docker
+PYTHONUNBUFFERED=1
+
+COMPOSE_PROJECT_NAME=superset
+DEV_MODE=false
+
+# database configurations (do not modify)
+DATABASE_DB=superset
+DATABASE_HOST=postgres
+# Make sure you set this to a unique secure random value on production
+# DATABASE_PASSWORD=superset
+DATABASE_USER=superset
+
+# EXAMPLES_DB=examples
+# EXAMPLES_HOST=db
+# EXAMPLES_USER=examples
+# Make sure you set this to a unique secure random value on production
+# EXAMPLES_PASSWORD=examples
+# EXAMPLES_PORT=5432
+
+# database engine specific environment variables
+# change the below if you prefer another database engine
+DATABASE_PORT=5432
+DATABASE_DIALECT=postgresql
+POSTGRES_DB=superset
+POSTGRES_USER=superset
+# Make sure you set this to a unique secure random value on production
+# POSTGRES_PASSWORD=superset
+#MYSQL_DATABASE=superset
+#MYSQL_USER=superset
+#MYSQL_PASSWORD=superset
+#MYSQL_RANDOM_ROOT_PASSWORD=yes
+
+# Add the mapped in /app/pythonpath_docker which allows devs to override stuff
+PYTHONPATH=/app/pythonpath:/app/docker/pythonpath
+# Points at the `valkey` compose service (Redis-protocol drop-in). The var name
+# stays REDIS_* — superset_config.py builds redis:// URLs, which Valkey speaks.
+REDIS_HOST=valkey
+REDIS_PORT=6379
+
+# Development and logging configuration
+# FLASK_DEBUG: Enables Flask dev features (auto-reload, better error pages) - keep 'true' for development
+FLASK_DEBUG=false
+# SUPERSET_LOG_LEVEL: Controls Superset application logging verbosity (debug, info, warning, error, critical)
+SUPERSET_LOG_LEVEL=info
+
+SUPERSET_APP_ROOT='/'
+SUPERSET_ENV=production
+SUPERSET_LOAD_EXAMPLES=no
+CYPRESS_CONFIG=false
+SUPERSET_PORT=8088
+MAPBOX_API_KEY=''
+
+# Make sure you set this to a unique secure random value on production
+# SUPERSET_SECRET_KEY=TEST_NON_DEV_SECRET
+ENABLE_PLAYWRIGHT=false
+PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+BUILD_SUPERSET_FRONTEND_IN_DOCKER=true

--- a/deploy/incus/superset_volumes/docker/docker-bootstrap.sh
+++ b/deploy/incus/superset_volumes/docker/docker-bootstrap.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -eo pipefail
+
+# Make python interactive
+if [ "$DEV_MODE" == "true" ]; then
+    if [ "$(whoami)" = "root" ] && command -v uv > /dev/null 2>&1; then
+      # Always ensure superset-core is available
+      echo "Installing superset-core in editable mode"
+      uv pip install --no-deps -e /app/superset-core
+
+      # Only reinstall the main app for non-worker processes
+      if [ "$1" != "worker" ] && [ "$1" != "beat" ]; then
+        echo "Reinstalling the app in editable mode"
+        uv pip install -e .
+      fi
+    fi
+fi
+REQUIREMENTS_LOCAL="/app/docker/requirements-local.txt"
+PORT=${PORT:-8088}
+# If Cypress run – overwrite the password for admin and export env variables
+if [ "$CYPRESS_CONFIG" == "true" ]; then
+    export SUPERSET_TESTENV=true
+    export POSTGRES_DB=superset_cypress
+    export SUPERSET__SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://superset:superset@db:5432/superset_cypress
+    PORT=8081
+fi
+# Skip postgres requirements installation for workers to avoid conflicts
+if [[ "$DATABASE_DIALECT" == postgres* ]] && [ "$(whoami)" = "root" ] && [ "$1" != "worker" ] && [ "$1" != "beat" ]; then
+    # older images may not have the postgres dev requirements installed
+    echo "Installing postgres requirements"
+    if command -v uv > /dev/null 2>&1; then
+        # Use uv in newer images
+        uv pip install -e .[postgres]
+    else
+        # Use pip in older images
+        pip install -e .[postgres]
+    fi
+fi
+#
+# Make sure we have dev requirements installed
+#
+if [ -f "${REQUIREMENTS_LOCAL}" ]; then
+  echo "Installing local overrides at ${REQUIREMENTS_LOCAL}"
+  if command -v uv > /dev/null 2>&1; then
+    uv pip install --no-cache-dir -r "${REQUIREMENTS_LOCAL}"
+  else
+    pip install --no-cache-dir -r "${REQUIREMENTS_LOCAL}"
+  fi
+else
+  echo "Skipping local overrides"
+fi
+
+case "${1}" in
+  worker)
+    echo "Installing Selenium requirements for Celery worker..."
+    apt-get update && apt-get install -y \
+      chromium \
+      chromium-driver \
+      fonts-liberation \
+      && rm -rf /var/lib/apt/lists/*
+
+    echo "Starting Celery worker..."
+    # setting up only 2 workers by default to contain memory usage in dev environments
+    celery --app=superset.tasks.celery_app:app worker -O fair -l INFO --concurrency=${CELERYD_CONCURRENCY:-2}
+    ;;
+  beat)
+    echo "Starting Celery beat..."
+    rm -f /tmp/celerybeat.pid
+    celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule
+    ;;
+  app)
+    echo "Starting web app (using development server)..."
+    flask run -p $PORT --reload --debugger --without-threads --host=0.0.0.0 --exclude-patterns "*/node_modules/*:*/.venv/*:*/build/*:*/__pycache__/*"
+    ;;
+  app-gunicorn)
+    echo "Starting web app..."
+    /usr/bin/run-server.sh
+    ;;
+  mcp)
+    echo "Starting MCP service..."
+    superset mcp run --host 0.0.0.0 --port ${MCP_PORT:-5008} --debug
+    ;;
+  *)
+    echo "Unknown Operation!!!"
+    ;;
+esac

--- a/deploy/incus/superset_volumes/docker/docker-healthcheck.sh
+++ b/deploy/incus/superset_volumes/docker/docker-healthcheck.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+curl -f "http://localhost:${SUPERSET_PORT}/${SUPERSET_APP_ROOT/\//}/health" || exit 1

--- a/deploy/incus/superset_volumes/docker/docker-init.sh
+++ b/deploy/incus/superset_volumes/docker/docker-init.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -e
+
+#
+# Always install local overrides first
+#
+/app/docker/docker-bootstrap.sh
+
+if [ "$SUPERSET_LOAD_EXAMPLES" = "yes" ]; then
+    STEP_CNT=4
+else
+    STEP_CNT=3
+fi
+
+echo_step() {
+cat <<EOF
+######################################################################
+Init Step ${1}/${STEP_CNT} [${2}] -- ${3}
+######################################################################
+EOF
+}
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin}"
+# If Cypress run – overwrite the password for admin and export env variables
+if [ "$CYPRESS_CONFIG" == "true" ]; then
+    ADMIN_PASSWORD="general"
+    export SUPERSET_TESTENV=true
+    export POSTGRES_DB=superset_cypress
+    export SUPERSET__SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://superset:superset@db:5432/superset_cypress
+fi
+# Initialize the database
+echo_step "1" "Starting" "Applying DB migrations"
+superset db upgrade
+echo_step "1" "Complete" "Applying DB migrations"
+
+# Create an admin user
+echo_step "2" "Starting" "Setting up admin user ( admin / $ADMIN_PASSWORD )"
+if [ "$CYPRESS_CONFIG" == "true" ]; then
+    superset load_test_users
+else
+    superset fab create-admin \
+        --username admin \
+        --email admin@superset.com \
+        --password "$ADMIN_PASSWORD" \
+        --firstname Superset \
+        --lastname Admin
+fi
+echo_step "2" "Complete" "Setting up admin user"
+# Create default roles and permissions
+echo_step "3" "Starting" "Setting up roles and perms"
+superset init
+echo_step "3" "Complete" "Setting up roles and perms"
+
+if [ "$SUPERSET_LOAD_EXAMPLES" = "yes" ]; then
+    # Load some data to play with
+    echo_step "4" "Starting" "Loading examples"
+
+
+    # If Cypress run which consumes superset_test_config – load required data for tests
+    if [ "$CYPRESS_CONFIG" == "true" ]; then
+        superset load_examples --load-test-data
+    else
+        superset load_examples
+    fi
+    echo_step "4" "Complete" "Loading examples"
+fi

--- a/deploy/incus/superset_volumes/docker/pythonpath/.gitignore
+++ b/deploy/incus/superset_volumes/docker/pythonpath/.gitignore
@@ -1,0 +1,4 @@
+*
+
+!.gitignore
+!superset_config.py

--- a/deploy/incus/superset_volumes/docker/pythonpath/superset_config.py
+++ b/deploy/incus/superset_volumes/docker/pythonpath/superset_config.py
@@ -39,7 +39,16 @@ logger = logging.getLogger()
 # endpoints live at the Authentik root (https://<host>/application/o/...).
 AUTHENTIK_ISSUER = os.environ.get("AUTHENTIK_ISSUER", "").rstrip("/") + "/"
 _ak = urlparse(AUTHENTIK_ISSUER)
-_AUTHENTIK_ROOT = f"{_ak.scheme}://{_ak.netloc}" if _ak.netloc else ""
+# Fail fast + loud: a missing/malformed issuer would otherwise yield invalid
+# OAuth endpoints (e.g. "/jwks/") that only break at sign-in time, far from here.
+if _ak.scheme not in ("http", "https") or not _ak.netloc:
+    raise RuntimeError(
+        "AUTHENTIK_ISSUER must be the full OIDC issuer URL, e.g. "
+        "https://auth.krg.ucsd.edu/application/o/fishsense-analytics/ — got "
+        f"{os.environ.get('AUTHENTIK_ISSUER')!r}. It is rendered into app.env from "
+        "secret/tenants/fishsense/oidc/analytics.issuer_url (secrets.nix)."
+    )
+_AUTHENTIK_ROOT = f"{_ak.scheme}://{_ak.netloc}"
 
 DATABASE_DIALECT = os.getenv("DATABASE_DIALECT")
 DATABASE_USER = os.getenv("DATABASE_USER")

--- a/deploy/incus/superset_volumes/docker/pythonpath/superset_config.py
+++ b/deploy/incus/superset_volumes/docker/pythonpath/superset_config.py
@@ -1,0 +1,214 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# This file is included in the final Docker image and SHOULD be overridden when
+# deploying the image to prod. Settings configured here are intended for use in local
+# development environments. Also note that superset_config_docker.py is imported
+# as a final step as a means to override "defaults" configured here
+#
+import logging
+import os
+import sys
+from urllib.parse import urlparse
+
+from celery.schedules import crontab
+from flask_caching.backends.filesystemcache import FileSystemCache
+
+from flask_appbuilder.security.manager import AUTH_OAUTH
+
+logger = logging.getLogger()
+
+# Incus deploy: OIDC endpoints are derived from the platform-provided issuer
+# (AUTHENTIK_ISSUER = secret/tenants/fishsense/oidc/analytics.issuer_url, rendered
+# into app.env by secrets.nix) rather than hardcoded at auth.fabricant. The issuer
+# is the app-specific base (https://<host>/application/o/<slug>/); the token/authorize
+# endpoints live at the Authentik root (https://<host>/application/o/...).
+AUTHENTIK_ISSUER = os.environ.get("AUTHENTIK_ISSUER", "").rstrip("/") + "/"
+_ak = urlparse(AUTHENTIK_ISSUER)
+_AUTHENTIK_ROOT = f"{_ak.scheme}://{_ak.netloc}" if _ak.netloc else ""
+
+DATABASE_DIALECT = os.getenv("DATABASE_DIALECT")
+DATABASE_USER = os.getenv("DATABASE_USER")
+DATABASE_PASSWORD = os.getenv("DATABASE_PASSWORD")
+DATABASE_HOST = os.getenv("DATABASE_HOST")
+DATABASE_PORT = os.getenv("DATABASE_PORT")
+DATABASE_DB = os.getenv("DATABASE_DB")
+
+# EXAMPLES_USER = os.getenv("EXAMPLES_USER")
+# EXAMPLES_PASSWORD = os.getenv("EXAMPLES_PASSWORD")
+# EXAMPLES_HOST = os.getenv("EXAMPLES_HOST")
+# EXAMPLES_PORT = os.getenv("EXAMPLES_PORT")
+# EXAMPLES_DB = os.getenv("EXAMPLES_DB")
+
+# The SQLAlchemy connection string.
+SQLALCHEMY_DATABASE_URI = (
+    f"{DATABASE_DIALECT}://"
+    f"{DATABASE_USER}:{DATABASE_PASSWORD}@"
+    f"{DATABASE_HOST}:{DATABASE_PORT}/{DATABASE_DB}"
+)
+
+# # Use environment variable if set, otherwise construct from components
+# # This MUST take precedence over any other configuration
+# SQLALCHEMY_EXAMPLES_URI = os.getenv(
+#     "SUPERSET__SQLALCHEMY_EXAMPLES_URI",
+#     (
+#         f"{DATABASE_DIALECT}://"
+#         f"{EXAMPLES_USER}:{EXAMPLES_PASSWORD}@"
+#         f"{EXAMPLES_HOST}:{EXAMPLES_PORT}/{EXAMPLES_DB}"
+#     ),
+# )
+
+
+REDIS_HOST = os.getenv("REDIS_HOST", "redis")
+REDIS_PORT = os.getenv("REDIS_PORT", "6379")
+REDIS_CELERY_DB = os.getenv("REDIS_CELERY_DB", "0")
+REDIS_RESULTS_DB = os.getenv("REDIS_RESULTS_DB", "1")
+
+RESULTS_BACKEND = FileSystemCache("/app/superset_home/sqllab")
+
+CACHE_CONFIG = {
+    "CACHE_TYPE": "RedisCache",
+    "CACHE_DEFAULT_TIMEOUT": 300,
+    "CACHE_KEY_PREFIX": "superset_",
+    "CACHE_REDIS_HOST": REDIS_HOST,
+    "CACHE_REDIS_PORT": REDIS_PORT,
+    "CACHE_REDIS_DB": REDIS_RESULTS_DB,
+}
+DATA_CACHE_CONFIG = CACHE_CONFIG
+THUMBNAIL_CACHE_CONFIG = CACHE_CONFIG
+
+
+class CeleryConfig:
+    broker_url = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_CELERY_DB}"
+    imports = (
+        "superset.sql_lab",
+        "superset.tasks.scheduler",
+        "superset.tasks.thumbnails",
+        "superset.tasks.cache",
+    )
+    result_backend = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_RESULTS_DB}"
+    worker_prefetch_multiplier = 1
+    task_acks_late = False
+    beat_schedule = {
+        "reports.scheduler": {
+            "task": "reports.scheduler",
+            "schedule": crontab(minute="*", hour="*"),
+        },
+        "reports.prune_log": {
+            "task": "reports.prune_log",
+            "schedule": crontab(minute=10, hour=0),
+        },
+    }
+
+
+CELERY_CONFIG = CeleryConfig
+
+SLACK_API_TOKEN = os.getenv("SLACK_API_TOKEN", "")
+
+SMTP_HOST = "smtp.ucsd.edu" # change to your host
+SMTP_PORT = 25 # your port, e.g. 587
+SMTP_STARTTLS = False
+SMTP_SSL_SERVER_AUTH = False # If you're using an SMTP server with a valid certificate
+SMTP_SSL = False
+SMTP_MAIL_FROM = os.getenv("SMTP_MAIL_FROM", "")
+SMTP_USER = None
+SMTP_PASSWORD = None
+EMAIL_NOTIFICATIONS = True
+EMAIL_REPORTS_SUBJECT_PREFIX = "[Superset] "
+
+FEATURE_FLAGS = {
+  "ALERT_REPORTS": True,
+  "ALERT_REPORT_SLACK_V2": True,  # use the v2 upload path
+}
+ALERT_REPORTS_NOTIFICATION_DRY_RUN = False
+
+WEBDRIVER_BASEURL = f"http://fishsense_superset:8088{os.environ.get('SUPERSET_APP_ROOT', '/')}/"  # When using docker compose baseurl should be http://superset_nginx{ENV{BASEPATH}}/  # noqa: E501
+# The base URL for the email report hyperlinks.
+WEBDRIVER_BASEURL_USER_FRIENDLY = (
+    f"http://fishsense_superset:8088{os.environ.get('SUPERSET_APP_ROOT', '/')}/"
+)
+WEBDRIVER_TYPE = "chrome"
+WEBDRIVER_OPTION_ARGS = [
+    "--headless=new",
+    "--no-sandbox",
+    "--disable-dev-shm-usage",
+    "--disable-gpu",
+    "--window-size=1920,1080",
+]
+SQLLAB_CTAS_NO_LIMIT = True
+ENABLE_PROXY_FIX = True
+
+log_level_text = os.getenv("SUPERSET_LOG_LEVEL", "INFO")
+LOG_LEVEL = getattr(logging, log_level_text.upper(), logging.INFO)
+
+# Set the authentication type to OAuth
+AUTH_TYPE = AUTH_OAUTH
+
+OAUTH_PROVIDERS = [
+    {
+        'name': 'authentik',
+        'icon': 'fa-address-card',
+        'token_key': 'access_token',
+        'remote_app': {
+            'client_id': os.environ.get('AUTHENTIK_KEY'),
+            'client_secret': os.environ.get('AUTHENTIK_SECRET'),
+            'api_base_url': AUTHENTIK_ISSUER,
+            'client_kwargs':{
+              'scope': 'email profile'
+            },
+            'jwks_uri': f'{AUTHENTIK_ISSUER}jwks/',
+            'request_token_url': None,
+            'access_token_url': f'{_AUTHENTIK_ROOT}/application/o/token/',
+            'authorize_url': f'{_AUTHENTIK_ROOT}/application/o/authorize/'
+        }
+    }
+]
+
+# Will allow user self registration, allowing to create Flask users from Authorized User
+AUTH_USER_REGISTRATION = True
+ALLOW_LOCAL_USER_LOGIN = True 
+
+# The default user self registration role
+AUTH_USER_REGISTRATION_ROLE = "Public"
+
+WEBDRIVER_AUTH = {"username": os.getenv("WEBDRIVER_AUTH_USERNAME", ""), "password":  os.getenv("WEBDRIVER_AUTH_PASSWORD", "")}
+
+if os.getenv("CYPRESS_CONFIG") == "true":
+    # When running the service as a cypress backend, we need to import the config
+    # located @ tests/integration_tests/superset_test_config.py
+    base_dir = os.path.dirname(__file__)
+    module_folder = os.path.abspath(
+        os.path.join(base_dir, "../../tests/integration_tests/")
+    )
+    sys.path.insert(0, module_folder)
+    from superset_test_config import *  # noqa
+
+    sys.path.pop(0)
+
+#
+# Optionally import superset_config_docker.py (which will have been included on
+# the PYTHONPATH) in order to allow for local settings to be overridden
+#
+try:
+    import superset_config_docker
+    from superset_config_docker import *  # noqa: F403
+
+    logger.info(
+        f"Loaded your Docker configuration at [{superset_config_docker.__file__}]"
+    )
+except ImportError:
+    logger.info("Using default Docker config...")

--- a/deploy/incus/superset_volumes/docker/requirements-local.txt
+++ b/deploy/incus/superset_volumes/docker/requirements-local.txt
@@ -1,0 +1,4 @@
+Authlib==1.6.11
+pillow==12.2.0
+selenium==4.38.0
+psycopg2-binary==2.9.11

--- a/deploy/incus/traefik-dynamic.yml
+++ b/deploy/incus/traefik-dynamic.yml
@@ -88,6 +88,13 @@ http:
     fishsense-auth:
       forwardAuth:
         address: "http://authentik-outpost:9000/outpost.goauthentik.io/auth/traefik"
+        # Required (HANDOFF §7): the outpost selects the fishsense_orchestrator
+        # provider by X-Forwarded-Host and builds sign-in redirects from it, so it
+        # must see the real public Host (api.fishsense.e4e.ucsd.edu), not this
+        # Traefik's internal view. Safe here because the ONLY ingress to this
+        # Traefik is the e4e edge (public → edge → krg-nat forward → :443), which
+        # sets these headers — no untrusted client path. Setting false re-introduces
+        # the wrong-Host redirect/cookie breakage Option A exists to avoid.
         trustForwardHeader: true
         authResponseHeaders:
           - X-authentik-username

--- a/deploy/incus/traefik-dynamic.yml
+++ b/deploy/incus/traefik-dynamic.yml
@@ -1,0 +1,98 @@
+# Traefik file-provider dynamic config for the fishsense-lite interior.
+#
+# Loaded by the inner traefik (compose.yml `--providers.file.filename`). Three
+# concerns: (1) serve the vault-agent `fishsense.vm` cert on :443 for every
+# route — the edge re-encrypts to us and verifies serverName=fishsense.vm
+# regardless of the public Host; (2) route Host → container; (3) reproduce the
+# old `authentik@docker` gate on the orchestrator router only, as a forwardAuth
+# middleware to the krg-prod Authentik proxy outpost (HANDOFF §7).
+
+tls:
+  # Single cert served for all routers. `fishsense.vm.{crt,key}` is rendered by
+  # the in-instance vault-agent to /run/tenant/tls (mounted read-only). It is
+  # the default cert, so the edge's re-encrypt handshake (SNI=fishsense.vm)
+  # always matches.
+  stores:
+    default:
+      defaultCertificate:
+        certFile: /etc/traefik/tls/fishsense.vm.crt
+        keyFile: /etc/traefik/tls/fishsense.vm.key
+  certificates:
+    - certFile: /etc/traefik/tls/fishsense.vm.crt
+      keyFile: /etc/traefik/tls/fishsense.vm.key
+
+http:
+  routers:
+    # Public landing + /portal (auth is in-app OIDC — no edge/traefik gate).
+    web:
+      rule: "Host(`fishsense.e4e.ucsd.edu`)"
+      entryPoints: [websecure]
+      service: web
+      tls: {}
+
+    # The outpost's own browser paths (sign-in redirect + callback) — served by the
+    # CO-LOCATED outpost so the handshake completes on api.fishsense's own domain
+    # (correct cookie domain). MUST out-prioritize the `api` router for this prefix;
+    # un-gated (the outpost is what does the gating). Higher priority via the longer
+    # rule, pinned explicitly for safety.
+    api-outpost:
+      rule: "Host(`api.fishsense.e4e.ucsd.edu`) && PathPrefix(`/outpost.goauthentik.io/`)"
+      entryPoints: [websecure]
+      service: authentik-outpost
+      priority: 100
+      tls: {}
+
+    # API — gated by the co-located Authentik proxy outpost (forward_single). The
+    # FishSense-group access policy lives on the `fishsense_orchestrator` proxy
+    # provider (external_host = https://api.fishsense.e4e.ucsd.edu, set platform-side
+    # #437). Direct replacement for the old authentik@docker middleware.
+    api:
+      rule: "Host(`api.fishsense.e4e.ucsd.edu`)"
+      entryPoints: [websecure]
+      service: api
+      middlewares: [fishsense-auth]
+      priority: 10
+      tls: {}
+
+    # Superset analytics — auth is in-app OIDC (fishsense_analytics provider).
+    superset:
+      rule: "Host(`analytics.fishsense.e4e.ucsd.edu`)"
+      entryPoints: [websecure]
+      service: superset
+      tls: {}
+
+  services:
+    web:
+      loadBalancer:
+        servers:
+          - url: "http://web:3000"
+    api:
+      loadBalancer:
+        servers:
+          - url: "http://fishsense-api:8000"
+    superset:
+      loadBalancer:
+        servers:
+          - url: "http://superset:8088"
+    authentik-outpost:
+      loadBalancer:
+        servers:
+          - url: "http://authentik-outpost:9000"
+
+  middlewares:
+    # forwardAuth → the CO-LOCATED Authentik outpost (compose service
+    # `authentik-outpost`), which dials krg-prod Authentik over a websocket and
+    # validates the session against the fishsense_orchestrator provider, returning
+    # the identity headers below or 302ing to the login flow. Local address (same
+    # interior network) — HANDOFF §7 / #440, structurally identical to guacamole_gate.
+    fishsense-auth:
+      forwardAuth:
+        address: "http://authentik-outpost:9000/outpost.goauthentik.io/auth/traefik"
+        trustForwardHeader: true
+        authResponseHeaders:
+          - X-authentik-username
+          - X-authentik-groups
+          - X-authentik-email
+          - X-authentik-name
+          - X-authentik-uid
+          - X-authentik-jwt

--- a/deploy/incus/worker_volumes/api_worker/config/settings.toml
+++ b/deploy/incus/worker_volumes/api_worker/config/settings.toml
@@ -1,0 +1,53 @@
+# fishsense-api-workflow-worker — Incus interior settings.
+#
+# Non-secret config only. Secrets (.secrets.toml, nrp.kubeconfig) are rendered
+# alongside this file by the in-instance vault-agent from secret/tenants/fishsense/*.
+#
+# DIFF vs the old orchestrator settings.toml: [temporal] now points at the
+# shared krg-prod cluster instead of the in-stack `fishsense-temporal`.
+
+[general]
+max_workers = 8
+
+# krg-prod shared Temporal (HANDOFF §6). mTLS-only; the gRPC TLS server-name is
+# overridden to workflows.krg.ucsd.edu even though we dial krg-prod.ucsd.edu.
+# The client cert/key/CA are rendered by the in-instance vault-agent.
+# PLATFORM TODO: `temporal-client` cert delivery is not wired yet — our AppRole
+# only grants `tenant-internal` (fishsense.vm) today. The worker will fail to
+# connect until these three files exist. See README §Temporal.
+[temporal]
+host = "krg-prod.ucsd.edu"
+port = "7233"
+tls = true
+client_cert = "/run/tenant/temporal/tls.crt"
+client_private_key = "/run/tenant/temporal/tls.key"
+domain = "workflows.krg.ucsd.edu"           # TLS server-name override (SNI)
+server_root_ca_cert = "/run/tenant/temporal/ca.crt"
+
+[label_studio]
+url = "https://labeler.e4e.ucsd.edu"
+
+[e4e_nas]
+url = "https://e4e-nas.ucsd.edu:6021"
+
+# Interior-network URL for SDK calls into fishsense-api — same compose network,
+# bypasses our traefik + the API forwardAuth gate.
+[fishsense_api]
+url = "http://fishsense-api:8000"
+
+# Hosted Garage (S3-compatible) object store on the NAS. S3 keys authenticate
+# from any IP (open egress NAT reaches it). access_key/secret_key in .secrets.toml.
+[object_store]
+endpoint_url = "https://garage.fishsense.e4e.ucsd.edu"
+region = "garage"
+bucket = "fishsense"
+
+# NRP data-worker scale-to-zero. Enabled here because the data-worker runs on
+# NRP/Kubernetes and the api-worker owns its replica count. The kubeconfig is
+# rendered by vault-agent next to this file.
+[kubernetes]
+kubeconfig_path = "/e4efs/config/nrp.kubeconfig"
+namespace = "fishsense"
+deployment_name = "fishsense-data-processing-workflow-worker"
+active_replicas = 1
+idle_cooldown_minutes = 15

--- a/deploy/incus/worker_volumes/backup_worker/config/settings.toml
+++ b/deploy/incus/worker_volumes/backup_worker/config/settings.toml
@@ -1,0 +1,42 @@
+# fishsense-backup-worker — Incus interior settings.
+#
+# Non-secret config only. Postgres + NAS credentials come from the vault-agent-
+# rendered .secrets.toml alongside this file (secret/tenants/fishsense/*).
+#
+# DIFF vs the old orchestrator settings.toml:
+#   * [temporal] repointed at the shared krg-prod cluster (see api-worker).
+#   * [backup].databases drops `temporal_db` — Temporal is external now, so its
+#     DB no longer lives in our in-slot Postgres. Only `fishsense` + `superset`.
+
+[general]
+max_workers = 8
+
+# krg-prod shared Temporal (HANDOFF §6, ADR 0023). Same client cert the
+# vault-agent renders for the api-worker.
+[temporal]
+host = "krg-prod.ucsd.edu"
+port = "7233"
+tls = true
+client_cert = "/run/tenant/temporal/tls.crt"
+client_private_key = "/run/tenant/temporal/tls.key"
+domain = "workflows.krg.ucsd.edu"           # TLS server-name override (SNI)
+server_root_ca_cert = "/run/tenant/temporal/ca.crt"
+
+# In-slot Postgres (compose service `postgres`, interior network).
+[postgres]
+host = "postgres"
+port = 5432
+username = "backup"
+
+[e4e_nas]
+# Synology DSM URL — hostname AND port. DB dumps are written here (distinct from
+# the retired object-store share; this is the backup path, not process-work).
+url = "https://e4e-nas.ucsd.edu:6021"
+
+[backup]
+databases = ["fishsense", "superset"]       # temporal_db dropped — now on krg-prod
+retention_count = 14
+nas_root_path = "/fishsense_process_work/database_backups"
+schedule_id = "fishsense-daily-db-backup"
+schedule_cron = "0 3 * * *"
+task_queue = "fishsense_backup_queue"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,11 @@ synology-filestation = { url = "https://github.com/UCSD-E4E/synology-filestation
 # `[tool.pylint.*]` section.
 [tool.pylint.main]
 extension-pkg-allow-list = ["cv2"]
+# `deploy/` is deployment config + vendored third-party (e.g. Apache Superset's
+# stock `superset_config.py`, which isn't pylint-clean by our standards), not
+# first-party package code — exclude it. The changed-files pylint job passes
+# file paths explicitly, and pylint honors `ignore-paths` for those too.
+ignore-paths = ["^deploy/.*$"]
 
 [tool.pylint."messages control"]
 # fail-under=10 with all checks on is unworkable for a real codebase;


### PR DESCRIPTION
## What

The **running half** of the fishsense-lite interior for the KRG Incus platform (tenant #1) — the compose stack + all committed service config. Companion to #222 (the flake in #222 references this `compose.yml`).

### Stack (`compose.yml` + `traefik-dynamic.yml`)
- `web`, `fishsense-api`, `superset` (+init/worker/beat + **valkey**), `fishsense-api-workflow-worker`, `fishsense-backup-worker`, `postgres`, an **inner traefik** (file provider, serves `fishsense.vm` on :443), and a **co-located Authentik proxy outpost** (Option A, krg-infra #440 — completes the API forward-auth on `api.fishsense`'s own domain).
- Workers → **krg-prod Temporal** (mTLS, certs at `/run/tenant/temporal/`). Garage-on-NAS via S3. Persistent data on named volumes. Secrets via `env_file` from the vault-agent render (#222's `secrets.nix`).

### Ported service config (self-contained under `deploy/incus/`)
- `pg_volumes/config/{postgres.conf,pg_hba.conf}`; `pg_volumes/scripts/README.md` (restore-based bootstrap — no init SQL).
- `superset_volumes/docker/*` — `superset_config.py` OIDC now derives from the platform `AUTHENTIK_ISSUER` (was hardcoded to `auth.fabricant`); `.env` points superset at `valkey`.
- `fishsense_api_volumes` + `worker_volumes` `settings.toml` — Temporal → krg-prod, Postgres → in-slot.

### Image pins (latest)
| image | pin | note |
|---|---|---|
| postgres | **17.10** | 16→17 via restore; backup worker's `pg_dump` client is pg17 (trixie) |
| valkey | **9.1.0** | Redis swapped for its BSD-licensed OSS fork (drop-in) |
| traefik | 3.7.6 | latest 3.x |
| superset | 6.0.0 | latest stable |
| `ghcr.io/ucsd-e4e/*` | latest releases | already current |
| goauthentik/proxy | 2026.2 | tracks krg-prod's Authentik version (not "latest") |

## Notes
- **DB bootstrap = restore** a prod `pg_dump` into `pgdata` (roles + passwords from the dump; seed OpenBao to match). See `pg_volumes/scripts/README.md`.
- `deploy/incus/` is inert staging until cutover, so merge order vs #222 doesn't matter.
- Remaining operator items (seed OpenBao, CNAMEs, NRP Temporal PEM, validate sign-in) are in `deploy/incus/README.md`. Observability deferred: #220 / #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
