### PR TITLE
fix(superset): use import-dashboards, not import-assets (6.0.0)

### DIFF
--- a/deploy/incus/superset_volumes/docker/docker-init.sh
+++ b/deploy/incus/superset_volumes/docker/docker-init.sh
@@ -106,7 +106,9 @@ if [ -d "$ASSETS_SRC" ]; then
         sed -i "s|__DB_PASSWORD__|${DATABASE_PASSWORD}|g" "$BUNDLE"/databases/*.yaml
         ZIP=/tmp/fishsense-assets.zip
         python -c "import shutil,sys; shutil.make_archive('/tmp/fishsense-assets','zip',sys.argv[1])" "$BUNDLE"
-        superset import-assets -p "$ZIP"
+        # `import-dashboards` (not `import-assets`, which doesn't exist in 6.0.0)
+        # imports the whole export bundle — databases/datasets/charts/dashboards.
+        superset import-dashboards -p "$ZIP" -u admin
         rm -rf "$BUNDLE" "$ZIP"
     ) || echo "WARN: dashboard asset import failed — Superset still starts (fix the bundle + re-converge)"
     echo_step "5" "Complete" "Importing committed dashboard assets"


### PR DESCRIPTION
## What

The dashboard-import step called `superset import-assets`, which **doesn't exist in Superset 6.0.0** (`Error: No such command 'import-assets'`). The correct command is **`import-dashboards -p <zip>`** (imports the full export bundle — databases/datasets/charts/dashboards); `-u admin` assigns ownership.

## Impact

None to Superset — the #284 containment turned the failed command into a non-fatal `WARN`, so the app came up **healthy** (verified: route `200`). The dashboard bundle just didn't import. This one-liner makes the import actually run.

`bash -n` clean.

## Note

The blind-authored bundle (#283) still hasn't been round-tripped through a running Superset, so the import may surface bundle-content issues — but those stay contained (WARN, Superset up) per #284, and are fixed via the UI→export loop in `assets/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)