### PR TITLE
feat(incus): re-enable api-worker → NRP data-worker scaling (reverses #242; ⚠️ seed kubeconfig first)

### DIFF
--- a/deploy/incus/compose.yml
+++ b/deploy/incus/compose.yml
@@ -214,6 +214,10 @@ services:
       # krg-prod Temporal mTLS client identity — vault-agent render (temporal opt-in
       # in flake.nix; krg-infra #435).
       - /run/tenant/temporal:/run/tenant/temporal:ro
+      # NRP kubeconfig for scaling the data-worker Deployment (vault-agent
+      # SOFT render — secrets.nix). Only this worker scales k8s; the backup
+      # worker doesn't get it. [kubernetes].kubeconfig_path points here.
+      - /run/tenant/nrp:/run/tenant/nrp:ro
     networks: [interior]
 
   # ── nightly Postgres → NAS backups ─────────────────────────────────────────────────────

--- a/deploy/incus/secrets.nix
+++ b/deploy/incus/secrets.nix
@@ -18,6 +18,9 @@
 #   label_studio  { api_key }
 #   object_store  { access_key, secret_key }   # Garage S3
 #   nas           { username, password }        # Synology FileStation
+#   nrp           { kubeconfig }                # NRP token kubeconfig — api-worker scales the
+#                                               # data-worker Deployment (ns e4e-fishsense). SOFT
+#                                               # render (below); token expires — reseed on rotation.
 # PLATFORM writes (tofu — do NOT seed):
 #   oidc/web                 { client_id, client_secret, issuer_url }   (#438)
 #   oidc/analytics           { client_id, client_secret, issuer_url }   (#438)
@@ -72,6 +75,29 @@
       destination = "/run/tenant/secrets/backup-postgres.env";
       contents = ''
         {{ with secret "secret/data/tenants/fishsense/postgres" }}E4EFS_POSTGRES__PASSWORD={{ .Data.data.backup_password }}{{ end }}
+      '';
+    }
+    {
+      # NRP token kubeconfig — the api-worker uses it to scale the data-worker
+      # Deployment on NRP (ns e4e-fishsense) via the k8s API. Rendered to a
+      # WRITABLE runtime path (the committed config dir is a read-only store
+      # bind) and mounted into the api-worker container (compose.yml);
+      # settings.toml `[kubernetes].kubeconfig_path` points at it.
+      #
+      # SOFT render (errorOnMissingKey=false) — same reasoning as the outpost
+      # token: an un-seeded kubeconfig must NOT fail-close the whole agent (that
+      # would also block the fishsense.vm cert → inner Traefik → the entire
+      # stack). If unseeded, the file renders empty and only api-worker scaling
+      # is affected, not the slot.
+      #
+      # ORDERING: seed `nrp.kubeconfig` in OpenBao BEFORE merging/converging the
+      # matching `kubeconfig_path` in settings.toml — otherwise the api-worker's
+      # path_validator sees a missing/empty kubeconfig (isolated to that worker,
+      # recoverable by seeding + reconverge; the rest of the slot stays up).
+      destination = "/run/tenant/nrp/kubeconfig";
+      errorOnMissingKey = false;
+      contents = ''
+        {{ with secret "secret/data/tenants/fishsense/nrp" }}{{ .Data.data.kubeconfig }}{{ end }}
       '';
     }
     {

--- a/deploy/incus/worker_volumes/api_worker/config/settings.toml
+++ b/deploy/incus/worker_volumes/api_worker/config/settings.toml
@@ -44,24 +44,23 @@ endpoint_url = "https://garage.fishsense.e4e.ucsd.edu"
 region = "garage"
 bucket = "fishsense"
 
-# NRP data-worker scale-to-zero — DISABLED until the NRP kubeconfig is
-# delivered to the slot.
+# NRP data-worker scale-to-zero. The api-worker scales the data-worker
+# Deployment (ns `e4e-fishsense`) 0 <-> active_replicas on demand.
 #
-# `kubeconfig_path` must point at a file that EXISTS: config.py validates it
-# with a `path_validator`, and Dynaconf runs every validator eagerly on first
-# settings access, so a dangling path crash-loops the worker at startup before
-# it can even connect to Temporal. With `kubeconfig_path` unset the scaling
-# activity no-ops (`resolve_scaling_config` returns disabled) and the
-# data-worker is assumed always-on — the supported pre-NRP mode.
+# `kubeconfig_path` points at a vault-agent SOFT render (secrets.nix →
+# /run/tenant/nrp/kubeconfig, mounted into this worker by compose.yml) — the
+# committed config dir is a read-only store bind, so the secret kubeconfig
+# can't live here. config.py validates the path with a `path_validator` that
+# runs eagerly at startup, so the file MUST exist: seed `nrp.kubeconfig` in
+# OpenBao BEFORE this converges, or the worker crash-loops (isolated to this
+# worker; the slot stays up because the render is soft). With `kubeconfig_path`
+# absent the scaling activity no-ops (data-worker assumed always-on).
 #
-# Re-enabling is NOT just uncommenting: this config dir is a read-only store
-# bind (workdir.nix symlinks it from the flake store), so vault-agent can't
-# render a secret kubeconfig here. It must render to a writable path (as it
-# does for the temporal certs under /run/tenant/temporal/), and this line must
-# then point there. The NRP kubeconfig delivery is still an open operator item.
+# `namespace` MUST match the NRP namespace + the kustomization pin in
+# deploy/k8s/data-worker (e4e-fishsense) — it's where the scale patch is applied.
 [kubernetes]
-# kubeconfig_path = "/run/tenant/<writable>/nrp.kubeconfig"
-namespace = "fishsense"
+kubeconfig_path = "/run/tenant/nrp/kubeconfig"
+namespace = "e4e-fishsense"
 deployment_name = "fishsense-data-processing-workflow-worker"
 active_replicas = 1
 idle_cooldown_minutes = 15


### PR DESCRIPTION
Staged reversal of #242 — wires the api-worker back up to scale the NRP data-worker Deployment, the proper way. **Do not merge until the NRP kubeconfig is seeded in OpenBao** (see the ordering warning).

## Why #242 disabled it, and what this changes

#242 commented out `[kubernetes].kubeconfig_path` because the kubeconfig wasn't on the slot and a dangling path crash-loops the api-worker (Dynaconf's eager `path_validator`). Now that the data-worker is coming up on NRP (namespace `e4e-fishsense`), this re-enables scaling:

- **`secrets.nix`** — SOFT vault-agent render of the NRP kubeconfig to `/run/tenant/nrp/kubeconfig` (from OpenBao `secret/tenants/fishsense/nrp { kubeconfig }`). `errorOnMissingKey=false`, same reasoning as the outpost token: an un-seeded kubeconfig must **not** fail-close the whole agent (that would also block the `fishsense.vm` cert → inner Traefik → the entire stack).
- **`compose.yml`** — mount `/run/tenant/nrp` into the **api-worker only** (the backup worker doesn't scale k8s).
- **`settings.toml`** — re-add `kubeconfig_path`, and **fix the stale `namespace = "fishsense"` → `"e4e-fishsense"`** (the real NRP namespace + the kustomization pin from #244). Without this the scale patch would target the wrong namespace.

## ⚠️ Ordering (why it's staged)

Seed `nrp.kubeconfig` in OpenBao **before** merging/converging. The render is soft so the slot stays up if it's unseeded, but a missing/empty kubeconfig fails the api-worker's `path_validator` → **that worker crash-loops** (isolated to the api-worker, recoverable by seeding + re-converge; the rest of the slot is fine). So: seed → merge → converge.

Also note: since this is a `deploy/incus/` change, merging cuts no release → converge manually (`deploy.yml` → `workflow_dispatch` → `target: incus`).

## Fits with the rest of the bring-up

Pairs with **#244** (data-worker manifests → krg-prod Temporal + `api.fishsense` + `namespace: e4e-fishsense`). Full operator sequence once both are ready:
1. Create the 3 Secrets in `e4e-fishsense` + seed OpenBao `nrp.kubeconfig`.
2. `kubectl apply -k deploy/k8s/data-worker` (merge #244 first).
3. Set repo secret `NRP_KUBECONFIG`.
4. Merge **this PR** + converge → api-worker starts scaling the data-worker.

Validated: flake evaluates, TOML + compose YAML parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)