### PR TITLE
fix(k8s): grant deployer `watch` on deployments (rollout status)

### DIFF
--- a/deploy/k8s/data-worker/deployer-rbac.yaml
+++ b/deploy/k8s/data-worker/deployer-rbac.yaml
@@ -27,7 +27,10 @@ metadata:
 # Exactly the surface the two non-interactive consumers need:
 #  - CI (deploy.yml) `kubectl apply -k`: get/list/create/update/patch on
 #    deployments + configmaps (the ConfigMap the kustomization generates).
-#  - api-worker scaling: patch on deployments/scale (ensure_data_worker_
+#  - CI `kubectl rollout status`: WATCH on deployments — client-go watches the
+#    Deployment object to observe rollout progress. Without it the apply
+#    succeeds but `rollout status` fails "cannot watch resource deployments".
+#  - api-worker scaling: get/patch on deployments/scale (ensure_data_worker_
 #    running_activity scales up; ScaleDownIdleDataWorkerWorkflow to 0).
 # No secrets, no serviceaccounts, no cluster-scoped verbs — least privilege.
 apiVersion: rbac.authorization.k8s.io/v1
@@ -37,8 +40,11 @@ metadata:
   namespace: e4e-fishsense
 rules:
   - apiGroups: ["apps"]
-    resources: ["deployments", "deployments/scale"]
-    verbs: ["get", "list", "create", "update", "patch"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale"]
+    verbs: ["get", "patch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "create", "update", "patch"]


### PR DESCRIPTION
## What

The `fishsense-deployer` Role from #265 was missing **`watch`** on deployments. This surfaced immediately on the first real deploy ([run 29390020808](https://github.com/UCSD-E4E/fishsense-lite/actions/runs/29390020808)): `kubectl apply -k` **succeeded** (ConfigMap + Deployment created), but the follow-on `kubectl rollout status` failed:

```
deployments.apps "fishsense-data-processing-workflow-worker" is forbidden:
User "system:serviceaccount:e4e-fishsense:fishsense-deployer" cannot watch
resource "deployments" in API group "apps" in the namespace "e4e-fishsense"
```

`rollout status` uses a client-go **watch** on the Deployment object to observe progress. The Role never granted it.

## Fix

- Add `watch` to the `deployments` rule (alongside the existing get/list/create/update/patch).
- Split `deployments/scale` into its own rule with just **`get, patch`** — the scale subresource never needs list/watch/create, so this also tightens least-privilege.

## Operator action

CI authenticates against the **live cluster Role**, not this file, so re-apply to patch it:

```sh
kubectl apply -f deploy/k8s/data-worker/deployer-rbac.yaml
```

Then re-run the failed deploy (or the next auto-deploy PR merge will pick it up).

## Note (separate issue)

That same run also showed the Deployment stuck at `0 of 1 available` for 5 min — the pod itself isn't going ready. That's a distinct problem to check on NRP (`kubectl -n e4e-fishsense describe pod -l app=... ` / `logs`), and is likely helped by #266 (the data-worker was connecting to the `default` Temporal namespace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)