### PR TITLE
feat(stage14): schedule fish measurement hourly at +40

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ DB (negligible). To add or remove, override
 | 11  | populate_label_studio_project | api-worker | ported |
 | 12  | sync_slate_label | api-worker | ported (hourly) |
 | 13  | perform_laser_calibration | api-worker (parent) + data-worker (child) | ported (hourly, +50min offset) |
-| 14  | measure_fish | api-worker (parent) + data-worker (child) | ported (on-demand; idempotent as of 2026-07-17) |
+| 14  | measure_fish | api-worker (parent) + data-worker (child) | ported (hourly, +40min offset; idempotent as of 2026-07-17) |
 
 Create and populate are split into separate workflows per stage. LS
 projects are now **per-dive**: each dive gets its own LS project
@@ -204,11 +204,13 @@ one replica):
 * Per-image activities are idempotent: S3 PutObject overwrites,
   SDK upserts.
 
-Applied to stages 0.1, 1, 2, 5.1, 9, 13 — each parent runs hourly.
-Schedule slots: 0.1 at +0, 1 at +5, 2 at +15, 5.1 at +30, 9 at +45,
-13 at +50 min — staggered so their selectors don't all hit
-`dives.get()` at the top of the hour. Stage 14 measurement is
-registered but not scheduled (see notes below). Per-stage cohort:
+Applied to stages 0.1, 1, 2, 5.1, 9, 13, 14 — each parent runs hourly.
+Schedule slots: 0.1 at +0, 1 at +5, 2 at +15, 5.1 at +30, 14 at +40,
+9 at +45, 13 at +50 min — staggered so their selectors don't all hit
+`dives.get()` at the top of the hour. The scale-to-zero sweeper takes
++55. `test_schedule_registration.py` pins the stagger (the four
+label-studio sync schedules deliberately share +0 — they select no
+dives). Per-stage cohort:
 
 | Stage | Parent cohort definition |
 |---|---|
@@ -353,9 +355,9 @@ keeps SDK fetches inline because the math kernels need opencv +
 fishsense-core, so splitting fetch/math across workers would add 5+
 activity handoffs per dive for no gain.
 
-**Stage 14 is idempotent as of 2026-07-17, but still not scheduled.**
-It used to be non-idempotent — `post_measurement` was a plain POST and
-the SDK had no per-image measurement query, so a re-run on a
+**Stage 14 became idempotent and got a schedule on 2026-07-17** (hourly,
++40 min). It used to be non-idempotent — `post_measurement` was a plain
+POST and the SDK had no per-image measurement query, so a re-run on a
 partially-failed dive duplicated measurements on already-bound
 clusters. Both halves are fixed:
 
@@ -368,10 +370,21 @@ clusters. Both halves are fixed:
   so a re-run causes no species/fish churn. Surfaced as
   `MeasureFishResult.skipped_already_measured`.
 
-It stays operator-triggered for now so the first drains can be watched
-on real dives; the cohort can now go empty (see the `measured` rescope
-below), so scheduling it is a live option rather than a hazard.
-`MeasureFishParentWorkflow`:
+Scheduling was blocked on *both* halves, not just idempotency: the old
+cohort predicate could never go false, so an hourly stage 14 would have
+re-selected the same dives forever. With the `measured` rescope (below)
+the cohort drains, so the schedule is safe. Validated on 2026-07-17
+against dive 466 — 23 already-measured images skipped, 1 measured, 0
+duplicates, and the dive dropped out of the cohort.
+
++40 rather than after calibration (+50) despite depending on it: that
+would leave <5 min before the +55 scale-down sweeper. A dive calibrated
+at :50 is measured at :40 the next hour, which is irrelevant at this
+cadence. Each run still drains exactly one dive, so a backlog clears one
+dive per hour.
+
+Still runnable on demand for backfill — use a non-colliding workflow id
+so the schedule's own id stays free. `MeasureFishParentWorkflow`:
 
 ```
 temporal workflow start \

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -377,6 +377,33 @@ async def schedule_workflows(client: Client):
                     overlap=ScheduleOverlapPolicy.SKIP,
                 )
             )
+            # Stage 14 measurement: hourly at +40 min, in the gap between
+            # the headtail (+30) and slate (+45) parents. Scheduled as of
+            # 2026-07-17 — it was operator-only while `post_measurement`
+            # was a plain POST (a re-run duplicated measurements) and
+            # while the cohort predicate could never go false (a schedule
+            # would have re-measured the same dives every hour forever).
+            # Both are fixed, and the cohort now drains to empty.
+            #
+            # Not slotted after calibration (+50) despite depending on it:
+            # that would leave <5 min before the +55 scale-down sweeper.
+            # A dive calibrated at :50 is instead measured at :40 the
+            # following hour, which is irrelevant at this pipeline's
+            # cadence — calibration is one-shot per dive and dives sit for
+            # days. Each run drains exactly one dive.
+            tg.create_task(
+                schedule_workflow(
+                    client,
+                    "measure-fish-workflow-schedule",
+                    MeasureFishParentWorkflow,
+                    timedelta(hours=1),
+                    offset=timedelta(minutes=40),
+                    # Child `execution_timeout` is 1h; add margin for the
+                    # selector + data-worker scale-up activities.
+                    run_timeout=timedelta(hours=1, minutes=30),
+                    overlap=ScheduleOverlapPolicy.SKIP,
+                )
+            )
             # Scale-to-zero sweeper for the NRP data-worker: hourly at
             # +55 min, after the last preprocess/calibration parent
             # firing, so it never races a parent that's still scaling

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/measure_fish_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/measure_fish_parent_workflow.py
@@ -11,12 +11,18 @@ data-worker activity does its own SDK fetches inline (per CLAUDE.md,
 stages 13 and 14 keep SDK fetches in the data-worker because the math
 kernels need fishsense-core anyway).
 
-**Deliberately not scheduled.** `measure_fish_activity` is non-idempotent
-(`post_measurement` is a POST and the SDK has no per-image measurement
-query), so a re-run on a partially-failed dive will duplicate
-measurements on already-bound clusters. Until that's resolved
-(probably by adding an SDK get-measurements query and per-image
-filtering in the activity), this parent is invoked on-demand:
+**Scheduled hourly at +40 min** (2026-07-17). It was operator-triggered
+for a long time because `measure_fish_activity` was non-idempotent
+(`post_measurement` was a plain POST with no per-image filter), so a
+re-run on a partially-measured dive duplicated measurements — and
+because the cohort predicate never went false, a schedule would have
+re-measured the same dives every hour forever. Both are fixed:
+measurement upserts on `(image_id, fish_id)`, the activity skips
+already-measured images, and the cohort is scoped to images that can
+actually be measured, so it drains to empty.
+
+Still runnable on demand for backfill; use a non-colliding workflow id
+so the schedule's own id stays free:
 
 ```
 temporal workflow start \
@@ -26,9 +32,12 @@ temporal workflow start \
 ```
 
 The selector activity returns the next eligible dive_id (HIGH priority
-+ has laser_extrinsics + has LABEL_STUDIO clusters with at least one
-unbound `fish_id`); the parent then dispatches the child and returns
-the dive_id processed.
++ has laser_extrinsics + at least one *measurable* image with no
+`Measurement` — "measurable" being a top-three species label whose image
+has a valid laser label, a valid head/tail label and a LABEL_STUDIO
+cluster). The parent then dispatches the child and returns the dive_id
+processed. Each run drains exactly one dive, so a backlog clears one
+dive per hour.
 
 Cluster-correctness invariants — relevant once the data-worker scales
 beyond a single replica:
@@ -38,8 +47,10 @@ beyond a single replica:
   `id_reuse_policy=ALLOW_DUPLICATE_FAILED_ONLY`; a duplicate parent
   run targeting the same dive hits `WorkflowAlreadyStarted` (whether
   the prior child is still running or completed successfully) and
-  the parent catches it — duplicate dispatch can't double-write
-  measurements.
+  the parent catches it. This is now a don't-redo-work guard rather
+  than a correctness one — a duplicate dispatch would be harmless
+  since measurement is idempotent at both the write layer and in the
+  activity's skip.
 * Per-cluster `fish_id` rebinds via `put_cluster` on the activity side
   are idempotent under retry within a single child run.
 """
@@ -104,10 +115,14 @@ class MeasureFishParentWorkflow:
                 id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
             )
         except WorkflowAlreadyStartedError:
+            # Not a safety gate any more — measurement is idempotent as of
+            # 2026-07-17 (`post_measurement` upserts on (image_id, fish_id)
+            # and the activity skips already-measured images), so a
+            # duplicate dispatch would be harmless. This just avoids
+            # re-doing work already done for this dive.
             workflow.logger.info(
                 "measure-fish-%d already ran successfully; skipping "
-                "duplicate dispatch (re-run requires manual cleanup of "
-                "existing measurements per the stage-14 idempotency note)",
+                "duplicate dispatch (no re-work needed)",
                 dive_id,
             )
 

--- a/services/fishsense-api-workflow-worker/tests/test_schedule_registration.py
+++ b/services/fishsense-api-workflow-worker/tests/test_schedule_registration.py
@@ -1,0 +1,119 @@
+"""What `schedule_workflows` actually registers.
+
+The hourly parents are deliberately staggered across the hour so their
+selectors don't all hit fishsense-api at the same moment (CLAUDE.md,
+"Cross-worker orchestration pattern"). That stagger only exists as a
+pile of `offset=timedelta(minutes=N)` literals, so two schedules landing
+on the same slot — or a parent silently never being registered — is a
+mistake nothing else catches.
+
+These are the first tests over the registration itself; the seven
+pre-existing schedules had none. `ensure_schedule` is patched out, so
+nothing here talks to Temporal.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from temporalio.client import ScheduleOverlapPolicy
+
+from fishsense_api_workflow_worker import worker as sut
+
+# The hourly parents that pick a dive off a cohort selector. These are
+# the ones the stagger exists for; the label-studio sync schedules are
+# excluded deliberately (they select no dives and share offset 0).
+_DIVE_SELECTING_PARENT_SCHEDULE_IDS = (
+    "preprocess-laser-images-workflow-schedule",
+    "cluster-dive-frames-workflow-schedule",
+    "preprocess-species-images-workflow-schedule",
+    "preprocess-headtail-images-workflow-schedule",
+    "preprocess-slate-images-workflow-schedule",
+    "perform-laser-calibration-workflow-schedule",
+    "measure-fish-workflow-schedule",
+)
+
+
+@pytest.fixture
+async def registered(monkeypatch):
+    """Run `schedule_workflows` with Temporal stubbed; return
+    {schedule_id: Schedule}."""
+    captured: dict = {}
+
+    async def _fake_ensure_schedule(_client, *, schedule_id, schedule):
+        captured[schedule_id] = schedule
+
+    monkeypatch.setattr(sut, "ensure_schedule", _fake_ensure_schedule)
+    await sut.schedule_workflows(MagicMock())
+    return captured
+
+
+def _offset(schedule) -> timedelta | None:
+    return schedule.spec.intervals[0].offset
+
+
+def _every(schedule) -> timedelta:
+    return schedule.spec.intervals[0].every
+
+
+async def test_measure_fish_is_scheduled_hourly_at_40(registered):
+    """Stage 14 went from operator-only to scheduled on 2026-07-17."""
+    schedule = registered["measure-fish-workflow-schedule"]
+
+    assert _every(schedule) == timedelta(hours=1)
+    assert _offset(schedule) == timedelta(minutes=40)
+
+
+async def test_measure_fish_skips_when_a_run_is_still_in_flight(registered):
+    """SKIP, not ALLOW_ALL: two selectors racing would both pick the same
+    dive. Every dive-selecting parent shares this."""
+    schedule = registered["measure-fish-workflow-schedule"]
+
+    assert schedule.policy.overlap is ScheduleOverlapPolicy.SKIP
+
+
+async def test_measure_fish_run_timeout_outlives_its_child(registered):
+    """The child's `execution_timeout` is 1h; the parent must outlast it
+    plus the selector and data-worker scale-up activities."""
+    schedule = registered["measure-fish-workflow-schedule"]
+
+    assert schedule.action.run_timeout > timedelta(hours=1)
+
+
+async def test_dive_selecting_parents_do_not_share_a_slot(registered):
+    """The stagger is the whole point — two selectors firing at the same
+    instant would both `dives.get()` at once, and (SKIP overlap only
+    guards a schedule against *itself*) could pick the same dive.
+
+    Scoped to the dive-selecting parents on purpose. The label-studio
+    sync schedules deliberately share offset 0: they don't select dives,
+    and they run `overlap=ALLOW_ALL`.
+    """
+    slots: dict[timedelta, list[str]] = {}
+    for schedule_id in _DIVE_SELECTING_PARENT_SCHEDULE_IDS:
+        schedule = registered[schedule_id]
+        slots.setdefault(_offset(schedule) or timedelta(0), []).append(schedule_id)
+
+    collisions = {
+        offset: ids for offset, ids in slots.items() if len(ids) > 1
+    }
+    assert not collisions, f"parents share a slot: {collisions}"
+
+
+async def test_measure_fish_lands_before_the_scale_down_sweeper(registered):
+    """The +55 sweeper scales the NRP data-worker to zero. Stage 14 must
+    fire early enough to have scaled it *up* and be visibly running by
+    then, or the sweeper could pull the floor out mid-measure."""
+    measure = _offset(registered["measure-fish-workflow-schedule"])
+    sweeper = _offset(registered["scale-down-idle-data-worker-workflow-schedule"])
+
+    assert measure < sweeper
+
+
+async def test_every_dive_selecting_parent_is_registered(registered):
+    """Guards against a parent being added to the worker but never
+    scheduled — it would simply never run."""
+    for schedule_id in _DIVE_SELECTING_PARENT_SCHEDULE_IDS:
+        assert schedule_id in registered

--- a/uv.lock
+++ b/uv.lock
@@ -765,7 +765,7 @@ wheels = [
 
 [[package]]
 name = "fishsense-api"
-version = "1.29.0"
+version = "1.29.1"
 source = { editable = "services/fishsense-api" }
 dependencies = [
     { name = "alembic" },
@@ -818,7 +818,7 @@ dev = [
 
 [[package]]
 name = "fishsense-api-sdk"
-version = "1.36.0"
+version = "1.36.1"
 source = { editable = "libs/fishsense-api-sdk" }
 dependencies = [
     { name = "httpx" },
@@ -1009,7 +1009,7 @@ requires-dist = [
 
 [[package]]
 name = "fishsense-data-processing-workflow-worker"
-version = "2.7.0"
+version = "2.7.1"
 source = { editable = "services/fishsense-data-processing-workflow-worker" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Follow-up to #287. Now that measurement is idempotent and the cohort can drain, stage 14 gets a schedule — plus the stale comments #287 left behind.

## The schedule

Hourly at **+40 min**, joining the other dive-selecting parents:

```
+0   preprocess-laser (0.1)        +40  measure-fish (14)   <- new
+5   cluster-dive-frames (1)       +45  preprocess-slate (9)
+15  preprocess-species (2)        +50  perform-laser-calibration (13)
+30  preprocess-headtail (5.1)     +55  scale-down-idle-data-worker
```

**Why +40 and not after calibration (+50)**, despite stage 14 depending on it: that leaves under 5 minutes before the +55 scale-down sweeper. A dive calibrated at :50 is measured at :40 the following hour instead — irrelevant at this cadence, since calibration is one-shot per dive and dives sit for days.

`run_timeout=1h30` (the child's `execution_timeout` is 1h, plus margin for the selector + scale-up activities). `overlap=SKIP`, matching every other dive-selecting parent — two selectors racing would both pick the same dive.

## Why it's safe now

Scheduling was blocked on **both** halves, not just idempotency:

* Measurement duplicated rows on re-run → fixed in #287 (upsert on `(image_id, fish_id)` + activity-side skip).
* The cohort predicate could never go false → fixed in #287 (rescoped to measurable images). Without this, an hourly stage 14 would have re-selected the same dives forever.

Confirmed live before opening this, on dive 466:

```json
{"measured": 1, "skipped_already_measured": 23,
 "dropped_nan": 0, "missing_cluster": 0, "missing_laser_or_headtail": 0}
```

Table went 242 → 243 (exactly +1), **0 duplicate pairs**, dive 466 flipped `measured` false → true, and the cohort drained to **0**.

## Stale comments from #287

The parent workflow still asserted the old world in three places — docstring "**Deliberately not scheduled**", the old unbound-`fish_id` cohort description, and a `WorkflowAlreadyStarted` handler citing "manual cleanup of existing measurements". The handler's *behavior* is unchanged and still correct; it's just a don't-redo-work guard now rather than a correctness one.

## Tests

First tests over schedule registration — the seven existing schedules had none, and the stagger exists only as a pile of `offset=` literals, so a collision or a never-registered parent was uncaught.

Writing them was worthwhile: my first cut asserted a repo-wide "no two hourly schedules share a slot" invariant, and **it failed** — the four label-studio sync schedules deliberately share +0 (they select no dives and run `ALLOW_ALL`). Rather than re-slot production schedules to satisfy my test, I scoped the invariant to the dive-selecting parents, which is what CLAUDE.md actually claims. Verified the collision check bites by temporarily clashing 14 onto 13's +50.

api-workflow-worker: **220 passed**, 3 skipped. pylint 10.00/10.

## Deploy note

The schedule registers idempotently at worker startup, so the first deploy creates it and later ones leave it alone. No operator action needed. Per the existing convention, changing its cron/offset later requires `temporal schedule delete measure-fish-workflow-schedule` and a worker restart.