### PR TITLE
feat(incus): disable superset by default (compose profile)

### DIFF
--- a/deploy/incus/README.md
+++ b/deploy/incus/README.md
@@ -21,7 +21,7 @@ Upstream hand-off:
 |---|---|---|
 | `web` (fishsense-lite-web) | `fishsense.e4e.ucsd.edu` | in-app OIDC (`fishsense_oauth`) |
 | `fishsense-api` | `api.fishsense.e4e.ucsd.edu` | forwardAuth → co-located outpost |
-| `superset` (+init/worker/beat + `valkey`) | `analytics.fishsense.e4e.ucsd.edu` | in-app OIDC (`fishsense_analytics`) |
+| `superset` (+init/worker/beat + `valkey`) — **off by default** (`superset` compose profile) | `analytics.fishsense.e4e.ucsd.edu` | in-app OIDC (`fishsense_analytics`) |
 | `authentik-outpost` (co-located outpost) | `/outpost.goauthentik.io/*` on api | gates the API route |
 | `fishsense-api-workflow-worker` | — | krg-prod Temporal (mTLS) |
 | `fishsense-backup-worker` | — | krg-prod Temporal (mTLS) |

--- a/deploy/incus/compose.yml
+++ b/deploy/incus/compose.yml
@@ -40,7 +40,7 @@ services:
     volumes:
       - /run/tenant/tls:/etc/traefik/tls:ro          # fishsense.vm.{crt,key} — vault-agent (#428)
       - ./traefik-dynamic.yml:/etc/traefik/dynamic.yml:ro
-    depends_on: [web, fishsense-api, superset, authentik-outpost]
+    depends_on: [web, fishsense-api, authentik-outpost]   # superset is profile-gated off (analytics route 502s until re-enabled)
     networks: [interior]
 
   # ── co-located Authentik proxy outpost (gates the API route) — HANDOFF §7 / #440 ───────
@@ -98,9 +98,14 @@ services:
     # at the service DNS name `fishsense-api:8000` for now.
 
   # ── analytics → analytics.fishsense.e4e.ucsd.edu (in-app OIDC) ─────────────────────────
+  # DISABLED BY DEFAULT via the `superset` compose profile: the composeStack runner does a
+  # plain `docker compose up -d` (no --profile), so superset + valkey don't start. Re-enable
+  # by adding `superset` to COMPOSE_PROFILES (composeStack envFile) or `--profile superset`.
+  # Requires the superset DB/role + restore before it will come up (see README).
   superset:
     image: &superset-image apache/superset:6.0.0
     container_name: fishsense_superset
+    profiles: ["superset"]
     command: ["/app/docker/docker-bootstrap.sh", "app-gunicorn"]
     user: "root"
     restart: unless-stopped
@@ -121,6 +126,7 @@ services:
   superset-init:
     image: *superset-image
     container_name: superset_init
+    profiles: ["superset"]
     command: ["/app/docker/docker-init.sh"]
     user: "root"
     env_file:
@@ -141,6 +147,7 @@ services:
   superset-worker:
     image: *superset-image
     container_name: superset_worker
+    profiles: ["superset"]
     command: ["/app/docker/docker-bootstrap.sh", "worker"]
     user: "root"
     restart: unless-stopped
@@ -164,6 +171,7 @@ services:
   superset-worker-beat:
     image: *superset-image
     container_name: superset_worker_beat
+    profiles: ["superset"]
     command: ["/app/docker/docker-bootstrap.sh", "beat"]
     user: "root"
     restart: unless-stopped
@@ -185,6 +193,7 @@ services:
   valkey:
     image: valkey/valkey:9.1.0
     container_name: superset_cache
+    profiles: ["superset"]   # only superset uses it — off with the superset profile
     restart: unless-stopped
     volumes:
       - valkey_data:/data   # named volume — persistent, docker-owned


### PR DESCRIPTION
Gates `superset` + `superset-init`/`worker`/`beat` + `valkey` behind the **`superset` compose profile**. The composeStack runner runs a plain `docker compose up -d` (no `--profile`), so they stay off — the core stack (`web`, `fishsense-api`, workers, `postgres`, `traefik`, `authentik-outpost`) comes up without them. Also removes `superset` from `traefik`'s `depends_on`.

**Why now:** on the slot, `superset-init` was exiting 1 (no superset DB — restore not done), failing the whole `docker compose up`. This drops it out so the core stack goes green, and defers analytics until it's wanted.

**Re-enable later:** set `COMPOSE_PROFILES=superset` (composeStack `envFile`) or run with `--profile superset` — after creating the `superset` DB/role and restoring. Nothing is deleted; the config stays in-tree, just dormant. `secrets.nix` still renders the superset secrets (harmless while off, ready when back), and the `analytics.` traefik route stays (502s until superset returns; its CNAME isn't filed yet anyway).

Verified: profile-gated = {superset, superset-init, superset-worker, superset-worker-beat, valkey}; core stack always-on; traefik no longer depends on superset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)