### PR TITLE
fix(incus): adopt krg-infra #459/#460 (compose force-recreate + auto-upgrade); track main + weekly auto-lock

### DIFF
--- a/.github/workflows/flake-lock-check.yml
+++ b/.github/workflows/flake-lock-check.yml
@@ -1,26 +1,20 @@
 name: Flake lock check
 
-# Fails when `flake.lock` disagrees with `flake.nix`.
+# Fails when `flake.lock` disagrees with `flake.nix` inputs.
 #
-# The repo-root flake is what `fishsense-selfupdate` builds on the Incus
-# slot. The `--refresh` in
-#   nixos-rebuild switch --flake github:UCSD-E4E/fishsense-lite#fishsense --refresh
-# only busts nix's tarball-TTL cache for the *top-level* repo ref; every
-# transitive input is resolved from the committed lock. So bumping the
-# `krg-infra.url` rev in flake.nix without re-locking is a silent no-op:
-# the slot keeps building the old krg-infra, and nix can't write the
-# corrected lock back because the flake source is read-only in the store.
+# The repo-root flake is what the slot builds every converge, from the
+# committed `flake.lock` — `--refresh` only re-fetches the top-level repo
+# ref, never re-resolves transitive inputs. So a `flake.nix` that names an
+# input the lock doesn't match would silently build the wrong thing.
 #
 # `nix flake lock --no-update-lock-file` re-resolves every input against
 # flake.nix and exits non-zero if the lock would have to change. It never
-# writes.
+# writes and never advances an already-locked input.
 #
-# NOT an updater. `krg-infra` is pinned to an explicit rev — ADR 0020 §5
-# calls that rev our stable contract with the platform, bumped
-# deliberately — and `nixpkgs` follows it, so there is no input for a
-# `nix flake update` to move. To bump: edit the rev in flake.nix and run
-#   nix flake update krg-infra
-# in the same PR. This check is what catches forgetting the second half.
+# NOT an updater. flake.nix tracks krg-infra `main`; the rev is pinned in
+# flake.lock and advanced deliberately — weekly by update-flake.yml, or by
+# hand with `nix flake update krg-infra`. This check just guards that a
+# hand-edit to a `flake.nix` input is accompanied by a matching re-lock.
 
 on:
   pull_request:

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -1,0 +1,86 @@
+name: Update krg-infra pin
+
+# "Axis B" (krg-infra docs/tenant-updates.md): advance the krg-infra pin so new
+# nixpkgs (kernel / bash / openssl / CVE fixes) flow in via
+# `nixpkgs.follows = "krg-infra/nixpkgs"`. flake.nix tracks krg-infra `main`; the
+# exact rev lives in flake.lock, so this job re-locks to current main HEAD.
+#
+# Unlike the upstream template, this commits the updated flake.lock STRAIGHT TO
+# main (no PR) — the deliberate review gate we accept instead is the eval below
+# plus the nightly auto-upgrade's atomic switch (a lock that doesn't build fails
+# the switch and rolls back to the previous generation; the running system is
+# never left broken). The nightly `system.autoUpgrade` (04:00, krg-infra #460)
+# then rolls the new packages out; a new kernel needs a manual `incus restart`.
+#
+# Runs on a GitHub-hosted runner (NOT the in-slot self-hosted runner).
+#
+# Requires the push to main to be allowed for the GitHub App (APP_ID) — if main
+# is a protected branch, add the app to its bypass list, or this job fails at push.
+
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Mondays 08:00 UTC
+  workflow_dispatch: {} # out-of-cycle bump (e.g. a named CVE)
+
+permissions: {} # the App token does the write; GITHUB_TOKEN needs nothing
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      # Same GitHub App release.yml uses; a PAT-less GITHUB_TOKEN can't push to a
+      # protected main, and the App can be granted bypass.
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: main
+
+      - uses: DeterminateSystems/nix-installer-action@v22
+
+      # Bump only krg-infra; nixpkgs moves with it via the follows.
+      - name: nix flake update krg-infra
+        run: nix flake update krg-infra
+
+      - name: Stop if nothing changed
+        id: diff
+        run: |
+          if git diff --quiet -- flake.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::krg-infra pin already current; nothing to commit."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Gate before pushing to main: instantiate the tenant system so an eval error
+      # or a failed module assertion (e.g. krg-infra changed a contract) blocks the
+      # commit instead of silently landing a lock the nightly switch would reject.
+      # Eval only — no full build; the nightly switch is the atomic build safety net.
+      - name: Eval-gate the new lock
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          nix eval --raw \
+            .#nixosConfigurations.fishsense.config.system.build.toplevel.drvPath
+
+      - name: Commit flake.lock to main
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          app="${{ steps.app-token.outputs.app-slug }}[bot]"
+          uid="$(gh api "/users/${app}" --jq .id)"
+          git config user.name "$app"
+          git config user.email "${uid}+${app}@users.noreply.github.com"
+          git add flake.lock
+          git commit -m "chore(flake): bump krg-infra pin (system package updates)
+
+          Weekly Axis-B bump (krg-infra docs/tenant-updates.md) — advances the
+          krg-infra input and, via the nixpkgs follows, the kernel/bash/openssl
+          closure. Rolls out on the next converge (nightly system.autoUpgrade or
+          an auto-deploy/** push). Reboot for a new kernel."
+          git push origin HEAD:main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -672,6 +672,22 @@ name:
 Never give a job a bare `runs-on: self-hosted` — the `fishsense` label
 is what keeps GitHub-hosted work (the NRP deploy) off the tenant slot.
 
+**Two other convergence paths beyond the pin-bump PR merge.** (1) A
+manual `deploy.yml` `workflow_dispatch` (`target: incus`) — for
+config-only `deploy/incus/` changes, which cut no release and so open no
+`auto-deploy/*` PR. (2) The **nightly `system.autoUpgrade`** (04:00,
+krg-infra #460) rebuilds the slot from `github:UCSD-E4E/fishsense-lite#fishsense`,
+so anything on main rolls out within a day unattended (`allowReboot=false`).
+
+**Committed config applies only because the converge force-recreates.**
+The composeStack unit runs `up -d --force-recreate` (krg-infra
+`recreateOnConfigChange`, their #459 / our krg-infra#458). A bind-mounted
+config file is a project-dir store symlink whose target changes on edit,
+but plain `up -d` sees no compose-spec change and won't re-read it — a
+stale bind mount once crash-looped the api-worker on old config while the
+fix "deployed" with no effect. Force-recreate fixes that, at the cost of
+recreating the whole stack (postgres included) on any changed converge.
+
 **The converge is a trigger, not a clean CI gate.** `fishsense-selfupdate`
 restarts the very runner executing the job (its first action is
 `systemctl stop github-runner-fishsense`). The step therefore uses

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -109,9 +109,21 @@ flow to the slot atomically with the image-pin bump in the same commit —
 no drift window where the new image runs against the old settings or
 vice versa.
 
+For a bind-mounted config change to actually take effect, the converge
+must **recreate** the container: the config is a project-dir store
+symlink whose target changes, but `docker compose up -d` alone doesn't
+re-read it (a plain `up -d` sees no compose-spec change). The tenant
+stack runs `up -d --force-recreate` (krg-infra `recreateOnConfigChange`,
+their #459 / our krg-infra#458 — a stale bind mount once crash-looped
+the api-worker), so a *changed* converge recreates the whole stack and
+committed config applies. Cost: a brief restart of every service
+(postgres included) on a converge that changed anything.
+
 Corollary: a config-only change to `incus/` produces no release and
-therefore no `auto-deploy/*` PR, so nothing converges it. Land it on
-main, then run `deploy.yml` by hand (`workflow_dispatch`, `target: incus`).
+therefore no `auto-deploy/*` PR, so no PR-merge converge fires. It still
+rolls out on the **nightly `system.autoUpgrade`** (04:00, rebuilds from
+main — krg-infra #460); to apply it immediately, run `deploy.yml` by
+hand (`workflow_dispatch`, `target: incus`).
 
 Editing files inside the slot doesn't survive a converge — `nixos-rebuild`
 rebuilds the interior from the flake. Always commit config changes.

--- a/deploy/incus/README.md
+++ b/deploy/incus/README.md
@@ -133,9 +133,11 @@ into the `pgdata` volume (roles + passwords come from the dump); seed OpenBao to
 ## Status — resolved vs. remaining
 
 **Resolved (baked into these files):**
-- ✅ `flake.nix` — **at the repo root** (activation done), pinned rev `4c10ed3e`
-  (incl. #435–#440, #443, #453, #459 compose force-recreate, #460 nightly auto-upgrade),
-  `temporal` opt-in, quota 6/12; imports this dir by root-relative paths.
+- ✅ `flake.nix` — **at the repo root** (activation done), tracks krg-infra `main`
+  with the exact rev pinned in `flake.lock` (currently `4c10ed3e`: #435–#440, #443,
+  #453, #459 compose force-recreate, #460 nightly auto-upgrade). `temporal` opt-in,
+  quota 6/12; imports this dir by root-relative paths. The pin is advanced weekly by
+  `.github/workflows/update-flake.yml` (Axis B — committed straight to `main`).
 - ✅ **Disk/boot via `incus-virtual-machine.nix`** (the same module the krg-golden image
   builds from) — systemd-boot + ESP/root fileSystems **by label** + `incus-agent` (keeps
   `incus exec` working post-switch). Replaces the fragile captured-UUID hardware-config;

--- a/deploy/incus/README.md
+++ b/deploy/incus/README.md
@@ -9,11 +9,16 @@ the repo-root [`flake.nix`](../../flake.nix) which imports this directory.
 Upstream hand-off:
 <https://github.com/KastnerRG/krg-infra/tree/main/docs/handoff/fishsense-lite>
 
-> **Status: activated, pre-bootstrap.** The `flake.nix` is at the repo root;
-> `compose.yml` + config + `secrets.nix` + `hardware-configuration.nix` live here and
-> are referenced by root-relative paths. `.github/workflows/deploy.yml` converges the
-> slot when a `promote.yml`-generated `auto-deploy/*` pin-bump PR merges, and on manual
-> `workflow_dispatch`. First bring-up is the admin's one-time `nixos-rebuild switch`.
+> **Status: live.** The slot is bootstrapped and serving (web + API up). The
+> `flake.nix` is at the repo root; `compose.yml` + config + `secrets.nix` +
+> `hardware-configuration.nix` live here and are referenced by root-relative paths.
+> Three convergence paths: a `promote.yml`-generated `auto-deploy/*` pin-bump PR
+> merge (`.github/workflows/deploy.yml`), a manual `workflow_dispatch` (`target: incus`,
+> for config-only changes that cut no release), and the **nightly `system.autoUpgrade`**
+> (04:00, rebuilds from main — krg-infra #460). The composeStack runs
+> `up -d --force-recreate` (krg-infra #459 / our krg-infra#458) so committed config
+> changes actually apply on converge. First bring-up was the admin's one-time
+> `nixos-rebuild switch`.
 
 ## What runs here
 
@@ -128,8 +133,9 @@ into the `pgdata` volume (roles + passwords come from the dump); seed OpenBao to
 ## Status — resolved vs. remaining
 
 **Resolved (baked into these files):**
-- ✅ `flake.nix` — **at the repo root** (activation done), pinned rev `2554daa`
-  (incl. #435–#440, #443), `temporal` opt-in, quota 6/12; imports this dir by root-relative paths.
+- ✅ `flake.nix` — **at the repo root** (activation done), pinned rev `4c10ed3e`
+  (incl. #435–#440, #443, #453, #459 compose force-recreate, #460 nightly auto-upgrade),
+  `temporal` opt-in, quota 6/12; imports this dir by root-relative paths.
 - ✅ **Disk/boot via `incus-virtual-machine.nix`** (the same module the krg-golden image
   builds from) — systemd-boot + ESP/root fileSystems **by label** + `incus-agent` (keeps
   `incus exec` working post-switch). Replaces the fragile captured-UUID hardware-config;
@@ -171,11 +177,18 @@ into the `pgdata` volume (roles + passwords come from the dump); seed OpenBao to
    `fishsense-worker` after #435's grant is live.
 
 **Notes (not blockers):**
-- **the converge is a trigger, not a clean CI gate.** `fishsense-selfupdate` is a
-  oneshot that propagates `nixos-rebuild`'s exit, but it stops the runner mid-switch
-  (the Actions job may report cancelled/interrupted) and exit 0 only means `compose up -d`
-  was *issued*, not that containers are healthy. Verify on-box (`systemctl status
-  fishsense-selfupdate`) or add a post-converge HTTP health probe.
+- **the converge is a trigger, not a clean CI gate.** `fishsense-selfupdate` stops the
+  runner mid-switch, so `deploy.yml` starts it with `systemctl start --no-block` (PR #241)
+  and reports success as soon as the converge is *enqueued* — green means "converge
+  fired", not "containers healthy". Verify on-box (`systemctl status fishsense-selfupdate`)
+  or add a post-converge HTTP health probe.
+- **committed config applies only via force-recreate.** The composeStack runs
+  `up -d --force-recreate` (krg-infra #459, from our krg-infra#458): plain `up -d` doesn't
+  re-read a bind-mounted config file whose store-symlink target changed, so a config edit
+  would "deploy" with no effect — it once crash-looped the api-worker on a stale
+  `settings.toml`. Trade-off: a *changed* converge recreates the whole stack (brief
+  restart of postgres et al.). The **nightly `system.autoUpgrade`** (04:00, #460) means
+  any main change also rolls out unattended within a day.
 - **Observability — deferred, tracked.** Central tenant metrics are **held** (ours:
   **#220**, upstream krg-infra **#441** — push-based Alloy → mTLS `remote_write` → central
   Grafana, fishsense pilot). No alerting exists yet (ours: **#221**, upstream krg-infra

--- a/flake.lock
+++ b/flake.lock
@@ -121,18 +121,18 @@
       },
       "locked": {
         "dir": "nix",
-        "lastModified": 1783612601,
-        "narHash": "sha256-vcUBbfGLGe+xXe6KgD50DBilYzJ7PnVBC7LU0j4sChY=",
+        "lastModified": 1783734753,
+        "narHash": "sha256-XsJWYxfwj/8+jHtOO4HzBXLIi87YwXNgNXLcVGOz8IA=",
         "owner": "KastnerRG",
         "repo": "krg-infra",
-        "rev": "c29ab5f735102e5bf37cdb6ecf8ec1458c6a1daa",
+        "rev": "4c10ed3e09095c1792709d8e7cf252f15f894a06",
         "type": "github"
       },
       "original": {
         "dir": "nix",
         "owner": "KastnerRG",
         "repo": "krg-infra",
-        "rev": "c29ab5f735102e5bf37cdb6ecf8ec1458c6a1daa",
+        "rev": "4c10ed3e09095c1792709d8e7cf252f15f894a06",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -132,7 +132,6 @@
         "dir": "nix",
         "owner": "KastnerRG",
         "repo": "krg-infra",
-        "rev": "4c10ed3e09095c1792709d8e7cf252f15f894a06",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -17,9 +17,15 @@
     #   #447 krg-deploy runner-repo-tag read fix (mints+pushes our runner token)
     #   #453 create the github-runner workDir (fixes the 226/NAMESPACE start failure
     #        that kept our runner from registering — the workaround we handed upstream)
+    #   #459 composeStack force-recreates on converge so committed config actually
+    #        applies (our issue #458 — a stale bind mount crash-looped the api-worker);
+    #        tenant.nix turns it on for repo-owns-deploy tenants. TRADE-OFF: a changed
+    #        converge now recreates the WHOLE stack (brief restart of postgres et al.).
+    #   #460 nightly system.autoUpgrade (04:00) rebuilds from THIS flake — the slot
+    #        self-heals/updates from main without an auto-deploy PR; allowReboot=false.
     # This rev IS our stable contract (ADR 0020 §5); bump deliberately to pick up
     # platform-seam changes.
-    krg-infra.url = "github:KastnerRG/krg-infra/c29ab5f735102e5bf37cdb6ecf8ec1458c6a1daa?dir=nix";
+    krg-infra.url = "github:KastnerRG/krg-infra/4c10ed3e09095c1792709d8e7cf252f15f894a06?dir=nix";
     nixpkgs.follows = "krg-infra/nixpkgs";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,24 +8,22 @@
   description = "fishsense-lite — KRG Incus platform tenant #1";
 
   inputs = {
-    # Pinned to a merged krg-infra main SHA that includes:
-    #   #431 vault-agent fishsense.vm cert + repo-owns-deploy runner
-    #   #435 ADR 0023 in-slot Temporal client-cert render
-    #   #436 quota 6/12   #437 api.fishsense SANs + external_host rename
-    #   #438 OIDC secrets → tenant KV + §9 app-secret render pattern
-    #   #439 root disk 50 GiB   #440 co-located proxy outpost (Option A)   #443 OIDC writer glob
-    #   #447 krg-deploy runner-repo-tag read fix (mints+pushes our runner token)
-    #   #453 create the github-runner workDir (fixes the 226/NAMESPACE start failure
-    #        that kept our runner from registering — the workaround we handed upstream)
-    #   #459 composeStack force-recreates on converge so committed config actually
-    #        applies (our issue #458 — a stale bind mount crash-looped the api-worker);
-    #        tenant.nix turns it on for repo-owns-deploy tenants. TRADE-OFF: a changed
-    #        converge now recreates the WHOLE stack (brief restart of postgres et al.).
-    #   #460 nightly system.autoUpgrade (04:00) rebuilds from THIS flake — the slot
-    #        self-heals/updates from main without an auto-deploy PR; allowReboot=false.
-    # This rev IS our stable contract (ADR 0020 §5); bump deliberately to pick up
-    # platform-seam changes.
-    krg-infra.url = "github:KastnerRG/krg-infra/4c10ed3e09095c1792709d8e7cf252f15f894a06?dir=nix";
+    # Tracks krg-infra `main`; the EXACT rev is pinned in `flake.lock`, not here.
+    # That lock rev is our stable contract (ADR 0020 §5): every converge builds from
+    # the committed lock, so `main` moving doesn't touch the slot until the lock is
+    # advanced — the deliberate act being a merge to our `main`.
+    #
+    # Advancing the pin is "Axis B" (krg-infra docs/tenant-updates.md) and it's OURS:
+    # `nixpkgs.follows = "krg-infra/nixpkgs"`, so bumping krg-infra drags in new
+    # nixpkgs (kernel / bash / openssl / CVE fixes). `.github/workflows/update-flake.yml`
+    # does it weekly — `nix flake update krg-infra`, committed straight to `main` — and
+    # the nightly `system.autoUpgrade` (#460) rolls it out. Skip it and the slot freezes
+    # on old, unpatched packages. A new kernel needs a manual `incus restart` (allowReboot=false).
+    #
+    # The lock currently carries krg-infra @ 4c10ed3e (incl. #435–#440/#443/#453,
+    # #459 compose force-recreate, #460 nightly auto-upgrade). `git log -p flake.lock`
+    # is the real history of what shipped.
+    krg-infra.url = "github:KastnerRG/krg-infra?dir=nix";
     nixpkgs.follows = "krg-infra/nixpkgs";
   };
 


### PR DESCRIPTION
Adopts krg-infra's fix for our [krg-infra#458](https://github.com/KastnerRG/krg-infra/issues/458), and moves us to the platform's "staying patched" model.

## 1. The compose fix + auto-upgrade (via the lock @ `4c10ed3e`)

- **[#459](https://github.com/KastnerRG/krg-infra/pull/459)** — composeStack now runs `up -d --force-recreate`, so bind-mounted config changes actually apply on converge (a stale bind mount crash-looped our api-worker; #458). Verified: `fishsense.service` ExecStart ends `--force-recreate`. Tradeoff: a *changed* converge recreates the whole stack (postgres included).
- **[#460](https://github.com/KastnerRG/krg-infra/pull/460)** — nightly `system.autoUpgrade` (04:00) rebuilds from our flake. Verified: `enable=true`, `flake=github:UCSD-E4E/fishsense-lite#fishsense`, `04:00`.

This is the real end of the worker outage: with `--force-recreate`, the next converge recreates the worker → it finally reads #242's `settings.toml` fix.

## 2. Track `main`, and own "Axis B"

krg-infra's `docs/tenant-updates.md` splits updates into **Apply** (automatic now) and **Advance the pin** (ours). Their guidance: advance the `krg-infra` pin regularly or the slot freezes on unpatched kernel/bash/openssl.

Their template `update-flake.yml` runs `nix flake update krg-infra` — which only advances if flake.nix **tracks a branch**. Ours pinned the rev in the URL, so it'd no-op. So:

- **flake.nix now tracks krg-infra `main`**; the exact rev is pinned in `flake.lock` (still `4c10ed3e`). The lock is the stable contract (ADR 0020 §5); `main` moving doesn't touch the slot until the lock advances.
- **New `.github/workflows/update-flake.yml`** (weekly Mon 08:00 + dispatch): `nix flake update krg-infra`, **eval-gates** the tenant toplevel, and commits `flake.lock` **straight to `main` — no PR** (per your call). The nightly auto-upgrade rolls it out. Atomic switch is the build safety net; the eval-gate blocks a lock that won't evaluate.
- `flake-lock-check` retained as a lock/flake.nix consistency guard (its old URL-rev-drift rationale is moot under track-main; comment updated).

## Verification

- ExecStart `--force-recreate` ✅, autoUpgrade enable/flake/04:00 ✅, tenant toplevel evaluates ✅ (the exact eval-gate the new workflow runs).
- nixpkgs did **not** move (module-only bump). Lock: only the krg-infra node; `original` spec is now branch-tracking. `flake lock --no-update-lock-file` in sync.
- actionlint clean on both workflows.

## Rollout / operator notes

- Repo-root flake change → no release → **converge manually** (`deploy.yml` → Run workflow → `target: incus`) to apply now and recover the worker. First real exercise of #241's `--no-block`.
- **Branch protection:** the weekly job pushes to `main` via the GitHub App (`APP_ID`). If `main` is protected, add the app to its bypass list or the weekly commit fails at push.
- **Kernel:** auto-upgrade is `allowReboot=false`; a new kernel needs a manual `incus restart fishsense --project fishsense`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)