### PR TITLE
fix(web): env-drive the migration-stale landing-page links (LABELER_BASE, Workflows, Analytics)

### DIFF
--- a/apps/fishsense-lite-web/lib/sections.test.ts
+++ b/apps/fishsense-lite-web/lib/sections.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ActiveProjects } from "./active-projects";
 import { buildSections } from "./sections";
 import type { StaticLink } from "./static-links";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 const EMPTY_ACTIVE: ActiveProjects = {
   laser: [],
@@ -32,9 +36,28 @@ describe("buildSections", () => {
       {
         title: "REEF Laser High",
         description: "REEF Laser High labeling project",
-        href: "https://labeler.e4e.ucsd.edu/projects/42",
+        // Default hosted-LS base when no env is set.
+        href: "https://app.heartex.com/projects/42",
       },
     ]);
+  });
+
+  it("derives the project link base from LABEL_STUDIO_URL, overridable by LABELER_BASE", () => {
+    vi.stubEnv("LABEL_STUDIO_URL", "https://ls.example.com");
+    expect(
+      buildSections(
+        { ...EMPTY_ACTIVE, laser: [{ id: 42, title: "P" }] },
+        NO_STATIC,
+      )[0].links[0].href,
+    ).toBe("https://ls.example.com/projects/42");
+
+    vi.stubEnv("LABELER_BASE", "https://override.example.com");
+    expect(
+      buildSections(
+        { ...EMPTY_ACTIVE, laser: [{ id: 42, title: "P" }] },
+        NO_STATIC,
+      )[0].links[0].href,
+    ).toBe("https://override.example.com/projects/42");
   });
 
   it("emits sections in the canonical order: Laser, Head/Tail, Species, Slate, Results, Administration", () => {

--- a/apps/fishsense-lite-web/lib/sections.ts
+++ b/apps/fishsense-lite-web/lib/sections.ts
@@ -1,5 +1,17 @@
 import type { ActiveProjects } from "./active-projects";
-import { LABELER_BASE, type StaticLink } from "./static-links";
+import type { StaticLink } from "./static-links";
+
+// User-facing base for Label Studio project links. Derived from the LS
+// instance URL (LABEL_STUDIO_URL, e.g. https://app.heartex.com) so the
+// cards point at the same instance the API resolves names from; overridable
+// via LABELER_BASE. Read at call time so it tracks the runtime env.
+function labelerBase(): string {
+  return (
+    process.env.LABELER_BASE ??
+    process.env.LABEL_STUDIO_URL ??
+    "https://app.heartex.com"
+  );
+}
 
 export type SectionLink = {
   title: string;
@@ -24,6 +36,7 @@ export function buildSections(
   staticLinks: { results: StaticLink[]; admin: StaticLink[] },
 ): Section[] {
   const sections: Section[] = [];
+  const base = labelerBase();
 
   for (const { key, title } of LABELING_KINDS) {
     const projects = active[key];
@@ -33,7 +46,7 @@ export function buildSections(
       links: projects.map((p) => ({
         title: p.title,
         description: `${p.title} labeling project`,
-        href: `${LABELER_BASE}/projects/${p.id}`,
+        href: `${base}/projects/${p.id}`,
       })),
     });
   }

--- a/apps/fishsense-lite-web/lib/static-links.ts
+++ b/apps/fishsense-lite-web/lib/static-links.ts
@@ -4,7 +4,17 @@ export type StaticLink = {
   href: string;
 };
 
-const ANALYTICS_BASE = "https://analytics.fishsense.e4e.ucsd.edu/superset/dashboard";
+// Overridable via env so a host change doesn't need a code deploy.
+const ANALYTICS_BASE =
+  process.env.ANALYTICS_BASE ??
+  "https://analytics.fishsense.e4e.ucsd.edu/superset/dashboard";
+
+// Temporal moved to the shared krg-prod cluster at the Incus migration; the
+// old in-orchestrator `workflows.fishsense.e4e.ucsd.edu` UI is gone. Set
+// WORKFLOWS_URL to the current UI (if any is exposed to tenants) — the
+// default below is the retired host and only a placeholder.
+const WORKFLOWS_URL =
+  process.env.WORKFLOWS_URL ?? "https://workflows.fishsense.e4e.ucsd.edu/";
 
 export const RESULTS_LINKS: StaticLink[] = [
   {
@@ -23,8 +33,6 @@ export const ADMIN_LINKS: StaticLink[] = [
   {
     title: "Workflows",
     description: "Temporal Workflows",
-    href: "https://workflows.fishsense.e4e.ucsd.edu/",
+    href: WORKFLOWS_URL,
   },
 ];
-
-export const LABELER_BASE = "https://labeler.e4e.ucsd.edu";


### PR DESCRIPTION
Three hardcoded hostnames in the landing page were left **dead** by the Incus migration. This env-drives them so a host change is config, not code.

- **Labeling-card base** was `https://labeler.e4e.ucsd.edu` (self-hosted LS, retired → hosted `app.heartex.com`). Now derived from `LABEL_STUDIO_URL` (the same instance the API resolves project names from), overridable via `LABELER_BASE`, default `https://app.heartex.com`. Read at call time in `buildSections`. **This is the important one** — it's what makes the labeling cards point at the hosted LS after re-population creates the new per-dive projects.
- **Admin "Workflows"** link pointed at `workflows.fishsense.e4e.ucsd.edu` (the in-orchestrator Temporal UI, gone — Temporal is on krg-prod now). Now `WORKFLOWS_URL`-driven; the default is the retired host as a placeholder — set the env to the current UI if one is exposed to tenants (or leave it).
- **`ANALYTICS_BASE`** env-driven too (likely still correct — the Incus superset hostname — but no longer hardcoded).

**TDD:** `sections.test.ts` updated for the new default + a new case asserting the `LABEL_STUDIO_URL`-derived base and the `LABELER_BASE` override. Full web vitest (50 tests) + `tsc --noEmit` clean.

Part of the Label-Studio-instance cleanup (Phase C). Ops sets `LABEL_STUDIO_URL` already (it's a required env when LS is enabled), so the labeling links work with no extra config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)