### PR TITLE
fix(incus): populate composeStack workdir so relative binds resolve

### DIFF
--- a/deploy/incus/workdir.nix
+++ b/deploy/incus/workdir.nix
@@ -1,0 +1,34 @@
+# Populate the composeStack working directory.
+#
+# The krg composeStack runner (krg-infra services/compose-stack.nix) invokes our
+# compose with `--project-directory /var/lib/krg/fishsense`, so docker resolves
+# the compose file's RELATIVE bind/env_file paths (`./superset_volumes/docker/.env`,
+# `./traefik-dynamic.yml`, `./pg_volumes/config`, …) against THAT dir — its doc
+# says "relative paths in compose files resolve here" — NOT the Nix-store compose
+# dir. That dir is otherwise empty, so `docker compose up` fails
+# (`env file .../superset_volumes/docker/.env not found`).
+#
+# Fix: symlink the repo-committed READ-ONLY config into the working dir, pointing
+# at the flake's store copy (the store path changes on every config edit, so
+# `L+` refreshes the link each converge — repo-owns-deploy preserved). The
+# READ-WRITE worker log dirs are made as real directories, not store symlinks.
+#
+# Paths (`./x`) are relative to this file (deploy/incus/), so each resolves to
+# that subtree's Nix store path.
+{
+  systemd.tmpfiles.rules = [
+    # read-only config (mounted :ro in compose)
+    "L+ /var/lib/krg/fishsense/traefik-dynamic.yml    - - - - ${./traefik-dynamic.yml}"
+    "L+ /var/lib/krg/fishsense/superset_volumes       - - - - ${./superset_volumes}"
+    "L+ /var/lib/krg/fishsense/pg_volumes             - - - - ${./pg_volumes}"
+    "L+ /var/lib/krg/fishsense/fishsense_api_volumes  - - - - ${./fishsense_api_volumes}"
+    # worker: config is read-only (symlink), logs are read-write (real dir)
+    "d  /var/lib/krg/fishsense/worker_volumes                       0755 root root -"
+    "d  /var/lib/krg/fishsense/worker_volumes/api_worker            0755 root root -"
+    "L+ /var/lib/krg/fishsense/worker_volumes/api_worker/config     - - - - ${./worker_volumes/api_worker/config}"
+    "d  /var/lib/krg/fishsense/worker_volumes/api_worker/logs       0755 root root -"
+    "d  /var/lib/krg/fishsense/worker_volumes/backup_worker         0755 root root -"
+    "L+ /var/lib/krg/fishsense/worker_volumes/backup_worker/config  - - - - ${./worker_volumes/backup_worker/config}"
+    "d  /var/lib/krg/fishsense/worker_volumes/backup_worker/logs    0755 root root -"
+  ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,7 @@
           krg.oecQualysTrellix.enable = lib.mkForce false;
         })
         ./deploy/incus/secrets.nix # extends krg.vaultAgent.renders → /run/tenant/secrets/app.env (HANDOFF §9)
+        ./deploy/incus/workdir.nix # populate /var/lib/krg/fishsense so the compose's relative binds resolve
       ];
     };
 


### PR DESCRIPTION
## Problem (blocking bring-up)
On the slot, `fishsense.service` (the compose stack) fails:
```
env file /var/lib/krg/fishsense/superset_volumes/docker/.env not found
```
The krg composeStack runner runs `docker compose --project-directory /var/lib/krg/fishsense -f <nix-store>/deploy/incus/compose.yml up -d`. Docker resolves the compose file's **relative** bind/env_file paths against `--project-directory` (krg-infra `compose-stack.nix` doc: *"relative paths in compose files resolve here"*), **not** the Nix-store compose dir. That dir is empty, so every `./…` mount is missing — a required env_file makes `up` exit 1.

## Fix
`deploy/incus/workdir.nix` (a `systemd.tmpfiles` module imported by the flake) populates `/var/lib/krg/fishsense`:
- **Symlinks** the committed **read-only** config (`traefik-dynamic.yml`, `superset_volumes`, `pg_volumes`, `fishsense_api_volumes`, `worker_volumes/*/config`) to the flake's **store copy**. The store path changes on any config edit, so `L+` refreshes the link every converge — repo-owns-deploy semantics preserved.
- **`mkdir`s** the **read-write** worker log dirs (`worker_volumes/*/logs`) as real directories (not store symlinks).

Keeps `compose.yml` unchanged/portable. This is the krg-idiomatic approach (populate the composeStack working directory).

## Verified
`nix eval .#nixosConfigurations.fishsense.config.system.build.toplevel` evaluates clean; the tmpfiles rules interpolate the correct store paths.

After merge + reconverge, docker resolves the binds and moves on to actually creating containers. (If the next failure is `unauthorized`/`pull access denied`, that's GHCR auth for `ghcr.io/ucsd-e4e/*` — separate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)