### PR TITLE
fix(web): repoint landing dashboard links (all 3 were 404ing)

### DIFF
--- a/apps/fishsense-lite-web/lib/static-links.ts
+++ b/apps/fishsense-lite-web/lib/static-links.ts
@@ -10,22 +10,25 @@ const ANALYTICS_BASE =
   "https://analytics.fishsense.e4e.ucsd.edu/superset/dashboard";
 
 // Temporal moved to the shared krg-prod cluster at the Incus migration; the
-// old in-orchestrator `workflows.fishsense.e4e.ucsd.edu` UI is gone. Set
-// WORKFLOWS_URL to the current UI (if any is exposed to tenants) — the
-// default below is the retired host and only a placeholder.
+// old in-orchestrator `workflows.fishsense.e4e.ucsd.edu` UI is gone. The krg
+// Temporal Web UI is namespace-scoped — the default deep-links to the
+// fishsense namespace. Override with WORKFLOWS_URL if the host/path changes.
 const WORKFLOWS_URL =
-  process.env.WORKFLOWS_URL ?? "https://workflows.fishsense.e4e.ucsd.edu/";
+  process.env.WORKFLOWS_URL ?? "https://workflows.krg.ucsd.edu/namespaces/fishsense";
 
+// Superset dashboard slugs (from the committed asset bundle under
+// deploy/incus/superset_volumes/docker/assets/dashboards/). These replaced the
+// retired hosted-Superset `reef-smile-*` slugs at the Incus migration.
 export const RESULTS_LINKS: StaticLink[] = [
   {
     title: "Lengths",
-    description: "Lengths dashboard from Apache Superset",
-    href: `${ANALYTICS_BASE}/reef-smile-lengths`,
+    description: "Fish length measurements dashboard from Apache Superset",
+    href: `${ANALYTICS_BASE}/fishsense-fish-measurements`,
   },
   {
     title: "Metrics",
-    description: "Metrics dashboard from Apache Superset",
-    href: `${ANALYTICS_BASE}/reef-smile-metrics`,
+    description: "Pipeline status dashboard from Apache Superset",
+    href: `${ANALYTICS_BASE}/fishsense-pipeline-status`,
   },
 ];
 

--- a/apps/fishsense-lite-web/tests/integration/dashboard.integration.test.ts
+++ b/apps/fishsense-lite-web/tests/integration/dashboard.integration.test.ts
@@ -45,17 +45,17 @@ describe("fishsense-lite-web SSR (against the local stack)", () => {
     expect(body).toContain("Lengths");
     expect(body).toContain("Metrics");
     expect(body).toContain(
-      "https://analytics.fishsense.e4e.ucsd.edu/superset/dashboard/reef-smile-lengths",
+      "https://analytics.fishsense.e4e.ucsd.edu/superset/dashboard/fishsense-fish-measurements",
     );
     expect(body).toContain(
-      "https://analytics.fishsense.e4e.ucsd.edu/superset/dashboard/reef-smile-metrics",
+      "https://analytics.fishsense.e4e.ucsd.edu/superset/dashboard/fishsense-pipeline-status",
     );
   });
 
   it("renders the Administration section with the Temporal Workflows link", () => {
     expect(body).toContain("Administration");
     expect(body).toContain("Workflows");
-    expect(body).toContain("https://workflows.fishsense.e4e.ucsd.edu/");
+    expect(body).toContain("https://workflows.krg.ucsd.edu/namespaces/fishsense");
   });
 
   it("collapses labeling sections when the local DB has no LS-attributed labels", () => {


### PR DESCRIPTION
## Problem

Every link on the public landing page (https://fishsense.e4e.ucsd.edu/) 404s. Confirmed live — the page renders exactly three static cards, all pointing at retired hosts/slugs:

| Card | Was pointing at | Status |
|---|---|---|
| Lengths | `…/superset/dashboard/reef-smile-lengths` | retired hosted-Superset slug |
| Metrics | `…/superset/dashboard/reef-smile-metrics` | retired hosted-Superset slug |
| Workflows | `https://workflows.fishsense.e4e.ucsd.edu/` | retired host (Temporal moved to krg-prod) |

The deploy (`deploy/incus/compose.yml` `web` service) sets no `ANALYTICS_BASE`/`WORKFLOWS_URL` override, so these code defaults in `lib/static-links.ts` are exactly what renders in prod.

## Fix

- **Lengths** → `fishsense-fish-measurements` — the reshaped Superset dashboard from #300
- **Metrics** → `fishsense-pipeline-status` — the already-shipped pipeline dashboard bundle
- **Workflows** → `https://workflows.krg.ucsd.edu/namespaces/fishsense` — krg-prod Temporal Web UI, deep-linked to the fishsense namespace

Updated the SSR integration test that had pinned the stale URLs. That test only runs against a live local stack (separate vitest config), which is why it never flagged the drift in normal CI.

## Deploy dependency

- The **Metrics** target (`fishsense-pipeline-status`) already exists in the Superset bundle on main.
- The **Lengths** target (`fishsense-fish-measurements`) only exists once **#300** merges and the converge re-imports the bundle. Merge #300 first (or together) or the Lengths card will 404 until then.
- This is a `fishsense-lite-web` code change, so it reaches prod on the normal release → promote → image-pin-bump cycle (deployed image is currently pinned `v0.7.2`).

## Verification

- `vitest run` — 50/50 unit tests pass
- `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)