### PR TITLE
fix(superset): asset-import step must never fail init (zip mtime + containment)

### DIFF
--- a/deploy/incus/superset_volumes/docker/docker-init.sh
+++ b/deploy/incus/superset_volumes/docker/docker-init.sh
@@ -90,16 +90,24 @@ fi
 ASSETS_SRC=/app/docker/assets
 if [ -d "$ASSETS_SRC" ]; then
     echo_step "5" "Starting" "Importing committed dashboard assets"
-    BUNDLE="$(mktemp -d)"
-    cp -a "$ASSETS_SRC"/. "$BUNDLE"/
-    # Inject the superset DB-role password into the FishSense connection URI.
-    sed -i "s|__DB_PASSWORD__|${DATABASE_PASSWORD}|g" "$BUNDLE"/databases/*.yaml 2>/dev/null || true
-    ZIP=/tmp/fishsense-assets.zip
-    python -c "import shutil,sys; shutil.make_archive('/tmp/fishsense-assets','zip',sys.argv[1])" "$BUNDLE"
-    if superset import-assets -p "$ZIP"; then
-        echo_step "5" "Complete" "Importing committed dashboard assets"
-    else
-        echo "WARN: superset import-assets failed — dashboards not applied (init continues)"
-    fi
-    rm -rf "$BUNDLE" "$ZIP"
+    # Whole block runs in a subshell with `set +e` and a trailing `|| echo` so a
+    # bad bundle can NEVER fail init — Superset (which depends on init completing
+    # successfully) must still come up. The script runs under `set -e`, so
+    # without this containment a single failed command here takes Superset down.
+    (
+        set +e
+        BUNDLE="$(mktemp -d)"
+        cp -r "$ASSETS_SRC"/. "$BUNDLE"/
+        # nix-store bind mounts carry 1970 mtimes and `zip` rejects timestamps
+        # before 1980 ("ZIP does not support timestamps before 1980"), so bump
+        # every copied file to now before archiving.
+        find "$BUNDLE" -exec touch {} +
+        # Inject the superset DB-role password into the FishSense connection URI.
+        sed -i "s|__DB_PASSWORD__|${DATABASE_PASSWORD}|g" "$BUNDLE"/databases/*.yaml
+        ZIP=/tmp/fishsense-assets.zip
+        python -c "import shutil,sys; shutil.make_archive('/tmp/fishsense-assets','zip',sys.argv[1])" "$BUNDLE"
+        superset import-assets -p "$ZIP"
+        rm -rf "$BUNDLE" "$ZIP"
+    ) || echo "WARN: dashboard asset import failed — Superset still starts (fix the bundle + re-converge)"
+    echo_step "5" "Complete" "Importing committed dashboard assets"
 fi


### PR DESCRIPTION
## Incident

The #283 dashboard-import step (autonomous deploy) took **Superset down**: `superset_init` exited 1, and Superset `depends_on` it completing successfully → stuck in `Created`.

## Root cause
```
ValueError: ZIP does not support timestamps before 1980
```
Asset files are bind-mounted from the **nix store, which normalizes mtimes to 1970**; `cp -a` preserved them and `zip` rejects pre-1980 timestamps → `make_archive` threw. Under `set -e` that aborted init (the original `if`-guard only wrapped `import-assets`).

## Fix
- `cp -r` + `find "$BUNDLE" -exec touch {} +` — bump mtimes to now before archiving.
- Wrap **all of step 5** in `( set +e … ) || echo WARN` so nothing there — malformed bundle included — can ever fail init.

## Verified
Pre-1980 mtime reproduces the exact error; after `touch`, `make_archive` succeeds (14 entries); `bash -n` clean.

⚠️ Superset is currently down from the #283 deploy — this restores it on the next converge (and contains any bundle-import failure as a warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)