### PR TITLE
fix(stage14): make fish measurement idempotent and unstick `measured`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ DB (negligible). To add or remove, override
 | 11  | populate_label_studio_project | api-worker | ported |
 | 12  | sync_slate_label | api-worker | ported (hourly) |
 | 13  | perform_laser_calibration | api-worker (parent) + data-worker (child) | ported (hourly, +50min offset) |
-| 14  | measure_fish | api-worker (parent) + data-worker (child) | ported (on-demand; idempotency caveat — see notes) |
+| 14  | measure_fish | api-worker (parent) + data-worker (child) | ported (on-demand; idempotent as of 2026-07-17) |
 
 Create and populate are split into separate workflows per stage. LS
 projects are now **per-dive**: each dive gets its own LS project
@@ -218,7 +218,7 @@ registered but not scheduled (see notes below). Per-stage cohort:
 | 5.1 | HIGH-priority + at least one image with a *valid* `LaserLabel` whose image carries no non-sentinel `HeadTailLabel` row |
 | 9   | HIGH-priority + `dive_slate_id` set + at least one `SpeciesLabel.content_of_image='Slate, Laser on slate'` whose image carries no `DiveSlateLabel` row at all |
 | 13  | HIGH-priority + `dive_slate_id` set + no `LaserExtrinsics` + ≥2 completed `DiveSlateLabel` rows (matches the data-worker activity's `MIN_LASER_POINTS=2` precondition) |
-| 14  | HIGH-priority + has `LaserExtrinsics` + has LABEL_STUDIO clusters with at least one `fish_id is None` |
+| 14  | HIGH-priority + has `LaserExtrinsics` + at least one *measurable* image with no `Measurement` (same predicate as the view's `measured`; keep the two in step) |
 
 Stages 1, 2, and 5.1 all cascade from the same "valid laser" gate.
 Stage 1 lands PREDICTION clusters that stage 2 then consumes; stage
@@ -305,7 +305,7 @@ Backs Superset dashboards reading the fishsense Postgres connection.
 | `slate_preprocessed` | every image with `SpeciesLabel.content_of_image='Slate, Laser on slate'` has a non-sentinel `DiveSlateLabel` row |
 | `slate_labeling_complete` | ≥1 completed `DiveSlateLabel` AND zero incomplete |
 | `calibrated` | dive has a `LaserExtrinsics` row |
-| `measured` | ≥1 LABEL_STUDIO `DiveFrameCluster` AND zero LABEL_STUDIO clusters with `fish_id IS NULL` |
+| `measured` | ≥1 `Measurement` for the dive AND zero *measurable* images without one. "Measurable" = a `top_three_photos_of_group` `SpeciesLabel` whose image has a valid laser label, a valid head/tail label, and a LABEL_STUDIO cluster — i.e. what `measure_fish_activity` actually attempts. Rescoped 2026-07-17; see the stage-14 notes. |
 
 **"Complete" semantics throughout** mirror
 `get_dives_with_complete_laser_labeling`: vacuous truth (zero rows of
@@ -353,13 +353,25 @@ keeps SDK fetches inline because the math kernels need opencv +
 fishsense-core, so splitting fetch/math across workers would add 5+
 activity handoffs per dive for no gain.
 
-**Stage 14 deliberately is not scheduled.** `measure_fish_activity` is
-non-idempotent (`post_measurement` is a POST and the SDK has no
-per-image measurement query), so a re-run on a partially-failed dive
-would duplicate measurements on already-bound clusters. Until that's
-resolved (likely by adding a `get_measurements` SDK method and
-per-image filtering in the activity), `MeasureFishParentWorkflow` is
-operator-triggered:
+**Stage 14 is idempotent as of 2026-07-17, but still not scheduled.**
+It used to be non-idempotent — `post_measurement` was a plain POST and
+the SDK had no per-image measurement query, so a re-run on a
+partially-failed dive duplicated measurements on already-bound
+clusters. Both halves are fixed:
+
+* `POST /api/v1/fish/{fish_id}/measurements` upserts on the natural key
+  `(image_id, fish_id)`, backed by a `uq_measurement_image_fish`
+  constraint. The key is the pair, not `image_id` alone — one frame can
+  hold two fish.
+* `measure_fish_activity` fetches `fish.get_measurements(dive_id)` once
+  per dive and skips already-measured images *before* `_ensure_fish`,
+  so a re-run causes no species/fish churn. Surfaced as
+  `MeasureFishResult.skipped_already_measured`.
+
+It stays operator-triggered for now so the first drains can be watched
+on real dives; the cohort can now go empty (see the `measured` rescope
+below), so scheduling it is a live option rather than a hazard.
+`MeasureFishParentWorkflow`:
 
 ```
 temporal workflow start \

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/fish_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/fish_client.py
@@ -55,6 +55,31 @@ class FishClient(ClientBase):
         response.raise_for_status()
         return response.json()
 
+    async def get_measurements(self, dive_id: int) -> list[Measurement] | None:
+        """Get every measurement recorded for the images in a dive.
+
+        Stage 14 reads this once per dive so it can skip images it has
+        already measured — `post_measurement` is a create, so without
+        this filter a re-run on a partially-measured dive would record
+        the same fish twice.
+
+        Args:
+            dive_id (int): The ID of the dive to retrieve measurements for.
+
+        Returns:
+            list[Measurement] | None: The measurements for the dive, or
+            None when the dive has none yet.
+        """
+        response = await self._get(f"/api/v1/dives/{dive_id}/measurements")
+        if response.status_code == 404:
+            self.logger.debug("No measurements found for dive ID %s", dive_id)
+            return None
+        response.raise_for_status()
+        json = response.json()
+        if json is None:
+            return None
+        return [Measurement.model_validate(m) for m in json]
+
     async def post_measurement(self, fish_id: int, measurement: Measurement) -> int:
         """Create a new measurement entry for a fish in the Fishsense API.
 

--- a/libs/fishsense-api-sdk/tests/clients/test_fish_client.py
+++ b/libs/fishsense-api-sdk/tests/clients/test_fish_client.py
@@ -309,3 +309,57 @@ class TestFishClient:
                 mock_post.assert_called_once()
                 call_args = mock_post.call_args
                 assert call_args[0][0] == "/api/v1/fish/species"
+
+    async def test_get_measurements_returns_list(self):
+        """Stage 14 reads this per dive to skip already-measured images."""
+        semaphore = asyncio.Semaphore(10)
+        client = FishClient(
+            base_url="http://test.com",
+            username="testuser",
+            password="testpass",
+            timeout=10,
+            semaphore=semaphore,
+        )
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {"id": 1, "length_m": 0.3, "image_id": 11, "fish_id": 101},
+            {"id": 2, "length_m": 0.4, "image_id": 12, "fish_id": 102},
+        ]
+        mock_response.raise_for_status = Mock()
+
+        with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            async with client:
+                measurements = await client.get_measurements(1)
+
+        mock_get.assert_awaited_once_with("/api/v1/dives/1/measurements")
+        assert [m.image_id for m in measurements] == [11, 12]
+        assert measurements[0].length_m == 0.3
+
+    async def test_get_measurements_returns_none_on_404(self):
+        """A dive with no measurements yet is not an error."""
+        semaphore = asyncio.Semaphore(10)
+        client = FishClient(
+            base_url="http://test.com",
+            username="testuser",
+            password="testpass",
+            timeout=10,
+            semaphore=semaphore,
+        )
+
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status = Mock(
+            side_effect=AssertionError(
+                "raise_for_status must not be called for the 404 case"
+            )
+        )
+
+        with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            async with client:
+                assert await client.get_measurements(999) is None

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/a3f1c7d94b52_add_unique_constraint_to_measurement.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/a3f1c7d94b52_add_unique_constraint_to_measurement.py
@@ -1,0 +1,46 @@
+"""add unique constraint to measurement on (image_id, fish_id)
+
+One length per fish per frame. A frame can hold several fish, so the key
+is the pair, not `image_id` alone.
+
+This is the DB-level backstop for stage 14 re-run safety. Previously
+`post_measurement` did `session.merge` on a body with `id=None`, which
+keys on the primary key only and therefore always INSERTed — so a re-run
+against a partially-measured dive duplicated every already-measured
+image. The endpoint now upserts on the natural key; this constraint is
+what refuses the duplicate even if some other writer skips that path.
+
+Safe to apply without a dedup backfill: verified against prod before
+writing this revision — 242 measurement rows, 0 duplicate
+(image_id, fish_id) pairs, and 0 NULLs in either column. (NULLs would
+matter because postgres treats them as distinct, so a row with a NULL
+member would slip past the constraint.)
+
+Revision ID: a3f1c7d94b52
+Revises: 7934e62a12c0
+Create Date: 2026-07-17 03:20:00.000000
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a3f1c7d94b52"
+down_revision: Union[str, Sequence[str], None] = "7934e62a12c0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_unique_constraint(
+        "uq_measurement_image_fish", "measurement", ["image_id", "fish_id"]
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint("uq_measurement_image_fish", "measurement", type_="unique")

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/b7c2e4d81a09_rescope_measured_in_dive_pipeline_status.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/b7c2e4d81a09_rescope_measured_in_dive_pipeline_status.py
@@ -1,0 +1,58 @@
+"""rescope `measured` in dive_pipeline_status to measurable images
+
+`measured` was "≥1 LABEL_STUDIO cluster AND zero with fish_id NULL",
+which is unreachable. A cluster is only bound to a fish through a
+top-three species label whose image has a valid laser + headtail, so any
+LABEL_STUDIO cluster without such an image held the dive at
+measured=false permanently.
+
+That is not theoretical: at the time of writing every one of the 8
+calibrated dives in prod was pinned false, and dive 466 carried 1632
+unbound clusters against only 24 measurable images (the residue of
+repeated stage-6.1 POSTs in the notebook era — the cluster API has no
+DELETE). The stage-14 cohort selector mirrors this predicate, so a
+scheduled stage 14 would have re-selected the same dives every hour
+forever.
+
+`measured` now means: ≥1 measurement for the dive AND no measurable
+image left unmeasured, where "measurable" mirrors what
+measure_fish_activity actually attempts. Validated against prod before
+writing: 7 of the 8 dives flip to true, and 466 reads false because it
+genuinely has 1 measurable image left.
+
+Drop + recreate rather than CREATE OR REPLACE — postgres is restrictive
+about column-shape changes and the view has no dependents.
+
+Revision ID: b7c2e4d81a09
+Revises: a3f1c7d94b52
+Create Date: 2026-07-17 03:55:00.000000
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from fishsense_api.views import (
+    DIVE_PIPELINE_STATUS_VIEW_SQL,
+    DROP_DIVE_PIPELINE_STATUS_VIEW_SQL,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c2e4d81a09"
+down_revision: Union[str, Sequence[str], None] = "a3f1c7d94b52"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)
+
+
+def downgrade() -> None:
+    """Drop the new view; the prior migration's upgrade is the
+    recreate. To roll back the predicate, manually re-run the prior
+    migration's `op.execute(...)` against the DB."""
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -13,12 +13,16 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from fishsense_api.database import get_async_session
 from fishsense_api.models.data_source import DataSource
 from fishsense_api.models.dive import Dive
-from fishsense_api.models.dive_frame_cluster import DiveFrameCluster
+from fishsense_api.models.dive_frame_cluster import (
+    DiveFrameCluster,
+    DiveFrameClusterImageMapping,
+)
 from fishsense_api.models.dive_slate_label import DiveSlateLabel
 from fishsense_api.models.head_tail_label import HeadTailLabel
 from fishsense_api.models.image import Image
 from fishsense_api.models.laser_extrinsics import LaserExtrinsics
 from fishsense_api.models.laser_label import LaserLabel
+from fishsense_api.models.measurement import Measurement
 from fishsense_api.models.priority import Priority
 from fishsense_api.models.species_label import SpeciesLabel
 from fishsense_api.server import app
@@ -337,30 +341,76 @@ async def select_next_for_measure_fish(
     session: AsyncSession = Depends(get_async_session),
 ) -> int | None:
     """Stage 14: HIGH-priority + has LaserExtrinsics + has at least one
-    LABEL_STUDIO cluster with fish_id IS NULL.
+    *measurable* image with no Measurement.
 
-    First-run gate, not a strict idempotency gate — measure_fish_activity
-    is non-idempotent (POST measurement, no per-image filter), so a
-    partially-failed run will re-fire and duplicate measurements on
-    already-bound clusters. Caller (parent workflow) is operator-
-    triggered, not scheduled."""
+    "Measurable" mirrors what measure_fish_activity attempts, and this
+    predicate mirrors `dive_pipeline_status.measured` — keep the two in
+    step.
+
+    Previously keyed on "has a LABEL_STUDIO cluster with fish_id IS
+    NULL", which never went false: a cluster is only bound to a fish
+    through a measurable image, so any cluster without one kept the dive
+    in the cohort permanently (prod dive 466 carried 1632 such clusters
+    against 24 measurable images). Combined with the old non-idempotent
+    write, a scheduled stage 14 would have re-measured the same dives
+    every hour. Both halves are fixed now — measurement upserts on
+    (image_id, fish_id) and the activity skips already-measured images —
+    so this cohort drains and the workflow is safe to schedule.
+    """
     has_laser_extrinsics = (
         select(LaserExtrinsics.id)
         .where(LaserExtrinsics.dive_id == Dive.id)
         .exists()
     )
-    has_unbound_label_studio_cluster = (
-        select(DiveFrameCluster.id)
-        .where(DiveFrameCluster.dive_id == Dive.id)
+    valid_laser = (
+        select(LaserLabel.id)
+        .where(LaserLabel.image_id == Image.id)
+        .where(LaserLabel.completed == True)
+        .where(LaserLabel.superseded == False)
+        .where(LaserLabel.x != None)
+        .where(LaserLabel.y != None)
+        .exists()
+    )
+    valid_headtail = (
+        select(HeadTailLabel.id)
+        .where(HeadTailLabel.image_id == Image.id)
+        .where(HeadTailLabel.completed == True)
+        .where(HeadTailLabel.superseded == False)
+        .where(HeadTailLabel.head_x != None)
+        .where(HeadTailLabel.head_y != None)
+        .where(HeadTailLabel.tail_x != None)
+        .where(HeadTailLabel.tail_y != None)
+        .exists()
+    )
+    in_label_studio_cluster = (
+        select(DiveFrameClusterImageMapping.image_id)
+        .join(
+            DiveFrameCluster,
+            DiveFrameCluster.id == DiveFrameClusterImageMapping.dive_frame_cluster_id,
+        )
+        .where(DiveFrameClusterImageMapping.image_id == Image.id)
         .where(DiveFrameCluster.data_source == DataSource.LABEL_STUDIO)
-        .where(DiveFrameCluster.fish_id == None)
+        .exists()
+    )
+    is_measured = (
+        select(Measurement.id).where(Measurement.image_id == Image.id).exists()
+    )
+    has_unmeasured_measurable_image = (
+        select(SpeciesLabel.id)
+        .join(Image, Image.id == SpeciesLabel.image_id)
+        .where(Image.dive_id == Dive.id)
+        .where(SpeciesLabel.top_three_photos_of_group == True)
+        .where(valid_laser)
+        .where(valid_headtail)
+        .where(in_label_studio_cluster)
+        .where(~is_measured)
         .exists()
     )
     query = (
         select(Dive.id)
         .where(Dive.priority == Priority.HIGH)
         .where(has_laser_extrinsics)
-        .where(has_unbound_label_studio_cluster)
+        .where(has_unmeasured_measurable_image)
         .order_by(Dive.id)
         .limit(1)
     )

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -29,6 +29,44 @@ from fishsense_api.server import app
 
 logger = logging.getLogger(__name__)
 
+
+def _valid_laser_conditions():
+    """The repo-wide definition of a *valid* laser label.
+
+    The labeler placed a point, the validator signed off, and
+    `ValidateLaserLabelsForDiveWorkflow`'s RANSAC fit hasn't superseded
+    it. Stages 1, 2, 5.1 and 14 all cascade from this gate, so it's
+    spelled once. Splat into a select: `.where(*_valid_laser_conditions())`.
+
+    Mirrors `views._VALID_LASER_SQL` — the view and these selectors are
+    two representations of the same predicate and must stay in step.
+    """
+    return (
+        LaserLabel.completed == True,
+        LaserLabel.superseded == False,
+        LaserLabel.x != None,
+        LaserLabel.y != None,
+    )
+
+
+def _valid_headtail_conditions():
+    """The repo-wide definition of a *valid* head/tail label.
+
+    Both keypoints fully placed. Only stage 14 needs this — every other
+    stage only cares that a HeadTailLabel row exists at all — but it
+    mirrors `_valid_laser_conditions` so the pair reads together.
+
+    Mirrors `views._VALID_HEADTAIL_SQL`.
+    """
+    return (
+        HeadTailLabel.completed == True,
+        HeadTailLabel.superseded == False,
+        HeadTailLabel.head_x != None,
+        HeadTailLabel.head_y != None,
+        HeadTailLabel.tail_x != None,
+        HeadTailLabel.tail_y != None,
+    )
+
 # Stage-13 cohort threshold; matches the data-worker calibration
 # activity's `MIN_LASER_POINTS = 2` precondition. Selecting a dive with
 # fewer than two completed slate labels would dispatch a child that
@@ -142,10 +180,7 @@ async def select_next_for_dive_frame_clustering(
         select(LaserLabel.id)
         .join(Image, Image.id == LaserLabel.image_id)
         .where(Image.dive_id == Dive.id)
-        .where(LaserLabel.completed == True)
-        .where(LaserLabel.superseded == False)
-        .where(LaserLabel.x != None)
-        .where(LaserLabel.y != None)
+        .where(*_valid_laser_conditions())
         .exists()
     )
     has_prediction_cluster = (
@@ -200,10 +235,7 @@ async def select_next_for_species_preprocessing(
         select(LaserLabel.id)
         .join(Image, Image.id == LaserLabel.image_id)
         .where(Image.dive_id == Dive.id)
-        .where(LaserLabel.completed == True)
-        .where(LaserLabel.superseded == False)
-        .where(LaserLabel.x != None)
-        .where(LaserLabel.y != None)
+        .where(*_valid_laser_conditions())
         .where(
             ~select(SpeciesLabel.id)
             .where(SpeciesLabel.image_id == Image.id)
@@ -247,10 +279,7 @@ async def select_next_for_headtail_preprocessing(
         select(LaserLabel.id)
         .join(Image, Image.id == LaserLabel.image_id)
         .where(Image.dive_id == Dive.id)
-        .where(LaserLabel.completed == True)
-        .where(LaserLabel.superseded == False)
-        .where(LaserLabel.x != None)
-        .where(LaserLabel.y != None)
+        .where(*_valid_laser_conditions())
         .where(
             ~select(HeadTailLabel.id)
             .where(HeadTailLabel.image_id == Image.id)
@@ -365,21 +394,13 @@ async def select_next_for_measure_fish(
     valid_laser = (
         select(LaserLabel.id)
         .where(LaserLabel.image_id == Image.id)
-        .where(LaserLabel.completed == True)
-        .where(LaserLabel.superseded == False)
-        .where(LaserLabel.x != None)
-        .where(LaserLabel.y != None)
+        .where(*_valid_laser_conditions())
         .exists()
     )
     valid_headtail = (
         select(HeadTailLabel.id)
         .where(HeadTailLabel.image_id == Image.id)
-        .where(HeadTailLabel.completed == True)
-        .where(HeadTailLabel.superseded == False)
-        .where(HeadTailLabel.head_x != None)
-        .where(HeadTailLabel.head_y != None)
-        .where(HeadTailLabel.tail_x != None)
-        .where(HeadTailLabel.tail_y != None)
+        .where(*_valid_headtail_conditions())
         .exists()
     )
     in_label_studio_cluster = (

--- a/services/fishsense-api/src/fishsense_api/controllers/fish_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/fish_controller.py
@@ -1,13 +1,16 @@
 """Fish controller for the FishSense API."""
 
 import logging
+from typing import List
 
 from fastapi import Depends, HTTPException
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from fishsense_api.database import get_async_session
+from fishsense_api.models.dive import Dive
 from fishsense_api.models.fish import Fish
+from fishsense_api.models.image import Image
 from fishsense_api.models.measurement import Measurement
 from fishsense_api.models.species import Species
 from fishsense_api.server import app
@@ -56,15 +59,59 @@ async def post_fish(
     return fish_id
 
 
+@app.get("/api/v1/dives/{dive_id}/measurements")
+async def get_measurements_for_dive(
+    dive_id: int, session: AsyncSession = Depends(get_async_session)
+) -> List[Measurement]:
+    """Retrieve all measurements for a given dive ID.
+
+    Stage 14 reads this once per dive to skip images it has already
+    measured, which is what makes a re-run on a partially-measured dive
+    safe.
+    """
+    logger.debug("Retrieving measurements for dive with id=%d", dive_id)
+    query = (
+        select(Measurement)
+        .join_from(Measurement, Image, Measurement.image_id == Image.id)
+        .join_from(Image, Dive, Image.dive_id == Dive.id)
+        .where(Dive.id == dive_id)
+    )
+
+    measurements = (await session.exec(query)).all()
+    if not measurements:
+        logger.warning("Measurements for dive with id=%d not found", dive_id)
+        raise HTTPException(status_code=404, detail="Measurements not found")
+    return measurements
+
+
 @app.post("/api/v1/fish/{fish_id}/measurements", status_code=201)
 async def post_measurement(
     fish_id: int,
     measurement: Measurement,
     session: AsyncSession = Depends(get_async_session),
 ) -> int:
-    """Create a new measurement for a specific fish."""
+    """Create or update the measurement for a specific fish.
+
+    Upserts on `(image_id, fish_id)`. `session.merge` keys on the primary
+    key alone, so a body with `id=None` always INSERTed — which is how a
+    re-run of stage 14 duplicated measurements on already-measured
+    images. Resolving the natural key to an existing row id first turns
+    the merge into an UPDATE.
+    """
     logger.debug("Creating a new measurement for fish with id=%d", fish_id)
     measurement.fish_id = fish_id
+
+    if measurement.id is None and measurement.image_id is not None:
+        existing = (
+            await session.exec(
+                select(Measurement)
+                .where(Measurement.image_id == measurement.image_id)
+                .where(Measurement.fish_id == fish_id)
+            )
+        ).first()
+        if existing is not None:
+            measurement.id = existing.id
+
     measurement = await session.merge(measurement)
     await session.flush()
 

--- a/services/fishsense-api/src/fishsense_api/models/measurement.py
+++ b/services/fishsense-api/src/fishsense_api/models/measurement.py
@@ -1,10 +1,24 @@
 """Measurement model for the FishSense API."""
 
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field, SQLModel, UniqueConstraint
 
 
 class Measurement(SQLModel, table=True):
     """Measurement model representing fish measurements in the database."""
+
+    # One length per fish per frame. A frame can hold several fish, so the
+    # key is the pair — not `image_id` alone. This is the DB-level backstop
+    # for stage 14's re-run safety; `post_measurement` upserts on the same
+    # pair, and the activity skips already-measured images before it gets
+    # here. Both layers are deliberate: the filter avoids pointless work,
+    # this refuses to record the duplicate even if the filter is bypassed.
+    __table_args__ = (
+        UniqueConstraint(
+            "image_id",
+            "fish_id",
+            name="uq_measurement_image_fish",
+        ),
+    )
 
     id: int | None = Field(default=None, primary_key=True)
     length_m: float | None = Field(default=None)

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -225,19 +225,60 @@ SELECT
         WHERE le.dive_id = d.id
     ) AS calibrated,
 
-    -- Stage 14: ≥1 LABEL_STUDIO cluster AND zero LABEL_STUDIO clusters
-    -- with fish_id NULL (every cluster bound to a fish via stage-14
-    -- measurement).
+    -- Stage 14: ≥1 measurement for the dive AND no measurable image left
+    -- unmeasured. "Measurable" mirrors what measure_fish_activity
+    -- actually attempts: a top-three species label whose image carries a
+    -- valid laser label, a valid headtail label, and a LABEL_STUDIO
+    -- cluster.
+    --
+    -- Rescoped 2026-07-17. The predicate used to be "≥1 LABEL_STUDIO
+    -- cluster AND zero with fish_id NULL", which was unreachable: a
+    -- cluster is only bound to a fish through a measurable image, so any
+    -- cluster without one held the dive at measured=false forever. Prod
+    -- had all 8 calibrated dives pinned that way (dive 466: 1632 unbound
+    -- clusters vs 24 measurable images, the residue of repeated stage-6.1
+    -- POSTs). Because the stage-14 cohort mirrors this predicate, a
+    -- scheduled stage 14 would also have re-selected the same dives
+    -- forever.
     (EXISTS (
-         SELECT 1 FROM diveframecluster dfc
-         WHERE dfc.dive_id = d.id
-           AND dfc.data_source = 'LABEL_STUDIO'
+         SELECT 1 FROM measurement m
+         JOIN image i ON i.id = m.image_id
+         WHERE i.dive_id = d.id
      )
      AND NOT EXISTS (
-         SELECT 1 FROM diveframecluster dfc
-         WHERE dfc.dive_id = d.id
-           AND dfc.data_source = 'LABEL_STUDIO'
-           AND dfc.fish_id IS NULL
+         SELECT 1 FROM specieslabel sl
+         JOIN image i ON i.id = sl.image_id
+         WHERE i.dive_id = d.id
+           AND sl.top_three_photos_of_group = TRUE
+           AND EXISTS (
+               SELECT 1 FROM laserlabel ll
+               WHERE ll.image_id = i.id
+                 AND ll.completed = TRUE
+                 AND ll.superseded = FALSE
+                 AND ll.x IS NOT NULL
+                 AND ll.y IS NOT NULL
+           )
+           AND EXISTS (
+               SELECT 1 FROM headtaillabel htl
+               WHERE htl.image_id = i.id
+                 AND htl.completed = TRUE
+                 AND htl.superseded = FALSE
+                 AND htl.head_x IS NOT NULL
+                 AND htl.head_y IS NOT NULL
+                 AND htl.tail_x IS NOT NULL
+                 AND htl.tail_y IS NOT NULL
+           )
+           AND EXISTS (
+               SELECT 1 FROM diveframeclusterimagemapping mm
+               JOIN diveframecluster dfc
+                 ON dfc.id = mm.dive_frame_cluster_id
+               WHERE mm.image_id = i.id
+                 AND dfc.data_source = 'LABEL_STUDIO'
+           )
+           AND NOT EXISTS (
+               SELECT 1 FROM measurement m
+               WHERE m.image_id = i.id
+           )
      )) AS measured
 
 FROM dive d

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -25,6 +25,27 @@ DIVE_PIPELINE_STATUS_VIEW_NAME = "dive_pipeline_status"
 # get this string before the FastAPI app is initialized).
 _SLATE_CONTENT_MARKER = "Slate, Laser on slate"
 
+# A *valid* laser label: the labeler placed a point, the validator signed
+# off, and `ValidateLaserLabelsForDiveWorkflow`'s RANSAC fit hasn't
+# superseded it. This is the gate stages 1, 2, 5.1 and 14 all cascade
+# from, so it's spelled once here rather than five times inline. Assumes
+# the enclosing subquery aliases laserlabel as `ll`.
+_VALID_LASER_SQL = """ll.completed = TRUE
+           AND ll.superseded = FALSE
+           AND ll.x IS NOT NULL
+           AND ll.y IS NOT NULL"""
+
+# A *valid* head/tail label: both keypoints fully placed. Only stage 14
+# needs this — every other stage only cares that a HeadTailLabel row
+# exists — but it mirrors `_VALID_LASER_SQL` so the pair reads together.
+# Assumes the enclosing subquery aliases headtaillabel as `htl`.
+_VALID_HEADTAIL_SQL = """htl.completed = TRUE
+                 AND htl.superseded = FALSE
+                 AND htl.head_x IS NOT NULL
+                 AND htl.head_y IS NOT NULL
+                 AND htl.tail_x IS NOT NULL
+                 AND htl.tail_y IS NOT NULL"""
+
 # "Complete" everywhere = ≥1 completed-non-superseded row AND zero
 # incomplete-non-superseded rows. Mirrors
 # `get_dives_with_complete_laser_labeling`'s semantics so a dive with
@@ -74,19 +95,13 @@ SELECT
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
          WHERE i.dive_id = d.id
-           AND ll.completed = TRUE
-           AND ll.superseded = FALSE
-           AND ll.x IS NOT NULL
-           AND ll.y IS NOT NULL
+           AND {_VALID_LASER_SQL}
      )
      AND NOT EXISTS (
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
          WHERE i.dive_id = d.id
-           AND ll.completed = TRUE
-           AND ll.superseded = FALSE
-           AND ll.x IS NOT NULL
-           AND ll.y IS NOT NULL
+           AND {_VALID_LASER_SQL}
            AND NOT EXISTS (
                SELECT 1 FROM headtaillabel htl
                WHERE htl.image_id = i.id
@@ -139,19 +154,13 @@ SELECT
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
          WHERE i.dive_id = d.id
-           AND ll.completed = TRUE
-           AND ll.superseded = FALSE
-           AND ll.x IS NOT NULL
-           AND ll.y IS NOT NULL
+           AND {_VALID_LASER_SQL}
      )
      AND NOT EXISTS (
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
          WHERE i.dive_id = d.id
-           AND ll.completed = TRUE
-           AND ll.superseded = FALSE
-           AND ll.x IS NOT NULL
-           AND ll.y IS NOT NULL
+           AND {_VALID_LASER_SQL}
            AND NOT EXISTS (
                SELECT 1 FROM specieslabel sl
                WHERE sl.image_id = i.id
@@ -253,20 +262,12 @@ SELECT
            AND EXISTS (
                SELECT 1 FROM laserlabel ll
                WHERE ll.image_id = i.id
-                 AND ll.completed = TRUE
-                 AND ll.superseded = FALSE
-                 AND ll.x IS NOT NULL
-                 AND ll.y IS NOT NULL
+                 AND {_VALID_LASER_SQL}
            )
            AND EXISTS (
                SELECT 1 FROM headtaillabel htl
                WHERE htl.image_id = i.id
-                 AND htl.completed = TRUE
-                 AND htl.superseded = FALSE
-                 AND htl.head_x IS NOT NULL
-                 AND htl.head_y IS NOT NULL
-                 AND htl.tail_x IS NOT NULL
-                 AND htl.tail_y IS NOT NULL
+                 AND {_VALID_HEADTAIL_SQL}
            )
            AND EXISTS (
                SELECT 1 FROM diveframeclusterimagemapping mm

--- a/services/fishsense-api/tests/test_dive_pipeline_status_view.py
+++ b/services/fishsense-api/tests/test_dive_pipeline_status_view.py
@@ -851,60 +851,142 @@ async def test_calibrated_false_when_no_laser_extrinsics(session):
 
 
 # ---------- measured (stage 14) ----------
+#
+# `measured` is scoped to what stage 14 can actually measure. The prior
+# definition ("every LABEL_STUDIO cluster has a fish_id") was
+# unreachable: a cluster only gets a fish via a top-three species label
+# whose image has a valid laser + headtail, so any cluster without such
+# an image kept the dive unmeasured forever. In prod that pinned all 8
+# calibrated dives at measured=false permanently — and, because the
+# stage-14 cohort mirrors this predicate, would have made a scheduled
+# stage 14 re-select the same dives every hour.
+#
+# "Measurable" here mirrors measure_fish_activity: a top-three species
+# label whose image has a valid laser label, a valid headtail label, and
+# a LABEL_STUDIO cluster.
 
 
-async def test_measured_true_when_every_label_studio_cluster_has_fish_id(session):
-    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster  # pylint: disable=import-outside-toplevel
+def _measurable_image(session, image_id: int, dive_id: int, *, cluster_id: int):
+    """Seed an image that stage 14 would attempt: top-three species label
+    + valid laser + valid headtail + a LABEL_STUDIO cluster."""
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+        DiveFrameClusterImageMapping,
+    )
+    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
 
+    session.add(_image(image_id, dive_id))
+    session.add(
+        DiveFrameCluster(id=cluster_id, dive_id=dive_id, data_source="LABEL_STUDIO")
+    )
+    session.add(
+        LaserLabel(image_id=image_id, completed=True, superseded=False, x=1.0, y=2.0)
+    )
+    session.add(
+        HeadTailLabel(
+            image_id=image_id, completed=True, superseded=False,
+            head_x=1.0, head_y=2.0, tail_x=3.0, tail_y=4.0,
+        )
+    )
+    session.add(
+        SpeciesLabel(
+            image_id=image_id, top_three_photos_of_group=True,
+            completed=True, superseded=False, label_studio_project_id=70,
+        )
+    )
+    return DiveFrameClusterImageMapping(
+        dive_frame_cluster_id=cluster_id, image_id=image_id
+    )
+
+
+def _measurement(image_id: int, fish_id: int = 100):
+    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+
+    return Measurement(image_id=image_id, fish_id=fish_id, length_m=0.3)
+
+
+async def test_measured_true_when_every_measurable_image_has_a_measurement(session):
     session.add(_dive(1))
     await session.flush()
-    session.add_all(
-        [
-            DiveFrameCluster(
-                dive_id=1, data_source="LABEL_STUDIO", index=0, fish_id=100,
-            ),
-            DiveFrameCluster(
-                dive_id=1, data_source="LABEL_STUDIO", index=1, fish_id=101,
-            ),
-        ]
-    )
+    mapping = _measurable_image(session, 11, 1, cluster_id=1)
+    await session.flush()
+    session.add(mapping)
+    session.add(_measurement(11))
     await session.flush()
 
     assert (await _row(session, 1))["measured"] is True
 
 
-async def test_measured_false_when_any_label_studio_cluster_unbound(session):
-    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster  # pylint: disable=import-outside-toplevel
-
+async def test_measured_false_when_a_measurable_image_is_unmeasured(session):
     session.add(_dive(1))
     await session.flush()
-    session.add_all(
-        [
-            DiveFrameCluster(
-                dive_id=1, data_source="LABEL_STUDIO", index=0, fish_id=100,
-            ),
-            DiveFrameCluster(
-                dive_id=1, data_source="LABEL_STUDIO", index=1, fish_id=None,
-            ),
-        ]
-    )
+    m1 = _measurable_image(session, 11, 1, cluster_id=1)
+    m2 = _measurable_image(session, 12, 1, cluster_id=2)
+    await session.flush()
+    session.add_all([m1, m2])
+    session.add(_measurement(11))  # 12 left unmeasured
     await session.flush()
 
     assert (await _row(session, 1))["measured"] is False
 
 
-async def test_measured_false_when_no_label_studio_clusters(session):
-    """Vacuous-truth guard: zero LABEL_STUDIO clusters -> not measured."""
+async def test_measured_false_when_dive_has_no_measurements(session):
+    """Vacuous-truth guard: nothing measured -> not measured."""
+    session.add(_dive(1))
+    await session.flush()
+    mapping = _measurable_image(session, 11, 1, cluster_id=1)
+    await session.flush()
+    session.add(mapping)
+    await session.flush()
+
+    assert (await _row(session, 1))["measured"] is False
+
+
+async def test_measured_ignores_unbound_clusters_with_no_measurable_image(session):
+    """The regression this rescope exists for.
+
+    A LABEL_STUDIO cluster with no measurable image can never be bound to
+    a fish. Under the old predicate its NULL fish_id pinned the dive at
+    measured=false forever. In prod dive 466 carried 1632 such clusters
+    against only 24 measurable images.
+    """
     from fishsense_api.models.dive_frame_cluster import DiveFrameCluster  # pylint: disable=import-outside-toplevel
 
     session.add(_dive(1))
     await session.flush()
-    # PREDICTION-only cluster; no LABEL_STUDIO ones.
+    mapping = _measurable_image(session, 11, 1, cluster_id=1)
+    await session.flush()
+    session.add(mapping)
+    session.add(_measurement(11))
+    # Unbound cluster carrying no measurable image — stage 14 can never
+    # touch it, so it must not hold the dive back.
+    session.add(DiveFrameCluster(id=99, dive_id=1, data_source="LABEL_STUDIO", fish_id=None))
+    await session.flush()
+
+    assert (await _row(session, 1))["measured"] is True
+
+
+async def test_measured_ignores_non_top_three_images(session):
+    """Stage 14 only measures top-three photos, so others can't block."""
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    mapping = _measurable_image(session, 11, 1, cluster_id=1)
+    await session.flush()
+    session.add(mapping)
+    session.add(_measurement(11))
+    # A second image that is NOT top-three and has no measurement.
+    session.add(_image(12, 1))
+    await session.flush()
     session.add(
-        DiveFrameCluster(
-            dive_id=1, data_source="PREDICTION", index=0,
+        SpeciesLabel(
+            image_id=12, top_three_photos_of_group=False,
+            completed=True, superseded=False, label_studio_project_id=70,
         )
     )
     await session.flush()
 
-    assert (await _row(session, 1))["measured"] is False
+    assert (await _row(session, 1))["measured"] is True

--- a/services/fishsense-api/tests/test_measurements_endpoint.py
+++ b/services/fishsense-api/tests/test_measurements_endpoint.py
@@ -1,0 +1,204 @@
+"""Measurement read + write semantics.
+
+Two things are pinned here, both in service of making stage 14
+(`measure_fish_activity`) safe to re-run:
+
+* `GET /api/v1/dives/{dive_id}/measurements` — the dive-scoped read the
+  activity uses to skip images it has already measured. Without it the
+  activity has no way to ask "did I already do this one?".
+* `POST /api/v1/fish/{fish_id}/measurements` upserts on
+  `(image_id, fish_id)` rather than always inserting. The old behavior
+  (`session.merge` with `id=None`) keyed on the primary key only, so a
+  re-run on a partially-measured dive silently duplicated every
+  already-measured image.
+
+Mirrors the in-memory-sqlite fixture style of
+test_dives_with_complete_laser_labeling_endpoint.py — testing query
+composition and write semantics, not referential integrity.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+def _dive(dive_id: int):
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+
+    return Dive(
+        id=dive_id,
+        path=f"/dev/null/{dive_id}",
+        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        priority=Priority.HIGH,
+    )
+
+
+def _image(image_id: int, dive_id: int):
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    return Image(
+        id=image_id,
+        path=f"/dev/null/img-{image_id}",
+        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        checksum=f"img-{image_id:032d}"[:32],
+        dive_id=dive_id,
+    )
+
+
+def _fish(fish_id: int):
+    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
+
+    return Fish(id=fish_id, species_id=None)
+
+
+def _measurement(measurement_id: int | None, image_id: int, fish_id: int, length_m: float):
+    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+
+    return Measurement(
+        id=measurement_id,
+        image_id=image_id,
+        fish_id=fish_id,
+        length_m=length_m,
+    )
+
+
+async def _seed_dive(session, dive_id: int, image_ids: list[int]):
+    session.add_all([_dive(dive_id)])
+    await session.flush()
+    session.add_all([_image(i, dive_id) for i in image_ids])
+    await session.flush()
+
+
+async def _get_measurements(session, dive_id: int):
+    from fishsense_api.controllers.fish_controller import (  # pylint: disable=import-outside-toplevel
+        get_measurements_for_dive,
+    )
+
+    return await get_measurements_for_dive(dive_id, session=session)
+
+
+async def _post(session, fish_id: int, measurement):
+    from fishsense_api.controllers.fish_controller import (  # pylint: disable=import-outside-toplevel
+        post_measurement,
+    )
+
+    return await post_measurement(fish_id, measurement, session=session)
+
+
+# ── GET /api/v1/dives/{dive_id}/measurements ─────────────────────────
+
+
+async def test_get_measurements_returns_only_that_dives_rows(session):
+    await _seed_dive(session, 1, [11, 12])
+    await _seed_dive(session, 2, [21])
+    session.add_all([_fish(101), _fish(102), _fish(201)])
+    await session.flush()
+    session.add_all(
+        [
+            _measurement(1, 11, 101, 0.30),
+            _measurement(2, 12, 102, 0.40),
+            _measurement(3, 21, 201, 0.50),  # different dive — must not leak
+        ]
+    )
+    await session.flush()
+
+    rows = await _get_measurements(session, 1)
+
+    assert sorted(m.image_id for m in rows) == [11, 12]
+
+
+async def test_get_measurements_404s_when_dive_has_none(session):
+    """Empty reads as 404, matching get_species_labels_for_dive."""
+    await _seed_dive(session, 1, [11])
+
+    with pytest.raises(Exception):  # HTTPException 404 — no measurements yet
+        await _get_measurements(session, 1)
+
+
+# ── POST is idempotent on (image_id, fish_id) ────────────────────────
+
+
+async def test_post_measurement_creates_row(session):
+    await _seed_dive(session, 1, [11])
+    session.add_all([_fish(101)])
+    await session.flush()
+
+    new_id = await _post(session, 101, _measurement(None, 11, 101, 0.30))
+    await session.flush()
+
+    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+
+    rows = (await session.exec(select(Measurement))).all()
+    assert len(rows) == 1
+    assert new_id is not None
+    assert rows[0].length_m == pytest.approx(0.30)
+
+
+async def test_post_measurement_twice_does_not_duplicate(session):
+    """The stage-14 re-run case: same (image, fish) must not stack rows."""
+    await _seed_dive(session, 1, [11])
+    session.add_all([_fish(101)])
+    await session.flush()
+
+    first_id = await _post(session, 101, _measurement(None, 11, 101, 0.30))
+    await session.flush()
+    second_id = await _post(session, 101, _measurement(None, 11, 101, 0.31))
+    await session.flush()
+
+    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+
+    rows = (await session.exec(select(Measurement))).all()
+    assert len(rows) == 1, "re-posting the same (image, fish) must upsert, not insert"
+    assert first_id == second_id
+    assert rows[0].length_m == pytest.approx(0.31), "latest length wins"
+
+
+async def test_post_measurement_distinct_fish_on_same_image_both_persist(session):
+    """Two fish in one frame are legitimately two measurements."""
+    await _seed_dive(session, 1, [11])
+    session.add_all([_fish(101), _fish(102)])
+    await session.flush()
+
+    await _post(session, 101, _measurement(None, 11, 101, 0.30))
+    await session.flush()
+    await _post(session, 102, _measurement(None, 11, 102, 0.40))
+    await session.flush()
+
+    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+
+    rows = (await session.exec(select(Measurement))).all()
+    assert len(rows) == 2
+
+
+async def test_post_measurement_binds_fish_id_from_path(session):
+    """fish_id comes from the URL, not the body."""
+    await _seed_dive(session, 1, [11])
+    session.add_all([_fish(101)])
+    await session.flush()
+
+    await _post(session, 101, _measurement(None, 11, 999, 0.30))
+    await session.flush()
+
+    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+
+    rows = (await session.exec(select(Measurement))).all()
+    assert rows[0].fish_id == 101

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -1261,50 +1261,113 @@ async def test_laser_calibration_requires_dive_slate_id(session):
 
 
 # ---------- stage 14: measure-fish ----------
+#
+# Cohort mirrors dive_pipeline_status.measured: a dive is selected iff it
+# has extrinsics and at least one *measurable* image with no measurement.
+# It used to key on "has a LABEL_STUDIO cluster with fish_id IS NULL",
+# which never goes false — a cluster is only bound through a measurable
+# image, so clusters without one kept every dive in the cohort forever.
+# Prod dive 466 carried 1632 such clusters against 24 measurable images.
 
 
-async def test_measure_fish_requires_extrinsics_and_unbound_label_studio_cluster(
+def _measurable_image(session, image_id: int, dive_id: int, *, cluster_id: int):
+    """An image stage 14 would attempt: top-three species label + valid
+    laser + valid headtail + a LABEL_STUDIO cluster."""
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+        DiveFrameClusterImageMapping,
+    )
+    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_image(image_id, dive_id))
+    session.add(
+        DiveFrameCluster(
+            id=cluster_id, dive_id=dive_id, data_source=DataSource.LABEL_STUDIO
+        )
+    )
+    session.add(
+        LaserLabel(image_id=image_id, completed=True, superseded=False, x=1.0, y=2.0)
+    )
+    session.add(
+        HeadTailLabel(
+            image_id=image_id, completed=True, superseded=False,
+            head_x=1.0, head_y=2.0, tail_x=3.0, tail_y=4.0,
+        )
+    )
+    session.add(
+        SpeciesLabel(
+            image_id=image_id, top_three_photos_of_group=True,
+            completed=True, superseded=False, label_studio_project_id=70,
+        )
+    )
+    return DiveFrameClusterImageMapping(
+        dive_frame_cluster_id=cluster_id, image_id=image_id
+    )
+
+
+def _measurement(image_id: int, fish_id: int = 100):
+    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+
+    return Measurement(image_id=image_id, fish_id=fish_id, length_m=0.3)
+
+
+async def test_measure_fish_requires_extrinsics_and_an_unmeasured_measurable_image(
     session,
 ):
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         select_next_for_measure_fish,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
-        DiveFrameCluster,
-    )
     from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
         LaserExtrinsics,
     )
 
-    # dive 1: no extrinsics -> excluded.
-    # dive 2: extrinsics + LABEL_STUDIO cluster all bound -> excluded.
-    # dive 3: extrinsics + unbound LABEL_STUDIO cluster -> picked.
-    # dive 4: extrinsics + only PREDICTION clusters -> excluded.
-    session.add_all([_dive(1), _dive(2), _dive(3), _dive(4)])
+    # dive 1: measurable image but no extrinsics -> excluded.
+    # dive 2: extrinsics + measurable image already measured -> excluded.
+    # dive 3: extrinsics + unmeasured measurable image -> picked.
+    session.add_all([_dive(1), _dive(2), _dive(3)])
     await session.flush()
     session.add_all(
-        [
-            LaserExtrinsics(dive_id=2, camera_id=1),
-            LaserExtrinsics(dive_id=3, camera_id=1),
-            LaserExtrinsics(dive_id=4, camera_id=1),
-            DiveFrameCluster(
-                dive_id=2, data_source=DataSource.LABEL_STUDIO, fish_id=42
-            ),
-            DiveFrameCluster(
-                dive_id=3, data_source=DataSource.LABEL_STUDIO, fish_id=None
-            ),
-            DiveFrameCluster(
-                dive_id=4, data_source=DataSource.PREDICTION, fish_id=None
-            ),
-        ]
+        [LaserExtrinsics(dive_id=2, camera_id=1), LaserExtrinsics(dive_id=3, camera_id=1)]
     )
+    m1 = _measurable_image(session, 11, 1, cluster_id=1)
+    m2 = _measurable_image(session, 21, 2, cluster_id=2)
+    m3 = _measurable_image(session, 31, 3, cluster_id=3)
+    await session.flush()
+    session.add_all([m1, m2, m3])
+    session.add(_measurement(21))
     await session.flush()
 
     assert await select_next_for_measure_fish(session=session) == 3
 
 
-async def test_measure_fish_returns_none_when_all_clusters_bound(session):
+async def test_measure_fish_returns_none_when_everything_measurable_is_measured(
+    session,
+):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_measure_fish,
+    )
+    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+        LaserExtrinsics,
+    )
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(LaserExtrinsics(dive_id=1, camera_id=1))
+    mapping = _measurable_image(session, 11, 1, cluster_id=1)
+    await session.flush()
+    session.add(mapping)
+    session.add(_measurement(11))
+    await session.flush()
+
+    assert await select_next_for_measure_fish(session=session) is None
+
+
+async def test_measure_fish_ignores_unbound_clusters_with_no_measurable_image(session):
+    """The regression: an unbound cluster stage 14 can never touch must
+    not keep the dive in the cohort forever."""
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         select_next_for_measure_fish,
     )
@@ -1318,13 +1381,15 @@ async def test_measure_fish_returns_none_when_all_clusters_bound(session):
 
     session.add(_dive(1))
     await session.flush()
-    session.add_all(
-        [
-            LaserExtrinsics(dive_id=1, camera_id=1),
-            DiveFrameCluster(
-                dive_id=1, data_source=DataSource.LABEL_STUDIO, fish_id=42
-            ),
-        ]
+    session.add(LaserExtrinsics(dive_id=1, camera_id=1))
+    mapping = _measurable_image(session, 11, 1, cluster_id=1)
+    await session.flush()
+    session.add(mapping)
+    session.add(_measurement(11))
+    session.add(
+        DiveFrameCluster(
+            id=99, dive_id=1, data_source=DataSource.LABEL_STUDIO, fish_id=None
+        )
     )
     await session.flush()
 

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/measure_fish_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/measure_fish_activity.py
@@ -52,6 +52,7 @@ class MeasureFishResult:
     dropped_nan: int
     missing_laser_or_headtail: int
     missing_cluster: int
+    skipped_already_measured: int = 0
 
 
 __all__ = ["MeasureFishResult", "measure_fish_activity"]
@@ -158,6 +159,16 @@ def _filter_top_three(
     ]
 
 
+async def _fetch_measured_image_ids(fs, dive_id: int) -> set[int]:
+    """Image ids in this dive that already carry a Measurement.
+
+    One fetch per dive, not per image — the caller loops over every
+    top-three label. `None` is the SDK's "no measurements yet" signal.
+    """
+    existing = await fs.fish.get_measurements(dive_id) or []
+    return {m.image_id for m in existing if m.image_id is not None}
+
+
 def _has_complete_keypoints(laser_label, headtail_label) -> bool:
     """True iff both labels exist and every keypoint coord is set."""
     if laser_label is None or headtail_label is None:
@@ -174,10 +185,13 @@ def _has_complete_keypoints(laser_label, headtail_label) -> bool:
 
 @activity.defn
 async def measure_fish_activity(dive_id: int) -> MeasureFishResult:
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals,too-many-statements
     # Orchestration function — gathers dive/camera/laser/cluster/label
     # context plus per-iteration locals. Splitting it would just push
-    # the same state into a parameter list of a helper.
+    # the same state into a parameter list of a helper. The same applies
+    # to the statement count: the body is a flat sequence of guard →
+    # log → count → continue per skip reason, which reads better inline
+    # than dispersed across helpers.
     """Walk the dive's top-three species labels and write a `Measurement`
     for each one whose laser + headtail + cluster context is present and
     whose triangulated length is finite.
@@ -212,15 +226,29 @@ async def measure_fish_activity(dive_id: int) -> MeasureFishResult:
         cluster_by_image = _index_clusters_by_image(clusters)
         top_three = _filter_top_three(species_labels)
 
+        # `post_measurement` upserts on (image_id, fish_id) so a duplicate
+        # can't be recorded, but re-measuring still means re-deriving a
+        # length and re-binding a fish for work already done — skip it.
+        already_measured = await _fetch_measured_image_ids(fs, dive_id)
+
         result = MeasureFishResult(
             measured=0,
             dropped_nan=0,
             missing_laser_or_headtail=0,
             missing_cluster=0,
+            skipped_already_measured=0,
         )
 
         for species_label in top_three:
             image_id = species_label.image_id
+
+            if image_id in already_measured:
+                activity.logger.info(
+                    "dive_id=%d image_id=%d: already measured; skipping",
+                    dive_id, image_id,
+                )
+                result.skipped_already_measured += 1
+                continue
 
             cluster = cluster_by_image.get(image_id)
             if cluster is None:

--- a/services/fishsense-data-processing-workflow-worker/tests/test_measure_fish_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_measure_fish_activity.py
@@ -178,6 +178,7 @@ def _make_fs(  # pylint: disable=too-many-arguments
     species_lookup: dict[str, Species] | None = None,
     new_species_id: int = 500,
     new_fish_id: int = 700,
+    existing_measurements: List[Measurement] | None = None,
 ):
     fs = MagicMock()
     fs.__aenter__ = AsyncMock(return_value=fs)
@@ -212,6 +213,8 @@ def _make_fs(  # pylint: disable=too-many-arguments
     fs.fish.get = AsyncMock(return_value=None)
     fs.fish.post = AsyncMock(return_value=new_fish_id)
     fs.fish.post_measurement = AsyncMock(return_value=None)
+    # `None` is the SDK's "dive has no measurements yet" signal (404).
+    fs.fish.get_measurements = AsyncMock(return_value=existing_measurements)
     return fs
 
 
@@ -411,3 +414,131 @@ async def test_existing_species_and_fish_are_reused(monkeypatch):
     fs.images.put_cluster.assert_not_called()
     fish_id_called, _ = fs.fish.post_measurement.call_args.args
     assert fish_id_called == existing_fish.id
+
+
+# ── idempotency: re-running a partially-measured dive ────────────────
+#
+# `post_measurement` upserts on (image_id, fish_id) server-side, but the
+# activity should not get that far: re-measuring means re-deriving a
+# length and re-binding a fish for work already done. These pin the
+# client-side skip. Motivated by real data — 7 of the 8 calibrated dives
+# in prod carry measurements from partial runs.
+
+
+@pytest.mark.asyncio
+async def test_skips_images_that_are_already_measured(monkeypatch):
+    image_id = 100
+    le = _laser_extrinsics()
+    head_pix, tail_pix, laser_pix = _build_observation(
+        le, np.array([-0.10, 0.00, 1.20]), np.array([0.20, 0.00, 1.20]), 1.20
+    )
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_camera_intrinsics(),
+        laser_extrinsics=le,
+        species_labels=[_species_label(image_id)],
+        laser_labels={image_id: _laser_label(image_id, *laser_pix)},
+        headtail_labels={image_id: _headtail_label(image_id, head_pix, tail_pix)},
+        clusters=[_cluster([image_id], fish_id=None)],
+        existing_measurements=[
+            Measurement(id=1, length_m=0.30, image_id=image_id, fish_id=700)
+        ],
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(sut.measure_fish_activity, 42)
+
+    fs.fish.post_measurement.assert_not_awaited()
+    assert result.measured == 0
+    assert result.skipped_already_measured == 1
+    # Skipped before _ensure_fish, so no fish/species churn either.
+    fs.fish.post.assert_not_awaited()
+    fs.fish.post_species.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_measures_only_the_unmeasured_images(monkeypatch):
+    img_done, img_todo = 100, 101
+    le = _laser_extrinsics()
+    head_pix, tail_pix, laser_pix = _build_observation(
+        le, np.array([-0.10, 0.00, 1.20]), np.array([0.20, 0.00, 1.20]), 1.20
+    )
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_camera_intrinsics(),
+        laser_extrinsics=le,
+        species_labels=[_species_label(img_done), _species_label(img_todo)],
+        laser_labels={
+            img_done: _laser_label(img_done, *laser_pix),
+            img_todo: _laser_label(img_todo, *laser_pix),
+        },
+        headtail_labels={
+            img_done: _headtail_label(img_done, head_pix, tail_pix),
+            img_todo: _headtail_label(img_todo, head_pix, tail_pix),
+        },
+        clusters=[_cluster([img_done]), _cluster([img_todo], fish_id=None)],
+        existing_measurements=[
+            Measurement(id=1, length_m=0.30, image_id=img_done, fish_id=700)
+        ],
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(sut.measure_fish_activity, 42)
+
+    assert result.measured == 1
+    assert result.skipped_already_measured == 1
+    fs.fish.post_measurement.assert_awaited_once()
+    _, measurement = fs.fish.post_measurement.call_args.args
+    assert measurement.image_id == img_todo
+
+
+@pytest.mark.asyncio
+async def test_no_existing_measurements_measures_everything(monkeypatch):
+    """A dive with no measurements (SDK returns None) is unaffected."""
+    image_id = 100
+    le = _laser_extrinsics()
+    head_pix, tail_pix, laser_pix = _build_observation(
+        le, np.array([-0.10, 0.00, 1.20]), np.array([0.20, 0.00, 1.20]), 1.20
+    )
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_camera_intrinsics(),
+        laser_extrinsics=le,
+        species_labels=[_species_label(image_id)],
+        laser_labels={image_id: _laser_label(image_id, *laser_pix)},
+        headtail_labels={image_id: _headtail_label(image_id, head_pix, tail_pix)},
+        clusters=[_cluster([image_id], fish_id=None)],
+        existing_measurements=None,
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(sut.measure_fish_activity, 42)
+
+    assert result.measured == 1
+    assert result.skipped_already_measured == 0
+    fs.fish.post_measurement.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_measurements_are_fetched_once_per_dive(monkeypatch):
+    """Per-dive fetch, not per-image — the loop can run ~50 images."""
+    le = _laser_extrinsics()
+    head_pix, tail_pix, laser_pix = _build_observation(
+        le, np.array([-0.10, 0.00, 1.20]), np.array([0.20, 0.00, 1.20]), 1.20
+    )
+    images = [100, 101, 102]
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_camera_intrinsics(),
+        laser_extrinsics=le,
+        species_labels=[_species_label(i) for i in images],
+        laser_labels={i: _laser_label(i, *laser_pix) for i in images},
+        headtail_labels={i: _headtail_label(i, head_pix, tail_pix) for i in images},
+        clusters=[_cluster([i], fish_id=None) for i in images],
+        existing_measurements=[],
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    await ActivityEnvironment().run(sut.measure_fish_activity, 42)
+
+    fs.fish.get_measurements.assert_awaited_once_with(42)

--- a/uv.lock
+++ b/uv.lock
@@ -847,7 +847,7 @@ dev = [
 
 [[package]]
 name = "fishsense-api-workflow-worker"
-version = "1.38.0"
+version = "1.39.0"
 source = { editable = "services/fishsense-api-workflow-worker" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Two coupled bugs kept stage 14 operator-only and its dashboard bucket permanently stuck. Split into two reviewable commits.

## 1. Measurement was not idempotent

`measure_fish_activity` walked every top-three species label and called `post_measurement` unconditionally, and `post_measurement` did `session.merge` on a body with `id=None` — which keys on the **primary key** alone and therefore always INSERTed. Re-running a partially-measured dive duplicated a `Measurement` for every image already done. That is why stage 14 has no schedule.

Not hypothetical — 7 of the 8 calibrated dives in prod carry measurements from earlier partial runs (279:12, 341:22, 347:42, 349:49, 383:12, 465:20, 466:1). Re-running any of them today would have duplicated exactly those rows.

Fixed in two independent layers:

* **`POST /api/v1/fish/{fish_id}/measurements` upserts** on the natural key `(image_id, fish_id)`, backed by a new `uq_measurement_image_fish` constraint. The key is the pair, not `image_id` alone — one frame can legitimately hold two fish (covered by a test).
* **The activity skips already-measured images up front**, via a new `GET /api/v1/dives/{dive_id}/measurements` + `fish.get_measurements`. Fetched once per dive, not per image. The skip lands *before* `_ensure_fish`, so a re-run causes no species/fish churn either, and is surfaced as `MeasureFishResult.skipped_already_measured`.

The constraint needs **no dedup backfill** — verified against prod first: 242 rows, **0 duplicate `(image_id, fish_id)` pairs, 0 NULLs** in either column (NULLs matter, since postgres treats them as distinct).

Uses select-then-`merge` rather than `postgresql.insert(...).on_conflict_do_update` deliberately: the dialect-specific construct breaks the in-memory sqlite fixture every controller test uses, and `merge` is the existing idiom across all 14 write paths.

## 2. `measured` was unreachable

`measured` was "≥1 LABEL_STUDIO cluster AND zero with `fish_id IS NULL`". A cluster is only bound to a fish **through a measurable image**, so any LABEL_STUDIO cluster without one held the dive at `measured=false` forever.

In prod that pinned **all 8** calibrated dives false permanently — the `5 measure` bucket could never clear regardless of work done. Dive 466 is the extreme: **1632 unbound clusters against 24 measurable images**, the residue of repeated stage-6.1 POSTs in the notebook era (the cluster API has no DELETE, so re-runs stacked duplicate clusters — 2× for most dives, 27× for 466).

The **cohort selector mirrored the same predicate**, so it never went false either: a scheduled stage 14 would have re-selected the same dives every hour and, before fix #1, re-measured them each time.

`measured` now means: ≥1 measurement for the dive AND no *measurable* image left unmeasured, where "measurable" mirrors what the activity attempts (top-three species label + valid laser + valid headtail + a LABEL_STUDIO cluster). `select_next_for_measure_fish` is rewritten to the same predicate — **the two must stay in step**.

### Validated against prod

Ran the new view SQL read-only against the real DB before committing:

```
279 341 347 349 383 465 471  -> measured = t
466                          -> measured = f   (genuinely 1 measurable image left)
```

So the bucket goes **8 -> 1** and drains from there, instead of being stuck at 8 forever.

Unbound clusters are no longer consulted at all, which means the duplicate-cluster mess does **not** have to be cleaned up before stage 14 can finish a dive. That cleanup is still worth doing on its own merits.

## Tests

TDD throughout — failing test first, then implementation:

* `test_measurements_endpoint.py` (new, 6 tests) — dive-scoped read, 404-on-empty, upsert-not-duplicate, two-fish-one-frame, fish_id-from-path.
* `test_fish_client.py` — SDK 200 + 404→None.
* `test_measure_fish_activity.py` — 4 new: skip already-measured (no fish/species churn), measure only the unmeasured, `None` means measure everything, fetched once per dive.
* `test_dive_pipeline_status_view.py` — 5 rewritten, incl. the regression: an unbound cluster with no measurable image must not block.
* `test_select_next_dive_endpoints.py` — 3 rewritten, same regression at the cohort level.

api 162 passed · sdk 108 passed · data-worker measure suites 19 passed · pylint 10.00/10.

Alembic chain verified: `7934e62a12c0` -> `a3f1c7d94b52` -> `b7c2e4d81a09`, single head across 46 migrations.

## Deliberately not included

**Stage 14 is still not scheduled.** Both blockers are gone and the cohort can now drain, so scheduling is a live option — but it's left operator-triggered here so the first real drains can be observed before adding a cron. Recommend running one dive (471 is the cleanest candidate) and checking `skipped_already_measured` before scheduling.