### PR TITLE
feat(superset): OIDC identity + Authentik group→role mapping

### DIFF
--- a/deploy/incus/superset_volumes/docker/pythonpath/superset_config.py
+++ b/deploy/incus/superset_volumes/docker/pythonpath/superset_config.py
@@ -177,7 +177,10 @@ OAUTH_PROVIDERS = [
             'client_secret': os.environ.get('AUTHENTIK_SECRET'),
             'api_base_url': AUTHENTIK_ISSUER,
             'client_kwargs':{
-              'scope': 'email profile'
+              # `openid` for the userinfo endpoint; `groups` carries the user's
+              # Authentik groups (requires a matching scope/property mapping on
+              # the analytics OIDC app in Authentik — see krg spec / PR notes).
+              'scope': 'openid email profile groups'
             },
             'jwks_uri': f'{AUTHENTIK_ISSUER}jwks/',
             'request_token_url': None,
@@ -191,8 +194,57 @@ OAUTH_PROVIDERS = [
 AUTH_USER_REGISTRATION = True
 ALLOW_LOCAL_USER_LOGIN = True 
 
-# The default user self registration role
+# The default user self registration role — the fallback for anyone who logs
+# in via OIDC but is in none of the mapped groups below (Public = no access).
 AUTH_USER_REGISTRATION_ROLE = "Public"
+
+# ── OIDC identity + group→role mapping ─────────────────────────────────────
+# Authentik is NOT a Flask-AppBuilder built-in OAuth provider, so FAB's default
+# `get_oauth_user_info` returns {} — OIDC login can't extract the user and
+# silently fails, and since AUTH_OAUTH also hides the local login form there is
+# no way in at all (exactly what happened on first bring-up). This custom
+# SecurityManager pulls the identity + Authentik groups from the userinfo
+# endpoint; FAB maps the group names to Superset roles via AUTH_ROLES_MAPPING.
+from superset.security import SupersetSecurityManager  # noqa: E402  pylint: disable=wrong-import-position
+
+
+class AuthentikSecurityManager(SupersetSecurityManager):
+    """Extract identity + groups from Authentik's OIDC userinfo endpoint.
+
+    `role_keys` = the user's Authentik group names, which FAB matches against
+    AUTH_ROLES_MAPPING (re-applied every login via AUTH_ROLES_SYNC_AT_LOGIN).
+    """
+
+    def get_oauth_user_info(self, provider, response=None):
+        if provider != "authentik":
+            return {}
+        userinfo = self.appbuilder.sm.oauth_remotes[provider].get(
+            f"{_AUTHENTIK_ROOT}/application/o/userinfo/"
+        )
+        userinfo.raise_for_status()
+        data = userinfo.json()
+        return {
+            "username": data.get("preferred_username") or data.get("email"),
+            "email": data.get("email"),
+            "first_name": data.get("given_name", ""),
+            "last_name": data.get("family_name", ""),
+            "role_keys": data.get("groups", []),
+        }
+
+
+CUSTOM_SECURITY_MANAGER = AuthentikSecurityManager
+
+# Authentik group name → Superset role(s). Membership lives in Authentik
+# (terraform / the Samba-LDAP source), so granting access = adding someone to a
+# group here; nothing to click in Superset. Roles re-sync on every login, so
+# removing a user from a group revokes the role too. Users in no mapped group
+# get AUTH_USER_REGISTRATION_ROLE (Public).
+AUTH_ROLES_MAPPING = {
+    "fishsense-superset-admin": ["Admin"],
+    "fishsense-superset-editor": ["Alpha"],
+    "fishsense-superset-viewer": ["Gamma"],
+}
+AUTH_ROLES_SYNC_AT_LOGIN = True
 
 WEBDRIVER_AUTH = {"username": os.getenv("WEBDRIVER_AUTH_USERNAME", ""), "password":  os.getenv("WEBDRIVER_AUTH_PASSWORD", "")}
 


### PR DESCRIPTION
## Problem

Superset was shipped with `AUTH_TYPE = AUTH_OAUTH` against a provider named `authentik` — which is **not** a Flask-AppBuilder built-in, and there was **no custom `SecurityManager`**. So FAB's `get_oauth_user_info` returns `{}`, OIDC login can't extract the user, and (because `AUTH_OAUTH` also hides the local `admin`/`admin` form) **there's no way to log in at all**. Confirmed on first bring-up: `ab_user` has only the seeded `admin` row — no OIDC login has ever succeeded.

This also answers "can we allocate users with terraform?" — yes, via Authentik group membership + native FAB role mapping. No Superset-specific Temporal job: FAB re-syncs roles from the groups claim on every login, so a reconciler would just duplicate that (reserve Temporal for apps like Outline that lack native OIDC group mapping).

## Change (`superset_config.py`)

- **`AuthentikSecurityManager`** — `get_oauth_user_info` pulls `email` / `preferred_username` and **`groups`** from Authentik's `/application/o/userinfo/`, returning the groups as `role_keys`. Set as `CUSTOM_SECURITY_MANAGER`. This is what makes OIDC login work.
- **`AUTH_ROLES_MAPPING`** — `fishsense-superset-admin → Admin`, `-editor → Alpha`, `-viewer → Gamma`; `AUTH_ROLES_SYNC_AT_LOGIN = True` (roles re-applied every login, so removing someone from a group revokes access). Unmapped users fall back to `Public`.
- **Scope** gains `openid` (userinfo) + `groups`.

pylint skips it (`ignore-paths = ["^deploy/.*$"]`); validated with `py_compile`.

## Authentik-side spec (krg / `terraform/authentik`)

The `fishsense_analytics` OIDC provider needs:

1. **A `groups` scope mapping** — a Scope Mapping with **Scope name `groups`** and expression:
   ```python
   return [group.name for group in request.user.ak_groups.all()]
   ```
   assigned to the provider's Scopes (so `groups` appears in userinfo).
2. **Three groups** — `fishsense-superset-admin`, `fishsense-superset-editor`, `fishsense-superset-viewer` (or map these names from existing Samba/LDAP groups), with members assigned.
3. **Redirect URI** on the app includes Superset's OAuth callback:
   `https://analytics.fishsense.e4e.ucsd.edu/oauth-authorized/authentik`

I can file this as a krg-infra issue if you'd like.

## Deploy / bootstrap sequence

1. **Prune the disk** first (the stack is at 100% — converges can't run until `docker image prune -af`; #280 automates it going forward).
2. Merge + converge (config-only `deploy/incus/` change → manual `deploy.yml` `workflow_dispatch target=incus` or nightly).
3. **First admin:** if the Authentik `fishsense-superset-admin` group + you-in-it is ready, you log in via OIDC and land as Admin automatically. If the group side isn't ready yet, log in once (you'll be `Public`) then one-time promote:
   ```sh
   docker exec fishsense-postgres-1 psql -U superset -d superset -c \
     "INSERT INTO ab_user_role (user_id, role_id) SELECT u.id, r.id FROM ab_user u JOIN ab_role r ON r.name='Admin' WHERE u.email='<you>' AND NOT EXISTS (SELECT 1 FROM ab_user_role x WHERE x.user_id=u.id AND x.role_id=r.id);"
   ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)