### PR TITLE
ci: add repo-wide YAML lint

### DIFF
--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,0 +1,17 @@
+name: YAML Lint
+
+# Catches malformed YAML (syntax, duplicate keys, broken indentation) across the
+# repo — most valuable for hand-authored bundles we can't otherwise validate,
+# like the Superset dashboard assets. Config + rule rationale in .yamllint.yaml.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: yamllint (config in .yamllint.yaml)
+        run: pipx run yamllint .

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,24 @@
+# Repo YAML lint. Deliberately relaxed: the goal is catching real breakage
+# (syntax errors, duplicate keys, broken/inconsistent indentation) — NOT style
+# nits — so existing compose / k8s / workflow YAML passes unchanged. The payoff
+# is guarding hand-authored YAML we can't otherwise validate in CI, e.g. the
+# Superset dashboard asset bundle (deploy/incus/superset_volumes/docker/assets).
+#
+# `extends: relaxed` keeps key-duplicates + syntax as errors (CI-failing) while
+# downgrading cosmetic rules; the disables below silence the purely-stylistic
+# ones the repo doesn't observe.
+extends: relaxed
+
+# Templates aren't valid standalone YAML (placeholder/interpolation syntax), so
+# they can't be parsed — exclude them rather than lint them.
+ignore: |
+  *config_template*
+  *.template.yaml
+  *.template.yml
+
+rules:
+  line-length: disable
+  trailing-spaces: disable
+  empty-lines: disable
+  comments: disable
+  document-start: disable


### PR DESCRIPTION
## What

A `YAML Lint` CI workflow (`yamllint`) + a relaxed `.yamllint.yaml`.

## Why

We're about to land hand-authored YAML that CI can't otherwise validate — the **Superset dashboard asset bundle** (databases/datasets/charts/dashboards under `deploy/incus/superset_volumes/docker/assets/`), which is imported blind on deploy. A YAML lint catches the failure modes that would silently break that import: syntax errors, duplicate keys, broken indentation.

## Scope / safety

- **Deliberately relaxed** — `extends: relaxed` keeps `key-duplicates` + syntax as errors, but cosmetic rules (line-length, trailing-spaces, etc.) are disabled, so **existing compose / k8s / workflow YAML passes unchanged**. Verified the whole repo is **exit 0**.
- **Templates ignored** (`*config_template*`, `*.template.{yaml,yml}`) — placeholder/interpolation syntax isn't parseable as standalone YAML (e.g. `deploy/temporal_volumes/config_template.yaml`).
- Runs on every PR + push to main; `pipx run yamllint .` auto-detects the root config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)