### PR TITLE
fix(api-worker): wake NRP data-worker before laser-label validation fan-out

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/sync_label_studio_laser_labels_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/sync_label_studio_laser_labels_workflow.py
@@ -9,6 +9,11 @@ from temporalio.exceptions import WorkflowAlreadyStartedError
 
 from fishsense_shared import ExceptionGroupErrorLogging
 
+with workflow.unsafe.imports_passed_through():
+    from fishsense_api_workflow_worker.workflows._retry_policies import (
+        SCALING_RETRY_POLICY,
+    )
+
 PROJECT_CONCURRENCY = 4
 
 # Bound on concurrent per-dive validation child workflows. Each child
@@ -73,6 +78,22 @@ class SyncLabelStudioLaserLabelsWorkflow:
             args=(),
             schedule_to_close_timeout=timedelta(minutes=10),
         )
+
+        # Wake the NRP data-worker before fanning out validation children.
+        # The validation children run on `fishsense_data_processing_queue`,
+        # which scales to zero when idle; unlike every other data-worker
+        # parent, this workflow used to dispatch without scaling the pod
+        # up first, so the children sat unpolled and hit their 20-minute
+        # execution_timeout. Only wake when there's real work (mirrors the
+        # "never wake on a quiet hour" contract in
+        # ensure_data_worker_running_activity).
+        if complete_dive_ids:
+            await workflow.execute_activity(
+                "ensure_data_worker_running_activity",
+                args=(),
+                schedule_to_close_timeout=timedelta(minutes=5),
+                retry_policy=SCALING_RETRY_POLICY,
+            )
 
         validation_sem = asyncio.Semaphore(VALIDATION_CONCURRENCY)
 

--- a/services/fishsense-api-workflow-worker/tests/test_sync_label_studio_laser_labels_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_sync_label_studio_laser_labels_workflow.py
@@ -470,4 +470,4 @@ async def test_workflow_does_not_wake_data_worker_when_no_dives_complete():
                 task_queue="test-laser-sync-no-wake",
             )
 
-    assert ensure_calls == []
+    assert not ensure_calls

--- a/services/fishsense-api-workflow-worker/tests/test_sync_label_studio_laser_labels_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_sync_label_studio_laser_labels_workflow.py
@@ -174,6 +174,10 @@ async def test_workflow_dispatches_validation_child_per_complete_dive():
     async def stub_get_complete_dives() -> List[int]:
         return [10, 20, 30]
 
+    @activity.defn(name="ensure_data_worker_running_activity")
+    async def stub_ensure() -> int:
+        return 1
+
     @activity.defn(name="validate_laser_labels_for_dive_activity")
     async def stub_validate(dive_id: int) -> int:
         validated.append(dive_id)
@@ -190,6 +194,7 @@ async def test_workflow_dispatches_validation_child_per_complete_dive():
                 stub_get_ids,
                 stub_sync_project,
                 stub_get_complete_dives,
+                stub_ensure,
             ],
         ):
             async with Worker(
@@ -303,6 +308,10 @@ async def test_workflow_completes_when_validation_children_fail():
     async def stub_get_complete_dives() -> List[int]:
         return [1, 2, 3]
 
+    @activity.defn(name="ensure_data_worker_running_activity")
+    async def stub_ensure() -> int:
+        return 1
+
     @activity.defn(name="validate_laser_labels_for_dive_activity")
     async def stub_validate_fails(dive_id: int) -> int:
         raise ApplicationError(
@@ -321,6 +330,7 @@ async def test_workflow_completes_when_validation_children_fail():
                 stub_get_ids,
                 stub_sync_project,
                 stub_get_complete_dives,
+                stub_ensure,
             ],
         ):
             async with Worker(
@@ -340,3 +350,124 @@ async def test_workflow_completes_when_validation_children_fail():
                     ),
                     timeout=30.0,
                 )
+
+
+@pytest.mark.asyncio
+async def test_workflow_wakes_data_worker_before_dispatching_validation():
+    """Regression: the validation children run on the scale-to-zero
+    data-worker queue, so the parent must scale the pod up
+    (`ensure_data_worker_running_activity`) before fanning them out —
+    otherwise they sit unpolled and hit their execution_timeout. The wake
+    must happen before any validation child runs."""
+    events: List[str] = []
+
+    @activity.defn(name="sync_users_label_studio_activity")
+    async def stub_sync_users() -> None:
+        return None
+
+    @activity.defn(name="get_laser_label_studio_project_ids_activity")
+    async def stub_get_ids() -> List[int]:
+        return []
+
+    @activity.defn(name="sync_laser_labels_for_label_studio_project_activity")
+    async def stub_sync_project(_: int) -> None:
+        return None
+
+    @activity.defn(name="get_dives_with_complete_laser_labeling_activity")
+    async def stub_get_complete_dives() -> List[int]:
+        return [10, 20, 30]
+
+    @activity.defn(name="ensure_data_worker_running_activity")
+    async def stub_ensure() -> int:
+        events.append("ensure")
+        return 1
+
+    @activity.defn(name="validate_laser_labels_for_dive_activity")
+    async def stub_validate(dive_id: int) -> int:
+        events.append(f"validate-{dive_id}")
+        return 0
+
+    queue_parent = "test-laser-sync-wake-parent"
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=queue_parent,
+            workflows=[SyncLabelStudioLaserLabelsWorkflow],
+            activities=[
+                stub_sync_users,
+                stub_get_ids,
+                stub_sync_project,
+                stub_get_complete_dives,
+                stub_ensure,
+            ],
+        ):
+            async with Worker(
+                env.client,
+                task_queue=DATA_PROCESSING_TASK_QUEUE,
+                workflows=[_StubValidateChildWorkflow],
+                activities=[stub_validate],
+            ):
+                await env.client.execute_workflow(
+                    SyncLabelStudioLaserLabelsWorkflow.run,
+                    id=f"test-laser-sync-wake-{uuid.uuid4()}",
+                    task_queue=queue_parent,
+                )
+
+    # Woken exactly once, and strictly before any validation child ran.
+    assert events.count("ensure") == 1
+    assert events[0] == "ensure"
+    assert {e for e in events if e.startswith("validate-")} == {
+        "validate-10",
+        "validate-20",
+        "validate-30",
+    }
+
+
+@pytest.mark.asyncio
+async def test_workflow_does_not_wake_data_worker_when_no_dives_complete():
+    """The wake is guarded on there being real work: when no dives are
+    complete, the parent must not scale the data-worker up (mirrors the
+    'never wake on a quiet hour' contract)."""
+    ensure_calls: List[str] = []
+
+    @activity.defn(name="sync_users_label_studio_activity")
+    async def stub_sync_users() -> None:
+        return None
+
+    @activity.defn(name="get_laser_label_studio_project_ids_activity")
+    async def stub_get_ids() -> List[int]:
+        return []
+
+    @activity.defn(name="sync_laser_labels_for_label_studio_project_activity")
+    async def stub_sync_project(_: int) -> None:
+        return None
+
+    @activity.defn(name="get_dives_with_complete_laser_labeling_activity")
+    async def stub_get_complete_dives() -> List[int]:
+        return []
+
+    @activity.defn(name="ensure_data_worker_running_activity")
+    async def stub_ensure() -> int:
+        ensure_calls.append("ensure")
+        return 1
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-laser-sync-no-wake",
+            workflows=[SyncLabelStudioLaserLabelsWorkflow],
+            activities=[
+                stub_sync_users,
+                stub_get_ids,
+                stub_sync_project,
+                stub_get_complete_dives,
+                stub_ensure,
+            ],
+        ):
+            await env.client.execute_workflow(
+                SyncLabelStudioLaserLabelsWorkflow.run,
+                id=f"test-laser-sync-no-wake-{uuid.uuid4()}",
+                task_queue="test-laser-sync-no-wake",
+            )
+
+    assert ensure_calls == []


### PR DESCRIPTION
## Symptom

`validate-laser-labels-*` workflows time out. Debugged run `validate-laser-labels-1` (`019f70ce-8455-7dfc-9aa5-b019266cc6b6`) live on the slot:

```
[1] WORKFLOW_EXECUTION_STARTED     16:00:10
[2] WORKFLOW_TASK_SCHEDULED
[3] WORKFLOW_EXECUTION_TIMED_OUT    16:20:10   (retryState=TIMEOUT)
```

The workflow task was **scheduled but never started** — nothing polled it, and it died at the 20-minute `execution_timeout`.

| Check (read-only, on-slot) | Result |
|---|---|
| Pollers on `fishsense_data_processing_queue` | **0** |
| Pollers on `fishsense_api_queue` | 1 (healthy) |
| NRP Deployment `fishsense-data-processing-workflow-worker` | exists, `spec.replicas: 0` (idle scale-to-zero) |

So the NRP data-worker is deployed and scale-to-zero works — it was simply idle at 0 replicas and nobody woke it.

## Root cause

Every data-worker parent calls `ensure_data_worker_running_activity` to scale the pod up before dispatching a child — **7 of them do**. `SyncLabelStudioLaserLabelsWorkflow` was the lone exception: it fans out `ValidateLaserLabelsForDiveWorkflow` children onto the scale-to-zero queue without waking the worker. Whenever the hourly laser sync's validation pass ran while the worker was scaled down, every child sat unpolled and timed out.

## Fix

Add the standard wake-up before the validation fan-out, guarded on there being work:

```python
if complete_dive_ids:
    await workflow.execute_activity(
        "ensure_data_worker_running_activity",
        args=(),
        schedule_to_close_timeout=timedelta(minutes=5),
        retry_policy=SCALING_RETRY_POLICY,
    )
```

Matches the sibling-parent convention exactly (5m `schedule_to_close`, `SCALING_RETRY_POLICY`). Cold start is safe within the children's 20m `execution_timeout`, and running validation children keep the :55 idle-sweeper from scaling back down mid-pass.

## Tests

- New `test_workflow_wakes_data_worker_before_dispatching_validation` — asserts the wake fires exactly once and strictly before any validation child.
- New `test_workflow_does_not_wake_data_worker_when_no_dives_complete` — asserts the guard skips the wake when no dives are complete.
- Existing non-empty-dive tests register the wake stub.
- **7/7** in the file; **207 passed, 3 skipped** in the api-worker unit suite (`-m "not integration"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)