### PR TITLE
feat(k8s): declarative deployer SA/RBAC + token-minting Secret

### DIFF
--- a/deploy/k8s/data-worker/README.md
+++ b/deploy/k8s/data-worker/README.md
@@ -16,6 +16,7 @@ differs.
 | `deployment.yaml` | The Deployment. `replicas` is **omitted** — the api-worker owns the count (scales it up on demand, back to 0 when idle; see below). amd64 nodeSelector, resource requests/limits, `maxSurge: 0`, no PDB, emptyDir scratch, no PVC/GPU/NAS. |
 | `settings.toml` | Source for the `fishsense-data-worker-settings` ConfigMap (built by kustomize's `configMapGenerator`; mounted at `/e4efs/config/settings.toml`). Credentials are **not** here — they're env vars from a Secret. |
 | `kustomization.yaml` | `kubectl apply -k` entrypoint. Holds the overridable image tag (CI bumps it). |
+| `deployer-rbac.yaml` | The **deploy identity**: ServiceAccount `fishsense-deployer` + a least-privilege Role (deployments/scale/configmaps) + RoleBinding + a token-minting Secret. **Not** in `kustomization.yaml` — operator-applied out-of-band (the SA can't create its own RBAC). Credential-free: the token controller populates the Secret's `.data.token` in-cluster; the JWT never enters git. |
 
 ## Who scales it
 
@@ -52,15 +53,53 @@ what CI uses to `kubectl apply` (repo secret `NRP_KUBECONFIG`).
    policy, and our pods are owned by a ReplicaSet so the 6-hour
    bare-pod rule doesn't apply either; the Deployment itself is the
    only thing that needs the exception.)
-2. Get a (token) kubeconfig for `e4e-fishsense`. It's used in two
-   places — the repo secret `NRP_KUBECONFIG` (CI deploys) and the
-   api-worker on the Incus slot (scaling). The slot's copy is **not**
-   a mounted file: seed it into OpenBao at
-   `secret/tenants/fishsense/nrp { kubeconfig }` and vault-agent renders
-   it to `/run/tenant/nrp/kubeconfig` in the slot (see
-   `deploy/incus/secrets.nix` + the api-worker's `[kubernetes].kubeconfig_path`;
-   wired by #245). The token **expires** — reseed OpenBao + rotate
-   `NRP_KUBECONFIG` on renewal.
+2. Build a **static-token kubeconfig** for `e4e-fishsense`. NRP's own
+   kubeconfig uses interactive `kubelogin`/OIDC (CILogon browser flow),
+   which can't run in CI or the api-worker — so both non-interactive
+   consumers authenticate as the `fishsense-deployer` ServiceAccount
+   instead. One human, once, with an interactive kubeconfig:
+
+   ```sh
+   # a. Create the deploy identity (SA + Role + RoleBinding + token Secret).
+   #    Declarative + credential-free; idempotent (adopts anything you
+   #    created imperatively).
+   kubectl apply -f deploy/k8s/data-worker/deployer-rbac.yaml
+
+   # b. Read back the token + CA the token controller populated. If TOKEN
+   #    is empty after ~10s, NRP policy stripped the long-lived Secret —
+   #    fall back to: kubectl -n e4e-fishsense create token \
+   #      fishsense-deployer --duration=168h  (expires; needs re-mint).
+   TOKEN=$(kubectl -n e4e-fishsense get secret fishsense-deployer-token \
+     -o jsonpath='{.data.token}' | base64 -d)
+   CA=$(kubectl -n e4e-fishsense get secret fishsense-deployer-token \
+     -o jsonpath='{.data.ca\.crt}')            # already base64
+   SERVER=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+
+   # c. Assemble a kubeconfig with NO exec block (that is what makes it
+   #    non-interactive). This file DOES carry the token — keep it out of
+   #    git; it only goes into the two secret stores in step (d).
+   cat > nrp.kubeconfig <<KUBECONFIG
+   apiVersion: v1
+   kind: Config
+   clusters: [{name: nrp, cluster: {server: $SERVER, certificate-authority-data: $CA}}]
+   users: [{name: fishsense-deployer, user: {token: $TOKEN}}]
+   contexts: [{name: fishsense, context: {cluster: nrp, user: fishsense-deployer, namespace: e4e-fishsense}}]
+   current-context: fishsense
+   KUBECONFIG
+
+   # d. Verify it in isolation, then seed both consumers.
+   KUBECONFIG=./nrp.kubeconfig kubectl -n e4e-fishsense auth can-i patch deployments/scale  # -> yes
+   ```
+
+   The verified `nrp.kubeconfig` is used in two places — the repo secret
+   `NRP_KUBECONFIG` (CI deploys) and the api-worker on the Incus slot
+   (scaling). The slot's copy is **not** a mounted file: seed it into
+   OpenBao at `secret/tenants/fishsense/nrp { kubeconfig }` and
+   vault-agent renders it to `/run/tenant/nrp/kubeconfig` in the slot
+   (see `deploy/incus/secrets.nix` + the api-worker's
+   `[kubernetes].kubeconfig_path`; wired by #245). A long-lived
+   SA-token Secret does not expire, but a **bound** token (the fallback)
+   does — on renewal, reseed OpenBao + rotate `NRP_KUBECONFIG`.
 3. Create the three Secrets the Deployment references:
 
    ```sh

--- a/deploy/k8s/data-worker/deployer-rbac.yaml
+++ b/deploy/k8s/data-worker/deployer-rbac.yaml
@@ -1,0 +1,75 @@
+# The CI/api-worker deploy identity for the e4e-fishsense namespace.
+#
+# This is OPERATOR bootstrap, applied out-of-band with an interactive
+# (kubelogin/OIDC) kubeconfig — NOT part of `kustomization.yaml`. It is
+# deliberately excluded because the ServiceAccount it defines can only
+# touch deployments/scale/configmaps (see the Role below); it cannot
+# create serviceaccounts, roles, or secrets, so CI (which authenticates
+# AS this SA) could never apply this file. Chicken-and-egg: a human with
+# cluster-admin applies this once, then everything else is non-interactive.
+#
+#   kubectl apply -f deploy/k8s/data-worker/deployer-rbac.yaml
+#
+# NOTHING here contains a credential. The token Secret at the bottom has
+# no `data:` field — the Kubernetes token controller populates
+# `.data.token` (+ `.data["ca.crt"]`) inside the cluster at apply time.
+# The JWT never lands in git. Read it back out to build the static-token
+# kubeconfig (see README "One-time bootstrap"); THAT kubeconfig — which
+# does carry the token — is the thing that must stay out of the repo
+# (goes into the NRP_KUBECONFIG CI secret + OpenBao nrp.kubeconfig seed).
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fishsense-deployer
+  namespace: e4e-fishsense
+---
+# Exactly the surface the two non-interactive consumers need:
+#  - CI (deploy.yml) `kubectl apply -k`: get/list/create/update/patch on
+#    deployments + configmaps (the ConfigMap the kustomization generates).
+#  - api-worker scaling: patch on deployments/scale (ensure_data_worker_
+#    running_activity scales up; ScaleDownIdleDataWorkerWorkflow to 0).
+# No secrets, no serviceaccounts, no cluster-scoped verbs — least privilege.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: fishsense-deployer
+  namespace: e4e-fishsense
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments", "deployments/scale"]
+    verbs: ["get", "list", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: fishsense-deployer
+  namespace: e4e-fishsense
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: fishsense-deployer
+subjects:
+  - kind: ServiceAccount
+    name: fishsense-deployer
+    namespace: e4e-fishsense
+---
+# Requests a long-lived token for the ServiceAccount. Since Kubernetes
+# 1.24 the SA no longer auto-mints one, so we ask for it explicitly.
+# The token controller fills in `.data.token` + `.data["ca.crt"]` after
+# apply — this manifest stays credential-free. If NRP policy strips
+# `kubernetes.io/service-account-token` Secrets (check: the Secret comes
+# back with an empty `.data.token`), fall back to a bound token
+# (`kubectl -n e4e-fishsense create token fishsense-deployer --duration=168h`)
+# and plan periodic re-mint of the NRP_KUBECONFIG + OpenBao seed.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fishsense-deployer-token
+  namespace: e4e-fishsense
+  annotations:
+    kubernetes.io/service-account.name: fishsense-deployer
+type: kubernetes.io/service-account-token


### PR DESCRIPTION
## What

Checks the **token-minting** bootstrap into the repo, per request — `deploy/k8s/data-worker/deployer-rbac.yaml`:

- `ServiceAccount/fishsense-deployer`
- least-privilege `Role` — `get/list/create/update/patch` on `deployments`, `deployments/scale`, `configmaps` (nothing else)
- `RoleBinding`
- a `kubernetes.io/service-account-token` `Secret` that mints a long-lived token

This is the identity the two **non-interactive** consumers authenticate as:
- CI `deploy.yml` (`kubectl apply -k`)
- the api-worker (scale up on demand / down when idle)

NRP's native kubeconfig is interactive `kubelogin`/OIDC (CILogon browser) — neither CI nor the api-worker can use it, hence a ServiceAccount token.

## Why this is safe to commit (public repo)

Every doc is **credential-free**. The `Secret` has **no `data:` field** — the Kubernetes token controller populates `.data.token` (+ `.data["ca.crt"]`) *inside the cluster* at apply time. The JWT never lands in git.

The **static-token kubeconfig** you build *from* that token is the thing that must **not** be committed — it goes into the `NRP_KUBECONFIG` CI secret and the OpenBao `nrp.kubeconfig` seed (rendered to the slot by vault-agent, #245).

## Not in `kustomization.yaml` — on purpose

The SA this defines can only touch deployments/scale/configmaps; it can't create serviceaccounts/roles/secrets. So CI (which authenticates *as* it) could never apply this file. It's operator bootstrap, applied once out-of-band with cluster-admin — same category as the three Secrets already in the README.

## README

- New file-table row for `deployer-rbac.yaml`.
- Bootstrap step 2 rewritten from a hand-wavy "get a (token) kubeconfig" into the concrete flow: `apply -f deployer-rbac.yaml` → read back token+CA → assemble an exec-less kubeconfig → verify (`auth can-i patch deployments/scale`) → seed `NRP_KUBECONFIG` + OpenBao. Includes the fallback if NRP policy strips long-lived SA-token Secrets (`kubectl create token --duration=168h`, which expires).

## Validation

- YAML parses to 4 docs (SA/Role/RoleBinding/Secret), all in `e4e-fishsense`.
- Secret carries **no** `data` field (asserted).
- `kubectl kustomize deploy/k8s/data-worker` still builds and contains **zero** `fishsense-deployer` references — confirming it's excluded from the CI-applied set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)