### PR TITLE
fix(ci): integration — LS S3 endpoint reachable from the LS container

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -125,6 +125,14 @@ jobs:
         working-directory: apps/fishsense-lite-web
         run: npm ci --no-audit --no-fund
 
+      - name: Alias `garage` to loopback for host-side S3 clients
+        # The object-store endpoint (below) is `http://garage:3900` so the Label
+        # Studio *container* can reach it via docker DNS. This maps the same name
+        # to the host's published :3900 port so the pytest/worker S3 clients that
+        # run on the runner host resolve it too — one endpoint string that works
+        # from both sides. See tests/_object_store_itest.py + populate_utils.
+        run: echo "127.0.0.1 garage" | sudo tee -a /etc/hosts
+
       - name: Run integration suite
         env:
           # Map the docker-internal hostnames the test fixtures fall
@@ -146,11 +154,15 @@ jobs:
           # CLAUDE.md "Worker config validation gotcha").
           E4EFS_LABEL_STUDIO__URL: http://localhost:8082
           E4EFS_LABEL_STUDIO__API_KEY: fishsense_local_test_token_42
-          # Garage object store via its published port. Creds match the
-          # fixed key garage-init imports. The data-worker integration
-          # tests (tests/_object_store_itest.py) and the api-worker's
-          # eager config validation both read these.
-          E4EFS_OBJECT_STORE__ENDPOINT_URL: http://localhost:3900
+          # Garage object store. Use the docker-network name `garage:3900`, NOT
+          # `localhost:3900`: this endpoint is handed to the Label Studio
+          # *container* (populate_utils.ensure_label_studio_s3_storage passes it
+          # as the storage `s3endpoint`, which LS validates with `head_bucket`),
+          # and a container can't reach the host's localhost. The "Alias garage to
+          # loopback" step above lets the host-side pytest/worker S3 clients
+          # resolve the same name to the published :3900 port. Creds match the
+          # fixed key garage-init imports.
+          E4EFS_OBJECT_STORE__ENDPOINT_URL: http://garage:3900
           E4EFS_OBJECT_STORE__REGION: garage
           E4EFS_OBJECT_STORE__BUCKET: fishsense
           E4EFS_OBJECT_STORE__ACCESS_KEY: GK31c2f3a4b5c6d7e8f9a0b1c2

--- a/services/fishsense-data-processing-workflow-worker/tests/_object_store_itest.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/_object_store_itest.py
@@ -7,8 +7,10 @@ addressing, as Garage requires) and seed the worker's
 bucket.
 
 Defaults match the `garage` service + the fixed key imported by
-`garage-init` in compose.local.yml (in-cluster hostname). CI overrides
-`E4EFS_OBJECT_STORE__ENDPOINT_URL` to the host-published `localhost:3900`.
+`garage-init` in compose.local.yml (in-cluster hostname). CI sets
+`E4EFS_OBJECT_STORE__ENDPOINT_URL` to `http://garage:3900` and aliases
+`garage` → 127.0.0.1 on the runner (so the same endpoint string resolves
+from both the host and the Label Studio container — see integration.yml).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Problem (surfaced on #208's integration run)

The integration suite fails on the Label Studio S3-storage registration:

```
ensure_label_studio_s3_storage → ls.import_storage.s3.create(s3endpoint=object_store.endpoint_url)
→ LS validate_connection → head_bucket("fishsense")
→ EndpointConnectionError: Could not connect to "http://localhost:3900/fishsense" (Connection refused)
```

`populate_utils.py` hands the object-store `endpoint_url` to Label Studio as the storage `s3endpoint`. integration.yml set it to **`http://localhost:3900`** (the host-published Garage port, correct for the host-side pytest). But **Label Studio runs as a container** — its `localhost` is itself, not Garage — so LS's `head_bucket` validation is refused.

**Not a #208 regression, not a prod issue.** Integration is label-gated (rarely runs), so this latent harness bug went unnoticed; in prod Garage is one public endpoint reachable by both the worker and LS.

## Fix (CI-only)

Use the docker-network name `http://garage:3900` for the endpoint (reachable from the LS container via docker DNS), and alias `garage → 127.0.0.1` on the runner so the **host-side** pytest/worker S3 clients resolve the same name to the published `:3900` port. One endpoint string, reachable from both sides.

- `.github/workflows/integration.yml`: endpoint → `garage:3900` + a `/etc/hosts` alias step (ordered before the test run).
- `_object_store_itest.py`: doc comment updated to match.

Once this lands on `main`, #208 (and any label-gated PR) picks it up on the next integration run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
