### PR TITLE
feat(incus): prune unused docker images after each converge

### DIFF
--- a/deploy/incus/prune.nix
+++ b/deploy/incus/prune.nix
@@ -1,0 +1,28 @@
+# Reclaim unused docker images after each compose-stack converge.
+#
+# The slot's root disk is only 20G, and the composeStack force-recreates on
+# every converge — pulling each release's new image tag while leaving the old
+# ones resident. Without cleanup that steadily fills the disk: we hit 100% on
+# 2026-07-16 (postgres `FATAL: could not write init file: No space left on
+# device`, superset_worker crash-loop, and every *new* DB connection at risk),
+# with ~5.4G of stale image versions reclaimable.
+#
+# This runs `docker image prune -af` ordered AFTER `fishsense.service` (the
+# compose stack) and pulled in whenever it starts — so the reclaim happens as
+# part of the deploy, right after `up -d` has the new containers running (their
+# images in-use and therefore kept; only the superseded versions are removed).
+#
+# Deliberately `wantedBy` (not `requiredBy`) and no `bindsTo`: a prune failure
+# must never fail or block the stack — worst case the disk isn't reclaimed and
+# we notice next time.
+{config, ...}: {
+  systemd.services.fishsense-image-prune = {
+    description = "Reclaim unused docker images after the compose-stack converge";
+    after = ["fishsense.service"];
+    wantedBy = ["fishsense.service"];
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = "${config.virtualisation.docker.package}/bin/docker image prune -af";
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,7 @@
         })
         ./deploy/incus/secrets.nix # extends krg.vaultAgent.renders → /run/tenant/secrets/app.env (HANDOFF §9)
         ./deploy/incus/workdir.nix # populate /var/lib/krg/fishsense so the compose's relative binds resolve
+        ./deploy/incus/prune.nix # docker image prune after each compose converge — the 20G disk fills otherwise
       ];
     };
 


### PR DESCRIPTION
## Problem

The slot's root disk is only **20G**, and the composeStack force-recreates on every converge — pulling each release's new image tag while leaving the old versions resident. With no cleanup, the disk fills.

**We hit 100% on 2026-07-16** while enabling Superset:
```
postgres: FATAL: could not write init file: No space left on device
```
`superset_worker` crash-looped, and *every new DB connection was at risk* (the main app survived only on its existing pool). `docker system df` showed **~5.4G reclaimable** — api-worker `v1.35.3 / v1.36.0 / v1.38.0 / v1.38.1 / v1.39.0` all resident, three `fishsense-api`, three web, three traefik, two authentik.

## Fix

`deploy/incus/prune.nix` adds `fishsense-image-prune.service` — a oneshot `docker image prune -af` ordered **after** and **`wantedBy`** `fishsense.service` (the compose stack). So the reclaim runs **as part of every deploy**, right after `up -d` has the new containers running (their images in-use → kept; only superseded versions removed).

- `wantedBy` (not `requiredBy`) + no `bindsTo`: a prune failure can **never fail or block the stack**.
- `after`: runs once the new containers are up, so nothing in-use is pruned.

## Validation

- Tenant config evaluates; `ExecStart` resolves to `${docker}/bin/docker image prune -af` (docker 29.6.1).
- `after` = `wantedBy` = `[fishsense.service]`.
- `flake.lock` untouched (no input change).

## ⚠️ Operator — do the manual prune first

The disk is **full right now**, so `nixos-rebuild` has no room to install this. Free space first, then merge + converge:
```sh
incus exec fishsense --project fishsense -- docker image prune -af
```
After this lands, every future converge self-cleans.

## Follow-up

This is arguably a **platform-wide** concern (every composeStack tenant on a small disk faces it) — worth upstreaming into krg-infra's composeStack module so all tenants get it. Happy to file that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)