### PR TITLE
feat(devshell): flake devShell with kube tooling (kubectl + OIDC kubelogin) + direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+# direnv + nix flake dev shell. `direnv allow` once, then the flake's
+# devShell (kubectl, kubelogin-oidc, kustomize — see flake.nix) is on PATH
+# whenever you're in the repo. Requires direnv >= 2.29 (built-in `use flake`);
+# install nix-direnv for evaluation caching.
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ services/fishsense-data-processing-workflow-worker/scripts/dry_run_stage13_*.jso
 # Claude Code local session state (lock file with sessionId/pid — not
 # repo content; committing it churns diffs across sessions)
 .claude/scheduled_tasks.lock
+
+# direnv (nix-direnv cache)
+.direnv/

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
     nixpkgs,
   }: let
     system = "x86_64-linux";
+    pkgs = nixpkgs.legacyPackages.${system};
 
     tenant = krg-infra.lib.mkTenant {
       name = "fishsense"; # Incus project + OpenBao role + runner scope (provisioned)
@@ -89,5 +90,24 @@
     # Reproducible boundary projection (admin copies into terraform/incus):
     #   nix eval .#krgTenant.terraformTenant --json
     krgTenant = tenant;
+
+    # Dev shell (`nix develop`, or auto via direnv + .envrc). Cluster tooling
+    # for the NRP/Nautilus data-worker: `kubectl`, the OIDC `kubelogin`
+    # (int128/kubelogin → `kubectl oidc-login`, which NRP's CILogon kubeconfig
+    # requires — NOT the Azure `kubelogin`), and `kustomize` for
+    # `deploy/k8s/data-worker`. Pinned to the same nixpkgs the slot builds from
+    # (nixpkgs.follows = krg-infra/nixpkgs), so it advances with the weekly
+    # flake bump.
+    devShells.${system}.default = pkgs.mkShell {
+      packages = [
+        pkgs.kubectl
+        pkgs.kubelogin-oidc
+        pkgs.kustomize
+      ];
+      shellHook = ''
+        echo "fishsense dev shell: kubectl + kubelogin-oidc (kubectl oidc-login) + kustomize"
+        echo "NRP login: kubectl get pods  (opens a CILogon browser window the first time)"
+      '';
+    };
   };
 }


### PR DESCRIPTION
Adds a `nix develop` shell (auto-loaded via direnv) with the tooling to work with the NRP/Nautilus data-worker — and specifically the **OIDC** `kubelogin`, since NRP's kubeconfig requires `kubectl oidc-login` (CILogon browser flow), not the Azure `kubelogin`.

## What's in it
- `kubectl`
- **`kubelogin-oidc`** — int128/kubelogin. Verified it puts **`kubectl-oidc_login`** on PATH, which is exactly the binary NRP's kubeconfig `exec` block invokes.
- `kustomize` for `deploy/k8s/data-worker`.

Pinned to the same nixpkgs the slot builds from (`nixpkgs.follows = krg-infra/nixpkgs`), so it advances with the weekly flake bump.

## Safety
- Additive output — the `nixosConfigurations.fishsense` tenant build still evaluates unchanged (verified `nix eval …toplevel`).
- **`flake.lock` untouched** (no input change; `flake lock --no-update-lock-file` in sync → the new `flake-lock-check` passes).
- `.envrc` is `use flake`; `.direnv/` gitignored. `direnv allow` once.

## Why now
While working the NRP data-worker bring-up (#244/#245), we found NRP auth is interactive `kubelogin`/CILogon — so this gives everyone the right `kubectl oidc-login` plugin out of the box (`nix develop` or direnv), rather than a manual per-machine install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)