### PR TITLE
fix(incus): disable NRP scaling — dangling kubeconfig_path crash-loops the worker

### DIFF
--- a/deploy/incus/worker_volumes/api_worker/config/settings.toml
+++ b/deploy/incus/worker_volumes/api_worker/config/settings.toml
@@ -1,7 +1,9 @@
 # fishsense-api-workflow-worker — Incus interior settings.
 #
-# Non-secret config only. Secrets (.secrets.toml, nrp.kubeconfig) are rendered
-# alongside this file by the in-instance vault-agent from secret/tenants/fishsense/*.
+# Non-secret config only. Secrets are rendered to WRITABLE runtime paths by the
+# in-instance vault-agent from secret/tenants/fishsense/* (e.g. the temporal
+# client cert trio under /run/tenant/temporal/) — NOT into this dir, which is a
+# read-only store bind. The NRP kubeconfig is not delivered yet; see [kubernetes].
 #
 # DIFF vs the old orchestrator settings.toml: [temporal] now points at the
 # shared krg-prod cluster instead of the in-stack `fishsense-temporal`.
@@ -11,10 +13,9 @@ max_workers = 8
 
 # krg-prod shared Temporal (HANDOFF §6). mTLS-only; the gRPC TLS server-name is
 # overridden to workflows.krg.ucsd.edu even though we dial krg-prod.ucsd.edu.
-# The client cert/key/CA are rendered by the in-instance vault-agent.
-# PLATFORM TODO: `temporal-client` cert delivery is not wired yet — our AppRole
-# only grants `tenant-internal` (fishsense.vm) today. The worker will fail to
-# connect until these three files exist. See README §Temporal.
+# The client cert/key/CA are rendered by the in-instance vault-agent to
+# /run/tenant/temporal/ (wired by krg-infra #435; the trio is present on the
+# slot). The CN switches to `fishsense-worker` once #435's grant is live.
 [temporal]
 host = "krg-prod.ucsd.edu"
 port = "7233"
@@ -43,11 +44,23 @@ endpoint_url = "https://garage.fishsense.e4e.ucsd.edu"
 region = "garage"
 bucket = "fishsense"
 
-# NRP data-worker scale-to-zero. Enabled here because the data-worker runs on
-# NRP/Kubernetes and the api-worker owns its replica count. The kubeconfig is
-# rendered by vault-agent next to this file.
+# NRP data-worker scale-to-zero — DISABLED until the NRP kubeconfig is
+# delivered to the slot.
+#
+# `kubeconfig_path` must point at a file that EXISTS: config.py validates it
+# with a `path_validator`, and Dynaconf runs every validator eagerly on first
+# settings access, so a dangling path crash-loops the worker at startup before
+# it can even connect to Temporal. With `kubeconfig_path` unset the scaling
+# activity no-ops (`resolve_scaling_config` returns disabled) and the
+# data-worker is assumed always-on — the supported pre-NRP mode.
+#
+# Re-enabling is NOT just uncommenting: this config dir is a read-only store
+# bind (workdir.nix symlinks it from the flake store), so vault-agent can't
+# render a secret kubeconfig here. It must render to a writable path (as it
+# does for the temporal certs under /run/tenant/temporal/), and this line must
+# then point there. The NRP kubeconfig delivery is still an open operator item.
 [kubernetes]
-kubeconfig_path = "/e4efs/config/nrp.kubeconfig"
+# kubeconfig_path = "/run/tenant/<writable>/nrp.kubeconfig"
 namespace = "fishsense"
 deployment_name = "fishsense-data-processing-workflow-worker"
 active_replicas = 1


### PR DESCRIPTION
## Symptom (found via read-only slot inspection)

The **api-workflow-worker crash-loops** on the Incus slot — `RestartCount=68`, container perpetually `Restarting`. That worker is the brain of the hourly pipeline (label sync, all five preprocess parents, laser calibration, measurement dispatch), so **all of it is currently down**. Every other container is healthy (web `v0.7.1`, api, authentik-outpost healthy, postgres, traefik, backup-worker); Superset is off by design.

## Root cause

Startup crash from Dynaconf:

```
dynaconf.validator.ValidationError:
  kubernetes.kubeconfig_path invalid for path_validator(/e4efs/config/nrp.kubeconfig)
```

`[kubernetes].kubeconfig_path` points at `/e4efs/config/nrp.kubeconfig`, but that file isn't on the slot — the NRP kubeconfig is an **undelivered operator secret**. `config.py` validates the path with `condition=path_validator`, and Dynaconf runs every validator eagerly on first `settings` access, so the dangling path raises before the worker can even connect to Temporal.

**Not a `v1.36.0` regression, and the deploy pipeline is fine.** The `path_validator` has existed since the NRP migration and the incus config has referenced the missing file since the interior was first created — any worker build crash-loops on this slot. It's a bootstrap gap.

I also confirmed the temporal client-cert trio (the *other* `path_validator` paths) **is** present on the slot under `/run/tenant/temporal/` (krg-infra #435 is wired), so `kubeconfig_path` is the sole Dynaconf blocker. Refreshed the now-stale "temporal cert not wired yet" comment.

## Fix

Comment out `kubeconfig_path`. A Dynaconf `Validator(..., condition=...)` with no `required=True` is skipped when the key is absent, and `resolve_scaling_config` does `section.get("kubeconfig_path")` → `if not kubeconfig_path:` → **scaling disabled**, i.e. the documented pre-NRP mode (data-worker assumed always-on). The worker validates, connects to krg-prod Temporal, and resumes the SDK-side pipeline.

Re-enabling NRP scaling later is **not** just uncommenting: this config dir is a read-only store bind, so the secret kubeconfig must be vault-agent-rendered to a writable path (like the temporal certs) and the line pointed there. Noted in the file.

## Rollout (manual — this does NOT auto-deploy)

`deploy/incus/.../settings.toml` is outside the worker's package path, so release-please cuts no release and no `auto-deploy/*` PR opens. After merge:

1. `deploy.yml` → **Run workflow** → `target: incus` to converge (first real exercise of #241's `--no-block`).
2. The worker container is a read-only store-symlink bind, so a plain `up -d` won't re-read the new `settings.toml` — force-recreate the worker container so it picks up the change.
3. Verify it reaches `Up` and starts polling Temporal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)