### PR TITLE
fix(incus): bump co-located Authentik outpost to 2026.5.4 (match krg-prod)

### DIFF
--- a/deploy/incus/README.md
+++ b/deploy/incus/README.md
@@ -153,7 +153,7 @@ into the `pgdata` volume (roles + passwords come from the dump); seed OpenBao to
   *branch push* that opens the PR, converging before a human reviews the pin diff, and on
   the data-worker's branch too. First bring-up doesn't use any of this (admin bootstraps
   manually).
-- ✅ **Option A co-located outpost** (`authentik-outpost`, image `2026.5.3` — matches
+- ✅ **Option A co-located outpost** (`authentik-outpost`, image `2026.5.4` — matches
   krg-prod's Authentik server per krg-infra `compose.authentik.yml`) — HANDOFF §7.
   Platform IaC **landed** (#440): dedicated `fishsense_proxy` outpost, token →
   `oidc/proxy-outpost-token`, soft-rendered (`errorOnMissingKey=false`).
@@ -169,7 +169,7 @@ into the `pgdata` volume (roles + passwords come from the dump); seed OpenBao to
    the `WE seed` KV paths above before the admin's first `nixos-rebuild switch`.
    Do **not** seed `oidc/*` (platform-written; the outpost token renders soft anyway).
 2. **Validate the sign-in round-trip** once the API route is up (the outpost image is
-   pinned to krg-prod's Authentik `2026.5.3`; bump both together on Authentik upgrades).
+   pinned to krg-prod's Authentik `2026.5.4`; bump both together on Authentik upgrades).
 3. **File CNAMEs** `api.` + `analytics.` → e4e-prod, confirm they resolve, then let
    #437's SAN re-issue run (staging ACME first, confirm, then off — like the apex).
 4. **Apply the quota/disk raise + restart** the instance (6/12 + 50 GiB now merged, #436/#439).

--- a/deploy/incus/compose.yml
+++ b/deploy/incus/compose.yml
@@ -51,7 +51,7 @@ services:
   # `fishsense_proxy` outpost whose API token is written to
   # secret/tenants/fishsense/oidc/proxy-outpost-token.
   authentik-outpost:
-    image: ghcr.io/goauthentik/proxy:2026.5.3   # matches krg-prod's Authentik server (krg-infra compose.authentik.yml); bump together
+    image: ghcr.io/goauthentik/proxy:2026.5.4   # matches krg-prod's Authentik server (krg-infra compose.authentik.yml); bump together
     restart: unless-stopped
     environment:
       AUTHENTIK_HOST: https://auth.krg.ucsd.edu


### PR DESCRIPTION
The platform bumped krg-prod's Authentik to **2026.5.4** (krg-infra `nix/docker-compose/krg-prod/compose.authentik.yml` — server + proxy + ldap all `2026.5.4`). Our co-located outpost proxy was pinned at `2026.5.3`.

CLAUDE.md and the incus README are explicit that the outpost proxy must track the Authentik **server** version and be bumped together — a version skew between the outpost and the server it dials over websocket can break the auth flow. This bumps the `goauthentik/proxy` pin `2026.5.3 → 2026.5.4` (+ the two README references).

This is the "held, platform-side" item from #251 — now unblocked because the platform moved.

**Rollout:** incus-only change → cuts no release, so converge via `deploy.yml` → Run workflow → `target: incus` after merge. (compose YAML validated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)