### PR TITLE
fix(incus): Label Studio → hosted app.heartex.com

### DIFF
--- a/deploy/incus/compose.yml
+++ b/deploy/incus/compose.yml
@@ -72,7 +72,7 @@ services:
     # host so SSR bypasses our traefik + the API forwardAuth gate.
     environment:
       FISHSENSE_API_URL: http://fishsense-api:8000
-      LABEL_STUDIO_URL: https://labeler.e4e.ucsd.edu
+      LABEL_STUDIO_URL: https://app.heartex.com   # hosted Label Studio (labeler.e4e.ucsd.edu retired)
       AUTH_URL: https://fishsense.e4e.ucsd.edu
     env_file:
       - /run/tenant/secrets/app.env

--- a/deploy/incus/worker_volumes/api_worker/config/settings.toml
+++ b/deploy/incus/worker_volumes/api_worker/config/settings.toml
@@ -25,7 +25,8 @@ domain = "workflows.krg.ucsd.edu"           # TLS server-name override (SNI)
 server_root_ca_cert = "/run/tenant/temporal/ca.crt"
 
 [label_studio]
-url = "https://labeler.e4e.ucsd.edu"
+# Hosted Label Studio (HumanSignal) — the self-hosted labeler.e4e.ucsd.edu was retired.
+url = "https://app.heartex.com"
 
 [e4e_nas]
 url = "https://e4e-nas.ucsd.edu:6021"


### PR DESCRIPTION
`labeler.e4e.ucsd.edu` (self-hosted Label Studio) was retired; fishsense now uses **hosted Label Studio at `https://app.heartex.com`**. Updates the runtime config the incus deploy reads:

- `deploy/incus/worker_volumes/api_worker/config/settings.toml` → `[label_studio].url`
- `deploy/incus/compose.yml` → web `LABEL_STUDIO_URL`

Seed `secret/tenants/fishsense/label_studio api_key=<token>` with an access token from the hosted account (`app.heartex.com` → Account & Settings → Access Token). Take effect on the next converge.

### Not in this PR (broader hosted-LS move — track separately)
Other `labeler.e4e.ucsd.edu` references exist repo-wide:
- **`apps/fishsense-lite-web/lib/static-links.ts`** — a **user-facing link** in the web app. Needs a source change **+ a new web release** (the deployed `fishsense-lite-web:v0.7.0` image has the old link baked in) before it updates.
- `deploy/web_volumes/.env.example`, `apps/.../.env.example`, `deploy/spider_volumes/...`, the old `deploy/worker_volumes/...` — docs/old-host configs.

### Also confirm (ops, not code)
Hosted LS at `app.heartex.com` reaches the NAS-hosted **Garage over the public S3 endpoint** to presign/serve JPEGs — so Garage's bucket **CORS must allow the `https://app.heartex.com` origin** (was `labeler.e4e.ucsd.edu`). That's a Garage-side config on the NAS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)