### PR TITLE
feat(labels): create per-dive LS projects in a configured workspace

### DIFF
--- a/deploy/incus/worker_volumes/api_worker/config/settings.toml
+++ b/deploy/incus/worker_volumes/api_worker/config/settings.toml
@@ -32,6 +32,9 @@ server_root_ca_cert = "/run/tenant/temporal/ca.crt"
 [label_studio]
 # Hosted Label Studio (HumanSignal) — the self-hosted labeler.e4e.ucsd.edu was retired.
 url = "https://app.heartex.com"
+# LS Enterprise workspace new per-dive projects are created in. Resolved to
+# its numeric id at runtime via workspaces.list(). Empty = personal/default.
+workspace = "FishSense"
 
 [e4e_nas]
 url = "https://e4e-nas.ucsd.edu:6021"

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
@@ -114,10 +114,20 @@ async def create_or_get_label_studio_project(
     `build_per_dive_title`.
     """
     ls = _get_ls_client()
+    workspace_id = await asyncio.to_thread(_resolve_workspace_id, ls)
 
-    matches = await asyncio.to_thread(
-        lambda: [p for p in ls.projects.list() if p.title == project_title]
-    )
+    def _list_titled():
+        # Scope the idempotency lookup to the target workspace so a same-
+        # titled project in another workspace can't shadow it. `workspaces`
+        # (plural) is a server-side filter; None means "all workspaces".
+        projects = (
+            ls.projects.list(workspaces=[workspace_id])
+            if workspace_id is not None
+            else ls.projects.list()
+        )
+        return [p for p in projects if p.title == project_title]
+
+    matches = await asyncio.to_thread(_list_titled)
     if matches:
         if len(matches) > 1:
             activity.logger.warning(
@@ -141,6 +151,7 @@ async def create_or_get_label_studio_project(
         ls.projects.create,
         title=project_title,
         label_config=labeling_config_xml,
+        workspace=workspace_id,
     )
     activity.logger.info(
         "Created LS project %r (id=%d)", project_title, project.id
@@ -231,3 +242,25 @@ def _get_ls_client() -> LabelStudio:
     both `create_or_get_label_studio_project` and
     `import_tasks_and_record_labels` pick up the fake client."""
     return get_ls_client()
+
+
+def _resolve_workspace_id(ls: LabelStudio) -> int | None:
+    """Resolve the configured `label_studio.workspace` name to its LS id.
+
+    LS Enterprise groups projects into workspaces; new per-dive projects
+    should be created in the tenant's workspace (`FishSense` in prod) rather
+    than the caller's personal one. Returns ``None`` when unset (OSS LS /
+    local dev / tests) so project creation falls back to the default
+    workspace. Raises if a name is configured but no such workspace exists —
+    a silent fallback would scatter projects into the wrong workspace.
+    """
+    name = (settings.label_studio.get("workspace") or "").strip()
+    if not name:
+        return None
+    matches = [w for w in ls.workspaces.list() if w.title == name]
+    if not matches:
+        raise RuntimeError(
+            f"Label Studio workspace {name!r} not found "
+            "(settings.label_studio.workspace) — create it or fix the config."
+        )
+    return matches[0].id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/config.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/config.py
@@ -36,6 +36,9 @@ _VALIDATORS = [
     Validator("temporal.server_root_ca_cert", cast=str, condition=path_validator),
     Validator("label_studio.url", required=True, condition=url_condition),
     Validator("label_studio.api_key", required=True, cast=str),
+    # LS Enterprise workspace new per-dive projects are created in. Empty =
+    # personal/default workspace (back-compat for OSS LS / local dev / tests).
+    Validator("label_studio.workspace", cast=str, default=""),
     Validator("e4e_nas.url", required=True, cast=str, condition=url_condition),
     Validator("e4e_nas.username", required=True, cast=str),
     Validator("e4e_nas.password", required=True, cast=str),

--- a/services/fishsense-api-workflow-worker/tests/test_create_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_create_laser_label_studio_project_activity.py
@@ -100,6 +100,7 @@ async def test_creates_project_when_no_match_and_xml_present(monkeypatch):
     ls.projects.create.assert_called_once_with(
         title=expected_title,
         label_config="<View><Image/></View>",
+        workspace=None,
     )
 
 
@@ -143,6 +144,7 @@ async def test_falls_back_to_dive_id_when_name_missing(monkeypatch):
     ls.projects.create.assert_called_once_with(
         title=expected_title,
         label_config="<View/>",
+        workspace=None,
     )
 
 
@@ -173,6 +175,7 @@ async def test_falls_back_to_dive_id_when_name_too_long(monkeypatch):
     ls.projects.create.assert_called_once_with(
         title=expected_title,
         label_config="<View/>",
+        workspace=None,
     )
 
 

--- a/services/fishsense-api-workflow-worker/tests/test_populate_utils_workspace.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_utils_workspace.py
@@ -1,0 +1,116 @@
+"""LS Enterprise workspace scoping for per-dive project creation.
+
+New per-dive projects must land in the tenant's workspace (`FishSense` in
+prod), not the service account's personal one. `create_or_get_label_studio_project`
+resolves `label_studio.workspace` to its numeric id, scopes the idempotency
+lookup to that workspace, and creates there. Unset → default workspace.
+"""
+
+from __future__ import annotations
+
+# Tests exercise the internal `_resolve_workspace_id` helper directly.
+# pylint: disable=protected-access
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from fishsense_api_workflow_worker import config as cfg
+from fishsense_api_workflow_worker.activities import populate_utils as pu
+
+
+def _workspace(ws_id: int, title: str):
+    w = MagicMock()
+    w.id = ws_id
+    w.title = title
+    return w
+
+
+def _fake_ls(*, workspaces=(), existing_projects=(), created_id=123):
+    ls = MagicMock()
+    ls.workspaces.list.return_value = list(workspaces)
+    ls.projects.list.return_value = list(existing_projects)
+    created = MagicMock()
+    created.id = created_id
+    ls.projects.create.return_value = created
+    return ls
+
+
+async def _noop(*_a, **_k):
+    return None
+
+
+def test_resolve_workspace_id_matches_by_title(monkeypatch):
+    monkeypatch.setenv("E4EFS_LABEL_STUDIO__WORKSPACE", "FishSense")
+    cfg.settings.reload()
+    ls = _fake_ls(workspaces=[_workspace(3, "Other"), _workspace(7, "FishSense")])
+    assert pu._resolve_workspace_id(ls) == 7
+
+
+def test_resolve_workspace_id_none_when_unset(monkeypatch):
+    monkeypatch.delenv("E4EFS_LABEL_STUDIO__WORKSPACE", raising=False)
+    cfg.settings.reload()
+    ls = _fake_ls(workspaces=[_workspace(7, "FishSense")])
+    assert pu._resolve_workspace_id(ls) is None
+    ls.workspaces.list.assert_not_called()
+
+
+def test_resolve_workspace_id_raises_when_configured_but_missing(monkeypatch):
+    monkeypatch.setenv("E4EFS_LABEL_STUDIO__WORKSPACE", "Nope")
+    cfg.settings.reload()
+    ls = _fake_ls(workspaces=[_workspace(7, "FishSense")])
+    with pytest.raises(RuntimeError, match="workspace 'Nope' not found"):
+        pu._resolve_workspace_id(ls)
+
+
+async def test_create_scopes_and_creates_in_workspace(monkeypatch):
+    monkeypatch.setenv("E4EFS_LABEL_STUDIO__WORKSPACE", "FishSense")
+    cfg.settings.reload()
+    ls = _fake_ls(workspaces=[_workspace(7, "FishSense")], existing_projects=[])
+    monkeypatch.setattr(pu, "_get_ls_client", lambda: ls)
+    monkeypatch.setattr(pu, "ensure_label_studio_s3_storage", _noop)
+
+    pid = await pu.create_or_get_label_studio_project(
+        project_title="2024 dive 3 - Laser Labeling",
+        labeling_config_xml="<View/>",
+    )
+
+    assert pid == 123
+    ls.projects.list.assert_called_once_with(workspaces=[7])
+    _, kwargs = ls.projects.create.call_args
+    assert kwargs["workspace"] == 7
+
+
+async def test_create_idempotent_finds_existing_in_workspace(monkeypatch):
+    monkeypatch.setenv("E4EFS_LABEL_STUDIO__WORKSPACE", "FishSense")
+    cfg.settings.reload()
+    existing = MagicMock()
+    existing.id = 55
+    existing.title = "X - Laser Labeling"
+    ls = _fake_ls(workspaces=[_workspace(7, "FishSense")], existing_projects=[existing])
+    monkeypatch.setattr(pu, "_get_ls_client", lambda: ls)
+    monkeypatch.setattr(pu, "ensure_label_studio_s3_storage", _noop)
+
+    pid = await pu.create_or_get_label_studio_project(
+        project_title="X - Laser Labeling", labeling_config_xml="<View/>"
+    )
+
+    assert pid == 55
+    ls.projects.create.assert_not_called()
+
+
+async def test_create_without_workspace_uses_default(monkeypatch):
+    monkeypatch.delenv("E4EFS_LABEL_STUDIO__WORKSPACE", raising=False)
+    cfg.settings.reload()
+    ls = _fake_ls(workspaces=[], existing_projects=[])
+    monkeypatch.setattr(pu, "_get_ls_client", lambda: ls)
+    monkeypatch.setattr(pu, "ensure_label_studio_s3_storage", _noop)
+
+    pid = await pu.create_or_get_label_studio_project(
+        project_title="X - Laser Labeling", labeling_config_xml="<View/>"
+    )
+
+    assert pid == 123
+    ls.projects.list.assert_called_once_with()  # no workspace filter
+    _, kwargs = ls.projects.create.call_args
+    assert kwargs["workspace"] is None


### PR DESCRIPTION
## What

New per-dive Label Studio projects now get created in a configurable **workspace** (LS Enterprise), instead of the service account's personal one. Set to **`FishSense`** in prod.

## Why

You've moved to Label Studio Enterprise, which groups projects into workspaces. Without this, every `Create…`/`Populate…` workflow drops its per-dive project into whoever's personal workspace the API token belongs to.

## Change

- **New config `label_studio.workspace`** — `Validator(..., default="")`. Empty = personal/default workspace (back-compat: OSS LS, local dev, tests). The api-worker's `settings.toml` sets `workspace = "FishSense"`.
- **`create_or_get_label_studio_project`** (`populate_utils.py`):
  - resolves the workspace **name → numeric id** once via `workspaces.list()` — and **raises** if a configured name has no match (a silent fallback would scatter projects into the wrong workspace);
  - scopes the idempotency lookup with `projects.list(workspaces=[id])` so a same-titled project in another workspace can't shadow it;
  - passes `workspace=id` to `projects.create`.
  - Unset (`""`) → id `None` → **behavior unchanged**.

Confirmed against the running image: `label_studio_sdk 2.0.19`, `projects.create(workspace: Optional[int])`, `Workspace.title`/`.id`, and `projects.list(workspaces=…)` all supported.

## Tests (TDD)

`test_populate_utils_workspace.py` — resolve (match by title / none when unset / raise when configured-but-missing) + create (scopes+creates in workspace / idempotent finds existing / default when unset). Updated the existing create-laser assertions for the new `workspace=` kwarg. 14 focused + 56 in the broader create/populate/label-studio sweep pass; pylint 10/10.

## Note

This is orthogonal to "no projects created yet" — the cohorts are currently empty (all 27 HIGH-priority dives are grandfathered with existing label rows), so nothing triggers creation. This PR ensures that *when* projects are created (new dives, or on-demand runs), they land in `FishSense`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)