### PR TITLE
feat(populate-species): make species populate idempotent for scheduling

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_species_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_species_label_studio_project_activity.py
@@ -9,10 +9,15 @@ validator's `_positive_xy` already use as "usable laser." Cascading
 from lasers lets species labeling kick off in parallel with head/tail
 (stage 5.1) as soon as laser labelers + the validator sign off.
 
-A supersede pass at the end marks previously-incomplete species rows
-for the dive as `superseded=True` so newly-created rows are canonical
-(mirrors headtail). `SpeciesLabel` gained a `superseded` column for
-uniform dead-letter semantics across all four label types.
+The activity is **idempotent** so it can run on a schedule: an image
+that already carries a non-superseded species row for the target
+project is skipped (no duplicate LS task), and the end-of-run supersede
+pass only dead-letters previously-incomplete rows belonging to a
+*different* (stale/old) project — the target project's own in-progress
+rows are left untouched. A re-run with no newly-laser-valid images
+imports nothing and writes nothing. `SpeciesLabel` gained a
+`superseded` column for uniform dead-letter semantics across all four
+label types.
 """
 
 from typing import List
@@ -47,21 +52,39 @@ def _select_target_images(
     laser_labels: List[LaserLabel],
     images_by_id: dict[int, Image],
     existing_species_labels: List[SpeciesLabel],
+    project_id: int,
 ) -> List[Image]:
     """Pick the images that need a fresh species LS task.
 
     Source: laser labels passing `_is_valid_laser`.
-    Filter: drop any image whose existing species label is already
-    completed (so re-running is a no-op for finished work).
+    Filter (idempotent — safe to schedule):
+      - drop any image whose existing species label is already
+        completed (finished work is a no-op on re-run);
+      - drop any image that already carries a *non-superseded* species
+        row for THIS project — a prior run already imported its task, so
+        a scheduled re-run must not re-import a duplicate LS task.
+
+    An image whose only species row is superseded, or belongs to a
+    different (stale/old) project, is still selected: that's the
+    migrate-onto-the-current-project path, and it stays idempotent
+    because the row this run writes then satisfies the second filter on
+    the next run.
     """
     completed_ids = {
         label.image_id for label in existing_species_labels if label.completed
+    }
+    already_in_project_ids = {
+        label.image_id
+        for label in existing_species_labels
+        if label.label_studio_project_id == project_id and not label.superseded
     }
     selected: List[Image] = []
     for label in laser_labels:
         if not _is_valid_laser(label):
             continue
         if label.image_id in completed_ids:
+            continue
+        if label.image_id in already_in_project_ids:
             continue
         image = images_by_id.get(label.image_id)
         if image is not None:
@@ -104,7 +127,7 @@ async def populate_species_label_studio_project_activity(
                 images_by_id[image.id] = image
 
         targets = _select_target_images(
-            laser_labels, images_by_id, existing_species
+            laser_labels, images_by_id, existing_species, project_id
         )
 
         new_count = 0
@@ -149,12 +172,17 @@ async def populate_species_label_studio_project_activity(
                 dive_id,
             )
 
-        # Supersede pass: mark previously-incomplete species labels for this
-        # dive as superseded so newly-created rows are canonical. Mirrors the
-        # headtail activity. Only acts on already-persisted rows (id set); the
-        # fresh rows from _record above aren't in `existing_species`.
+        # Supersede pass: dead-letter previously-incomplete species rows that
+        # belong to a *different* (stale/old) project so the current project's
+        # rows are canonical. Rows already in `project_id` are this project's
+        # live tasks and are left untouched — that's what makes a re-run
+        # idempotent and the activity safe to schedule. Only acts on
+        # already-persisted rows (id set); the fresh rows from _record above
+        # aren't in `existing_species`.
         for old in existing_species:
             if old.completed or old.superseded or old.id is None:
+                continue
+            if old.label_studio_project_id == project_id:
                 continue
             old.superseded = True
             await fs.labels.put_species_label(old.image_id, old)

--- a/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_activity.py
@@ -5,10 +5,11 @@ images carrying a *valid* LaserLabel (completed=True, superseded=False,
 both x/y populated) are candidates — same gate as head/tail. Cascades
 from laser labelers + the validator signing off.
 
-Unlike head/tail, there is no supersede pass here because
-`SpeciesLabel` has no `superseded` column. The cohort selector's
-"no non-sentinel species row" predicate is what prevents re-imports;
-a partial prior run's stale rows linger until manual cleanup.
+The activity is idempotent so it can run on a schedule: an image that
+already has a non-superseded species row for the target project is not
+re-imported, and the end-of-run supersede pass only dead-letters
+incomplete rows in *other* (stale) projects — never the target
+project's own in-progress rows.
 """
 
 from __future__ import annotations
@@ -116,9 +117,25 @@ def test_select_targets_filters_by_valid_laser_and_drops_completed():
     }
     existing = [_species_label(1, completed=True)]
 
-    selected = sut._select_target_images(laser, images_by_id, existing)  # pylint: disable=protected-access
+    selected = sut._select_target_images(laser, images_by_id, existing, 70)  # pylint: disable=protected-access
 
     assert [img.id for img in selected] == [3]
+
+
+def test_select_targets_skips_images_already_in_this_project():
+    """Idempotency filter: an image with a non-superseded species row for
+    the *target* project is not re-selected, but one whose only row is in
+    a different (stale) project still is."""
+    laser = [_laser(1), _laser(2)]
+    images_by_id = {1: _image(1, "a"), 2: _image(2, "b")}
+    existing = [
+        _species_label(1, completed=False, project_id=70),   # already in target -> skip
+        _species_label(2, completed=False, project_id=99),   # stale old project -> keep
+    ]
+
+    selected = sut._select_target_images(laser, images_by_id, existing, 70)  # pylint: disable=protected-access
+
+    assert [img.id for img in selected] == [2]
 
 
 def test_build_task_uses_groups_jpeg_folder_and_dual_keys(monkeypatch):
@@ -172,12 +189,12 @@ def _make_ls_client(returned_task_ids: List[int]):
 
 @pytest.mark.asyncio
 async def test_imports_targets_and_writes_new_labels(monkeypatch):
-    """Image 1 has a completed old row -> skip. Image 2 has an
-    incomplete old row with id -> get a new task. Image 3 is fresh ->
-    get a new task. Image 4 has an incomplete old row but no id -> get
-    a new task. The activity writes only fresh (id=None) rows; stale
-    incomplete rows are left in place because SpeciesLabel has no
-    `superseded` column."""
+    """Migration path onto a fresh project (70), with stale rows in an
+    old project (99). Image 1 has a completed old row -> skip. Image 2
+    has an incomplete stale-project row with id -> new task + the stale
+    row is superseded. Image 3 is fresh -> new task. Image 4 has an
+    incomplete stale-project row but no id -> new task, stale row left
+    (can't supersede an unpersisted row)."""
     laser = [
         _laser(1),
         _laser(2),
@@ -191,9 +208,9 @@ async def test_imports_targets_and_writes_new_labels(monkeypatch):
         4: _image(4, "d"),
     }
     existing = [
-        _species_label(1, completed=True),
-        _species_label(2, completed=False, has_id=True),
-        _species_label(4, completed=False, has_id=False),
+        _species_label(1, completed=True, project_id=99),
+        _species_label(2, completed=False, has_id=True, project_id=99),
+        _species_label(4, completed=False, has_id=False, project_id=99),
     ]
 
     fs = _make_fs_client(laser, existing, images_by_id)
@@ -221,10 +238,11 @@ async def test_imports_targets_and_writes_new_labels(monkeypatch):
 @pytest.mark.asyncio
 async def test_no_valid_laser_targets_skips_import_but_supersedes_stale(monkeypatch):
     """No laser-valid images -> no task import, but the supersede pass still
-    retires a pre-existing incomplete-with-id species row."""
+    retires a pre-existing incomplete-with-id species row in a stale
+    (different) project."""
     laser = [_laser(1, completed=False)]
     images_by_id = {1: _image(1, "a")}
-    existing = [_species_label(1, completed=False, has_id=True)]
+    existing = [_species_label(1, completed=False, has_id=True, project_id=99)]
 
     fs = _make_fs_client(laser, existing, images_by_id)
     ls = _make_ls_client(returned_task_ids=[])
@@ -240,6 +258,36 @@ async def test_no_valid_laser_targets_skips_import_but_supersedes_stale(monkeypa
     ls.projects.import_tasks.assert_not_called()
     written = [c.args[1] for c in fs.labels.put_species_label.await_args_list]
     assert [(w.image_id, w.superseded) for w in written] == [(1, True)]
+
+
+@pytest.mark.asyncio
+async def test_rerun_is_idempotent_for_same_project(monkeypatch):
+    """Scheduling invariant: a re-run where every laser-valid image
+    already has a non-superseded task row *for this project* imports
+    nothing and supersedes nothing — so the activity can be put on a
+    schedule without churning duplicate LS tasks."""
+    laser = [_laser(1), _laser(2)]
+    images_by_id = {1: _image(1, "a"), 2: _image(2, "b")}
+    # both already have a live (non-superseded, incomplete) task in project 70
+    existing = [
+        _species_label(1, completed=False, project_id=70),
+        _species_label(2, completed=False, project_id=70),
+    ]
+
+    fs = _make_fs_client(laser, existing, images_by_id)
+    ls = _make_ls_client(returned_task_ids=[])
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+
+    n = await ActivityEnvironment().run(
+        sut.populate_species_label_studio_project_activity, 42, 70
+    )
+
+    assert n == 0
+    ls.projects.import_tasks.assert_not_called()
+    # the project's own in-progress rows are left untouched (no supersede churn)
+    assert not fs.labels.put_species_label.await_args_list
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why
To put `PopulateSpeciesLabelStudioProjectWorkflow` on a **schedule**, its activity must be idempotent. Today it isn't:

1. `_select_target_images` skips only **completed** images, so an already-populated-but-unlabeled image gets a **duplicate** LS task on every run.
2. The end-of-run supersede pass dead-letters **the project's own** in-progress rows, forcing recreation each run.

## Change
- `_select_target_images(..., project_id)` also skips images that already carry a **non-superseded species row for the target project** — a prior run already imported that task.
- The supersede pass only dead-letters incomplete rows in **other** (stale/old) projects; the target project's live rows are left untouched.

Net: a re-run with no newly-laser-valid images imports nothing and writes nothing. The migrate-stale-old-project-rows path (used when moving a dive onto a fresh hosted project) is preserved and is itself idempotent — the row written this run satisfies the skip filter next run.

## Tests (TDD)
- New `test_rerun_is_idempotent_for_same_project`: every laser-valid image already has a live task in the target project → 0 imports, 0 writes (red before the change).
- New `test_select_targets_skips_images_already_in_this_project`.
- Updated the migrate/supersede tests to place stale rows in a *different* project (the scenario the supersede pass now targets).
- pylint 10.00/10, `pytest` green (7 passed).

Pairs with #307 (Garage endpoint fix) toward populating the stuck species dives onto hosted Label Studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)