### PR TITLE
fix(worker): label sync tolerates an unmapped annotator (don't crash)

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_dive_slate_labels_for_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_dive_slate_labels_for_label_studio_project_activity.py
@@ -189,8 +189,11 @@ async def _update_slate_label(
         return
 
     if task.annotators:
+        # Unmapped annotator (get_by_label_studio_id 404s -> None) mustn't
+        # crash the task sync — skip attribution instead.
         user = await fs.users.get_by_label_studio_id(task.annotators[-1])
-        slate_label.user_id = user.id
+        if user is not None:
+            slate_label.user_id = user.id
 
     slate_label.label_studio_json = json.loads(task.json())
     slate_label.completed = task.is_labeled

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_headtail_labels_for_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_headtail_labels_for_label_studio_project_activity.py
@@ -25,8 +25,11 @@ async def __update_headtail_label(fs: Client, task: Any) -> None:
         return
 
     if task.annotators:
+        # Unmapped annotator (get_by_label_studio_id 404s -> None) mustn't
+        # crash the task sync — skip attribution instead.
         user = await fs.users.get_by_label_studio_id(task.annotators[-1])
-        headtail_label.user_id = user.id
+        if user is not None:
+            headtail_label.user_id = user.id
 
     headtail_label.label_studio_json = json.loads(task.json())
     headtail_label.completed = task.is_labeled

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_laser_labels_for_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_laser_labels_for_label_studio_project_activity.py
@@ -27,8 +27,12 @@ async def __update_laser_label(fs: Client, task: Any) -> None:
         return
 
     if task.annotators:
+        # The annotator may not be user-synced yet (get_by_label_studio_id
+        # 404s -> None), e.g. mid Label-Studio-instance transition. Skip
+        # attribution rather than crash the whole task sync.
         user = await fs.users.get_by_label_studio_id(task.annotators[-1])
-        laser_label.user_id = user.id
+        if user is not None:
+            laser_label.user_id = user.id
 
     laser_label.label_studio_json = json.loads(task.json())
     laser_label.updated_at = task.updated_at

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_species_labels_for_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_species_labels_for_label_studio_project_activity.py
@@ -121,8 +121,11 @@ async def _update_species_label(fs: Client, task: Any) -> None:
         return
 
     if task.annotators:
+        # Unmapped annotator (get_by_label_studio_id 404s -> None) mustn't
+        # crash the task sync — skip attribution instead.
         user = await fs.users.get_by_label_studio_id(task.annotators[-1])
-        species_label.user_id = user.id
+        if user is not None:
+            species_label.user_id = user.id
 
     species_label.label_studio_json = json.loads(task.json())
     species_label.completed = task.is_labeled

--- a/services/fishsense-api-workflow-worker/tests/test_sync_species_labels_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_sync_species_labels_activity.py
@@ -32,10 +32,15 @@ from fishsense_api_workflow_worker.activities import (
 )
 
 
-def _make_task(task_id: int, *, annotations: List[dict] | None = None) -> Any:
+def _make_task(
+    task_id: int,
+    *,
+    annotations: List[dict] | None = None,
+    annotators: List[int] | None = None,
+) -> Any:
     return SimpleNamespace(
         id=task_id,
-        annotators=[],
+        annotators=annotators or [],
         annotations=annotations or [],
         is_labeled=False,
         updated_at="2026-05-01T00:00:00Z",
@@ -59,6 +64,9 @@ def _make_fs_client(label_lookup, *, cursor=None):
     fs.labels.put_species_label = AsyncMock()
     fs.labels.get_sync_cursor = AsyncMock(side_effect=_get_cursor)
     fs.labels.put_sync_cursor = AsyncMock()
+    # Default: the annotator isn't user-synced yet -> None.
+    fs.users = MagicMock()
+    fs.users.get_by_label_studio_id = AsyncMock(return_value=None)
     return fs
 
 
@@ -234,6 +242,29 @@ async def test_skips_tasks_with_no_existing_label(monkeypatch):
 
     assert fs.labels.get_species_label.await_count == 3
     fs.labels.put_species_label.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unmapped_annotator_does_not_crash_sync(monkeypatch):
+    """A task annotated by someone not yet user-synced (get_by_label_studio_id
+    -> None) must sync without crashing; user_id is simply left unset. Happens
+    during a Label-Studio-instance transition."""
+    task = _make_task(1, annotators=[999])
+    label = _empty_species_label(11)
+    fs = _make_fs_client(label_lookup={1: label})  # annotator maps to None
+    ls = _make_ls_client([task])
+
+    monkeypatch.setattr(sut_utils, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "get_ls_client", lambda: ls)
+
+    await ActivityEnvironment().run(
+        sut.sync_species_labels_for_label_studio_project_activity, 1
+    )
+
+    fs.users.get_by_label_studio_id.assert_awaited_once_with(999)
+    written = fs.labels.put_species_label.await_args_list
+    assert len(written) == 1
+    assert written[0].args[1].user_id is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
All four label-sync activities (laser/headtail/species/dive-slate) did:

```python
if task.annotators:
    user = await fs.users.get_by_label_studio_id(task.annotators[-1])
    <label>.user_id = user.id
```

But `get_by_label_studio_id` returns **`None`** (404) when the annotator hasn't been user-synced yet — so `user.id` raises `AttributeError` and the whole task sync fails. This bites during the **Label-Studio-instance transition**: a task annotated in the new hosted instance by someone the hourly user-sync hasn't mapped yet crashes the sync.

Fix: None-check and skip attribution (`user_id` left unset); the next sync picks it up once the user is mapped.

**TDD:** new `test_unmapped_annotator_does_not_crash_sync` — `fs.users` returns `None`, the put still happens, `user_id` is `None`. Full worker suite (205) green; lint 10/10 (clean `--all-packages` invocation).

## Context — the two sync residuals from the LS-cleanup plan
Investigating these turned up that neither needs what I first thought:
- **Sync-noise guard: already exists.** `sync_label_studio_project` catches `ApiError` on a missing project, logs, and no-ops — so dead old project IDs don't fail the sync (just a warning log). No change needed.
- **`user.label_studio_id`: auto-remapped.** `sync_users_label_studio_activity` re-maps each user's `label_studio_id` to the new instance keyed by **email**, so a bulk NULL isn't needed for the common case. The real gap was this crash on an unmapped annotator — which this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)