### PR TITLE
fix(web): add LABEL_STUDIO_ENABLED kill-switch, default off

### DIFF
--- a/apps/fishsense-lite-web/lib/active-projects.test.ts
+++ b/apps/fishsense-lite-web/lib/active-projects.test.ts
@@ -17,9 +17,13 @@ const projectsMock = vi.mocked(getProjects);
 beforeEach(() => {
   idsMock.mockReset();
   projectsMock.mockReset();
+  // The Label Studio path is off by default (see labelStudioEnabled).
+  // These tests cover the enabled path, so opt in explicitly.
+  vi.stubEnv("LABEL_STUDIO_ENABLED", "true");
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
 
@@ -74,5 +78,56 @@ describe("getActiveProjects", () => {
     const result = await getActiveProjects(60);
 
     expect(result).toEqual({ laser: [], species: [], headtail: [], slate: [] });
+  });
+});
+
+// Kill-switch behavior. With LABEL_STUDIO_ENABLED off (the default), the
+// landing page must render without touching Label Studio at all: a single
+// unresolvable project ID used to throw out of SSR and 500 the whole page.
+// buildSections() drops any kind with zero projects, so empty buckets
+// collapse the four labeling sections and leave Results + Administration.
+describe("getActiveProjects (Label Studio disabled)", () => {
+  beforeEach(() => {
+    vi.stubEnv("LABEL_STUDIO_ENABLED", "false");
+  });
+
+  it("returns an empty four-bucket map", async () => {
+    const result = await getActiveProjects(60);
+
+    expect(result).toEqual({ laser: [], species: [], headtail: [], slate: [] });
+  });
+
+  it("does not call Label Studio", async () => {
+    await getActiveProjects(60);
+
+    expect(projectsMock).not.toHaveBeenCalled();
+  });
+
+  it("does not even fetch project IDs from fishsense-api", async () => {
+    await getActiveProjects(60);
+
+    expect(idsMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves rather than throwing when Label Studio would 401", async () => {
+    // Guards the actual prod failure: getProject threw on a 401 and the
+    // rejection propagated through Promise.all out of the server component.
+    projectsMock.mockRejectedValue(new Error("401 Unauthorized"));
+
+    await expect(getActiveProjects(60)).resolves.toEqual({
+      laser: [],
+      species: [],
+      headtail: [],
+      slate: [],
+    });
+  });
+
+  it("is disabled when LABEL_STUDIO_ENABLED is unset entirely", async () => {
+    vi.unstubAllEnvs();
+
+    await getActiveProjects(60);
+
+    expect(idsMock).not.toHaveBeenCalled();
+    expect(projectsMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/fishsense-lite-web/lib/active-projects.ts
+++ b/apps/fishsense-lite-web/lib/active-projects.ts
@@ -1,3 +1,4 @@
+import { labelStudioEnabled } from "./env";
 import { getIncompleteProjectIds } from "./fishsense-api";
 import { getProjects, type LabelStudioProject } from "./label-studio";
 
@@ -8,7 +9,24 @@ export type ActiveProjects = {
   slate: LabelStudioProject[];
 };
 
+// Fresh object per call — a shared constant would hand every caller the
+// same mutable arrays.
+const noActiveProjects = (): ActiveProjects => ({
+  laser: [],
+  species: [],
+  headtail: [],
+  slate: [],
+});
+
 export async function getActiveProjects(revalidate = 300): Promise<ActiveProjects> {
+  // Label Studio is off by default — see `labelStudioEnabled`. Short-circuit
+  // before the fishsense-api call too: the project IDs it returns are only
+  // ever used to resolve names out of Label Studio, so fetching them would
+  // be pure waste.
+  if (!labelStudioEnabled()) {
+    return noActiveProjects();
+  }
+
   const ids = await getIncompleteProjectIds(revalidate);
   const [laser, species, headtail, slate] = await Promise.all([
     getProjects(ids.laser, revalidate),

--- a/apps/fishsense-lite-web/lib/env.test.ts
+++ b/apps/fishsense-lite-web/lib/env.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { __test, env } from "./env";
+import { __test, env, labelStudioEnabled } from "./env";
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -59,5 +59,44 @@ describe("env proxy", () => {
     expect(env.fishsenseApiUrl).toBe("http://first");
     vi.stubEnv("FISHSENSE_API_URL", "http://second");
     expect(env.fishsenseApiUrl).toBe("http://second");
+  });
+});
+
+describe("labelStudioEnabled", () => {
+  it("defaults to false when LABEL_STUDIO_ENABLED is unset", () => {
+    expect(labelStudioEnabled()).toBe(false);
+  });
+
+  it("is false when set to an empty string", () => {
+    vi.stubEnv("LABEL_STUDIO_ENABLED", "");
+    expect(labelStudioEnabled()).toBe(false);
+  });
+
+  // The E4EFS_DOCKER footgun, restated: a naive `Boolean(process.env.X)`
+  // reads the literal string "false" as true. These two cases pin the
+  // explicitly-truthy semantics so nobody "simplifies" it back.
+  it("is false for the literal string 'false'", () => {
+    vi.stubEnv("LABEL_STUDIO_ENABLED", "false");
+    expect(labelStudioEnabled()).toBe(false);
+  });
+
+  it("is false for an arbitrary non-truthy string", () => {
+    vi.stubEnv("LABEL_STUDIO_ENABLED", "maybe");
+    expect(labelStudioEnabled()).toBe(false);
+  });
+
+  it.each(["true", "TRUE", "True", "1", "yes", "YES"])(
+    "is true for the explicitly-truthy value %j",
+    (value) => {
+      vi.stubEnv("LABEL_STUDIO_ENABLED", value);
+      expect(labelStudioEnabled()).toBe(true);
+    },
+  );
+
+  it("re-reads on each call (no stale cache)", () => {
+    vi.stubEnv("LABEL_STUDIO_ENABLED", "true");
+    expect(labelStudioEnabled()).toBe(true);
+    vi.stubEnv("LABEL_STUDIO_ENABLED", "false");
+    expect(labelStudioEnabled()).toBe(false);
   });
 });

--- a/apps/fishsense-lite-web/lib/env.ts
+++ b/apps/fishsense-lite-web/lib/env.ts
@@ -30,4 +30,27 @@ export const env: Env = new Proxy({} as Env, {
   },
 });
 
+const TRUTHY = new Set(["true", "1", "yes"]);
+
+// Kill-switch for the Label Studio integration. **Defaults to off.**
+//
+// The hosted instance (app.heartex.com) rejects the legacy
+// `Authorization: Token <key>` scheme this app sends, so every
+// `/api/projects/<id>` fetch 401s. `getProject` throws on a non-OK
+// response and `getProjects` fans them out through `Promise.all`, so a
+// single bad ID rejected out of the server component and 500'd the whole
+// landing page. Disabled, `getActiveProjects` returns empty buckets and
+// `buildSections` collapses the four labeling sections.
+//
+// Re-enable with `LABEL_STUDIO_ENABLED=true` once the new instance's auth
+// scheme and project IDs are reconciled with what fishsense-api stores.
+//
+// Compared explicitly against a truthy allowlist rather than
+// `Boolean(process.env.X)` — the latter reads the literal string "false"
+// as true. Same footgun as `E4EFS_DOCKER`; see CLAUDE.md.
+export function labelStudioEnabled(): boolean {
+  const value = process.env.LABEL_STUDIO_ENABLED;
+  return value !== undefined && TRUTHY.has(value.toLowerCase());
+}
+
 export const __test = { required };

--- a/deploy/web_volumes/.env.example
+++ b/deploy/web_volumes/.env.example
@@ -4,12 +4,16 @@
 # alongside this example on the orchestrator deploy host. The file is
 # loaded by the `fishsense-lite-web` compose service (deploy/compose.yml).
 #
-# Nine variables are required; the Next.js server throws on the first
-# request that touches one of them if it's unset. The five
-# FISHSENSE_/LABEL_STUDIO_ keys back the public landing page; the four
-# AUTH_* keys back the Authentik OIDC sign-in that gates /portal.
-# Missing AUTH_* keys surface as a 500 on /portal (landing stays up
-# because the gate is in app/portal/page.tsx, not the landing route).
+# Seven variables are always required; the Next.js server throws on the
+# first request that touches one of them if it's unset. The three
+# FISHSENSE_API_* keys back the public landing page; the four AUTH_* keys
+# back the Authentik OIDC sign-in that gates /portal. Missing AUTH_* keys
+# surface as a 500 on /portal (landing stays up because the gate is in
+# app/portal/page.tsx, not the landing route).
+#
+# The two LABEL_STUDIO_URL / LABEL_STUDIO_API_KEY vars are required only
+# when LABEL_STUDIO_ENABLED is truthy (see below); with the kill-switch
+# off they are never read.
 #
 # AUTH_URL is also strongly recommended in any non-localhost deploy
 # (see the AUTH_URL block at the bottom of this file): without it,
@@ -29,12 +33,30 @@ FISHSENSE_API_URL=http://fishsense-api:8000
 FISHSENSE_API_USERNAME=
 FISHSENSE_API_PASSWORD=
 
+# Kill-switch for the Label Studio integration on the landing page.
+# **Defaults to off** when unset — the two LABEL_STUDIO_* vars below are
+# then never read, and the four labeling sections collapse, leaving the
+# Results + Administration cards.
+#
+# Turned off during the migration to the hosted Label Studio instance:
+# app.heartex.com rejects the legacy `Authorization: Token <key>` scheme
+# the app sends (its personal access tokens are JWTs, presented as
+# `Bearer`), so every project fetch 401s. A single unresolvable project
+# threw out of SSR and 500'd the whole landing page.
+#
+# Set to `true` (or `1` / `yes`) to re-enable once the new instance's
+# auth scheme and project IDs are reconciled with what fishsense-api
+# stores. Any other value — including the literal `false` — leaves it off.
+LABEL_STUDIO_ENABLED=false
+
 # Label Studio is reached over its public hostname; there is no internal
-# docker-network route from the orchestrator host.
+# docker-network route from the orchestrator host. Only read when
+# LABEL_STUDIO_ENABLED is truthy.
 LABEL_STUDIO_URL=https://labeler.e4e.ucsd.edu
 
 # Service-account API key from Label Studio (Account & Settings -> Access
-# Token). Same key the api-workflow-worker uses for sync.
+# Token). Same key the api-workflow-worker uses for sync. Only read when
+# LABEL_STUDIO_ENABLED is truthy.
 LABEL_STUDIO_API_KEY=
 
 # JWT / cookie signing secret for next-auth. Must be a stable random


### PR DESCRIPTION
## Problem

The landing page at `fishsense.e4e.ucsd.edu` is returning **Something went wrong**. The user-facing error reference `2261213736` is a Next.js digest that maps to a specific server log line:

```
⨯ Error: Label Studio project 42 fetch failed: 401 Unauthorized
  digest: '2261213736'
```

Every Label Studio project fetch against the hosted instance (`app.heartex.com`) 401s. `getProject` throws on a non-OK response, and `getProjects` fans the IDs out through `Promise.all` — so a **single** unresolvable project rejects out of the server component and 500s the whole page. The parallel fan-out also draws `429 Too Many Requests` from the hosted API.

Two things look wrong on the Label Studio side (diagnosed, **not** fixed here):

- The API key is a **239-char JWT**, but the app sends the legacy `Authorization: Token <key>` scheme. Hosted Label Studio expects `Bearer` for personal access tokens.
- The project IDs `fishsense-api` stores (42, 43, 45, 88–110, …) belong to the **old** Label Studio instance. The new one is a fresh install.

## Fix

Add a `LABEL_STUDIO_ENABLED` kill-switch, **defaulting to off**. `getActiveProjects` short-circuits to empty buckets without calling Label Studio — or `fishsense-api`, whose project IDs are only ever used to resolve LS names, so fetching them would be pure waste.

`buildSections` already drops any labeling kind with zero projects, so the four labeling sections collapse and the **Results + Administration** cards remain. That is the same empty-collapse contract the existing unit and integration tests already pin down — no test had to be weakened to accommodate this.

The flag is compared against an explicit truthy allowlist (`true` / `1` / `yes`, case-insensitive) rather than `Boolean(process.env.X)`, which would read the literal string `"false"` as true. That's the `E4EFS_DOCKER` footgun documented in CLAUDE.md; there are tests pinning the semantics so nobody "simplifies" it back.

## Tests

TDD per CLAUDE.md — tests written first, confirmed red (`labelStudioEnabled is not a function`), then the implementation.

- `env.test.ts` — default-off, empty string, literal `"false"`, arbitrary non-truthy string, the truthy allowlist, and no stale caching.
- `active-projects.test.ts` — disabled path returns an empty four-bucket map, calls **neither** Label Studio nor `fishsense-api`, is off when the var is unset entirely, and **resolves rather than throws when Label Studio would 401** (the actual prod failure). Existing enabled-path tests now opt in explicitly.

`49/49` unit tests pass, `tsc --noEmit` clean, ESLint clean.

## Deploying

Default-off means **no `.env` edit is required** — but note the page will not recover until a new `fishsense-lite-web` image is built and the pin in `deploy/incus/compose.yml` (currently `v0.7.0`) is bumped. That pin, and the reason the incus stack isn't picking up auto-deploys, is being handled separately.

## Deliberately not addressed

`getProjects` should degrade per-project (fallback title) instead of throwing, and should bound its concurrency to stop the 429s. Both left alone on purpose — the kill-switch is the smaller, safer change while the Label Studio migration is in flight. Worth revisiting when `LABEL_STUDIO_ENABLED` is flipped back on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)