### PR TITLE
feat(temporal): connect all workers to the `fishsense` namespace

### DIFF
--- a/deploy/incus/worker_volumes/api_worker/config/settings.toml
+++ b/deploy/incus/worker_volumes/api_worker/config/settings.toml
@@ -20,6 +20,10 @@ max_workers = 8
 host = "krg-prod.ucsd.edu"
 port = "7233"
 tls = true
+# Tenant namespace on the shared krg-prod cluster (krg-infra terraform/temporal).
+# OSS mTLS authenticates the client but does NOT pin it to a namespace (ADR 0023),
+# so it must be requested explicitly — omitting it lands workflows in `default`.
+namespace = "fishsense"
 client_cert = "/run/tenant/temporal/tls.crt"
 client_private_key = "/run/tenant/temporal/tls.key"
 domain = "workflows.krg.ucsd.edu"           # TLS server-name override (SNI)

--- a/deploy/incus/worker_volumes/backup_worker/config/settings.toml
+++ b/deploy/incus/worker_volumes/backup_worker/config/settings.toml
@@ -17,6 +17,10 @@ max_workers = 8
 host = "krg-prod.ucsd.edu"
 port = "7233"
 tls = true
+# Tenant namespace on the shared krg-prod cluster (krg-infra terraform/temporal).
+# OSS mTLS authenticates the client but does NOT pin it to a namespace (ADR 0023),
+# so it must be requested explicitly — omitting it lands the schedule in `default`.
+namespace = "fishsense"
 client_cert = "/run/tenant/temporal/tls.crt"
 client_private_key = "/run/tenant/temporal/tls.key"
 domain = "workflows.krg.ucsd.edu"           # TLS server-name override (SNI)

--- a/deploy/k8s/data-worker/settings.toml
+++ b/deploy/k8s/data-worker/settings.toml
@@ -34,6 +34,11 @@ max_workers = 8
 host = "krg-prod.ucsd.edu"
 port = "7233"
 tls = true
+# Tenant namespace on the shared krg-prod cluster (krg-infra terraform/temporal),
+# matching the api-worker. OSS mTLS authenticates but does NOT pin the namespace
+# (ADR 0023); the child workflows the api-worker dispatches run here, so a
+# mismatch means they'd never be picked up. Must equal the api-worker's value.
+namespace = "fishsense"
 # Data-worker's own mTLS client identity (distinct from the api-worker's),
 # authorized for the fishsense tenant on krg-prod (CN `fishsense-worker`).
 # Mounted from the `fishsense-data-worker-temporal-certs` Secret at /certs.

--- a/libs/fishsense-shared/src/fishsense_shared/__init__.py
+++ b/libs/fishsense-shared/src/fishsense_shared/__init__.py
@@ -17,7 +17,11 @@ from fishsense_shared.preprocess_contracts import (
     PreprocessSlateImagesInput,
     PreprocessSpeciesImagesInput,
 )
-from fishsense_shared.temporal import build_tls_config, ensure_schedule
+from fishsense_shared.temporal import (
+    build_tls_config,
+    ensure_schedule,
+    temporal_namespace,
+)
 
 __all__ = [
     "IS_DOCKER",
@@ -35,5 +39,6 @@ __all__ = [
     "get_config_path",
     "get_log_path",
     "path_validator",
+    "temporal_namespace",
     "url_condition",
 ]

--- a/libs/fishsense-shared/src/fishsense_shared/temporal.py
+++ b/libs/fishsense-shared/src/fishsense_shared/temporal.py
@@ -45,6 +45,23 @@ def build_tls_config(temporal_settings) -> TLSConfig | None:
     )
 
 
+def temporal_namespace(temporal_settings) -> str:
+    """Return the configured Temporal namespace, defaulting to ``default``.
+
+    OSS Temporal mTLS authenticates the client but does NOT pin it to a
+    namespace (krg-infra ADR 0023 — "namespace isolation is by convention,
+    not enforced"). A worker that omits ``namespace=`` on ``Client.connect``
+    silently lands in ``default`` instead of the tenant's ``fishsense``
+    namespace, so every worker threads this in. Tolerant of an unset key the
+    same way ``build_tls_config`` is for ``domain`` — falls back rather than
+    raising, so local dev / tests that don't set it match temporalio's own
+    ``default``.
+    """
+    if "namespace" in temporal_settings:
+        return temporal_settings.namespace
+    return "default"
+
+
 async def ensure_schedule(
     client: Client,
     *,

--- a/libs/fishsense-shared/tests/test_temporal_namespace.py
+++ b/libs/fishsense-shared/tests/test_temporal_namespace.py
@@ -1,0 +1,32 @@
+"""Unit tests for `temporal_namespace`.
+
+The contract: every worker threads the configured Temporal namespace into
+`Client.connect(..., namespace=...)`. krg-infra ADR 0023 warns that OSS
+Temporal mTLS authenticates the client but does NOT pin it to a namespace,
+so a worker that omits `namespace=` silently lands in `default` instead of
+the tenant's `fishsense` namespace. This helper reads it off the standard
+`settings.temporal` shape, defaulting to `default` when unset (local dev /
+tests) so the behaviour matches temporalio's own default.
+"""
+
+from fishsense_shared import temporal_namespace
+
+
+class _Settings(dict):
+    """Minimal Dynaconf-like object: supports `"k" in s` and `s.k`."""
+
+    __getattr__ = dict.__getitem__
+
+
+def test_returns_configured_namespace():
+    assert temporal_namespace(_Settings(namespace="fishsense")) == "fishsense"
+
+
+def test_defaults_to_default_when_absent():
+    # Matches build_tls_config's `"key" in settings` tolerance for optional
+    # keys — an un-set namespace must fall back, not raise.
+    assert temporal_namespace(_Settings()) == "default"
+
+
+def test_honours_an_explicit_default_namespace():
+    assert temporal_namespace(_Settings(namespace="default")) == "default"

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/scale_down_data_worker_if_idle_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/scale_down_data_worker_if_idle_activity.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timedelta, timezone
 
-from fishsense_shared import build_tls_config
+from fishsense_shared import build_tls_config, temporal_namespace
 from temporalio import activity
 from temporalio.client import Client
 
@@ -62,6 +62,7 @@ async def _data_worker_task_queue_busy(cooldown_minutes: int) -> bool:
     client = await Client.connect(
         f"{settings.temporal.host}:{settings.temporal.port}",
         tls=build_tls_config(settings.temporal),
+        namespace=temporal_namespace(settings.temporal),
     )
     async for _ in client.list_workflows(query=query):
         return True

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/config.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/config.py
@@ -29,6 +29,10 @@ _VALIDATORS = [
     Validator("temporal.client_cert", cast=str, condition=path_validator),
     Validator("temporal.client_private_key", cast=str, condition=path_validator),
     Validator("temporal.domain", cast=str),
+    # Which Temporal namespace to connect to. OSS mTLS doesn't pin the client
+    # to one (krg-infra ADR 0023), so it MUST be requested explicitly; prod
+    # settings.toml sets `fishsense`. Defaults to `default` for local dev/tests.
+    Validator("temporal.namespace", cast=str, default="default"),
     Validator("temporal.server_root_ca_cert", cast=str, condition=path_validator),
     Validator("label_studio.url", required=True, condition=url_condition),
     Validator("label_studio.api_key", required=True, cast=str),

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -10,6 +10,7 @@ from fishsense_shared import (
     ExceptionGroupErrorLogging,
     build_tls_config,
     ensure_schedule,
+    temporal_namespace,
 )
 from temporalio.client import (
     Client,
@@ -410,7 +411,9 @@ async def main():
         bool(tls_config),
     )
     client = await Client.connect(
-        f"{settings.temporal.host}:{settings.temporal.port}", tls=tls_config
+        f"{settings.temporal.host}:{settings.temporal.port}",
+        tls=tls_config,
+        namespace=temporal_namespace(settings.temporal),
     )
 
     with ThreadPoolExecutor(max_workers=settings.general.max_workers) as executor:

--- a/services/fishsense-api-workflow-worker/tests/test_scale_down_query_integration.py
+++ b/services/fishsense-api-workflow-worker/tests/test_scale_down_query_integration.py
@@ -26,7 +26,7 @@ from fishsense_api_workflow_worker.activities.scale_down_data_worker_if_idle_act
     _data_worker_task_queue_busy,
 )
 from fishsense_api_workflow_worker.config import settings
-from fishsense_shared import build_tls_config
+from fishsense_shared import build_tls_config, temporal_namespace
 from temporalio.client import Client
 
 pytestmark = pytest.mark.integration
@@ -68,6 +68,7 @@ async def _connect() -> Client:
     return await Client.connect(
         f"{settings.temporal.host}:{settings.temporal.port}",
         tls=build_tls_config(settings.temporal),
+        namespace=temporal_namespace(settings.temporal),
     )
 
 

--- a/services/fishsense-backup-worker/src/fishsense_backup_worker/config.py
+++ b/services/fishsense-backup-worker/src/fishsense_backup_worker/config.py
@@ -37,6 +37,10 @@ _VALIDATORS = [
     Validator("temporal.client_cert", cast=str, condition=path_validator),
     Validator("temporal.client_private_key", cast=str, condition=path_validator),
     Validator("temporal.domain", cast=str),
+    # Which Temporal namespace to connect to. OSS mTLS doesn't pin the client
+    # to one (krg-infra ADR 0023), so it MUST be requested explicitly; prod
+    # settings.toml sets `fishsense`. Defaults to `default` for local dev/tests.
+    Validator("temporal.namespace", cast=str, default="default"),
     Validator("temporal.server_root_ca_cert", cast=str, condition=path_validator),
     # NAS (where dumps land).
     Validator("e4e_nas.url", required=True, cast=str, condition=url_condition),

--- a/services/fishsense-backup-worker/src/fishsense_backup_worker/worker.py
+++ b/services/fishsense-backup-worker/src/fishsense_backup_worker/worker.py
@@ -10,7 +10,7 @@ import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
 
-from fishsense_shared import build_tls_config, ensure_schedule
+from fishsense_shared import build_tls_config, ensure_schedule, temporal_namespace
 from temporalio.client import Client
 from temporalio.worker import Worker
 
@@ -35,7 +35,9 @@ async def main() -> None:
     tls_config = build_tls_config(settings.temporal)
 
     client = await Client.connect(
-        f"{settings.temporal.host}:{settings.temporal.port}", tls=tls_config
+        f"{settings.temporal.host}:{settings.temporal.port}",
+        tls=tls_config,
+        namespace=temporal_namespace(settings.temporal),
     )
 
     schedule = build_backup_schedule(

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/config.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/config.py
@@ -30,6 +30,10 @@ _VALIDATORS = [
     Validator("temporal.client_cert", cast=str, condition=path_validator),
     Validator("temporal.client_private_key", cast=str, condition=path_validator),
     Validator("temporal.domain", cast=str),
+    # Which Temporal namespace to connect to. OSS mTLS doesn't pin the client
+    # to one (krg-infra ADR 0023), so it MUST be requested explicitly; prod
+    # settings.toml sets `fishsense`. Defaults to `default` for local dev/tests.
+    Validator("temporal.namespace", cast=str, default="default"),
     Validator("temporal.server_root_ca_cert", cast=str, condition=path_validator),
     Validator("fishsense_api.url", required=True, cast=str, condition=url_condition),
     Validator("fishsense_api.username", cast=str),

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
@@ -4,7 +4,7 @@ import signal
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 
-from fishsense_shared import build_tls_config
+from fishsense_shared import build_tls_config, temporal_namespace
 from temporalio.client import Client
 from temporalio.worker import Worker
 
@@ -129,7 +129,9 @@ async def main():
         bool(tls_config),
     )
     client = await Client.connect(
-        f"{settings.temporal.host}:{settings.temporal.port}", tls=tls_config
+        f"{settings.temporal.host}:{settings.temporal.port}",
+        tls=tls_config,
+        namespace=temporal_namespace(settings.temporal),
     )
 
     interrupt_event = asyncio.Event()


### PR DESCRIPTION
## Problem

Every worker called `Client.connect(...)` **without `namespace=`**, so all workflows and schedules landed in Temporal's **`default`** namespace — not the tenant's **`fishsense`** namespace (which krg-infra `terraform/temporal` already provisions). That's why the `fishsense` namespace looks empty in the Temporal UI even though schedules are firing.

krg-infra ADR 0023 is explicit: **"namespace isolation is by convention, not enforced — OSS Temporal mTLS does not enforce per-namespace authorization."** The mTLS cert authenticates you; it does not pin you to a namespace. The client has to ask.

## Change

- **New shared helper** `temporal_namespace(temporal_settings)` in `fishsense_shared.temporal` — reads `settings.temporal.namespace`, defaulting to `default` the same tolerant way `build_tls_config` treats `domain`. **TDD**: unit tests written first (`libs/fishsense-shared/tests/test_temporal_namespace.py`, 3 cases).
- **Threaded `namespace=` into all four `Client.connect` sites**: api-worker (`worker.py` + `scale_down_data_worker_if_idle_activity.py`), data-worker (`worker.py`), backup-worker (`worker.py`). The scale-down integration test's mirror `_connect()` gets it too, so the two never diverge.
- **`temporal.namespace` validator** (default `default`) added to all three worker configs.
- **`namespace = "fishsense"`** set in the three prod `settings.toml` (api-worker, backup-worker, data-worker). The data-worker's value **must** match the api-worker's, or the child workflows the api-worker dispatches never get picked up.

Default stays `default` so local dev / tests / the integration stack are unaffected; only the prod configs opt into `fishsense`.

## Operator follow-up (after this converges)

The schedules currently registered in `default` — hourly preprocess parents, laser-cal, scale-down, daily backup — get **re-registered in `fishsense`** on next worker startup (registration is idempotent per-namespace). Delete the stale `default` ones so they don't double-fire:

```
temporal schedule list --namespace default        # identify the fishsense-owned ones
temporal schedule delete <id> --namespace default
```

## Tests

- `libs/fishsense-shared/tests/test_temporal_namespace.py` — 3 new cases (green).
- Full suites green: fishsense-shared (21), api-worker (205 passed / 3 skipped), backup-worker (29). Data-worker config resolves `fishsense` from the new setting.
- pylint 10.00/10 on all changed source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)