### PR TITLE
feat(incus): activate — flake.nix to repo root (Phase 4)

### DIFF
--- a/deploy/incus/README.md
+++ b/deploy/incus/README.md
@@ -2,16 +2,19 @@
 
 This directory is the **repo-owned interior** for fishsense as tenant #1 on the
 KRG Incus platform (ADR 0017 / 0020). The platform runs this compose stack on
-our Incus slot (`10.100.0.10`); a merged `auto-deploy/*` PR converges the
-instance via `fishsense-selfupdate` → `nixos-rebuild switch --flake
-github:UCSD-E4E/fishsense-lite#fishsense`.
+our Incus slot (`10.100.0.10`); `fishsense-selfupdate` converges the instance via
+`nixos-rebuild switch --flake github:UCSD-E4E/fishsense-lite#fishsense`, reading
+the repo-root [`flake.nix`](../../flake.nix) which imports this directory.
 
 Upstream hand-off:
 <https://github.com/KastnerRG/krg-infra/tree/main/docs/handoff/fishsense-lite>
 
-> **Status: skeleton / staging.** Staged under `deploy/incus/` so it does not
-> clobber the running orchestrator-host stack (the sibling `deploy/compose*.yml`)
-> before cutover. At cutover the flake's `mkTenant` `compose = ` points here.
+> **Status: activated flake, pre-bootstrap.** The `flake.nix` is at the repo root
+> (activation done); `compose.yml` + config + `secrets.nix` + `hardware-configuration.nix`
+> live here and are referenced by root-relative paths. `auto-deploy.yml` is **not**
+> wired into `.github/workflows/` yet — its trigger needs to not collide with the
+> existing `auto-deploy/*` deploy pipeline (see the status section). First bring-up
+> is the admin's one-time `nixos-rebuild switch`, which doesn't need it.
 
 ## What runs here
 
@@ -75,10 +78,10 @@ backup-worker alike).
 ## Secrets (HANDOFF §9 — vault-agent renders, `secret/tenants/fishsense/*`)
 
 Nothing secret is committed. `nixosModules.tenant` renders only the **certs**;
-`secrets.nix` (in the companion pipeline PR — `deploy/incus/secrets.nix`, moved to
-repo-root `secrets.nix` at activation) extends `krg.vaultAgent.renders` to produce
-one consolidated **`/run/tenant/secrets/app.env`**, `env_file`-mounted into the
-services that need it. Vault-agent is **fail-closed** — seed every referenced
+`deploy/incus/secrets.nix` (imported by the repo-root `flake.nix`) extends
+`krg.vaultAgent.renders` to produce one consolidated
+**`/run/tenant/secrets/app.env`**, `env_file`-mounted into the services that need
+it. Vault-agent is **fail-closed** — seed every referenced
 path before the first converge or the stack won't start.
 
 **Vault-agent render targets:**
@@ -126,11 +129,17 @@ into the `pgdata` volume (roles + passwords come from the dump); seed OpenBao to
 ## Status — resolved vs. remaining
 
 **Resolved (baked into these files):**
-- ✅ `flake.nix` — pinned rev `2554daa` (incl. #435–#440, #443), `temporal` opt-in, quota 6/12.
+- ✅ `flake.nix` — **at the repo root** (activation done), pinned rev `2554daa`
+  (incl. #435–#440, #443), `temporal` opt-in, quota 6/12; imports this dir by root-relative paths.
 - ✅ `hardware-configuration.nix` — captured on-box, imported by the flake.
   (⚠️ instance-specific disk UUIDs; durable fix = label-keyed golden profile, ADR 0022 §4.)
 - ✅ `secrets.nix` — §9 app-secret renders (`app.env` + `backup-postgres.env` + soft `token.env`).
-- ✅ `auto-deploy.yml` — runner trigger, `runs-on: [self-hosted, fishsense]`.
+- ⏸️ `auto-deploy.yml` — **not yet wired into `.github/workflows/`.** The handoff's
+  `on: push: auto-deploy/**` collides with this monorepo's existing deploy pipeline
+  (`deploy.yml` fires on `auto-deploy/*`; `promote.yml` *creates* those branches), so
+  it would converge the incus instance on unrelated releases. Needs a scoped trigger
+  (or `workflow_dispatch`) — decision pending. Not needed for first bring-up (admin
+  bootstraps manually).
 - ✅ **Option A co-located outpost** (`authentik-outpost`, image `2026.2`) — matches HANDOFF §7.
   Platform IaC **landed** (#440): dedicated `fishsense_proxy` outpost, token →
   `oidc/proxy-outpost-token`, soft-rendered (`errorOnMissingKey=false`).

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,9 @@
 # fishsense-lite deploy target — INTERIOR half of the mkTenant contract (ADR 0020).
 #
-# STAGING NOTE: at cutover this file moves to the REPO ROOT as `flake.nix` (that's
-# where `fishsense-selfupdate` fetches it: `nixos-rebuild switch --flake
-# github:UCSD-E4E/fishsense-lite#fishsense`). It's kept here under deploy/incus/
-# during staging so it doesn't collide with the old orchestrator deploy. The
-# `compose = ` path below is written ROOT-RELATIVE for that final location.
+# This is the REPO-ROOT flake that `fishsense-selfupdate` builds on the Incus slot:
+# `nixos-rebuild switch --flake github:UCSD-E4E/fishsense-lite#fishsense`. The rest
+# of the interior (compose, config, secrets.nix, hardware-configuration.nix) lives
+# under `deploy/incus/`; this flake references it by root-relative paths.
 {
   description = "fishsense-lite — KRG Incus platform tenant #1";
 
@@ -42,9 +41,6 @@
         ram = "12GiB";
       };
       image = "krg-golden"; # slot boots from the hardened template (already applied)
-      # ROOT-relative path: correct once this flake lives at the repo root (the
-      # activation move — see STAGING NOTE header). NOT evaluated from the staging
-      # location; the runner only builds via `#fishsense` after activation.
       compose = ./deploy/incus/compose.yml; # YOUR interior — repo-owns-deploy
       repo = "UCSD-E4E/fishsense-lite"; # LOAD-BEARING: scopes the auto-provisioned runner (ADR 0022)
       # In-VM vault-agent renders a `fishsense-worker` Temporal client cert to
@@ -61,8 +57,8 @@
       modules = [
         krg-infra.nixosModules.tenant
         {krg.tenant = tenant;}
-        ./hardware-configuration.nix # captured on-box 2026-07-07; ⚠ instance-specific disk UUIDs (re-capture if the slot is reprovisioned)
-        ./secrets.nix # extends krg.vaultAgent.renders → /run/tenant/secrets/app.env (HANDOFF §9)
+        ./deploy/incus/hardware-configuration.nix # captured on-box 2026-07-07; ⚠ instance-specific disk UUIDs (re-capture if the slot is reprovisioned)
+        ./deploy/incus/secrets.nix # extends krg.vaultAgent.renders → /run/tenant/secrets/app.env (HANDOFF §9)
       ];
     };
 


### PR DESCRIPTION
## What

**Phase 4 activation** of the Incus interior (follows #222 + #223). `fishsense-selfupdate` on the slot runs `nixos-rebuild switch --flake github:UCSD-E4E/fishsense-lite#fishsense`, which requires `flake.nix` **at the repo root** — so this moves it there.

- `deploy/incus/flake.nix` → **`flake.nix`** (git rename, history preserved).
- Imports repointed to keep the rest of the interior organized under `deploy/incus/`:
  - `compose = ./deploy/incus/compose.yml`
  - `imports = ./deploy/incus/{hardware-configuration,secrets}.nix`
- README updated to match (flake at root; secrets/hardware stay under `deploy/incus/`).

Verified: `flake.nix` parses, all three referenced paths resolve from the repo root.

## Deliberately **not** included: wiring `auto-deploy.yml`

The handoff's `auto-deploy.yml` uses `on: push: auto-deploy/**`. This monorepo **already uses that branch namespace** — `deploy.yml` fires on `auto-deploy/*` (catch-all → orchestrator) and `promote.yml` *creates* `auto-deploy/<pkg>-<ver>` branches on every release. Wiring the incus workflow as-is would converge the Incus instance on **unrelated releases**.

So `auto-deploy.yml` stays under `deploy/incus/` for now. Its trigger needs a scoped design (e.g. `workflow_dispatch`, or a dedicated non-`auto-deploy/*` branch pattern) — tracked as a follow-up. **First bring-up doesn't need it** — the admin's one-time `nixos-rebuild switch` on the slot installs the runner and converges the interior.

## After this merges
Remaining to first light: admin one-time bootstrap → restore the DB into `pgdata` → validate (traefik serves `fishsense.vm`, the `api.fishsense` sign-in round-trip). See `deploy/incus/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
