### PR TITLE
feat(superset): pipeline-status dashboard as an importable asset bundle

### DIFF
--- a/deploy/incus/superset_volumes/docker/assets/README.md
+++ b/deploy/incus/superset_volumes/docker/assets/README.md
@@ -1,0 +1,47 @@
+# Superset dashboards-as-code
+
+Superset assets (database connection, datasets, charts, dashboards) as YAML,
+in Superset's native export format. `docker-init.sh` (step 5) re-imports this
+bundle on **every converge** — idempotent, overwrites by `uuid` — so the
+dashboards are declarative and versioned instead of clicked-in-the-UI.
+
+```
+assets/
+  metadata.yaml
+  databases/FishSense.yaml          # fishsense Postgres connection (password injected at import, see below)
+  datasets/FishSense/
+    dive_pipeline_status.yaml        # the physical view — one bool per stage per dive
+    pipeline_labeling_queue.yaml     # virtual: count of HIGH dives waiting at each stage
+    pipeline_partial_dives.yaml      # virtual: one row per unfinished dive + its blocker
+  charts/                            # Labeling queue + Partially-done dives (table viz)
+  dashboards/FishSense_Pipeline_Status.yaml
+```
+
+## Secret handling
+
+`databases/FishSense.yaml` ships with `__DB_PASSWORD__` in the SQLAlchemy URI.
+`docker-init.sh` `sed`-substitutes `$DATABASE_PASSWORD` (the `superset` DB
+role's password, already in the container env) into a temp copy before import,
+so the credential is **never committed**. The `superset` role can already read
+the `fishsense` DB, so no extra grant is needed.
+
+## The maintenance loop (recommended)
+
+This first bundle is **hand-authored** and hasn't been round-tripped through a
+running Superset, so the charts/dashboard layout may need a fixup pass. The
+durable workflow:
+
+1. Let it import on converge (or `superset import-assets -p bundle.zip` by hand).
+2. Adjust datasets/charts/dashboard **in the UI** until they're right.
+3. **Settings → Export** (or `superset export-dashboards`) → drop the exported
+   YAML back into this directory, keeping the same `uuid`s.
+4. Commit — now the running state is the committed state.
+
+CI runs `yamllint` over these files (syntax / duplicate-key checks), but that
+does **not** validate Superset-import semantics — the loop above does.
+
+## UUIDs
+
+Assets cross-reference by `uuid` (dataset → `database_uuid`, chart →
+`dataset_uuid`, dashboard `position` → chart `uuid`). Keep them stable across
+edits so imports update in place instead of creating duplicates.

--- a/deploy/incus/superset_volumes/docker/assets/charts/Labeling_Queue.yaml
+++ b/deploy/incus/superset_volumes/docker/assets/charts/Labeling_Queue.yaml
@@ -1,0 +1,17 @@
+slice_name: Labeling queue (HIGH priority)
+viz_type: table
+params: |
+  {
+    "datasource": "33333333-3333-4333-8333-333333333333__table",
+    "viz_type": "table",
+    "query_mode": "raw",
+    "all_columns": ["stage", "cnt"],
+    "order_by_cols": ["[\"stage\", true]"],
+    "row_limit": 100,
+    "server_page_length": 10,
+    "include_search": false
+  }
+cache_timeout: null
+uuid: 66666666-6666-4666-8666-666666666666
+version: 1.0.0
+dataset_uuid: 33333333-3333-4333-8333-333333333333

--- a/deploy/incus/superset_volumes/docker/assets/charts/Partially_Done_Dives.yaml
+++ b/deploy/incus/superset_volumes/docker/assets/charts/Partially_Done_Dives.yaml
@@ -1,0 +1,17 @@
+slice_name: Partially-done dives (HIGH priority)
+viz_type: table
+params: |
+  {
+    "datasource": "44444444-4444-4444-8444-444444444444__table",
+    "viz_type": "table",
+    "query_mode": "raw",
+    "all_columns": ["dive_id", "blocker", "laser_labeling_complete", "species_labeling_complete", "headtail_labeling_complete", "slate_labeling_complete", "calibrated", "measured"],
+    "order_by_cols": ["[\"dive_id\", true]"],
+    "row_limit": 500,
+    "server_page_length": 25,
+    "include_search": true
+  }
+cache_timeout: null
+uuid: 77777777-7777-4777-8777-777777777777
+version: 1.0.0
+dataset_uuid: 44444444-4444-4444-8444-444444444444

--- a/deploy/incus/superset_volumes/docker/assets/dashboards/FishSense_Pipeline_Status.yaml
+++ b/deploy/incus/superset_volumes/docker/assets/dashboards/FishSense_Pipeline_Status.yaml
@@ -1,0 +1,85 @@
+dashboard_title: FishSense Pipeline Status
+description: Counts of dives at each pipeline stage and which dives are partially done. Source, dive_pipeline_status.
+css: ''
+slug: fishsense-pipeline-status
+certified_by: ''
+certification_details: ''
+published: true
+uuid: 88888888-8888-4888-8888-888888888888
+position:
+  DASHBOARD_VERSION_KEY: v2
+  ROOT_ID:
+    type: ROOT
+    id: ROOT_ID
+    children:
+      - GRID_ID
+  GRID_ID:
+    type: GRID
+    id: GRID_ID
+    parents:
+      - ROOT_ID
+    children:
+      - ROW-queue
+      - ROW-partial
+  HEADER_ID:
+    type: HEADER
+    id: HEADER_ID
+    meta:
+      text: FishSense Pipeline Status
+  ROW-queue:
+    type: ROW
+    id: ROW-queue
+    parents:
+      - ROOT_ID
+      - GRID_ID
+    children:
+      - CHART-queue
+    meta:
+      background: BACKGROUND_TRANSPARENT
+  ROW-partial:
+    type: ROW
+    id: ROW-partial
+    parents:
+      - ROOT_ID
+      - GRID_ID
+    children:
+      - CHART-partial
+    meta:
+      background: BACKGROUND_TRANSPARENT
+  CHART-queue:
+    type: CHART
+    id: CHART-queue
+    children: []
+    parents:
+      - ROOT_ID
+      - GRID_ID
+      - ROW-queue
+    meta:
+      uuid: 66666666-6666-4666-8666-666666666666
+      sliceName: Labeling queue (HIGH priority)
+      width: 5
+      height: 50
+  CHART-partial:
+    type: CHART
+    id: CHART-partial
+    children: []
+    parents:
+      - ROOT_ID
+      - GRID_ID
+      - ROW-partial
+    meta:
+      uuid: 77777777-7777-4777-8777-777777777777
+      sliceName: Partially-done dives (HIGH priority)
+      width: 12
+      height: 70
+metadata:
+  color_scheme: ''
+  refresh_frequency: 0
+  expanded_slices: {}
+  label_colors: {}
+  timed_refresh_immune_slices: []
+  cross_filters_enabled: true
+  default_filters: '{}'
+  chart_configuration: {}
+  global_chart_configuration: {}
+version: 1.0.0

--- a/deploy/incus/superset_volumes/docker/assets/databases/FishSense.yaml
+++ b/deploy/incus/superset_volumes/docker/assets/databases/FishSense.yaml
@@ -1,0 +1,16 @@
+# __DB_PASSWORD__ is replaced with $DATABASE_PASSWORD by docker-init.sh at
+# import time (the superset DB role can read the fishsense DB) — the secret is
+# never committed. Same role/password Superset uses for its own metadata DB.
+database_name: FishSense
+sqlalchemy_uri: postgresql+psycopg2://superset:__DB_PASSWORD__@postgres:5432/fishsense
+cache_timeout: null
+expose_in_sqllab: true
+allow_run_async: true
+allow_ctas: false
+allow_cvas: false
+allow_dml: false
+allow_file_upload: false
+extra:
+  allows_virtual_table_explore: true
+uuid: 11111111-1111-4111-8111-111111111111
+version: 1.0.0

--- a/deploy/incus/superset_volumes/docker/assets/datasets/FishSense/dive_pipeline_status.yaml
+++ b/deploy/incus/superset_volumes/docker/assets/datasets/FishSense/dive_pipeline_status.yaml
@@ -1,0 +1,120 @@
+table_name: dive_pipeline_status
+main_dttm_col: null
+description: One row per dive with a boolean per pipeline stage (see fishsense_api.views). Backs the pipeline-status dashboard.
+default_endpoint: null
+offset: 0
+cache_timeout: null
+catalog: null
+schema: public
+sql: null
+params: null
+template_params: null
+filter_select_enabled: true
+fetch_values_predicate: null
+extra: null
+normalize_columns: false
+always_filter_main_dttm: false
+uuid: 22222222-2222-4222-8222-222222222222
+metrics:
+  - metric_name: count
+    verbose_name: Dives
+    metric_type: count
+    expression: COUNT(*)
+    description: null
+    d3format: null
+    extra: {}
+    warning_text: null
+  - metric_name: unfinished
+    verbose_name: Unfinished
+    metric_type: null
+    expression: COUNT(*) FILTER (WHERE NOT measured)
+    description: Dives not yet measured (terminal stage)
+    d3format: null
+    extra: {}
+    warning_text: null
+  - metric_name: ready_to_measure
+    verbose_name: Ready to measure
+    metric_type: null
+    expression: COUNT(*) FILTER (WHERE calibrated AND NOT measured)
+    description: Calibrated but not yet measured (stage 14 is operator-triggered)
+    d3format: null
+    extra: {}
+    warning_text: null
+columns:
+  - column_name: dive_id
+    type: INTEGER
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: priority
+    type: VARCHAR
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: dive_slate_id
+    type: INTEGER
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: laser_preprocessed
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: laser_labeling_complete
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: has_prediction_clusters
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: dive_images_preprocessed
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: species_labeling_complete
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: headtail_preprocessed
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: headtail_labeling_complete
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: slate_applicable
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: slate_preprocessed
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: slate_labeling_complete
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: calibrated
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: measured
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+version: 1.0.0
+database_uuid: 11111111-1111-4111-8111-111111111111

--- a/deploy/incus/superset_volumes/docker/assets/datasets/FishSense/pipeline_labeling_queue.yaml
+++ b/deploy/incus/superset_volumes/docker/assets/datasets/FishSense/pipeline_labeling_queue.yaml
@@ -1,0 +1,46 @@
+table_name: pipeline_labeling_queue
+main_dttm_col: null
+description: Count of HIGH-priority dives waiting at each labeling / processing stage.
+default_endpoint: null
+offset: 0
+cache_timeout: null
+catalog: null
+schema: null
+sql: |
+  SELECT stage, cnt FROM (VALUES
+    ('1 laser',    (SELECT count(*) FROM dive_pipeline_status WHERE priority = 'HIGH' AND laser_preprocessed AND NOT laser_labeling_complete)),
+    ('2 species',  (SELECT count(*) FROM dive_pipeline_status WHERE priority = 'HIGH' AND has_prediction_clusters AND dive_images_preprocessed AND NOT species_labeling_complete)),
+    ('3 headtail', (SELECT count(*) FROM dive_pipeline_status WHERE priority = 'HIGH' AND headtail_preprocessed AND NOT headtail_labeling_complete)),
+    ('4 slate',    (SELECT count(*) FROM dive_pipeline_status WHERE priority = 'HIGH' AND slate_applicable AND slate_preprocessed AND NOT slate_labeling_complete)),
+    ('5 measure',  (SELECT count(*) FROM dive_pipeline_status WHERE priority = 'HIGH' AND calibrated AND NOT measured))
+  ) AS t(stage, cnt)
+params: null
+template_params: null
+filter_select_enabled: true
+fetch_values_predicate: null
+extra: null
+normalize_columns: false
+always_filter_main_dttm: false
+uuid: 33333333-3333-4333-8333-333333333333
+metrics:
+  - metric_name: total
+    verbose_name: Dives waiting
+    metric_type: null
+    expression: SUM(cnt)
+    description: null
+    d3format: null
+    extra: {}
+    warning_text: null
+columns:
+  - column_name: stage
+    type: STRING
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: cnt
+    type: BIGINT
+    is_dttm: false
+    groupby: false
+    filterable: true
+version: 1.0.0
+database_uuid: 11111111-1111-4111-8111-111111111111

--- a/deploy/incus/superset_volumes/docker/assets/datasets/FishSense/pipeline_partial_dives.yaml
+++ b/deploy/incus/superset_volumes/docker/assets/datasets/FishSense/pipeline_partial_dives.yaml
@@ -1,0 +1,84 @@
+table_name: pipeline_partial_dives
+main_dttm_col: null
+description: One row per unfinished HIGH-priority dive with its current blocker — the "which dives are partially done" list.
+default_endpoint: null
+offset: 0
+cache_timeout: null
+catalog: null
+schema: null
+sql: |
+  SELECT dive_id, priority,
+    laser_labeling_complete, species_labeling_complete, headtail_labeling_complete,
+    slate_labeling_complete, calibrated, measured,
+    CASE
+      WHEN NOT laser_labeling_complete THEN 'needs laser'
+      WHEN calibrated AND NOT measured THEN 'ready to measure'
+      WHEN species_labeling_complete AND headtail_labeling_complete AND dive_slate_id IS NULL THEN 'blocked: no slate'
+      WHEN NOT species_labeling_complete AND NOT headtail_labeling_complete THEN 'needs species + headtail'
+      WHEN NOT species_labeling_complete THEN 'needs species'
+      WHEN NOT headtail_labeling_complete THEN 'needs headtail'
+      ELSE 'other'
+    END AS blocker
+  FROM dive_pipeline_status
+  WHERE priority = 'HIGH' AND NOT measured
+  ORDER BY dive_id
+params: null
+template_params: null
+filter_select_enabled: true
+fetch_values_predicate: null
+extra: null
+normalize_columns: false
+always_filter_main_dttm: false
+uuid: 44444444-4444-4444-8444-444444444444
+metrics:
+  - metric_name: count
+    verbose_name: Dives
+    metric_type: count
+    expression: COUNT(*)
+    description: null
+    d3format: null
+    extra: {}
+    warning_text: null
+columns:
+  - column_name: dive_id
+    type: INTEGER
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: blocker
+    type: STRING
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: laser_labeling_complete
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: species_labeling_complete
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: headtail_labeling_complete
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: slate_labeling_complete
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: calibrated
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: measured
+    type: BOOLEAN
+    is_dttm: false
+    groupby: true
+    filterable: true
+version: 1.0.0
+database_uuid: 11111111-1111-4111-8111-111111111111

--- a/deploy/incus/superset_volumes/docker/assets/metadata.yaml
+++ b/deploy/incus/superset_volumes/docker/assets/metadata.yaml
@@ -1,0 +1,3 @@
+version: 1.0.0
+type: Dashboard
+timestamp: '2026-07-16T00:00:00+00:00'

--- a/deploy/incus/superset_volumes/docker/docker-init.sh
+++ b/deploy/incus/superset_volumes/docker/docker-init.sh
@@ -79,3 +79,27 @@ if [ "$SUPERSET_LOAD_EXAMPLES" = "yes" ]; then
     fi
     echo_step "4" "Complete" "Loading examples"
 fi
+
+# ── Step 5: import committed dashboard assets (IaC) ──────────────────────────
+# Superset dashboards-as-code: databases/datasets/charts/dashboards live as YAML
+# under docker/assets/ and are re-imported on every converge (idempotent —
+# import overwrites by UUID). The FishSense DB connection's password is injected
+# from $DATABASE_PASSWORD at import time via a placeholder, so the secret never
+# lives in git. A failed import must NOT fail init (Superset still comes up), so
+# this is best-effort.
+ASSETS_SRC=/app/docker/assets
+if [ -d "$ASSETS_SRC" ]; then
+    echo_step "5" "Starting" "Importing committed dashboard assets"
+    BUNDLE="$(mktemp -d)"
+    cp -a "$ASSETS_SRC"/. "$BUNDLE"/
+    # Inject the superset DB-role password into the FishSense connection URI.
+    sed -i "s|__DB_PASSWORD__|${DATABASE_PASSWORD}|g" "$BUNDLE"/databases/*.yaml 2>/dev/null || true
+    ZIP=/tmp/fishsense-assets.zip
+    python -c "import shutil,sys; shutil.make_archive('/tmp/fishsense-assets','zip',sys.argv[1])" "$BUNDLE"
+    if superset import-assets -p "$ZIP"; then
+        echo_step "5" "Complete" "Importing committed dashboard assets"
+    else
+        echo "WARN: superset import-assets failed — dashboards not applied (init continues)"
+    fi
+    rm -rf "$BUNDLE" "$ZIP"
+fi


### PR DESCRIPTION
## What

Superset **dashboards-as-code**: the FishSense Postgres connection, datasets, charts, and a **Pipeline Status** dashboard as YAML under `deploy/incus/superset_volumes/docker/assets/`, plus a step in `docker-init.sh` that re-imports the bundle on **every converge** (idempotent — overwrites by `uuid`). Same file-based, deploy-applied model as krg's `terraform/grafana` dashboards, but native to Superset (no Superset TF provider exists, and krg's Grafana can't reach the in-slot fishsense DB).

Answers your question — counts at every stage + which dives are partially done — off the `dive_pipeline_status` view:
- **dataset** `dive_pipeline_status` (the physical view)
- **virtual dataset** `pipeline_labeling_queue` — HIGH dives waiting per stage
- **virtual dataset** `pipeline_partial_dives` — one row per unfinished dive + its `blocker`
- **charts** — "Labeling queue" + "Partially-done dives" (table viz — chosen for import-robustness)
- **dashboard** — FishSense Pipeline Status

## Secret handling

The connection ships with `__DB_PASSWORD__`; `docker-init.sh` `sed`-injects `$DATABASE_PASSWORD` into a temp copy before import, so the credential is **never committed**. The `superset` role already reads the fishsense DB (verified — 479 rows), so no grant needed.

## ⚠️ Validation caveat

This bundle is **hand-authored and has not been round-tripped through a running Superset** (login was blocked on the JWKS fix during authoring), so the **charts/dashboard layout may need a fixup pass**. The durable loop (in `assets/README.md`): import → adjust in the UI → `export-dashboards` → commit the exported YAML (same `uuid`s). YAML lint (#282) covers syntax; it does **not** validate Superset-import semantics.

**Validated here:** yamllint clean · chart `params` parse as JSON · `uuid` cross-refs consistent (dataset→database, chart→dataset, dashboard→charts) · `docker-init.sh` `bash -n` clean.

## Deploy

Config-only `deploy/incus/` change → converge via `deploy.yml workflow_dispatch target=incus` (or nightly). On import, the dashboard appears at `analytics.fishsense.e4e.ucsd.edu`; if any chart didn't bind, fix + re-export per the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)