### PR TITLE
fix(scaling): verify NRP apiserver TLS without OpenSSL 3.x strict mode

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/k8s_scaling.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/k8s_scaling.py
@@ -25,6 +25,7 @@ accident:
 
 from __future__ import annotations
 
+import ssl
 from dataclasses import dataclass
 
 from fishsense_api_workflow_worker.config import settings
@@ -103,7 +104,54 @@ def apps_v1_api(kubeconfig_path: str):
     k8s_config.load_kube_config(
         config_file=kubeconfig_path, client_configuration=configuration
     )
-    return k8s_client.AppsV1Api(k8s_client.ApiClient(configuration))
+    api_client = k8s_client.ApiClient(configuration)
+    _relax_x509_strict_verification(api_client, configuration)
+    return k8s_client.AppsV1Api(api_client)
+
+
+def _apply_relaxed_verification(ctx: ssl.SSLContext) -> None:
+    """Clear OpenSSL 3.x strict mode on ``ctx`` — nothing else.
+
+    Verification stays fully on (``CERT_REQUIRED`` + hostname check); we only
+    drop the ``VERIFY_X509_STRICT`` flag that Python 3.13 enabled by default.
+    Kept separate so the security-critical invariant is unit-testable.
+    """
+    ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
+
+
+def _relax_x509_strict_verification(api_client, configuration) -> None:
+    """Verify NRP's apiserver cert fully, minus OpenSSL 3.x strict mode.
+
+    Python 3.13 turned on ``ssl.VERIFY_X509_STRICT`` by default, which enforces
+    RFC 5280 to the letter — including a mandatory Authority Key Identifier on
+    leaf certs. NRP/Nautilus's kubeadm-generated kube-apiserver cert omits AKI,
+    so the (otherwise valid) cert is rejected with "Missing Authority Key
+    Identifier" and every scale call fails the TLS handshake.
+
+    The kubernetes 36.x client's ``Configuration`` exposes no ``ssl_context``;
+    it builds its own strict urllib3 context from ``ca_certs``/``cert_reqs``.
+    We swap in a context that keeps full verification — ``CERT_REQUIRED``
+    against the pinned cluster CA plus hostname/IP checking — and clears ONLY
+    the strict flag. This is emphatically NOT ``insecure-skip-tls-verify``: it
+    restores the verification level Python used by default through 3.12.
+
+    No-op when the kubeconfig disables verification (``verify_ssl`` False) —
+    there's nothing to relax and we must not silently re-enable it.
+    """
+    if not (configuration.verify_ssl and configuration.ssl_ca_cert):
+        return
+    ctx = ssl.create_default_context(cafile=configuration.ssl_ca_cert)
+    _apply_relaxed_verification(ctx)
+    # Client-cert kubeconfigs (not our token-based one, but stay correct):
+    # the context now owns the whole client-side of the handshake.
+    if configuration.cert_file and configuration.key_file:
+        ctx.load_cert_chain(configuration.cert_file, configuration.key_file)
+    # urllib3 gets ambiguous if both ssl_context and ca_certs/cert_reqs are
+    # set — hand verification entirely to our context.
+    pool_kw = api_client.rest_client.pool_manager.connection_pool_kw
+    pool_kw["ssl_context"] = ctx
+    for key in ("ca_certs", "cert_reqs", "cert_file", "key_file"):
+        pool_kw.pop(key, None)
 
 
 def set_deployment_replicas(api, namespace: str, name: str, replicas: int) -> None:

--- a/services/fishsense-api-workflow-worker/tests/test_k8s_scaling_tls.py
+++ b/services/fishsense-api-workflow-worker/tests/test_k8s_scaling_tls.py
@@ -12,9 +12,13 @@ we relax strictness, we do NOT disable verification.
 
 from __future__ import annotations
 
+# Tests exercise an internal helper and pass stub callbacks whose signatures
+# must match `load_kube_config` (so some args are intentionally unused).
+# pylint: disable=protected-access,unused-argument
+
 import ssl
 
-from kubernetes import client as k8s_client, config as k8s_config
+from kubernetes import config as k8s_config
 
 from fishsense_api_workflow_worker.activities import k8s_scaling
 
@@ -24,7 +28,7 @@ def test_relaxed_verification_clears_strict_but_keeps_verification():
     k8s_scaling._apply_relaxed_verification(ctx)
 
     # the whole point: strict off...
-    assert not (ctx.verify_flags & ssl.VERIFY_X509_STRICT)
+    assert not ctx.verify_flags & ssl.VERIFY_X509_STRICT
     # ...but still verifying the peer cert + hostname (NOT insecure).
     assert ctx.verify_mode == ssl.CERT_REQUIRED
     assert ctx.check_hostname is True
@@ -34,7 +38,7 @@ def test_apps_v1_api_injects_nonstrict_verifying_context(monkeypatch):
     """The context reaches the urllib3 pool, and ca_certs/cert_reqs are
     dropped so the injected context owns verification (no urllib3 ambiguity)."""
 
-    def fake_load(config_file, client_configuration):  # noqa: ARG001
+    def fake_load(config_file, client_configuration):
         client_configuration.verify_ssl = True
         client_configuration.ssl_ca_cert = "/ignored/by/the/stub"
         client_configuration.cert_file = None
@@ -54,7 +58,7 @@ def test_apps_v1_api_injects_nonstrict_verifying_context(monkeypatch):
     assert pool_kw["ssl_context"] is sentinel_ctx
     assert "ca_certs" not in pool_kw
     assert "cert_reqs" not in pool_kw
-    assert not (sentinel_ctx.verify_flags & ssl.VERIFY_X509_STRICT)
+    assert not sentinel_ctx.verify_flags & ssl.VERIFY_X509_STRICT
     assert sentinel_ctx.verify_mode == ssl.CERT_REQUIRED
     assert sentinel_ctx.check_hostname is True
 
@@ -63,7 +67,7 @@ def test_apps_v1_api_leaves_insecure_kubeconfigs_alone(monkeypatch):
     """If verification is already off (verify_ssl False), don't build a
     context — nothing to relax, and we must not silently re-enable it."""
 
-    def fake_load(config_file, client_configuration):  # noqa: ARG001
+    def fake_load(config_file, client_configuration):
         client_configuration.verify_ssl = False
         client_configuration.ssl_ca_cert = None
         client_configuration.cert_file = None
@@ -72,7 +76,7 @@ def test_apps_v1_api_leaves_insecure_kubeconfigs_alone(monkeypatch):
 
     monkeypatch.setattr(k8s_config, "load_kube_config", fake_load)
 
-    def _boom(cafile=None):  # noqa: ARG001
+    def _boom(cafile=None):
         raise AssertionError("must not build a context when verify_ssl is False")
 
     monkeypatch.setattr(k8s_scaling.ssl, "create_default_context", _boom)

--- a/services/fishsense-api-workflow-worker/tests/test_k8s_scaling_tls.py
+++ b/services/fishsense-api-workflow-worker/tests/test_k8s_scaling_tls.py
@@ -1,0 +1,81 @@
+"""TLS verification for the NRP k8s client.
+
+Python 3.13 turned on ``ssl.VERIFY_X509_STRICT`` by default. NRP/Nautilus's
+kubeadm-generated kube-apiserver cert omits the Authority Key Identifier
+extension, so strict RFC-5280 verification rejects it ("Missing Authority
+Key Identifier") and every scale call fails the TLS handshake.
+
+`apps_v1_api` swaps in a context that clears ONLY the strict flag while
+keeping full verification. These tests pin the security-critical invariant:
+we relax strictness, we do NOT disable verification.
+"""
+
+from __future__ import annotations
+
+import ssl
+
+from kubernetes import client as k8s_client, config as k8s_config
+
+from fishsense_api_workflow_worker.activities import k8s_scaling
+
+
+def test_relaxed_verification_clears_strict_but_keeps_verification():
+    ctx = ssl.create_default_context()
+    k8s_scaling._apply_relaxed_verification(ctx)
+
+    # the whole point: strict off...
+    assert not (ctx.verify_flags & ssl.VERIFY_X509_STRICT)
+    # ...but still verifying the peer cert + hostname (NOT insecure).
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    assert ctx.check_hostname is True
+
+
+def test_apps_v1_api_injects_nonstrict_verifying_context(monkeypatch):
+    """The context reaches the urllib3 pool, and ca_certs/cert_reqs are
+    dropped so the injected context owns verification (no urllib3 ambiguity)."""
+
+    def fake_load(config_file, client_configuration):  # noqa: ARG001
+        client_configuration.verify_ssl = True
+        client_configuration.ssl_ca_cert = "/ignored/by/the/stub"
+        client_configuration.cert_file = None
+        client_configuration.key_file = None
+        client_configuration.host = "https://10.0.0.1:443"
+
+    monkeypatch.setattr(k8s_config, "load_kube_config", fake_load)
+
+    sentinel_ctx = ssl.create_default_context()
+    monkeypatch.setattr(
+        k8s_scaling.ssl, "create_default_context", lambda cafile=None: sentinel_ctx
+    )
+
+    apps = k8s_scaling.apps_v1_api("/ignored")
+    pool_kw = apps.api_client.rest_client.pool_manager.connection_pool_kw
+
+    assert pool_kw["ssl_context"] is sentinel_ctx
+    assert "ca_certs" not in pool_kw
+    assert "cert_reqs" not in pool_kw
+    assert not (sentinel_ctx.verify_flags & ssl.VERIFY_X509_STRICT)
+    assert sentinel_ctx.verify_mode == ssl.CERT_REQUIRED
+    assert sentinel_ctx.check_hostname is True
+
+
+def test_apps_v1_api_leaves_insecure_kubeconfigs_alone(monkeypatch):
+    """If verification is already off (verify_ssl False), don't build a
+    context — nothing to relax, and we must not silently re-enable it."""
+
+    def fake_load(config_file, client_configuration):  # noqa: ARG001
+        client_configuration.verify_ssl = False
+        client_configuration.ssl_ca_cert = None
+        client_configuration.cert_file = None
+        client_configuration.key_file = None
+        client_configuration.host = "https://10.0.0.1:443"
+
+    monkeypatch.setattr(k8s_config, "load_kube_config", fake_load)
+
+    def _boom(cafile=None):  # noqa: ARG001
+        raise AssertionError("must not build a context when verify_ssl is False")
+
+    monkeypatch.setattr(k8s_scaling.ssl, "create_default_context", _boom)
+
+    apps = k8s_scaling.apps_v1_api("/ignored")
+    assert "ssl_context" not in apps.api_client.rest_client.pool_manager.connection_pool_kw

--- a/uv.lock
+++ b/uv.lock
@@ -765,7 +765,7 @@ wheels = [
 
 [[package]]
 name = "fishsense-api"
-version = "1.28.0"
+version = "1.29.0"
 source = { editable = "services/fishsense-api" }
 dependencies = [
     { name = "alembic" },
@@ -818,7 +818,7 @@ dev = [
 
 [[package]]
 name = "fishsense-api-sdk"
-version = "1.35.0"
+version = "1.36.0"
 source = { editable = "libs/fishsense-api-sdk" }
 dependencies = [
     { name = "httpx" },
@@ -847,7 +847,7 @@ dev = [
 
 [[package]]
 name = "fishsense-api-workflow-worker"
-version = "1.36.0"
+version = "1.38.0"
 source = { editable = "services/fishsense-api-workflow-worker" }
 dependencies = [
     { name = "boto3" },
@@ -908,7 +908,7 @@ dev = [
 
 [[package]]
 name = "fishsense-backup-worker"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "services/fishsense-backup-worker" }
 dependencies = [
     { name = "dynaconf" },
@@ -1009,7 +1009,7 @@ requires-dist = [
 
 [[package]]
 name = "fishsense-data-processing-workflow-worker"
-version = "2.5.0"
+version = "2.7.0"
 source = { editable = "services/fishsense-data-processing-workflow-worker" }
 dependencies = [
     { name = "boto3" },
@@ -1130,7 +1130,7 @@ dev = [
 
 [[package]]
 name = "fishsense-shared"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "libs/fishsense-shared" }
 dependencies = [
     { name = "dynaconf" },


### PR DESCRIPTION
## Problem

The api-worker's data-worker scaling (`ensure_data_worker_running_activity` + hourly `ScaleDownIdleDataWorkerWorkflow`) **failed every run** on the k8s scale call:

```
SSLCertVerificationError: certificate verify failed: Missing Authority Key Identifier
  on PATCH /apis/apps/v1/namespaces/e4e-fishsense/deployments/.../scale
```

Consequence: the data-worker **never scaled to 0** (pinned at `replicas: 1`, idling on NRP), and a **failed workflow every :55**. The pipeline itself was unaffected (the Deployment keeps the pod up) — this is purely the scaling control path.

## Root cause (confirmed in-pod)

**Python 3.13 enabled `ssl.VERIFY_X509_STRICT` by default.** Strict mode enforces RFC 5280 to the letter — including a mandatory Authority Key Identifier on leaf certs. NRP/Nautilus's kubeadm-generated apiserver cert (`CN=kube-apiserver`, issued by `CN=kubernetes`) **omits AKI**, so strict verification rejects an otherwise-valid cert.

`kubectl` (Go TLS) doesn't enforce this — which is exactly why CI `apply -k` worked and **only the api-worker's Python client tripped**.

Proven empirically in the pod:
```
default ctx has X509_STRICT: True          ← the 3.13 change
default       : SSLCertVerificationError: ... Missing Authority Key Identifier
strict-cleared: OK verified, cipher=TLS_AES_128_GCM_SHA256
```
and an authenticated `read_namespaced_deployment` succeeded with `verify_mode=CERT_REQUIRED, check_hostname=True, strict=False`.

## Fix

kubernetes 36.x's `Configuration` exposes no `ssl_context` and builds its own strict urllib3 context from `ca_certs`/`cert_reqs`. `apps_v1_api` now injects a context that **clears only `VERIFY_X509_STRICT`** while keeping **full verification** — `CERT_REQUIRED` against the pinned cluster CA plus hostname/IP checking.

**This is not `insecure-skip-tls-verify`.** The cert chain is still verified against the pinned CA and the hostname/IP is still checked; we only drop the strict-extension pedantry that kubeadm certs don't satisfy — i.e. the verification level Python used by default through 3.12. A `verify_ssl: false` kubeconfig is left untouched (we never silently re-enable *or* weaken).

## Tests (TDD, failing-first)

- `test_relaxed_verification_clears_strict_but_keeps_verification` — the security invariant: strict off, but `CERT_REQUIRED` + `check_hostname` stay on.
- `test_apps_v1_api_injects_nonstrict_verifying_context` — the context reaches the urllib3 pool and `ca_certs`/`cert_reqs` are dropped.
- `test_apps_v1_api_leaves_insecure_kubeconfigs_alone` — no context built when `verify_ssl` is False.

16 scaling tests green; pylint 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)