### PR TITLE
fix(superset): make the committed asset bundle actually importable

### DIFF
--- a/deploy/incus/superset_volumes/docker/assets/charts/Labeling_Queue.yaml
+++ b/deploy/incus/superset_volumes/docker/assets/charts/Labeling_Queue.yaml
@@ -1,16 +1,19 @@
+# `params` must be a YAML MAPPING — the v1 importer's chart schema rejects a
+# JSON string ("params: Not a valid mapping type").
 slice_name: Labeling queue (HIGH priority)
 viz_type: table
-params: |
-  {
-    "datasource": "33333333-3333-4333-8333-333333333333__table",
-    "viz_type": "table",
-    "query_mode": "raw",
-    "all_columns": ["stage", "cnt"],
-    "order_by_cols": ["[\"stage\", true]"],
-    "row_limit": 100,
-    "server_page_length": 10,
-    "include_search": false
-  }
+params:
+  datasource: 33333333-3333-4333-8333-333333333333__table
+  viz_type: table
+  query_mode: raw
+  all_columns:
+    - stage
+    - cnt
+  order_by_cols:
+    - '["stage", true]'
+  row_limit: 100
+  server_page_length: 10
+  include_search: false
 cache_timeout: null
 uuid: 66666666-6666-4666-8666-666666666666
 version: 1.0.0

--- a/deploy/incus/superset_volumes/docker/assets/charts/Partially_Done_Dives.yaml
+++ b/deploy/incus/superset_volumes/docker/assets/charts/Partially_Done_Dives.yaml
@@ -1,16 +1,25 @@
+# `params` must be a YAML MAPPING — the v1 importer's chart schema rejects a
+# JSON string ("params: Not a valid mapping type").
 slice_name: Partially-done dives (HIGH priority)
 viz_type: table
-params: |
-  {
-    "datasource": "44444444-4444-4444-8444-444444444444__table",
-    "viz_type": "table",
-    "query_mode": "raw",
-    "all_columns": ["dive_id", "blocker", "laser_labeling_complete", "species_labeling_complete", "headtail_labeling_complete", "slate_labeling_complete", "calibrated", "measured"],
-    "order_by_cols": ["[\"dive_id\", true]"],
-    "row_limit": 500,
-    "server_page_length": 25,
-    "include_search": true
-  }
+params:
+  datasource: 44444444-4444-4444-8444-444444444444__table
+  viz_type: table
+  query_mode: raw
+  all_columns:
+    - dive_id
+    - blocker
+    - laser_labeling_complete
+    - species_labeling_complete
+    - headtail_labeling_complete
+    - slate_labeling_complete
+    - calibrated
+    - measured
+  order_by_cols:
+    - '["dive_id", true]'
+  row_limit: 500
+  server_page_length: 25
+  include_search: true
 cache_timeout: null
 uuid: 77777777-7777-4777-8777-777777777777
 version: 1.0.0

--- a/deploy/incus/superset_volumes/docker/assets/dashboards/FishSense_Pipeline_Status.yaml
+++ b/deploy/incus/superset_volumes/docker/assets/dashboards/FishSense_Pipeline_Status.yaml
@@ -55,6 +55,9 @@ position:
       - GRID_ID
       - ROW-queue
     meta:
+      # `chartId` must be present — the importer's build_uuid_to_id_map reads it
+      # (KeyError otherwise); the value is a placeholder remapped via `uuid`.
+      chartId: 1
       uuid: 66666666-6666-4666-8666-666666666666
       sliceName: Labeling queue (HIGH priority)
       width: 5
@@ -68,6 +71,7 @@ position:
       - GRID_ID
       - ROW-partial
     meta:
+      chartId: 2
       uuid: 77777777-7777-4777-8777-777777777777
       sliceName: Partially-done dives (HIGH priority)
       width: 12

--- a/deploy/incus/superset_volumes/docker/docker-init.sh
+++ b/deploy/incus/superset_volumes/docker/docker-init.sh
@@ -97,13 +97,21 @@ if [ -d "$ASSETS_SRC" ]; then
     (
         set +e
         BUNDLE="$(mktemp -d)"
-        cp -r "$ASSETS_SRC"/. "$BUNDLE"/
+        # Superset's v1 importer runs remove_root() on every zip path (strips the
+        # top-level folder) and then requires metadata.yaml, so the assets MUST
+        # live under one. Without it every path is mangled, metadata.yaml is
+        # never found, v1 raises IncorrectVersionError, and the dispatcher
+        # silently falls back to the legacy v0 JSON importer — which then chokes
+        # on our YAML ("Expecting value: line 1 column 1").
+        ROOT="$BUNDLE/fishsense_assets"
+        mkdir -p "$ROOT"
+        cp -r "$ASSETS_SRC"/. "$ROOT"/
         # nix-store bind mounts carry 1970 mtimes and `zip` rejects timestamps
         # before 1980 ("ZIP does not support timestamps before 1980"), so bump
         # every copied file to now before archiving.
         find "$BUNDLE" -exec touch {} +
         # Inject the superset DB-role password into the FishSense connection URI.
-        sed -i "s|__DB_PASSWORD__|${DATABASE_PASSWORD}|g" "$BUNDLE"/databases/*.yaml
+        sed -i "s|__DB_PASSWORD__|${DATABASE_PASSWORD}|g" "$ROOT"/databases/*.yaml
         ZIP=/tmp/fishsense-assets.zip
         python -c "import shutil,sys; shutil.make_archive('/tmp/fishsense-assets','zip',sys.argv[1])" "$BUNDLE"
         # `import-dashboards` (not `import-assets`, which doesn't exist in 6.0.0)


### PR DESCRIPTION
## Problem

The dashboard-asset import from #283/#284/#285 runs and exits 0, but imports **only a bare dashboard**:

```
databases=0  datasets=0  charts=0  dashboards=1
```

So the Superset home page still shows nothing useful.

## Root cause — three bundle-format bugs

The v1 importer reports these poorly or not at all:

1. **Chart `params` was a JSON string.** The v1 chart schema declares `params = fields.Dict()` → `{'params': ['Not a valid mapping type.']}`. Now a YAML mapping.
2. **Dashboard `position` CHART nodes lacked `chartId`.** `build_uuid_to_id_map()` reads `child["meta"]["chartId"]` unconditionally → `KeyError: 'chartId'`. Placeholder value; the importer remaps it via `uuid`.
3. **Zip entries were at the root.** The importer runs `remove_root()` on every path then requires `metadata.yaml`. Without a top folder, v1 raises `IncorrectVersionError` and the dispatcher **silently falls back to the legacy v0 JSON importer**, which chokes on YAML (`Expecting value: line 1 column 1`). The zip is now built under `fishsense_assets/`.

## Verification

Replicated `docker-init.sh`'s bundle build against the running Superset and ran the importer's own `load_configs()` + dependency-resolution chain **read-only** (no writes):

```
V exceptions: []
V databases/   loaded: 1
V datasets/    loaded: 3
V charts/      loaded: 2
V dashboards/  loaded: 1
V RESOLVED charts: 2 datasets: 2 databases: 1
V db uri has placeholder left?: False
```

Previously the chain resolved to 0/0/0 — the dependency walk starts at the dashboard's chart uuids and cascades charts → datasets → databases, so any one of the three bugs collapses the whole import to a bare dashboard.

## Notes

* The CLI calls `ImportDashboardsCommand(contents, overwrite=True)`, so the bare dashboard left by the earlier partial import is **replaced** on the next converge, not blocked.
* Import stays best-effort (`set +e` subshell + `|| echo WARN`) — a bad bundle can never take Superset down.
* `deploy/incus/` is config-only, so this does **not** auto-trigger `deploy.yml`; needs `gh workflow run deploy.yml -f target=incus` (or the nightly).

## Debugging note

While chasing this I hit a red herring worth recording: loading `ImportV1ChartSchema` **in isolation** parses `uuid` into a `UUID` object, which made it look like the importer's `config["uuid"] in chart_uuids` check could never match a string. Instrumenting the **real** import path showed uuids arrive as **strings** there and match fine. The actual failure was the three format bugs above.