### PR TITLE
chore(flake): bump krg-infra pin — runner auto-restart (krg-infra#496)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -810,6 +810,36 @@ only when `.credentials` is absent). If the runner is down: it is
 platform-provisioned (ADR 0022), so don't hand-register it — a krg fleet
 deploy re-mints for any instance missing `.credentials`.
 
+**A pushed token is inert until the runner restarts to consume it**, and
+that is the half that is *ours*. krg stages the token to
+`/var/lib/krg/github-runner/registration-token`; the runner reads it on
+start. Nothing reads it on its own — upstream's module hardcodes
+`Restart = "no"`, so a runner that 404'd once stays dead while perfectly
+good tokens pile up underneath it. krg-infra#496 adds
+`Restart = lib.mkForce "on-failure"` + `RestartSec = 30`, but that lives
+in `nix/modules/tenant.nix` — Axis B, so it only reaches the slot when
+`flake.lock`'s krg-infra pin moves (`nix flake update krg-infra`;
+`update-flake.yml` does it Mondays 08:00 UTC). On an old pin, a token
+delivery fixes nothing.
+
+To recover a dead runner: converge (see the hand-converge box above)
+*within the token's ~1h life*. Verified 2026-07-17 — token staged 06:12,
+converge at 06:53, `Listening for Jobs` at 06:54, and the converge itself
+went back to `Result=success` because the failed unit was the only thing
+producing exit 4. Waiting for the 11:00 nightly would have found the
+token expired and 404'd again.
+
+**Check the right file.** `$STATE_DIRECTORY/.new-token`
+(`/var/lib/github-runner/fishsense/.new-token`) is the *module's* copy,
+written by its own `copy_tokens()` when the runner **starts** — krg never
+writes it. Its mtime tracks the last runner start, not the last push, so
+on a dead runner it is frozen and cannot tell you whether a token was
+delivered. Ask `/var/lib/krg/github-runner/registration-token` instead.
+(Learned the hard way: an entire "their fix isn't pushing to us"
+diagnosis was built on the wrong file's mtime, plus a fleet-deploy run's
+*start* time misread as its finish — the push lands in a later job,
+~10min in.)
+
 Until the slot is bootstrapped the converge job fails; the
 `deploy-data-worker` job runs but fails fast until `NRP_KUBECONFIG` is
 set. The retired `deploy-orchestrator` job (docker compose on a
@@ -883,6 +913,14 @@ The pre-Incus orchestrator host's compose files (`deploy/compose.yml` +
 bind-mount `*_volumes/` dirs were deleted when that host was
 decommissioned. `git log --diff-filter=D -- deploy/compose.yml` recovers
 them.
+
+**Don't use `git merge-base --is-ancestor` to check whether a fix
+shipped.** Squash merges are enabled here, so a merged PR's *content* is
+in main under a new commit while its original commits are not ancestors
+of anything — the ancestry test returns a false negative. Same trap in
+reverse when checking a release tag: ask whether the *content* is there
+(`git show <tag>:<path> | grep`, or diff the file), not whether a commit
+is reachable.
 
 Race guard: promote.yml polls for the `:sha-<short>` image to appear
 (up to 20 min) before retagging. build.yml is triggered by the same

--- a/flake.lock
+++ b/flake.lock
@@ -121,11 +121,11 @@
       },
       "locked": {
         "dir": "nix",
-        "lastModified": 1783908576,
-        "narHash": "sha256-GZQMN1TRHnnLiGLhu5a6HxxylK9gJJVY5WnT6NkDD0o=",
+        "lastModified": 1784266910,
+        "narHash": "sha256-Yi03BlKlwsq6KaUWPqMEjwDwBHc/6zTmJ1b69vjPBH0=",
         "owner": "KastnerRG",
         "repo": "krg-infra",
-        "rev": "a0849fe87d5d17de315f75fb685dc4783bbba5be",
+        "rev": "309364dfc49a58121aaa5998686bc56f2d35752a",
         "type": "github"
       },
       "original": {
@@ -137,11 +137,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783703440,
-        "narHash": "sha256-O3/YajjWo001VUIgD8BwaRdSNLUFe7nZ1qV5TwhRBcw=",
+        "lastModified": 1784011430,
+        "narHash": "sha256-lDebytrYdd47IBLwvNOD+6AGeoqZ78CIKlp70hzW280=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f0500b9660505dc3cb647775fe9a978a74b5283",
+        "rev": "8eeec934ae0dbeca3d7868c059568a65c08b2fc3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,9 +20,17 @@
     # the nightly `system.autoUpgrade` (#460) rolls it out. Skip it and the slot freezes
     # on old, unpatched packages. A new kernel needs a manual `incus restart` (allowReboot=false).
     #
-    # The lock currently carries krg-infra @ 4c10ed3e (incl. #435–#440/#443/#453,
-    # #459 compose force-recreate, #460 nightly auto-upgrade). `git log -p flake.lock`
-    # is the real history of what shipped.
+    # The lock currently carries krg-infra @ 309364df (incl. #435–#440/#443/#453,
+    # #459 compose force-recreate, #460 nightly auto-upgrade, #496 runner
+    # registration-token churn gate + `Restart = "on-failure"` on the runner).
+    # `git log -p flake.lock` is the real history of what shipped.
+    #
+    # #496 is why this axis being ours is not academic: krg fixed the runner
+    # fleet-side, but the half that keeps a dead runner from staying dead
+    # (`Restart = lib.mkForce "on-failure"` in nix/modules/tenant.nix) only
+    # reaches the slot when this pin moves. Sit on an old pin and the module
+    # keeps upstream's `Restart = "no"` — the platform can hand us a perfectly
+    # good token and nothing will ever pick it up.
     krg-infra.url = "github:KastnerRG/krg-infra?dir=nix";
     nixpkgs.follows = "krg-infra/nixpkgs";
   };


### PR DESCRIPTION
Advances the krg-infra pin `a0849fe8` → `309364df` (#496's merge commit). Ordinary **Axis B** routine — the same `nix flake update krg-infra` that `update-flake.yml` runs Mondays — done by hand because today's outage is precisely the toil the new pin removes.

## Why now

krg fixed their half fleet-side in [krg-infra#496](https://github.com/KastnerRG/krg-infra/pull/496): they were minting a fresh registration token **per fleet deploy**, and the upstream module diffs the token file's *contents*, so every deploy forced a re-registration — turning a GitHub round-trip into a hard dependency of system activation. They now push only when `.credentials` is absent.

**But the half that matters for a runner that's already down is ours.** `Restart = lib.mkForce "on-failure"` + `RestartSec = 30` live in `nix/modules/tenant.nix`, which only reaches the slot when this pin moves. On the old pin the module keeps upstream's `Restart = "no"`, so a runner that 404s once **stays dead while valid tokens pile up underneath it**.

That's not hypothetical — it's this morning. The platform staged us a good token at **06:12** and nothing consumed it until a hand converge at **06:53**:

```
06:12:51  krg stages registration-token   (their gate fired correctly)
06:53:27  hand converge
06:54:54  Listening for Jobs
          fishsense-selfupdate: Result=success  ExecMainStatus=0
```

The converge went back to **exit 0** because the failed runner was the only thing producing exit 4 all morning.

## Verified on the evaluated config, not the source

```
nixosConfigurations.fishsense.config.systemd.services."github-runner-fishsense".serviceConfig
  Restart:     on-failure
  RestartSec:  30
```

`nix flake check` passes; the tenant toplevel still evaluates to a derivation.

## Risk

`nixpkgs.follows = "krg-infra/nixpkgs"`, so nixpkgs moves too (`8eeec934`) — the usual kernel/openssl delta this axis exists to deliver. **A new kernel needs a manual `incus restart`** (`allowReboot=false`). The slot is healthy right now, so this is a deliberate choice to take the delta ~3 days before Monday's automatic bump would.

## Docs

Records what today cost us, all of it absent from CLAUDE.md this morning:

* **A pushed token is inert until the runner restarts to consume it** — and `Restart=on-failure` is Axis B, ours, not krg's.
* **Recover a dead runner by converging inside the token's ~1h life.** Waiting for the 11:00 nightly would have found it expired and 404'd again.
* **`$STATE_DIRECTORY/.new-token` cannot answer "was a token delivered?"** It's the module's own copy, written when the runner *starts*; krg never writes it. On a dead runner its mtime is frozen. Ask `/var/lib/krg/github-runner/registration-token`. I built an entire wrong diagnosis on that file's mtime today (compounded by reading a fleet-deploy run's *start* time as its finish — the push lands ~10min in, in a later job).
* **`git merge-base --is-ancestor` false-negatives on squash merges.** Check content, not reachability, when asking whether a fix shipped.