### PR TITLE
fix(deploy): verify-incus reds every deploy — the runner has no diffutils

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -207,16 +207,35 @@ jobs:
 
           # Every pin must match. A stale slot differs here even though the
           # containers are happily serving the old version.
-          if ! diff -u /tmp/expected-pins.txt /tmp/deployed-pins.txt; then
-            echo "::error title=Deploy verify::the slot is NOT running the versions on main (-expected/+deployed above). The converge did not land; check 'journalctl -u fishsense-selfupdate' on the slot."
+          #
+          # Compared as strings, and reported with `comm`, because the slot's
+          # runner has NO diffutils: its PATH is bash/coreutils/findutils/git/
+          # gnugrep/gnused/gnutar/gzip/nix/openssh/systemd, so `diff` AND `cmp`
+          # are both absent. `if ! diff ...` there is a trap — the missing
+          # binary exits non-zero, which reads as "pins differ" and reds every
+          # deploy no matter what is on the slot (it did exactly that on this
+          # job's first live run). `comm` and `sort` are coreutils, so they are
+          # present. Anything added here must be checked against that PATH, not
+          # against a dev box.
+          if [ "$(cat /tmp/expected-pins.txt)" != "$(cat /tmp/deployed-pins.txt)" ]; then
+            echo "::error title=Deploy verify::the slot is NOT running the versions on main (see the expected/deployed lists above). The converge did not land; check 'journalctl -u fishsense-selfupdate' on the slot."
             {
               echo "### ❌ deploy did not land"
               echo "The compose spec the slot deployed does not match main's pins."
               echo ""
-              echo '```diff'
-              diff -u /tmp/expected-pins.txt /tmp/deployed-pins.txt || true
+              echo "**On main but not deployed:**"
+              echo '```'
+              comm -23 /tmp/expected-pins.txt /tmp/deployed-pins.txt
+              echo '```'
+              echo "**Deployed but not on main:**"
+              echo '```'
+              comm -13 /tmp/expected-pins.txt /tmp/deployed-pins.txt
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
+            echo "--- on main but not deployed ---"
+            comm -23 /tmp/expected-pins.txt /tmp/deployed-pins.txt
+            echo "--- deployed but not on main ---"
+            comm -13 /tmp/expected-pins.txt /tmp/deployed-pins.txt
             exit 1
           fi
 


### PR DESCRIPTION
**The gate I added in #297 is broken on main and reds every deploy.** Caught on its first live run (`workflow_dispatch`, run 29562228343), against a slot that was correctly deployed.

## The failure

```
--- expected (main) ---                --- deployed (slot) ---
ghcr.io/ucsd-e4e/fishsense-api:v1.29.1              ghcr.io/ucsd-e4e/fishsense-api:v1.29.1
ghcr.io/ucsd-e4e/fishsense-api-workflow-worker:v1.40.0        ...identical, all four...

/var/lib/gh-runner/work/_temp/….sh: line 38: diff: command not found
##[error]the slot is NOT running the versions on main
```

All four pins match. The slot's runner PATH is `bash / coreutils / findutils / git / gnugrep / gnused / gnutar / gzip / nix / openssh / systemd` — **no diffutils**, so neither `diff` nor `cmp` exists. `if ! diff a b` takes the mismatch branch on "command not found", so the gate fails **unconditionally**.

That's worse than the false green it replaced: the old probe only lied when a deploy had failed; this lies always.

## The fix

Compare as strings; report with `comm` (coreutils, verified present). `pins()` already `sort -u`s both files, which is what `comm` requires.

## Verified in the runner's PATH this time

My #297 claim to have "verified against the real slot" was wrong in the way that mattered: I ran the comparison **on a dev box**, where `diff` exists, and only queried the slot for the pin *values*. Re-tested inside the runner's actual PATH, both directions:

```
case 1: identical pins                          -> MATCH (pass)      <- the false red, fixed
case 2: main v1.40.0 vs deployed v1.39.0        -> MISMATCH (exit 1)
          on main but not deployed:  …fishsense-api-workflow-worker:v1.40.0
          deployed but not on main:  …fishsense-api-workflow-worker:v1.39.0
```

So it still catches this morning's real outage, and no longer flags a healthy slot.

The comment now names the PATH constraint explicitly, so the next person adding a tool to this job checks it against the runner rather than their laptop.