### PR TITLE
chore(k8s): drop unused ghcr-pull imagePullSecret (image is public)

### DIFF
--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -58,11 +58,11 @@ jobs:
           kubectl create namespace e4e-fishsense
 
       - name: Create stub Secrets the Deployment references
-        # Real values don't matter — the pod won't pull the private
-        # image and we never wait for it to be Ready; this just lets
-        # `kubectl apply -k` resolve the secretKeyRef / imagePullSecrets
-        # so the apply is a faithful server-side validation. Secrets go
-        # in the pinned namespace so the secretKeyRefs resolve.
+        # Real values don't matter — we never wait for the pod to be Ready;
+        # this just lets `kubectl apply -k` resolve the secretKeyRefs so the
+        # apply is a faithful server-side validation. Secrets go in the
+        # pinned namespace so the secretKeyRefs resolve. No ghcr-pull stub —
+        # the Deployment has no imagePullSecrets (the GHCR image is public).
         run: |
           kubectl create secret generic fishsense-data-worker-secrets -n e4e-fishsense \
             --from-literal=fishsense_api_username=ci \
@@ -73,10 +73,6 @@ jobs:
             --from-literal=client.pem=ci \
             --from-literal=client.key=ci \
             --from-literal=root-ca.pem=ci
-          kubectl create secret docker-registry ghcr-pull -n e4e-fishsense \
-            --docker-server=ghcr.io \
-            --docker-username=ci \
-            --docker-password=ci
 
       - name: Apply the data-worker manifests (server-side validation)
         run: |

--- a/deploy/k8s/data-worker/README.md
+++ b/deploy/k8s/data-worker/README.md
@@ -100,16 +100,19 @@ what CI uses to `kubectl apply` (repo secret `NRP_KUBECONFIG`).
    `[kubernetes].kubeconfig_path`; wired by #245). A long-lived
    SA-token Secret does not expire, but a **bound** token (the fallback)
    does — on renewal, reseed OpenBao + rotate `NRP_KUBECONFIG`.
-3. Create the three Secrets the Deployment references:
+3. Create the two Secrets the Deployment references. (No image pull
+   secret — the GHCR image is public, so the Deployment has no
+   `imagePullSecrets` and kubelet pulls it anonymously.)
 
    ```sh
    # (all in the e4e-fishsense namespace — the kubeconfig context or -n)
 
-   # 1. Service-account creds (SDK HTTP Basic, via authentik passthrough)
-   #    + Garage S3 access key/secret for the object store
+   # 1. Service-account creds (SDK HTTP Basic — the password is the authentik
+   #    app-password from `secret/tenants/fishsense/oidc/data-worker-apppw`,
+   #    NOT the raw AD password; see krg-infra #484) + Garage S3 key/secret.
    kubectl create secret generic fishsense-data-worker-secrets -n e4e-fishsense \
      --from-literal=fishsense_api_username='<svc>' \
-     --from-literal=fishsense_api_password='<svc-pw>' \
+     --from-literal=fishsense_api_password='<app-password>' \
      --from-literal=object_store_access_key='<garage-access-key>' \
      --from-literal=object_store_secret_key='<garage-secret-key>'
 
@@ -123,12 +126,6 @@ what CI uses to `kubectl apply` (repo secret `NRP_KUBECONFIG`).
      --from-file=client.pem=/path/to/fishsense-data-processing-workflow-worker.pem \
      --from-file=client.key=/path/to/fishsense-data-processing-workflow-worker.key \
      --from-file=root-ca.pem=/path/to/root-ca.pem
-
-   # 3. Pull secret for the private GHCR image
-   kubectl create secret docker-registry ghcr-pull -n e4e-fishsense \
-     --docker-server=ghcr.io \
-     --docker-username='<github-user>' \
-     --docker-password='<PAT with read:packages on UCSD-E4E>'
    ```
 
    (Credentials in git are out of scope here — if you want them

--- a/deploy/k8s/data-worker/deployment.yaml
+++ b/deploy/k8s/data-worker/deployment.yaml
@@ -55,8 +55,9 @@ spec:
       # The data-worker never talks to the k8s API (only the api-worker
       # does, from outside the cluster) — don't mount a SA token.
       automountServiceAccountToken: false
-      imagePullSecrets:
-        - name: ghcr-pull
+      # No imagePullSecrets: the GHCR image is public, so kubelet pulls it
+      # anonymously. (A dead pull-secret ref isn't fatal — it just logs a
+      # FailedToRetrieveImagePullSecret warning on every pod create.)
       securityContext:
         seccompProfile:
           type: RuntimeDefault


### PR DESCRIPTION
## What

The data-worker's GHCR image is **public**, so the `ghcr-pull` `imagePullSecret` was never needed. This removes it and the dead scaffolding around it.

Confirmed on NRP during bring-up: the pod's **first image pull succeeded anonymously** despite `ghcr-pull` not existing — the only symptom was a repeating `FailedToRetrieveImagePullSecret (ghcr-pull)` **warning** on every pod create. Cosmetic, but dead weight.

## Changes

- **`deployment.yaml`** — remove `imagePullSecrets: [ghcr-pull]`; leave a comment so it isn't re-added.
- **`.github/workflows/k8s-tests.yml`** — drop the `ghcr-pull` stub Secret the job created *only* so `kubectl apply -k` could resolve the reference (it never pulls the image); comment updated.
- **`README.md`** — "three Secrets" → "two", drop the `ghcr-pull` bootstrap step, and (drive-by) correct the note to say the API password is the authentik **app-password** (krg-infra #484), not the raw AD password.

## Not a behaviour change

The image was already being pulled anonymously; this just stops referencing a secret that doesn't need to exist.

## Validation

- `kubectl kustomize deploy/k8s/data-worker` builds with **0** `imagePullSecrets`/`ghcr-pull` lines.
- `k8s-tests.yml` parses; the only remaining `ghcr-pull` string is the explanatory comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)