### PR TITLE
ci: cache + retry uv sync to harden against GitHub CDN 504s

### DIFF
--- a/.github/actions/setup-uv-sync/action.yml
+++ b/.github/actions/setup-uv-sync/action.yml
@@ -1,0 +1,57 @@
+name: Setup uv + sync (cached, retried)
+description: >-
+  Install a pinned uv with its download cache enabled, then run
+  `uv sync <args>` with retry-on-transient-failure backoff.
+
+  Hardens every CI job that resolves the workspace against GitHub's
+  release-asset CDN. Two of our deps — fishsense-core and
+  synology-filestation — are wheels hosted as GitHub release assets
+  (see [tool.uv.sources] in the root pyproject.toml), and that CDN
+  intermittently returns 504 Gateway Timeout. uv only retries a fetch
+  3× before failing the whole sync, so a single blip used to red-X the
+  entire test matrix (it did, 3× in a row, 2026-07-09).
+
+  Mitigations layered here:
+    1. enable-cache keyed on uv.lock — on a cache hit the two wheels
+       are served from the runner cache and never fetched from GitHub,
+       so reruns and same-lock matrix jobs skip the CDN entirely.
+    2. retry loop — on a cold cache (new lock after a dep bump) the
+       sync still hits the CDN; retrying with backoff rides out a
+       transient 504 instead of failing the job on the first one.
+
+inputs:
+  args:
+    description: >-
+      Arguments passed verbatim to `uv sync` (e.g.
+      `--all-packages --all-groups` or
+      `--frozen --no-dev --no-editable --package fishsense-api`).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Pins the uv version (reproducibility win over floating
+    # `pip install uv`) and caches uv's download cache keyed on
+    # uv.lock. setup-uv auto-detects the repo-root uv.lock.
+    - uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+
+    - name: Sync workspace (retry on transient CDN 504s)
+      shell: bash
+      # 5 attempts, linear backoff (15s, 30s, 45s, 60s between tries →
+      # ~2.5 min of resilience). A warm cache makes attempt 1 succeed
+      # without touching the CDN; a cold cache rides out a blip.
+      run: |
+        attempts=5
+        for i in $(seq 1 $attempts); do
+          if uv sync ${{ inputs.args }}; then
+            exit 0
+          fi
+          if [ "$i" -lt "$attempts" ]; then
+            echo "::warning::uv sync attempt $i failed (likely transient GitHub CDN 504); retrying..."
+            sleep $((i * 15))
+          fi
+        done
+        echo "::error::uv sync failed after $attempts attempts"
+        exit 1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -105,11 +105,10 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install uv
-        run: pip install uv
-
-      - name: Sync workspace (all packages, all groups)
-        run: uv sync --all-packages --all-groups
+      - name: Setup uv + sync (cached, retried)
+        uses: ./.github/actions/setup-uv-sync
+        with:
+          args: --all-packages --all-groups
 
       # Node + npm install must precede `./check.sh integration` because
       # check.sh's run_npm_integration step calls `npm run test:integration`

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -82,10 +82,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - name: Install uv
-        run: pip install uv
-      - name: Sync workspace (all packages, all groups)
-        run: uv sync --all-packages --all-groups
+      - name: Setup uv + sync (cached, retried)
+        uses: ./.github/actions/setup-uv-sync
+        with:
+          args: --all-packages --all-groups
 
       - name: Run the k8s scaling integration tests
         # KUBECONFIG (set above) points pytest at the kind cluster.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - name: Install uv
-        run: pip install uv
-      - name: Sync workspace (all packages, dev groups)
-        run: uv sync --all-packages --all-groups
+      - name: Setup uv + sync (cached, retried)
+        uses: ./.github/actions/setup-uv-sync
+        with:
+          args: --all-packages --all-groups
       - name: Determine changed Python files
         id: changes
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - name: Install uv
-        run: pip install uv
-      - name: Sync workspace (all packages, all groups)
-        run: uv sync --all-packages --all-groups
+      - name: Setup uv + sync (cached, retried)
+        uses: ./.github/actions/setup-uv-sync
+        with:
+          args: --all-packages --all-groups
       - name: Run pytest with coverage
         run: |
           uv run --directory ${{ matrix.package }} pytest -v \
@@ -96,17 +96,18 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - name: Install uv
-        run: pip install uv
       - name: Install system libs (mirror Dockerfile)
         if: matrix.apt != ''
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ${{ matrix.apt }}
-      - name: Sync runtime-only env (mirrors Dockerfile)
-        # `--frozen --no-dev --no-editable --package <name>` matches
-        # the install line in services/<name>/Dockerfile exactly, so a
-        # runtime/dev dep drift surfaces with the same import error
-        # the container would crash on at startup.
-        run: uv sync --frozen --no-dev --no-editable --package ${{ matrix.package }}
+      # Sync the runtime-only env (mirrors the Dockerfile). The
+      # `--frozen --no-dev --no-editable --package <name>` args match
+      # the install line in services/<name>/Dockerfile exactly, so a
+      # runtime/dev dep drift surfaces with the same import error the
+      # container would crash on at startup.
+      - name: Setup uv + sync (cached, retried)
+        uses: ./.github/actions/setup-uv-sync
+        with:
+          args: --frozen --no-dev --no-editable --package ${{ matrix.package }}
       - name: Import entry-point module
         # If a runtime module imports something declared only in
         # `[dependency-groups.dev]`, this exits non-zero with


### PR DESCRIPTION
## Problem

On 2026-07-09 the whole test matrix red-X'd **three times in a row** — not from any code change, but from transient `504 Gateway Timeout`s on GitHub's release-asset CDN. Two workspace deps are wheels hosted as GitHub release assets (see `[tool.uv.sources]` in the root `pyproject.toml`):

- `fishsense-core`
- `synology-filestation`

`uv` retries a fetch only 3× before failing the entire sync, and CI has **no download cache**, so every job in the matrix independently hammers the CDN on every run. One blip fails everything; even manual reruns kept catching the tail of the outage.

## Fix

A new composite action, `.github/actions/setup-uv-sync`, that every workspace-syncing job now calls instead of `pip install uv` + `uv sync`:

1. **Cache** — `astral-sh/setup-uv@v6` with `enable-cache: true`, keyed on `uv.lock`. On a cache hit the two wheels are served from the runner cache and **never fetched from the CDN** — reruns and same-lock matrix jobs skip GitHub entirely. Also pins the uv version (reproducibility win over the floating `pip install uv`).
2. **Retry** — wraps `uv sync` in a 5-attempt linear-backoff loop (~2.5 min) so a cold-cache sync (new lock after a dep bump) rides out a transient 504 instead of failing on the first one. Skips the final sleep so a genuine hard failure still fails fast.

## Sites wired

| Workflow | Job |
|---|---|
| `lint.yml` | pylint |
| `test.yml` | pytest (matrix) |
| `test.yml` | runtime-import (matrix; distinct `--frozen --no-dev` sync) |
| `k8s-tests.yml` | k8s scaling tests |
| `integration.yml` | integration |

## Not covered

`build.yml` runs `uv sync` *inside* the service Dockerfiles (a `RUN` layer), so it hits the same two CDN wheels but can't use this action — it relies on buildx layer caching instead. If Docker builds start flaking on the same 504, that needs a separate fix (retry in the Dockerfile `RUN`, or a buildx cache mount).

## Validation

- YAML parses clean on all files.
- **actionlint passes (exit 0)** — resolved the local `./.github/actions/setup-uv-sync` reference and confirmed the `args` input matches.
- `setup-python@v5` steps left in place (they provide the 3.13 interpreter uv picks up); no stray `pip install uv` / bare `uv sync` remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)