### PR TITLE
fix(incus): pin authentik outpost image to krg-prod's 2026.5.3

### DIFF
--- a/deploy/incus/README.md
+++ b/deploy/incus/README.md
@@ -140,7 +140,8 @@ into the `pgdata` volume (roles + passwords come from the dump); seed OpenBao to
   it would converge the incus instance on unrelated releases. Needs a scoped trigger
   (or `workflow_dispatch`) — decision pending. Not needed for first bring-up (admin
   bootstraps manually).
-- ✅ **Option A co-located outpost** (`authentik-outpost`, image `2026.2`) — matches HANDOFF §7.
+- ✅ **Option A co-located outpost** (`authentik-outpost`, image `2026.5.3` — matches
+  krg-prod's Authentik server per krg-infra `compose.authentik.yml`) — HANDOFF §7.
   Platform IaC **landed** (#440): dedicated `fishsense_proxy` outpost, token →
   `oidc/proxy-outpost-token`, soft-rendered (`errorOnMissingKey=false`).
 - ✅ API renamed `orchestrator.` → `api.fishsense.e4e.ucsd.edu`; provider `external_host`
@@ -154,8 +155,8 @@ into the `pgdata` volume (roles + passwords come from the dump); seed OpenBao to
    switch returns non-zero but is recoverable: seed, re-run the switch). Seed **all**
    the `WE seed` KV paths above before the admin's first `nixos-rebuild switch`.
    Do **not** seed `oidc/*` (platform-written; the outpost token renders soft anyway).
-2. **Pin the outpost image** to krg-prod's Authentik server version (currently `2026.2`),
-   and **validate the sign-in round-trip** once the API route is up.
+2. **Validate the sign-in round-trip** once the API route is up (the outpost image is
+   pinned to krg-prod's Authentik `2026.5.3`; bump both together on Authentik upgrades).
 3. **File CNAMEs** `api.` + `analytics.` → e4e-prod, confirm they resolve, then let
    #437's SAN re-issue run (staging ACME first, confirm, then off — like the apex).
 4. **Apply the quota/disk raise + restart** the instance (6/12 + 50 GiB now merged, #436/#439).

--- a/deploy/incus/compose.yml
+++ b/deploy/incus/compose.yml
@@ -51,7 +51,7 @@ services:
   # `fishsense_proxy` outpost whose API token is written to
   # secret/tenants/fishsense/oidc/proxy-outpost-token.
   authentik-outpost:
-    image: ghcr.io/goauthentik/proxy:2026.2   # keep in step with krg-prod's Authentik server version
+    image: ghcr.io/goauthentik/proxy:2026.5.3   # matches krg-prod's Authentik server (krg-infra compose.authentik.yml); bump together
     restart: unless-stopped
     environment:
       AUTHENTIK_HOST: https://auth.krg.ucsd.edu


### PR DESCRIPTION
Resolves the go-live loose end **A2** (outpost image must match krg-prod's Authentik server).

krg-prod runs Authentik **2026.5.3** — krg-infra `nix/docker-compose/krg-prod/compose.authentik.yml` pins `ghcr.io/goauthentik/{server,proxy}:2026.5.3`. Our co-located proxy outpost was pinned to the placeholder `2026.2`; a version skew between the outpost and the server breaks the outpost's API/websocket handshake.

- `deploy/incus/compose.yml`: `authentik-outpost` image `2026.2` → **`2026.5.3`**.
- README: status + remaining-items updated (image now pinned; only the sign-in round-trip validation remains for that item).

Bump both together on future Authentik upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)