### PR TITLE
fix(ci): deploy-incus converge with --no-block to stop false-red exits

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,10 +37,10 @@ name: Deploy
 #     -> this workflow converges the slot
 #
 # The converge is a TRIGGER, not a clean CI gate. `fishsense-selfupdate`
-# stops the GitHub runner mid-switch and restarts it after, so this job
-# often reports cancelled/interrupted even on a successful converge; and
-# a zero exit only means `docker compose up -d` was *issued*, not that
-# the containers came up healthy. Verify on-box with
+# stops the GitHub runner mid-switch and restarts it after, so the job
+# starts the unit with `--no-block` (see the step comment) and reports
+# success as soon as the converge is *enqueued* — its green means
+# "converge fired", never "containers are healthy". Verify on-box with
 # `systemctl status fishsense-selfupdate`, or add a post-converge HTTP
 # health probe.
 #
@@ -105,7 +105,18 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Converge the instance
-        run: systemctl start fishsense-selfupdate # polkit-authorized on the slot
+        # --no-block: enqueue the converge and return 0 immediately, rather
+        # than blocking on the oneshot. `fishsense-selfupdate`'s first action
+        # is `systemctl stop github-runner-fishsense` — it restarts the very
+        # runner executing this job. A blocking `systemctl start` is therefore
+        # SIGINT'd (exit 130, false red) whenever `nixos-rebuild` outlives the
+        # runner's graceful-stop window; a fast converge finishes inside the
+        # window and passes, so the same command reports non-deterministic
+        # red/green (observed: PR #238 red at ~6min, #240 green at 34s, same
+        # code). This job can only honestly assert "converge fired" anyway —
+        # its exit 0 never meant the containers came up healthy (see header).
+        # Convergence health belongs in a separate post-converge probe.
+        run: systemctl start --no-block fishsense-selfupdate # polkit-authorized on the slot
 
   deploy-data-worker:
     # Fires on:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -661,23 +661,28 @@ name:
   `[self-hosted, fishsense]` — the slot's own runner, auto-provisioned
   and auto-registered by the platform because the tenant flake sets
   `repo = "UCSD-E4E/fishsense-lite"` (ADR 0022). Its one step is
-  `systemctl start fishsense-selfupdate` (polkit-authorized for the
-  non-admin `gh-runner` user). The unit runs `nixos-rebuild switch
-  --flake github:UCSD-E4E/fishsense-lite#fishsense --refresh`, so the
-  slot pulls the flake from GitHub itself — nothing is checked out onto
-  it. The `deploy-incus` job carries a `concurrency: deploy-incus` group
-  (`cancel-in-progress: false`) so two pin-bump PRs merged back to back
-  converge in sequence rather than the second cancelling the first.
+  `systemctl start --no-block fishsense-selfupdate` (polkit-authorized
+  for the non-admin `gh-runner` user). The unit runs `nixos-rebuild
+  switch --flake github:UCSD-E4E/fishsense-lite#fishsense --refresh`, so
+  the slot pulls the flake from GitHub itself — nothing is checked out
+  onto it. The `deploy-incus` job carries a `concurrency: deploy-incus`
+  group (`cancel-in-progress: false`) so two pin-bump PRs merged back to
+  back converge in sequence rather than the second cancelling the first.
 
 Never give a job a bare `runs-on: self-hosted` — the `fishsense` label
 is what keeps GitHub-hosted work (the NRP deploy) off the tenant slot.
 
 **The converge is a trigger, not a clean CI gate.** `fishsense-selfupdate`
-stops the GitHub runner mid-switch and restarts it after, so
-`deploy-incus` often reports cancelled/interrupted even on success; and
-a zero exit only means `docker compose up -d` was *issued*, not that
-containers came up healthy. Verify on-box (`systemctl status
-fishsense-selfupdate`) or add a post-converge HTTP health probe.
+restarts the very runner executing the job (its first action is
+`systemctl stop github-runner-fishsense`). The step therefore uses
+`systemctl start --no-block`: it returns 0 the instant the converge is
+*enqueued*, so the job's green means "converge fired", never "containers
+are healthy". Without `--no-block` a blocking `systemctl start` gets
+SIGINT'd (exit 130, false red) whenever `nixos-rebuild` outlives the
+runner's graceful-stop window — observed live on PR #238 (red at ~6min)
+vs #240 (green at 34s), same code path, non-deterministic. Verify a real
+converge on-box (`systemctl status fishsense-selfupdate`) or add a
+post-converge HTTP health probe.
 
 Until the slot is bootstrapped the converge job fails; the
 `deploy-data-worker` job runs but fails fast until `NRP_KUBECONFIG` is


### PR DESCRIPTION
Follow-up to #237, prompted by its first live run.

## Symptom

When the three auto-deploy PRs from release #208 merged, the `deploy-incus` job reported **red on #238 (web, ~6min)** but **green on #240 (api-worker, 34s)** — same job, same one-line command, opposite results. #238 failed with **exit 130** (SIGINT) 0.3s into `systemctl start fishsense-selfupdate`.

## Cause

`fishsense-selfupdate`'s first action is `systemctl stop github-runner-fishsense` — it restarts the very runner executing this job. A **blocking** `systemctl start` waits on the oneshot, so:

- **Slow converge** (real container recreate): the runner's graceful-stop window expires before `nixos-rebuild` finishes → runner hard-killed → job SIGINT'd → exit 130 (false red).
- **Fast converge**: the oneshot completes inside the window → `systemctl start` returns 0 → green.

Non-deterministic red/green on a converge that *actually succeeded*. Worse, it makes a genuine converge failure indistinguishable from a runner-restart artifact.

The converges themselves worked — by the time #238's converge ran (queued in the `deploy-incus` concurrency group), main HEAD already carried all three pins, and `--refresh` pulls HEAD, so the slot converged to everything. The runner came back (that's how #240 ran after it).

## Fix

`systemctl start --no-block fishsense-selfupdate` returns 0 the instant the converge is enqueued, so the job reports success before the runner is stopped. The converge proceeds asynchronously.

This loses nothing: the job can only honestly assert "converge fired", and its exit 0 never meant the containers came up healthy (the workflow header already said so). Real convergence health belongs in the separate post-converge probe that's a tracked follow-up.

Also updates the "trigger, not a clean CI gate" notes in the workflow header and CLAUDE.md to describe the `--no-block` behavior.

`actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)