### PR TITLE
feat(incus): enable Superset by default + traefik 3.7.8 (whole-stack freshness)

### DIFF
--- a/deploy/incus/compose.yml
+++ b/deploy/incus/compose.yml
@@ -28,7 +28,7 @@
 services:
   # ── inner edge: TLS on :443 with fishsense.vm, route Host → containers ─────────────────
   traefik:
-    image: traefik:3.7.7
+    image: traefik:3.7.8
     restart: unless-stopped
     command:
       - --providers.file.filename=/etc/traefik/dynamic.yml
@@ -40,7 +40,7 @@ services:
     volumes:
       - /run/tenant/tls:/etc/traefik/tls:ro          # fishsense.vm.{crt,key} — vault-agent (#428)
       - ./traefik-dynamic.yml:/etc/traefik/dynamic.yml:ro
-    depends_on: [web, fishsense-api, authentik-outpost]   # superset is profile-gated off (analytics route 502s until re-enabled)
+    depends_on: [web, fishsense-api, authentik-outpost]   # traefik's analytics route → superset, started separately below (not a depends_on so init delay can't block traefik)
     networks: [interior]
 
   # ── co-located Authentik proxy outpost (gates the API route) — HANDOFF §7 / #440 ───────
@@ -98,14 +98,16 @@ services:
     # at the service DNS name `fishsense-api:8000` for now.
 
   # ── analytics → analytics.fishsense.e4e.ucsd.edu (in-app OIDC) ─────────────────────────
-  # DISABLED BY DEFAULT via the `superset` compose profile: the composeStack runner does a
-  # plain `docker compose up -d` (no --profile), so superset + valkey don't start. Re-enable
-  # by adding `superset` to COMPOSE_PROFILES (composeStack envFile) or `--profile superset`.
-  # Requires the superset DB/role + restore before it will come up (see README).
+  # Superset + valkey run by default (enabled 2026-07-15; #233 had profile-gated them off
+  # while the metadata DB was sorted out). Metadata = the in-slot `superset` Postgres DB,
+  # accessed as the least-priv `superset` role (secret_key / db_password / analytics-OIDC come
+  # from the vault-agent app.env render). `superset-init` runs `db upgrade` + creates the local
+  # `admin` user on startup; the `superset` DB must be OWNED BY the `superset` role or the
+  # upgrade can't ALTER its tables (the original init failure). Fresh/new setup:
+  #   DROP DATABASE superset; CREATE DATABASE superset OWNER superset;   -- then converge
   superset:
     image: &superset-image apache/superset:6.0.0
     container_name: fishsense_superset
-    profiles: ["superset"]
     command: ["/app/docker/docker-bootstrap.sh", "app-gunicorn"]
     user: "root"
     restart: unless-stopped
@@ -126,7 +128,6 @@ services:
   superset-init:
     image: *superset-image
     container_name: superset_init
-    profiles: ["superset"]
     command: ["/app/docker/docker-init.sh"]
     user: "root"
     env_file:
@@ -147,7 +148,6 @@ services:
   superset-worker:
     image: *superset-image
     container_name: superset_worker
-    profiles: ["superset"]
     command: ["/app/docker/docker-bootstrap.sh", "worker"]
     user: "root"
     restart: unless-stopped
@@ -171,7 +171,6 @@ services:
   superset-worker-beat:
     image: *superset-image
     container_name: superset_worker_beat
-    profiles: ["superset"]
     command: ["/app/docker/docker-bootstrap.sh", "beat"]
     user: "root"
     restart: unless-stopped
@@ -192,8 +191,7 @@ services:
   # protocol-compatible replacement for superset's cache + celery broker.
   valkey:
     image: valkey/valkey:9.1.0
-    container_name: superset_cache
-    profiles: ["superset"]   # only superset uses it — off with the superset profile
+    container_name: superset_cache   # only superset uses it (cache + celery broker)
     restart: unless-stopped
     volumes:
       - valkey_data:/data   # named volume — persistent, docker-owned


### PR DESCRIPTION
## What

Brings **Superset up by default** (for visibility into the fishsense DB / `dive_pipeline_status`) and makes the whole stack current in one converge, per "all containers up to date at the same time."

- **Enable Superset** — drop `profiles: ["superset"]` from `superset`, `superset-init`, `superset-worker`, `superset-worker-beat`, and `valkey`. They were gated off in #233 while the metadata DB was sorted out; now they start on the plain `docker compose up -d`. (Reverses #233; we own the compose file, so this is cleaner than the `COMPOSE_PROFILES` envFile route.)
- **traefik 3.7.7 → 3.7.8** (patch) — the only third-party image behind. **postgres 17.10, valkey 9.1.0, authentik 2026.5.4** (platform-matched — must track krg-prod's server, so it does *not* jump ahead) and every `fishsense-*` pin were already at latest.

## Operator steps (fresh setup — no restore)

The existing `superset` Postgres DB is **not** a clean slate: 51 stale tables **owned by `postgres`**, not `superset`. That's why `superset_init` exited 1 five days ago — `db upgrade` runs as the least-priv `superset` role and can't `ALTER` postgres-owned tables. Since you want it new:

1. **Recreate the metadata DB owned by `superset`** (secrets `secret_key`/`db_password` are already seeded — the fail-closed `app.env` render proves it):
   ```sh
   docker exec fishsense-postgres-1 psql -U postgres -c \
     'DROP DATABASE superset; CREATE DATABASE superset OWNER superset;'
   ```
2. **Converge** — this is a config-only `deploy/incus/` change, so it does **not** auto-open an auto-deploy PR. Trigger `deploy.yml` `workflow_dispatch` (`target: incus`), or wait for the nightly. `superset-init` then runs `db upgrade` (clean schema, `superset`-owned) + creates the local `admin` user.
3. **Log in** at `analytics.fishsense.e4e.ucsd.edu` — via the analytics **Authentik OIDC** app, or the local `admin` user `superset-init` creates (default password from `docker-init.sh` — **change it**). Then add the in-slot fishsense Postgres as a database connection and build dashboards.

## Notes

- No secret changes needed — Superset's `secret_key`/`db_password` and the analytics OIDC client are already in the vault-agent `app.env` render (the stack wouldn't be up otherwise, since that render is fail-closed).
- Superset stays on `6.0.0` (recent stable; Docker Hub's newer tags are rolling SHA/GHA builds, not a newer semver). Bump later if a newer stable release lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)