### PR TITLE
fix(incus): bump krg-infra pin to c29ab5f (runner workDir + token mint)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -121,28 +121,28 @@
       },
       "locked": {
         "dir": "nix",
-        "lastModified": 1783454574,
-        "narHash": "sha256-pOhUXnktqSlDl49/66hbe16X9XMGMwA8HTARgIOaUPc=",
+        "lastModified": 1783612601,
+        "narHash": "sha256-vcUBbfGLGe+xXe6KgD50DBilYzJ7PnVBC7LU0j4sChY=",
         "owner": "KastnerRG",
         "repo": "krg-infra",
-        "rev": "2554daa6f026fee17f34827e5bd4e3712dcec3fd",
+        "rev": "c29ab5f735102e5bf37cdb6ecf8ec1458c6a1daa",
         "type": "github"
       },
       "original": {
         "dir": "nix",
         "owner": "KastnerRG",
         "repo": "krg-infra",
-        "rev": "2554daa6f026fee17f34827e5bd4e3712dcec3fd",
+        "rev": "c29ab5f735102e5bf37cdb6ecf8ec1458c6a1daa",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783148766,
-        "narHash": "sha256-uslt2pqShTIXDdAHRHv2QkYLsVdY8Oqwz0EA48/RSM8=",
+        "lastModified": 1783389287,
+        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a50de1b7d8a586adc18d2395c19de7d6058e6030",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,9 +14,12 @@
     #   #436 quota 6/12   #437 api.fishsense SANs + external_host rename
     #   #438 OIDC secrets → tenant KV + §9 app-secret render pattern
     #   #439 root disk 50 GiB   #440 co-located proxy outpost (Option A)   #443 OIDC writer glob
+    #   #447 krg-deploy runner-repo-tag read fix (mints+pushes our runner token)
+    #   #453 create the github-runner workDir (fixes the 226/NAMESPACE start failure
+    #        that kept our runner from registering — the workaround we handed upstream)
     # This rev IS our stable contract (ADR 0020 §5); bump deliberately to pick up
     # platform-seam changes.
-    krg-infra.url = "github:KastnerRG/krg-infra/2554daa6f026fee17f34827e5bd4e3712dcec3fd?dir=nix";
+    krg-infra.url = "github:KastnerRG/krg-infra/c29ab5f735102e5bf37cdb6ecf8ec1458c6a1daa?dir=nix";
     nixpkgs.follows = "krg-infra/nixpkgs";
   };
 


### PR DESCRIPTION
Bumps the `krg-infra` flake input `2554daa` → `c29ab5f` to consume the two upstream fixes that unblock our tenant's self-hosted runner — the runner registration we were pushing on, which we'd handed to krg-infra as their tenant-module bug.

## What this consumes
- **[krg-infra #453](https://github.com/KastnerRG/krg-infra/pull/453)** — `nixosModules.tenant` now creates the runner `workDir`. The `github-runners` unit sandbox bind-mounts `workDir` (`/var/lib/gh-runner/work`), which `createHome` never made, so `github-runner-fishsense` died at `status=226/NAMESPACE` before it could register. This is exactly the diagnosis + fix we handed upstream instead of carrying a workaround in our own flake.
- **[krg-infra #447](https://github.com/KastnerRG/krg-infra/pull/447)** — krg-deploy's `stage-tenant-secret-zero.sh` now reads the `user.krg_repo` tag correctly (`--project` before the positional, `${REMOTE}:` prefix, `owner/repo` guard), so it actually mints + pushes our runner registration token instead of feeding an Incus usage string to the minter. (krg-deploy-side; complements the workDir fix.)

Also picks up the followed **nixpkgs** bump (#218448) via the relock.

## Not affected
`mkTenant`'s interface is unchanged (no `nix/lib` diff between the two revs). The other `nix/` changes in range (`nas-mount.nix`, `incus.nix` metrics, prometheus, authentik LS icon) are platform-host modules our tenant flake doesn't import. The Garage declarative bucket/key work (#451) and NAS firewall scoping (#448/#449) are NAS-side; they add a separate hosted-Label-Studio Garage key (ops follow-up: seed into OpenBao) but don't change our interior compose/secrets.

## Verification
- `nix eval .#nixosConfigurations.fishsense.config.system.build.toplevel.drvPath` resolves clean.
- Resolved config's `systemd.tmpfiles.rules` now includes `d /var/lib/gh-runner/work 0700 gh-runner gh-runner -`.

## Reconverge order
1. krg-deploy re-runs secret-zero staging → mints + pushes the runner token to `/var/lib/krg/github-runner/registration-token`.
2. `nixos-rebuild switch` on the slot → tmpfiles creates the workDir, `github-runner-fishsense` starts and registers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)