### PR TITLE
fix(data-worker): NRP config → krg-prod Temporal + api.fishsense; pin namespace e4e-fishsense

### DIFF
--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -53,23 +53,27 @@ jobs:
           # `kind create cluster` writes the kubeconfig + sets the
           # current context here; expose the path to the pytest step.
           echo "KUBECONFIG=$HOME/.kube/config" >> "$GITHUB_ENV"
+          # The kustomization pins `namespace: e4e-fishsense`, so the
+          # ephemeral cluster must have it before the Secrets + apply.
+          kubectl create namespace e4e-fishsense
 
       - name: Create stub Secrets the Deployment references
         # Real values don't matter — the pod won't pull the private
         # image and we never wait for it to be Ready; this just lets
         # `kubectl apply -k` resolve the secretKeyRef / imagePullSecrets
-        # so the apply is a faithful server-side validation.
+        # so the apply is a faithful server-side validation. Secrets go
+        # in the pinned namespace so the secretKeyRefs resolve.
         run: |
-          kubectl create secret generic fishsense-data-worker-secrets \
+          kubectl create secret generic fishsense-data-worker-secrets -n e4e-fishsense \
             --from-literal=fishsense_api_username=ci \
             --from-literal=fishsense_api_password=ci \
             --from-literal=object_store_access_key=ci \
             --from-literal=object_store_secret_key=ci
-          kubectl create secret generic fishsense-data-worker-temporal-certs \
+          kubectl create secret generic fishsense-data-worker-temporal-certs -n e4e-fishsense \
             --from-literal=client.pem=ci \
             --from-literal=client.key=ci \
             --from-literal=root-ca.pem=ci
-          kubectl create secret docker-registry ghcr-pull \
+          kubectl create secret docker-registry ghcr-pull -n e4e-fishsense \
             --docker-server=ghcr.io \
             --docker-username=ci \
             --docker-password=ci
@@ -77,7 +81,7 @@ jobs:
       - name: Apply the data-worker manifests (server-side validation)
         run: |
           kubectl apply -k deploy/k8s/data-worker
-          kubectl get deployment fishsense-data-processing-workflow-worker -o yaml
+          kubectl get deployment fishsense-data-processing-workflow-worker -n e4e-fishsense -o yaml
 
       - uses: actions/setup-python@v5
         with:
@@ -89,4 +93,8 @@ jobs:
 
       - name: Run the k8s scaling integration tests
         # KUBECONFIG (set above) points pytest at the kind cluster.
+        # K8S_NAMESPACE matches the namespace the kustomization pins, so
+        # the scaling test finds the Deployment it just applied.
+        env:
+          K8S_NAMESPACE: e4e-fishsense
         run: uv run --directory services/fishsense-api-workflow-worker pytest -v -m k8s

--- a/deploy/k8s/data-worker/README.md
+++ b/deploy/k8s/data-worker/README.md
@@ -21,7 +21,7 @@ differs.
 
 The data-worker is a **pull-based Temporal worker** — at `replicas: 0`
 no pods run, and work just waits on `fishsense_data_processing_queue`
-until a worker appears. The **api-worker** (running on the orchestrator,
+until a worker appears. The **api-worker** (running in the Incus slot,
 outside this cluster) brings it back:
 
 * Each parent workflow that dispatches a data-worker child calls
@@ -31,16 +31,19 @@ outside this cluster) brings it back:
   the data-worker task queue has had no running or recently-closed
   workflow for `kubernetes.idle_cooldown_minutes`.
 
-For that to work the api-worker needs an NRP kubeconfig and the
-`[kubernetes]` config section (`kubeconfig_path`, `namespace`,
-`deployment_name`, `active_replicas`, `idle_cooldown_minutes`) — see
-the api-worker's `settings.toml` / `deploy/README.md`. The same
-kubeconfig is what CI uses to `kubectl apply` (repo secret
-`NRP_KUBECONFIG`).
+For that to work the api-worker needs the `e4e-fishsense` kubeconfig
+(vault-agent-rendered from OpenBao to `/run/tenant/nrp/kubeconfig`, #245)
+and the `[kubernetes]` config section (`kubeconfig_path`, `namespace =
+"e4e-fishsense"`, `deployment_name`, `active_replicas`,
+`idle_cooldown_minutes`) — see the api-worker's `settings.toml` in
+`deploy/incus/worker_volumes/api_worker/config/`. The same kubeconfig is
+what CI uses to `kubectl apply` (repo secret `NRP_KUBECONFIG`).
 
 ## One-time bootstrap (per NRP namespace)
 
-1. Request a namespace + enough quota from NRP support for
+1. Namespace: **`e4e-fishsense`** (already provisioned; pinned in
+   `kustomization.yaml`). If standing up a fresh one, request the
+   namespace + enough quota from NRP support for
    `active_replicas × the Deployment's limits`, **and** ask (in
    Matrix, per <https://nrp.ai/contact>) for a permanent-service
    exception for the namespace. NRP garbage-collects Deployments
@@ -49,30 +52,41 @@ kubeconfig is what CI uses to `kubectl apply` (repo secret
    policy, and our pods are owned by a ReplicaSet so the 6-hour
    bare-pod rule doesn't apply either; the Deployment itself is the
    only thing that needs the exception.)
-2. Get a (token) kubeconfig for that namespace. It's used in two
+2. Get a (token) kubeconfig for `e4e-fishsense`. It's used in two
    places — the repo secret `NRP_KUBECONFIG` (CI deploys) and the
-   api-worker's mounted kubeconfig (scaling) — and **expires**, so put
-   a renewal reminder somewhere.
+   api-worker on the Incus slot (scaling). The slot's copy is **not**
+   a mounted file: seed it into OpenBao at
+   `secret/tenants/fishsense/nrp { kubeconfig }` and vault-agent renders
+   it to `/run/tenant/nrp/kubeconfig` in the slot (see
+   `deploy/incus/secrets.nix` + the api-worker's `[kubernetes].kubeconfig_path`;
+   wired by #245). The token **expires** — reseed OpenBao + rotate
+   `NRP_KUBECONFIG` on renewal.
 3. Create the three Secrets the Deployment references:
 
    ```sh
+   # (all in the e4e-fishsense namespace — the kubeconfig context or -n)
+
    # 1. Service-account creds (SDK HTTP Basic, via authentik passthrough)
    #    + Garage S3 access key/secret for the object store
-   kubectl create secret generic fishsense-data-worker-secrets \
+   kubectl create secret generic fishsense-data-worker-secrets -n e4e-fishsense \
      --from-literal=fishsense_api_username='<svc>' \
      --from-literal=fishsense_api_password='<svc-pw>' \
      --from-literal=object_store_access_key='<garage-access-key>' \
      --from-literal=object_store_secret_key='<garage-secret-key>'
 
-   # 2. Temporal mTLS material (the data-worker's OWN client cert/key +
-   #    the same root CA the other workers use)
-   kubectl create secret generic fishsense-data-worker-temporal-certs \
+   # 2. Temporal mTLS material — the data-worker's OWN krg-prod client
+   #    identity, distinct from the api-worker's. Mint on krg-deploy:
+   #      bao write pki_int/issue/temporal-client \
+   #        common_name=fishsense-worker ttl=720h
+   #    (CN authorized for the fishsense tenant now that krg-infra #435's
+   #    grant is live). Renew ~30d. root-ca.pem is krg-prod's Temporal CA.
+   kubectl create secret generic fishsense-data-worker-temporal-certs -n e4e-fishsense \
      --from-file=client.pem=/path/to/fishsense-data-processing-workflow-worker.pem \
      --from-file=client.key=/path/to/fishsense-data-processing-workflow-worker.key \
      --from-file=root-ca.pem=/path/to/root-ca.pem
 
    # 3. Pull secret for the private GHCR image
-   kubectl create secret docker-registry ghcr-pull \
+   kubectl create secret docker-registry ghcr-pull -n e4e-fishsense \
      --docker-server=ghcr.io \
      --docker-username='<github-user>' \
      --docker-password='<PAT with read:packages on UCSD-E4E>'
@@ -81,8 +95,8 @@ kubeconfig is what CI uses to `kubectl apply` (repo secret
    (Credentials in git are out of scope here — if you want them
    reconciled by `kubectl apply` instead, add Sealed Secrets / SOPS.)
 4. First apply manually: `kubectl apply -k deploy/k8s/data-worker`
-   (set the namespace via `-n` / the kubeconfig context, or pin it in
-   `kustomization.yaml`). The Deployment manifest omits `replicas`
+   (the namespace `e4e-fishsense` is pinned in `kustomization.yaml`, so
+   no `-n` needed). The Deployment manifest omits `replicas`
    (the api-worker owns it), so this first create comes up at the k8s
    default of 1 — `kubectl scale deployment/fishsense-data-processing-workflow-worker --replicas=0`
    right after, or just leave it: the hourly idle-sweeper scales it to
@@ -91,26 +105,33 @@ kubeconfig is what CI uses to `kubectl apply` (repo secret
    `auto-deploy/fishsense-data-processing-workflow-worker-*` PR;
    merging it triggers `deploy.yml` to `kubectl apply -k` again.
 
-## Prerequisite on the orchestrator side
+## Prerequisite on the Incus slot side
 
-Storage is the hosted Garage (S3-compatible) object store, reached
-directly at its public endpoint with S3 access keys — there's no
-Traefik/authentik route for the worker's bytes to survive anymore (the
-old `/api/v1/exchange/*` forward-auth route is gone with the Garage
-migration). So the orchestrator-side TODO is just credentials +
-network reachability:
+The data-worker is Garage-only: it reaches the hosted Garage (S3) object
+store directly at its public endpoint with S3 access keys, talks to the
+public `api.fishsense.e4e.ucsd.edu` route, and polls the shared **krg-prod**
+Temporal cluster (`settings.toml` `[temporal]` → `krg-prod.ucsd.edu`,
+matching the api-worker — the two share `fishsense_data_processing_queue`,
+so a mismatched cluster means dispatched children time out forever). Slot /
+platform-side TODO:
 
+- **Seed OpenBao `secret/tenants/fishsense/nrp { kubeconfig }`** with the
+  `e4e-fishsense` token kubeconfig, so vault-agent renders it into the slot
+  and the api-worker can scale this Deployment (#245). Do this **before**
+  the api-worker converge that enables `[kubernetes].kubeconfig_path`, or it
+  crash-loops on the missing file (isolated to that worker).
 - Mint a Garage S3 access key scoped to read the `raw/` + `slate_pdf/`
   scratch prefixes and write the JPEG prefixes; put it in the
   `fishsense-data-worker-secrets` Secret above.
 - Garage must send CORS headers for the labeler origin (Label Studio
   presigns the JPEGs and the browser fetches them directly) — but
   that's a Label-Studio-serving concern, not a worker one.
-- The SDK still presents `fishsense_api.username/password` to
-  fishsense-api through authentik basic-auth-passthrough; reuse the
-  existing service account.
-- Confirm the orchestrator's firewall allows Temporal `:7233` ingress
-  from NRP node ranges.
+- The SDK presents `fishsense_api.username/password` to
+  `api.fishsense.e4e.ucsd.edu` through authentik basic-auth-passthrough;
+  reuse the existing service account. Confirm the passthrough policy
+  covers the service account on the API paths the SDK hits.
+- Temporal reachability is to krg-prod (`:7233`) from NRP node ranges —
+  a krg-prod ingress concern, not the (now-decommissioned) orchestrator's.
 
 ## Not here
 

--- a/deploy/k8s/data-worker/kustomization.yaml
+++ b/deploy/k8s/data-worker/kustomization.yaml
@@ -7,10 +7,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# NRP assigns you a namespace. Either uncomment + pin it here, or pass
-# `-n <namespace>` / rely on the kubeconfig context default at apply
-# time. CI's deploy.yml does the latter via the NRP_KUBECONFIG context.
-# namespace: fishsense-...
+# NRP-assigned namespace. Pinned so both a manual `kubectl apply -k` and
+# CI's deploy.yml target it deterministically, regardless of the
+# NRP_KUBECONFIG context's default.
+namespace: e4e-fishsense
 
 resources:
   - deployment.yaml

--- a/deploy/k8s/data-worker/settings.toml
+++ b/deploy/k8s/data-worker/settings.toml
@@ -10,9 +10,11 @@
 # README.md). Dynaconf reads `E4EFS_<SECTION>__<KEY>`, so e.g.
 # `E4EFS_FISHSENSE_API__USERNAME` populates `fishsense_api.username`.
 #
-# Networking: the data-worker runs off the orchestrator's docker
-# network (NRP pods, no stable egress IP), so every URL must be
-# publicly routable. Storage is the hosted Garage (S3-compatible)
+# Networking: the data-worker runs on NRP (no stable egress IP) — off
+# the fishsense Incus slot entirely — so every URL must be publicly
+# routable. Temporal is the shared krg-prod cluster (mTLS), matching the
+# api-worker; fishsense-api is the public `api.` route (behind authentik
+# basic-auth-passthrough — see README). Storage is the hosted Garage (S3-compatible)
 # object store — Garage S3 access keys authenticate from any IP, so
 # there's no IP allowlist / forward-auth to survive (this is what lets
 # the worker run on NRP with no stable egress IP). The api-worker
@@ -23,19 +25,29 @@
 [general]
 max_workers = 8
 
+# Shared krg-prod Temporal (mTLS). MUST match the api-worker's cluster +
+# TLS server-name — the two workers share the `fishsense_data_processing_queue`
+# (api-worker dispatches, this worker polls), and neither passes a namespace
+# to `Client.connect`, so cluster membership is entirely host/domain/cert.
+# The old in-orchestrator `workflows.fishsense.e4e.ucsd.edu` cluster is gone.
 [temporal]
-host = "workflows.fishsense.e4e.ucsd.edu"
+host = "krg-prod.ucsd.edu"
 port = "7233"
 tls = true
-# Data-worker's own mTLS client identity (distinct from the api-worker's).
+# Data-worker's own mTLS client identity (distinct from the api-worker's),
+# authorized for the fishsense tenant on krg-prod (CN `fishsense-worker`).
 # Mounted from the `fishsense-data-worker-temporal-certs` Secret at /certs.
 client_cert = "/certs/client/fishsense-data-processing-workflow-worker.pem"
 client_private_key = "/certs/client/fishsense-data-processing-workflow-worker.key"
-domain = "workflows.fishsense.e4e.ucsd.edu"
+domain = "workflows.krg.ucsd.edu"           # TLS server-name override (SNI), matches api-worker
 server_root_ca_cert = "/certs/ca/root-ca.pem"
 
+# Public API route (the worker is off-slot, so no internal fishsense-api
+# host). Renamed from `orchestrator.` at the Incus migration; the old host
+# is decommissioned. The SDK's HTTP Basic creds pass through authentik's
+# basic-auth-passthrough policy on this route (README, orchestrator-side prereq).
 [fishsense_api]
-url = "https://orchestrator.fishsense.e4e.ucsd.edu"
+url = "https://api.fishsense.e4e.ucsd.edu"
 
 # Hosted Garage (S3-compatible) object store. The data-worker reads
 # staged raw `.ORF` + slate PDFs and writes processed JPEGs back. S3


### PR DESCRIPTION
Makes the NRP data-worker manifests actually deploy-ready. Its `settings.toml` was written before the Incus migration and never updated, so a `kubectl apply -k` today would come up pointed at **dead endpoints and silently do nothing** — which is exactly the `ChildWorkflowError: Child Workflow execution timed out` we've been seeing on the slot (api-worker dispatches to `fishsense_data_processing_queue`, nothing polls it).

## Fixes

- **[temporal] → krg-prod.** Was `workflows.fishsense.e4e.ucsd.edu` (the retired in-orchestrator cluster). Now `host = krg-prod.ucsd.edu`, `domain = workflows.krg.ucsd.edu` (SNI), matching the api-worker. Neither worker passes a namespace to `Client.connect` ([worker.py:131-133](services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py#L131-L133)), so cluster membership is purely host/domain/cert — this is what puts both workers on the same queue.
- **[fishsense_api].url → api.fishsense.** Was the decommissioned `orchestrator.` host. Now the public `api.fishsense.e4e.ucsd.edu` route (SDK Basic creds via authentik basic-auth-passthrough).
- **Pin `namespace: e4e-fishsense`** in `kustomization.yaml` so manual + CI applies are deterministic.

## Verified

- `kustomize build` → namespace propagates to ConfigMap + Deployment, image `v2.5.0`, all Secret/ConfigMap refs intact.
- `settings.toml` parses.
- Cert mount paths + Secret keys already matched the Deployment/README — unchanged. `object_store` matches the api-worker — unchanged (flagged below to verify the minted key's scope).

## Still operator-gated (this PR is repo-side only)

This makes the manifests correct; it does **not** deploy. To bring the worker up (namespace `e4e-fishsense` exists):
1. Create the three Secrets in `e4e-fishsense`: `fishsense-data-worker-secrets` (fishsense-api svc creds + a Garage S3 key scoped to `raw/`+`slate_pdf/` read / JPEG write), `fishsense-data-worker-temporal-certs` (data-worker's own krg-prod client cert trio, CN `fishsense-worker`, via `bao write pki_int/issue/temporal-client`), `ghcr-pull` (GHCR PAT).
2. `kubectl apply -k deploy/k8s/data-worker` (then `scale --replicas=0`, or let the idle-sweeper).
3. Set repo secret `NRP_KUBECONFIG` so CI can roll future image bumps.
4. Re-enable api-worker scaling (reverses #242): render the kubeconfig into the slot + re-add `[kubernetes].kubeconfig_path` — I can draft that PR next.

See `deploy/k8s/data-worker/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)