### PR TITLE
feat(superset): fish-measurements dashboard as an importable asset bundle

### DIFF
--- a/deploy/incus/superset_volumes/docker/assets/README.md
+++ b/deploy/incus/superset_volumes/docker/assets/README.md
@@ -13,9 +13,14 @@ assets/
     dive_pipeline_status.yaml        # the physical view — one bool per stage per dive
     pipeline_labeling_queue.yaml     # virtual: count of HIGH dives waiting at each stage
     pipeline_partial_dives.yaml      # virtual: one row per unfinished dive + its blocker
-  charts/                            # Labeling queue + Partially-done dives (table viz)
+    fish_measurements.yaml           # virtual: one row per stage-14 measurement (dive/image/species)
+  charts/                            # Labeling queue + Partially-done dives + fish-measurement tiles
   dashboards/FishSense_Pipeline_Status.yaml
+  dashboards/Fish_Measurements.yaml  # reshaped from the retired hosted "REEF - SMILE Lengths"
 ```
+
+Two dashboards ship in this one bundle — `import-dashboards` imports every
+dashboard/chart/dataset in the zip in one pass.
 
 ## Secret handling
 

--- a/deploy/incus/superset_volumes/docker/assets/charts/Fish_Measured_Count.yaml
+++ b/deploy/incus/superset_volumes/docker/assets/charts/Fish_Measured_Count.yaml
@@ -1,0 +1,20 @@
+# New summary tile: distinct fish measured. The old dashboard was a bare table
+# with no headline number.
+slice_name: Fish measured
+viz_type: big_number_total
+params:
+  datasource: 55555555-5555-4555-8555-555555555555__table
+  viz_type: big_number_total
+  metric: fish_measured
+  subheader: distinct fish with a length
+  adhoc_filters:
+    - clause: WHERE
+      subject: Taken Date
+      operator: TEMPORAL_RANGE
+      comparator: No filter
+      expressionType: SIMPLE
+  y_axis_format: SMART_NUMBER
+cache_timeout: null
+uuid: aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa
+version: 1.0.0
+dataset_uuid: 55555555-5555-4555-8555-555555555555

--- a/deploy/incus/superset_volumes/docker/assets/charts/Fish_Measurements_Detail.yaml
+++ b/deploy/incus/superset_volumes/docker/assets/charts/Fish_Measurements_Detail.yaml
@@ -1,0 +1,39 @@
+# `params` must be a YAML MAPPING (v1 importer rejects a JSON string).
+# Reshaped from the old "Lengths" chart: query_mode raw (was aggregate with a
+# GROUP BY on every column — an accidental DISTINCT), leads with "Image Path"
+# (the NAS key rows are joined to the stereo measurements on) and sorts by it
+# so same-image rows sit together, search + paging on, and a wider row_limit
+# (the old 1000 truncated a season of fish).
+slice_name: Fish measurements (detail)
+viz_type: table
+params:
+  datasource: 55555555-5555-4555-8555-555555555555__table
+  viz_type: table
+  query_mode: raw
+  all_columns:
+    - Image Path
+    - Fish ID
+    - Dive Name
+    - Taken Date
+    - Species Name
+    - Scientific Name
+    - Length (mm)
+  order_by_cols:
+    - '["Image Path", true]'
+  temporal_columns_lookup:
+    Taken Date: true
+  adhoc_filters:
+    - clause: WHERE
+      subject: Taken Date
+      operator: TEMPORAL_RANGE
+      comparator: No filter
+      expressionType: SIMPLE
+  row_limit: 10000
+  server_page_length: 25
+  include_search: true
+  show_cell_bars: true
+  table_timestamp_format: smart_date
+cache_timeout: null
+uuid: 99999999-9999-4999-8999-999999999999
+version: 1.0.0
+dataset_uuid: 55555555-5555-4555-8555-555555555555

--- a/deploy/incus/superset_volumes/docker/assets/charts/Length_By_Species.yaml
+++ b/deploy/incus/superset_volumes/docker/assets/charts/Length_By_Species.yaml
@@ -1,0 +1,32 @@
+# New summary: per-species measurement counts + mean length. Kept as a `table`
+# viz (same shape as the rest of this bundle — a categorical bar would need the
+# UI round-trip pass to validate viz params). Sorted by fish measured.
+slice_name: Length by species
+viz_type: table
+params:
+  datasource: 55555555-5555-4555-8555-555555555555__table
+  viz_type: table
+  query_mode: aggregate
+  groupby:
+    - Species Name
+    - Scientific Name
+  metrics:
+    - fish_measured
+    - avg_length_mm
+  temporal_columns_lookup:
+    Taken Date: true
+  adhoc_filters:
+    - clause: WHERE
+      subject: Taken Date
+      operator: TEMPORAL_RANGE
+      comparator: No filter
+      expressionType: SIMPLE
+  order_desc: true
+  timeseries_limit_metric: fish_measured
+  row_limit: 200
+  server_page_length: 25
+  show_cell_bars: true
+cache_timeout: null
+uuid: bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb
+version: 1.0.0
+dataset_uuid: 55555555-5555-4555-8555-555555555555

--- a/deploy/incus/superset_volumes/docker/assets/dashboards/Fish_Measurements.yaml
+++ b/deploy/incus/superset_volumes/docker/assets/dashboards/Fish_Measurements.yaml
@@ -1,0 +1,104 @@
+dashboard_title: FishSense Fish Measurements
+description: Stage-14 fish length measurements — headline count, per-species breakdown, and a filterable detail table. Reshaped from the retired "REEF - SMILE Lengths" dashboard.
+css: ''
+slug: fishsense-fish-measurements
+certified_by: ''
+certification_details: ''
+published: true
+uuid: cccccccc-cccc-4ccc-8ccc-cccccccccccc
+position:
+  DASHBOARD_VERSION_KEY: v2
+  ROOT_ID:
+    type: ROOT
+    id: ROOT_ID
+    children:
+      - GRID_ID
+  GRID_ID:
+    type: GRID
+    id: GRID_ID
+    parents:
+      - ROOT_ID
+    children:
+      - ROW-summary
+      - ROW-detail
+  HEADER_ID:
+    type: HEADER
+    id: HEADER_ID
+    meta:
+      text: FishSense Fish Measurements
+  ROW-summary:
+    type: ROW
+    id: ROW-summary
+    parents:
+      - ROOT_ID
+      - GRID_ID
+    children:
+      - CHART-count
+      - CHART-species
+    meta:
+      background: BACKGROUND_TRANSPARENT
+  ROW-detail:
+    type: ROW
+    id: ROW-detail
+    parents:
+      - ROOT_ID
+      - GRID_ID
+    children:
+      - CHART-detail
+    meta:
+      background: BACKGROUND_TRANSPARENT
+  CHART-count:
+    type: CHART
+    id: CHART-count
+    children: []
+    parents:
+      - ROOT_ID
+      - GRID_ID
+      - ROW-summary
+    meta:
+      # `chartId` must be present — the importer's build_uuid_to_id_map reads it
+      # (KeyError otherwise); the value is a placeholder remapped via `uuid`.
+      chartId: 1
+      uuid: aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa
+      sliceName: Fish measured
+      width: 3
+      height: 50
+  CHART-species:
+    type: CHART
+    id: CHART-species
+    children: []
+    parents:
+      - ROOT_ID
+      - GRID_ID
+      - ROW-summary
+    meta:
+      chartId: 2
+      uuid: bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb
+      sliceName: Length by species
+      width: 9
+      height: 50
+  CHART-detail:
+    type: CHART
+    id: CHART-detail
+    children: []
+    parents:
+      - ROOT_ID
+      - GRID_ID
+      - ROW-detail
+    meta:
+      chartId: 3
+      uuid: 99999999-9999-4999-8999-999999999999
+      sliceName: Fish measurements (detail)
+      width: 12
+      height: 80
+metadata:
+  color_scheme: ''
+  refresh_frequency: 0
+  expanded_slices: {}
+  label_colors: {}
+  timed_refresh_immune_slices: []
+  cross_filters_enabled: true
+  default_filters: '{}'
+  chart_configuration: {}
+  global_chart_configuration: {}
+version: 1.0.0

--- a/deploy/incus/superset_volumes/docker/assets/datasets/FishSense/fish_measurements.yaml
+++ b/deploy/incus/superset_volumes/docker/assets/datasets/FishSense/fish_measurements.yaml
@@ -1,0 +1,106 @@
+# Virtual dataset: one row per stage-14 fish measurement, joined out to
+# dive / image / species. Built for cross-run analysis — "Image Path" is the
+# NAS key rows are joined to the stereo-camera measurements on, so it leads the
+# SELECT and is never dropped. Reshaped from the retired hosted-Superset dataset
+# "REEF SMILE Project Lengths":
+#   - FROM measurement (the real grain) instead of FROM fish;
+#   - LEFT JOIN species so measurements on not-yet-species-labeled fish are
+#     still shown (the old INNER JOIN silently dropped them);
+#   - WHERE length_m IS NOT NULL so failed/blank measurements don't render as
+#     empty cells.
+# Length is reported to the nearest mm (ROUND(length_m*1000)) — the measurement
+# precision doesn't warrant sub-mm.
+table_name: fish_measurements
+main_dttm_col: Taken Date
+description: One row per fish measurement (stage 14), keyed on the NAS Image Path for comparison against stereo.
+default_endpoint: null
+offset: 0
+cache_timeout: null
+catalog: null
+schema: null
+sql: |
+  SELECT
+      image.path                         AS "Image Path",
+      fish.id                            AS "Fish ID",
+      dive.name                          AS "Dive Name",
+      image.taken_datetime               AS "Taken Date",
+      species.common_name                AS "Species Name",
+      species.scientific_name            AS "Scientific Name",
+      ROUND(measurement.length_m * 1000) AS "Length (mm)"
+  FROM measurement
+  JOIN fish   ON fish.id   = measurement.fish_id
+  JOIN image  ON image.id  = measurement.image_id
+  JOIN dive   ON dive.id   = image.dive_id
+  LEFT JOIN species ON species.id = fish.species_id
+  WHERE measurement.length_m IS NOT NULL
+params: null
+template_params: null
+filter_select_enabled: true
+fetch_values_predicate: null
+extra: null
+normalize_columns: false
+always_filter_main_dttm: false
+uuid: 55555555-5555-4555-8555-555555555555
+metrics:
+  - metric_name: measurements
+    verbose_name: Measurements
+    metric_type: null
+    expression: COUNT(*)
+    description: Number of individual length measurements.
+    d3format: null
+    extra: {}
+    warning_text: null
+  - metric_name: fish_measured
+    verbose_name: Fish measured
+    metric_type: null
+    expression: COUNT(DISTINCT "Fish ID")
+    description: Distinct fish that have at least one length measurement.
+    d3format: null
+    extra: {}
+    warning_text: null
+  - metric_name: avg_length_mm
+    verbose_name: Avg length (mm)
+    metric_type: null
+    expression: ROUND(AVG("Length (mm)"))
+    description: Mean measured length in millimetres.
+    d3format: null
+    extra: {}
+    warning_text: null
+columns:
+  - column_name: Image Path
+    type: STRING
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: Fish ID
+    type: INTEGER
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: Dive Name
+    type: STRING
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: Taken Date
+    type: DATETIMETZ
+    is_dttm: true
+    groupby: true
+    filterable: true
+  - column_name: Species Name
+    type: STRING
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: Scientific Name
+    type: STRING
+    is_dttm: false
+    groupby: true
+    filterable: true
+  - column_name: Length (mm)
+    type: FLOAT
+    is_dttm: false
+    groupby: true
+    filterable: true
+version: 1.0.0
+database_uuid: 11111111-1111-4111-8111-111111111111


### PR DESCRIPTION
## What

Pulls the retired hosted-Superset **REEF - SMILE Lengths** dashboard out of a Superset DB dump and reshapes it into the committed asset bundle, so it imports into prod Superset on the next converge (same mechanism as the pipeline-status dashboard).

Adds:
- `datasets/FishSense/fish_measurements.yaml` — virtual dataset, one row per stage-14 measurement joined to dive/image/species.
- `charts/Fish_Measurements_Detail.yaml` — the detail table (the analysis extract).
- `charts/Fish_Measured_Count.yaml` — distinct fish measured (big number).
- `charts/Length_By_Species.yaml` — per-species count + mean length.
- `dashboards/Fish_Measurements.yaml` — **FishSense Fish Measurements**.

## Why it's reshaped, not copied

Purpose is cross-run analysis: the extract gets joined against the **stereo camera** measurements on the NAS image path.

- **`Image Path` leads and sorts the table** — it's the join key to stereo.
- **`LEFT JOIN species`** (was `INNER JOIN`) — the original silently dropped every measurement on a fish whose species wasn't labeled yet, so the fishsense side would have looked like it was missing fish the stereo side has.
- **`WHERE length_m IS NOT NULL`** drops failed/blank measurements.
- **Length reported to nearest mm** — measurement precision doesn't warrant sub-mm.
- Detail table switched from `query_mode: aggregate` (an accidental `GROUP BY` on every column) to `raw`; `row_limit` 1000 → 10000.

Grain is one row per **(Image Path, Fish ID)**.

## Verification

Real `superset import-dashboards` against `apache/superset:6.0.0` on the full bundle (existing pipeline assets + these): **exit 0, idempotent on second import**, dataset created with 7 columns / 3 metrics, all three charts attached to the dashboard. (The existing bundle had only ever been yamllint-checked, never import-tested.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)