### PR TITLE
feat(populate-species): scheduled populate parent (decoupled, superseded-aware)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,27 @@ on-demand (`temporal workflow start` with a `dive_id` for populate,
 no args for create). The eight workflows are: Create/Populate ×
 Laser/Species/HeadTail/DiveSlate.
 
-The four populate workflows are also dispatched automatically as
-child workflows from the matching preprocess parent (stages 0.1 →
-laser, 2 → species, 5.1 → headtail, 9 → dive-slate). After
+**Species populate is decoupled (scheduled parent).** As of the
+`PopulateSpeciesLabelStudioProjectParentWorkflow`, the stage-2
+preprocess parent no longer chains into
+`PopulateSpeciesLabelStudioProjectWorkflow` — it only writes JPEGs.
+A dedicated hourly parent (schedule `populate-species-labels-workflow-schedule`,
++20 min, SKIP overlap) selects the **superseded-aware** cohort via
+`GET /api/v1/dives/needing-species-population/` (HIGH + laser-valid
+image with no *non-superseded* real-project species row — so dives
+whose old-project rows were superseded, e.g. post hosted-LS migration,
+re-enter) and fans out the populate child per dive. The populate
+activity is now **idempotent** (skips images already having a
+non-superseded row for the target project; supersede pass only
+dead-letters *other*-project rows) and **JPEG-gated** (per-image
+`ObjectStoreClient.has_processed_jpeg` — never seeds a species row
+before the stage-2 JPEG exists, which would strand the image outside
+the preprocess cohort). Laser/headtail/dive-slate populate are still
+preprocess-dispatched (below); only species is decoupled so far.
+
+The other three populate workflows are still dispatched automatically
+as child workflows from the matching preprocess parent (stages 0.1 →
+laser, 5.1 → headtail, 9 → dive-slate). After
 `cleanup_raw_bytes_for_dive_activity` (Garage raw-scratch eviction),
 the parent runs
 `execute_child_workflow("Populate<Stage>LabelStudioProjectWorkflow",
@@ -205,7 +223,9 @@ one replica):
   SDK upserts.
 
 Applied to stages 0.1, 1, 2, 5.1, 9, 13, 14 — each parent runs hourly.
-Schedule slots: 0.1 at +0, 1 at +5, 2 at +15, 5.1 at +30, 14 at +40,
+Schedule slots: 0.1 at +0, 1 at +5, 2 at +15, species-populate at +20
+(the decoupled `PopulateSpeciesLabelStudioProjectParentWorkflow`, just
+after the +15 species-preprocess writes JPEGs), 5.1 at +30, 14 at +40,
 9 at +45, 13 at +50 min — staggered so their selectors don't all hit
 `dives.get()` at the top of the hour. The scale-to-zero sweeper takes
 +55. `test_schedule_registration.py` pins the stagger (the four

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
@@ -113,6 +113,15 @@ class DiveClient(ClientBase):
         """Stage 14 cohort selector. See `select_next_for_laser_preprocessing`."""
         return await self._select_next("measure-fish")
 
+    async def get_dives_needing_species_population(self) -> list[int]:
+        """Every dive needing species LS tasks (re)populated onto a live
+        project — superseded-aware, returns *all* matches (not one), so
+        the scheduled populate parent can fan out one populate child per
+        dive. See the `needing-species-population` endpoint docstring."""
+        response = await self._get("/api/v1/dives/needing-species-population/")
+        response.raise_for_status()
+        return response.json() or []
+
     async def _select_next(self, cohort: str) -> int | None:
         response = await self._get(f"/api/v1/dives/select-next/{cohort}/")
         response.raise_for_status()

--- a/libs/fishsense-api-sdk/tests/clients/test_dive_client.py
+++ b/libs/fishsense-api-sdk/tests/clients/test_dive_client.py
@@ -248,3 +248,35 @@ class TestDiveClient:
                 assert payload["camera_id"] == 12
                 assert payload["laser_position"] == [1.0, 2.0, 3.0]
                 assert payload["laser_axis"] == [0.0, 0.0, 1.0]
+
+    async def test_get_dives_needing_species_population_returns_list(self):
+        """Returns the full list of dive ids from the population endpoint."""
+        client = _make_client()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [3, 7, 11]
+        mock_response.raise_for_status = Mock()
+
+        with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            async with client:
+                result = await client.get_dives_needing_species_population()
+                assert result == [3, 7, 11]
+                mock_get.assert_awaited_once_with(
+                    "/api/v1/dives/needing-species-population/"
+                )
+
+    async def test_get_dives_needing_species_population_empty_on_null(self):
+        """A null/absent body degrades to an empty list, not None."""
+        client = _make_client()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = None
+        mock_response.raise_for_status = Mock()
+
+        with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            async with client:
+                assert await client.get_dives_needing_species_population() == []

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_species_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_species_label_studio_project_activity.py
@@ -32,10 +32,40 @@ from fishsense_api_workflow_worker.activities.populate_utils import (
     import_tasks_and_record_labels,
 )
 from fishsense_api_workflow_worker.activities.utils import get_fs_client
+from fishsense_api_workflow_worker.object_store import open_object_store_client
 
 # Physical Garage prefix the data-worker writes species JPEGs to
 # (stage 2). Was the nginx virtual name "groups_jpeg".
 SPECIES_FOLDER = "preprocess_groups_jpeg"
+
+
+async def _gate_on_jpeg_presence(images: List[Image]) -> List[Image]:
+    """Keep only images whose stage-2 species JPEG is already in Garage.
+
+    When populate runs decoupled from preprocess (on its own schedule),
+    seeding a species row for an image whose JPEG isn't written yet would
+    satisfy the preprocess cohort's "has species row" exit — the image
+    would then never get preprocessed and its LS task would point at a
+    missing JPEG forever. Gating on JPEG existence defers those images to
+    a later run (once preprocess has written them); it's a no-op when
+    populate is chained right after preprocess (all JPEGs present).
+    """
+    if not images:
+        return images
+    store = open_object_store_client()
+    present: List[Image] = []
+    for image in images:
+        if await store.has_processed_jpeg(SPECIES_FOLDER, image.checksum):
+            present.append(image)
+        else:
+            activity.logger.info(
+                "species JPEG not yet in Garage for image %d (checksum=%s); "
+                "deferring to a later populate run",
+                image.id,
+                image.checksum,
+            )
+        activity.heartbeat()
+    return present
 
 
 def _is_valid_laser(label: LaserLabel) -> bool:
@@ -129,6 +159,10 @@ async def populate_species_label_studio_project_activity(
         targets = _select_target_images(
             laser_labels, images_by_id, existing_species, project_id
         )
+        # Only import tasks for images whose species JPEG is already in
+        # Garage (see `_gate_on_jpeg_presence`). Deferred images stay in
+        # the cohort and are picked up on a later run.
+        targets = await _gate_on_jpeg_presence(targets)
 
         new_count = 0
         if targets:

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_dives_needing_species_population_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_dives_needing_species_population_activity.py
@@ -1,0 +1,31 @@
+"""Activity: list every dive that needs species LS tasks (re)populated.
+
+Superseded-aware cohort (see the api's `needing-species-population`
+endpoint): HIGH-priority dives with a laser-valid image that has no
+non-superseded, real-project SpeciesLabel row. Returns *all* matches so
+the scheduled populate parent fans out one populate child per dive.
+Unlike the species-preprocessing selector, a dive whose old-project
+species rows were superseded (post hosted-LS migration) re-enters the
+cohort here.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.utils import get_fs_client
+
+
+@activity.defn
+async def select_dives_needing_species_population_activity() -> List[int]:
+    async with get_fs_client() as fs:
+        dive_ids = await fs.dives.get_dives_needing_species_population()
+
+    activity.logger.info(
+        "%d dive(s) need species population: %s",
+        len(dive_ids),
+        dive_ids,
+    )
+    return dive_ids

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/object_store.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/object_store.py
@@ -56,6 +56,16 @@ def slate_pdf_key(slate_id: int) -> str:
     return f"{SLATE_PDF_PREFIX}/{slate_id}.pdf"
 
 
+def processed_jpeg_key(folder: str, checksum: str) -> str:
+    """Physical Garage key for a data-worker-written processed JPEG.
+
+    `folder` is the per-stage prefix (`preprocess_groups_jpeg`,
+    `preprocess_jpeg`, `preprocess_headtail_jpeg`,
+    `preprocess_slate_images_jpeg`) — the exact key the JPEG lives at.
+    """
+    return f"{folder}/{checksum}.JPG"
+
+
 def build_s3_client(
     *, endpoint_url: str, region: str, access_key: str, secret_key: str
 ):
@@ -136,6 +146,15 @@ class ObjectStoreClient:
 
     async def has_raw(self, checksum: str) -> bool:
         return await self._exists(raw_key(checksum))
+
+    async def has_processed_jpeg(self, folder: str, checksum: str) -> bool:
+        """True iff the data-worker has already written this stage's
+        processed JPEG to Garage. Used by the scheduled species-populate
+        activity to gate task import on the JPEG existing (a decoupled
+        populate must never seed rows for an image whose JPEG isn't
+        written yet — that would drop the dive out of the preprocess
+        cohort with a broken image)."""
+        return await self._exists(processed_jpeg_key(folder, checksum))
 
     async def upload_raw(self, checksum: str, data: bytes) -> None:
         await self._put(raw_key(checksum), data)

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -96,6 +96,9 @@ from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for
 from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for_species_preprocessing_activity import (  # pylint: disable=line-too-long
     select_next_high_priority_dive_for_species_preprocessing_activity,
 )
+from fishsense_api_workflow_worker.activities.select_dives_needing_species_population_activity import (  # pylint: disable=line-too-long
+    select_dives_needing_species_population_activity,
+)
 from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for_headtail_preprocessing_activity import (  # pylint: disable=line-too-long
     select_next_high_priority_dive_for_headtail_preprocessing_activity,
 )
@@ -159,6 +162,9 @@ from fishsense_api_workflow_worker.workflows.populate_laser_label_studio_project
 )
 from fishsense_api_workflow_worker.workflows.populate_species_label_studio_project_workflow import (  # pylint: disable=line-too-long
     PopulateSpeciesLabelStudioProjectWorkflow,
+)
+from fishsense_api_workflow_worker.workflows.populate_species_label_studio_project_parent_workflow import (  # pylint: disable=line-too-long
+    PopulateSpeciesLabelStudioProjectParentWorkflow,
 )
 from fishsense_api_workflow_worker.workflows.cluster_dive_frames_parent_workflow import (  # pylint: disable=line-too-long
     ClusterDiveFramesParentWorkflow,
@@ -339,6 +345,23 @@ async def schedule_workflows(client: Client):
                     overlap=ScheduleOverlapPolicy.SKIP,
                 )
             )
+            # Species populate parent: hourly at +20 min, just after the
+            # +15 species-preprocess firing has written the JPEGs.
+            # Decoupled from preprocess (which no longer chains into
+            # populate). The activity is idempotent + JPEG-gated so
+            # SKIP-overlap hourly firings converge — images whose JPEG
+            # isn't written yet defer to the next run.
+            tg.create_task(
+                schedule_workflow(
+                    client,
+                    "populate-species-labels-workflow-schedule",
+                    PopulateSpeciesLabelStudioProjectParentWorkflow,
+                    timedelta(hours=1),
+                    offset=timedelta(minutes=20),
+                    run_timeout=timedelta(hours=1),
+                    overlap=ScheduleOverlapPolicy.SKIP,
+                )
+            )
             tg.create_task(
                 schedule_workflow(
                     client,
@@ -458,6 +481,7 @@ async def main():
                 CreateDiveSlateLabelStudioProjectWorkflow,
                 PopulateLaserLabelStudioProjectWorkflow,
                 PopulateSpeciesLabelStudioProjectWorkflow,
+                PopulateSpeciesLabelStudioProjectParentWorkflow,
                 PopulateHeadTailLabelStudioProjectWorkflow,
                 PopulateDiveSlateLabelStudioProjectWorkflow,
                 UpdateDiveImageGroupsWorkflow,
@@ -500,6 +524,7 @@ async def main():
                 select_next_high_priority_dive_for_clustering_activity,
                 select_next_high_priority_dive_for_laser_preprocessing_activity,
                 select_next_high_priority_dive_for_species_preprocessing_activity,
+                select_dives_needing_species_population_activity,
                 select_next_high_priority_dive_for_headtail_preprocessing_activity,
                 select_next_high_priority_dive_for_slate_preprocessing_activity,
                 select_next_high_priority_dive_for_laser_calibration_activity,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/populate_species_label_studio_project_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/populate_species_label_studio_project_parent_workflow.py
@@ -1,0 +1,88 @@
+"""Scheduled parent: (re)populate species LS tasks for every dive needing it.
+
+Selects the superseded-aware "needs species population" cohort (see the
+api's `needing-species-population` endpoint) and fans out one
+`PopulateSpeciesLabelStudioProjectWorkflow` child per dive. Populate is
+now the decoupled, scheduled home for species task import — the stage-2
+preprocess parent no longer chains into it.
+
+Safe to run on a schedule because the populate activity is idempotent
+(a dive with no new laser-valid images imports nothing) and JPEG-gated
+(images whose stage-2 JPEG isn't in Garage yet are deferred to a later
+run rather than seeded ahead of preprocess). One dive's failure doesn't
+abort the rest of the fan-out.
+"""
+
+import asyncio
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.common import WorkflowIDReusePolicy
+from temporalio.exceptions import WorkflowAlreadyStartedError
+
+from fishsense_shared import ExceptionGroupErrorLogging
+
+with workflow.unsafe.imports_passed_through():
+    from fishsense_api_workflow_worker.workflows._retry_policies import (
+        SDK_FAIL_FAST_RETRY_POLICY,
+    )
+
+# Bound on concurrent per-dive populate children. Each is a handful of
+# LS API calls + SDK upserts; keep it modest so a large backlog doesn't
+# hammer the hosted Label Studio import endpoint.
+POPULATE_CONCURRENCY = 4
+
+
+@workflow.defn
+class PopulateSpeciesLabelStudioProjectParentWorkflow:
+    # pylint: disable=too-few-public-methods
+    """Fan out species populate across every dive needing it.
+
+    Returns the list of dive_ids it dispatched (empty when the cohort is
+    empty).
+    """
+
+    @workflow.run
+    async def run(self) -> list[int]:
+        dive_ids = await workflow.execute_activity(
+            "select_dives_needing_species_population_activity",
+            args=(),
+            schedule_to_close_timeout=timedelta(minutes=5),
+            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+        )
+        if not dive_ids:
+            return []
+
+        sem = asyncio.Semaphore(POPULATE_CONCURRENCY)
+
+        async def __populate(dive_id: int) -> None:
+            async with sem:
+                try:
+                    await workflow.execute_child_workflow(
+                        "PopulateSpeciesLabelStudioProjectWorkflow",
+                        dive_id,
+                        # Deterministic id dedupes against an overlapping
+                        # firing; ALLOW_DUPLICATE (not FAILED_ONLY) so a
+                        # scheduled re-run can populate newly-laser-valid
+                        # images after the prior run closed — the child is
+                        # idempotent, so a no-op re-run is cheap.
+                        id=f"populate-species-{dive_id}",
+                        execution_timeout=timedelta(minutes=30),
+                        id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+                    )
+                except WorkflowAlreadyStartedError:
+                    workflow.logger.info(
+                        "populate-species-%d already running; skipping "
+                        "duplicate dispatch",
+                        dive_id,
+                    )
+
+        # suppress=True: one dive's populate failure must not abort the
+        # whole fan-out (mirrors SyncLabelStudioLaserLabelsWorkflow's
+        # validation pass).
+        async with ExceptionGroupErrorLogging(workflow.logger, suppress=True):
+            async with asyncio.TaskGroup() as tg:
+                for dive_id in dive_ids:
+                    tg.create_task(__populate(dive_id))
+
+        return dive_ids

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_species_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_species_images_parent_workflow.py
@@ -3,17 +3,21 @@
 Picks the next HIGH-priority dive needing species preprocessing,
 resolves its PREDICTION clusters + camera intrinsics + laser/species
 labels via SDK, and dispatches `PreprocessSpeciesImagesWorkflow` as a
-child on the data-worker (`fishsense_data_processing_queue`). After
-archive+cleanup, chains into `PopulateSpeciesLabelStudioProjectWorkflow`
-so the group-preprocessed JPEGs land in the per-dive species LS
-project in the same hourly run that produced them.
+child on the data-worker (`fishsense_data_processing_queue`). After the
+child writes the group-preprocessed JPEGs to Garage, it cleans up the
+staged raw scratch and stops there.
+
+Species LS-task population is **decoupled** from this workflow — it no
+longer chains into `PopulateSpeciesLabelStudioProjectWorkflow`. The
+hourly `PopulateSpeciesLabelStudioProjectParentWorkflow` (+20 min)
+selects the superseded-aware "needs species population" cohort and fans
+out the idempotent, JPEG-gated populate per dive. Decoupling lets dives
+whose old-project species rows were superseded (post hosted-LS
+migration) get (re)populated without re-preprocessing.
 
 Same cluster-correctness invariants as
 `PreprocessLaserImagesParentWorkflow` — see CLAUDE.md's "Cross-worker
-orchestration pattern" section. The populate child uses a
-deterministic id (`populate-species-{dive_id}`) so subsequent
-re-firings on the same cohort dive no-op via WorkflowAlreadyStarted
-rather than re-importing duplicate LS tasks.
+orchestration pattern" section.
 """
 
 from datetime import timedelta
@@ -119,19 +123,9 @@ class PreprocessSpeciesImagesParentWorkflow:
             heartbeat_timeout=timedelta(minutes=5),
         )
 
-        try:
-            await workflow.execute_child_workflow(
-                "PopulateSpeciesLabelStudioProjectWorkflow",
-                dive_id,
-                id=f"populate-species-{dive_id}",
-                execution_timeout=timedelta(minutes=30),
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
-            )
-        except WorkflowAlreadyStartedError:
-            workflow.logger.info(
-                "populate-species-%d already ran in a prior hourly firing; "
-                "skipping LS task import",
-                dive_id,
-            )
-
+        # NOTE: species LS-task population is decoupled from preprocess as
+        # of the scheduled-populate parent — this workflow only writes the
+        # JPEGs. `PopulateSpeciesLabelStudioProjectParentWorkflow`
+        # (hourly, +20 min) selects the superseded-aware cohort and fans
+        # out the idempotent, JPEG-gated populate per dive.
         return inputs.dive_id

--- a/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_activity.py
@@ -98,6 +98,16 @@ def _species_label(
     )
 
 
+@pytest.fixture(autouse=True)
+def _all_jpegs_present(monkeypatch):
+    """Default the JPEG gate to "present" so activity tests exercise the
+    import path; the gate test overrides this with a selective fake."""
+    store = MagicMock()
+    store.has_processed_jpeg = AsyncMock(return_value=True)
+    monkeypatch.setattr(sut, "open_object_store_client", lambda: store)
+    return store
+
+
 def test_select_targets_filters_by_valid_laser_and_drops_completed():
     laser = [
         _laser(1),                             # valid + completed species -> drop
@@ -258,6 +268,40 @@ async def test_no_valid_laser_targets_skips_import_but_supersedes_stale(monkeypa
     ls.projects.import_tasks.assert_not_called()
     written = [c.args[1] for c in fs.labels.put_species_label.await_args_list]
     assert [(w.image_id, w.superseded) for w in written] == [(1, True)]
+
+
+@pytest.mark.asyncio
+async def test_defers_images_whose_jpeg_is_not_in_garage(monkeypatch):
+    """JPEG gate: an image whose species JPEG isn't in Garage yet is not
+    imported (deferred to a later run), so a scheduled populate never
+    seeds a species row ahead of preprocess writing the JPEG — which
+    would strand the image outside the preprocess cohort."""
+    laser = [_laser(1), _laser(2)]
+    images_by_id = {1: _image(1, "aaa"), 2: _image(2, "bbb")}
+    existing: List[SpeciesLabel] = []
+
+    fs = _make_fs_client(laser, existing, images_by_id)
+    ls = _make_ls_client(returned_task_ids=[9001])  # only image 1 imports
+
+    store = MagicMock()
+
+    async def _has(_folder, checksum):
+        return checksum == "aaa"  # image 2's JPEG (bbb) is missing
+
+    store.has_processed_jpeg = AsyncMock(side_effect=_has)
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+    monkeypatch.setattr(sut, "open_object_store_client", lambda: store)
+
+    n = await ActivityEnvironment().run(
+        sut.populate_species_label_studio_project_activity, 42, 70
+    )
+
+    assert n == 1
+    written = [c.args[1] for c in fs.labels.put_species_label.await_args_list]
+    new_writes = [w for w in written if w.id is None]
+    assert {w.image_id for w in new_writes} == {1}  # image 2 deferred
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_parent_workflow.py
@@ -1,0 +1,108 @@
+# pylint: disable=unused-argument
+"""Workflow contract test for PopulateSpeciesLabelStudioProjectParentWorkflow."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from typing import List
+
+import pytest
+from temporalio import activity, workflow
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from fishsense_api_workflow_worker.workflows.populate_species_label_studio_project_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PopulateSpeciesLabelStudioProjectParentWorkflow,
+)
+
+
+@workflow.defn(name="PopulateSpeciesLabelStudioProjectWorkflow")
+class _StubPopulateWorkflow:
+    # pylint: disable=too-few-public-methods
+    @workflow.run
+    async def run(self, dive_id: int) -> int:
+        await workflow.execute_activity(
+            "_record_populate",
+            args=(workflow.info().workflow_id, dive_id),
+            schedule_to_close_timeout=timedelta(seconds=5),
+        )
+        return 0
+
+
+def _make_selector(dive_ids: List[int], calls: List[int]):
+    @activity.defn(name="select_dives_needing_species_population_activity")
+    async def select() -> List[int]:
+        calls.append(1)
+        return dive_ids
+
+    return select
+
+
+def _make_recorder(captures: List[tuple]):
+    @activity.defn(name="_record_populate")
+    async def record(workflow_id: str, dive_id: int) -> None:
+        captures.append((workflow_id, dive_id))
+
+    return record
+
+
+@pytest.mark.asyncio
+async def test_fans_out_idempotent_populate_child_per_dive():
+    dispatched: List[tuple] = []
+    selector_calls: List[int] = []
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-queue",
+            workflows=[
+                PopulateSpeciesLabelStudioProjectParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[
+                _make_selector([10, 20, 30], selector_calls),
+                _make_recorder(dispatched),
+            ],
+        ):
+            result = await env.client.execute_workflow(
+                PopulateSpeciesLabelStudioProjectParentWorkflow.run,
+                id=f"parent-{uuid.uuid4()}",
+                task_queue="test-queue",
+            )
+
+    assert result == [10, 20, 30]
+    assert len(selector_calls) == 1
+    assert {d for _, d in dispatched} == {10, 20, 30}
+    assert {wid for wid, _ in dispatched} == {
+        "populate-species-10",
+        "populate-species-20",
+        "populate-species-30",
+    }
+
+
+@pytest.mark.asyncio
+async def test_no_dispatch_when_cohort_empty():
+    dispatched: List[tuple] = []
+    selector_calls: List[int] = []
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-queue",
+            workflows=[
+                PopulateSpeciesLabelStudioProjectParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[
+                _make_selector([], selector_calls),
+                _make_recorder(dispatched),
+            ],
+        ):
+            result = await env.client.execute_workflow(
+                PopulateSpeciesLabelStudioProjectParentWorkflow.run,
+                id=f"parent-{uuid.uuid4()}",
+                task_queue="test-queue",
+            )
+
+    assert result == []
+    assert len(selector_calls) == 1
+    assert not dispatched

--- a/services/fishsense-api-workflow-worker/tests/test_preprocess_species_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preprocess_species_images_parent_workflow.py
@@ -157,7 +157,7 @@ async def test_dispatches_child_with_deterministic_id_and_clusters():
     # Populate is decoupled now — the preprocess parent no longer chains
     # into PopulateSpeciesLabelStudioProjectWorkflow (the scheduled
     # PopulateSpeciesLabelStudioProjectParentWorkflow owns it).
-    assert populate_runs == []
+    assert not populate_runs
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-api-workflow-worker/tests/test_preprocess_species_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preprocess_species_images_parent_workflow.py
@@ -154,7 +154,10 @@ async def test_dispatches_child_with_deterministic_id_and_clusters():
     assert child_id == "preprocess-species-440"
     assert child_dive_id == 440
     assert flat == ["a", "b", "c"]
-    assert populate_runs == [("populate-species-440", 440)]
+    # Populate is decoupled now — the preprocess parent no longer chains
+    # into PopulateSpeciesLabelStudioProjectWorkflow (the scheduled
+    # PopulateSpeciesLabelStudioProjectParentWorkflow owns it).
+    assert populate_runs == []
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-api-workflow-worker/tests/test_schedule_registration.py
+++ b/services/fishsense-api-workflow-worker/tests/test_schedule_registration.py
@@ -29,6 +29,7 @@ _DIVE_SELECTING_PARENT_SCHEDULE_IDS = (
     "preprocess-laser-images-workflow-schedule",
     "cluster-dive-frames-workflow-schedule",
     "preprocess-species-images-workflow-schedule",
+    "populate-species-labels-workflow-schedule",
     "preprocess-headtail-images-workflow-schedule",
     "preprocess-slate-images-workflow-schedule",
     "perform-laser-calibration-workflow-schedule",
@@ -64,6 +65,17 @@ async def test_measure_fish_is_scheduled_hourly_at_40(registered):
 
     assert _every(schedule) == timedelta(hours=1)
     assert _offset(schedule) == timedelta(minutes=40)
+
+
+async def test_species_populate_is_scheduled_hourly_at_20(registered):
+    """The decoupled species-populate parent fires at +20, just after the
+    +15 species-preprocess writes JPEGs, with SKIP overlap like the other
+    dive-selecting parents."""
+    schedule = registered["populate-species-labels-workflow-schedule"]
+
+    assert _every(schedule) == timedelta(hours=1)
+    assert _offset(schedule) == timedelta(minutes=20)
+    assert schedule.policy.overlap is ScheduleOverlapPolicy.SKIP
 
 
 async def test_measure_fish_skips_when_a_run_is_still_in_flight(registered):

--- a/services/fishsense-api-workflow-worker/tests/test_select_dives_needing_species_population_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_select_dives_needing_species_population_activity.py
@@ -1,0 +1,53 @@
+# pylint: disable=unused-argument
+"""Unit tests for select_dives_needing_species_population_activity.
+
+Superseded-aware cohort predicate lives server-side; see
+`services/fishsense-api/tests/test_select_next_dive_endpoints.py`. The
+activity is a passthrough to the SDK's list-returning method.
+"""
+
+from __future__ import annotations
+
+from typing import List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from temporalio.testing import ActivityEnvironment
+
+from fishsense_api_workflow_worker.activities import (
+    select_dives_needing_species_population_activity as sut,
+)
+
+
+def _make_fs(*, dive_ids: List[int]):
+    fs = MagicMock()
+    fs.__aenter__ = AsyncMock(return_value=fs)
+    fs.__aexit__ = AsyncMock(return_value=None)
+    fs.dives = MagicMock()
+    fs.dives.get_dives_needing_species_population = AsyncMock(return_value=dive_ids)
+    return fs
+
+
+@pytest.mark.asyncio
+async def test_passes_through_dive_ids_from_sdk(monkeypatch):
+    fs = _make_fs(dive_ids=[3, 7, 11])
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.select_dives_needing_species_population_activity
+    )
+
+    assert result == [3, 7, 11]
+    fs.dives.get_dives_needing_species_population.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_list_when_cohort_empty(monkeypatch):
+    fs = _make_fs(dive_ids=[])
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.select_dives_needing_species_population_activity
+    )
+
+    assert result == []

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -255,6 +255,56 @@ async def select_next_for_species_preprocessing(
     return (await session.exec(query)).first()
 
 
+@app.get("/api/v1/dives/needing-species-population/")
+async def select_dives_needing_species_population(
+    session: AsyncSession = Depends(get_async_session),
+) -> List[int]:
+    """Dives that need species LS tasks (re)populated onto a live project.
+
+    Cohort: HIGH priority + at least one image carrying a *valid*
+    LaserLabel (completed, not superseded, both x/y populated) that has
+    no *non-superseded* SpeciesLabel row with a `project_id` — i.e. no
+    live species task. Superseded rows are dead-lettered and don't
+    count, which is exactly what lets a dive whose old-project rows were
+    superseded (e.g. after the hosted-LS migration) re-enter the cohort.
+
+    Unlike `select-next/species-preprocessing`, this is superseded-aware
+    (that endpoint's `project_id IS NOT NULL` check ignores supersede,
+    so it permanently excludes migrated dives) and drops the
+    PREDICTION-cluster gate — populate only needs the species JPEGs to
+    exist, which the populate activity gates per-image against Garage.
+    The activity is idempotent + JPEG-gated, so this coarse candidate
+    set is safe to over-select.
+
+    Returns every matching dive id; the scheduled populate parent fans
+    out one `PopulateSpeciesLabelStudioProjectWorkflow` child per dive.
+    """
+    has_valid_laser_image_without_live_species = (
+        select(LaserLabel.id)
+        .join(Image, Image.id == LaserLabel.image_id)
+        .where(Image.dive_id == Dive.id)
+        .where(LaserLabel.completed == True)
+        .where(LaserLabel.superseded == False)
+        .where(LaserLabel.x != None)
+        .where(LaserLabel.y != None)
+        .where(
+            ~select(SpeciesLabel.id)
+            .where(SpeciesLabel.image_id == Image.id)
+            .where(SpeciesLabel.label_studio_project_id != None)
+            .where(SpeciesLabel.superseded == False)
+            .exists()
+        )
+        .exists()
+    )
+    query = (
+        select(Dive.id)
+        .where(Dive.priority == Priority.HIGH)
+        .where(has_valid_laser_image_without_live_species)
+        .order_by(Dive.id)
+    )
+    return list((await session.exec(query)).all())
+
+
 @app.get("/api/v1/dives/select-next/headtail-preprocessing/")
 async def select_next_for_headtail_preprocessing(
     session: AsyncSession = Depends(get_async_session),

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -843,6 +843,137 @@ async def test_species_preprocessing_returns_none_when_only_label_studio_cluster
     assert await select_next_for_species_preprocessing(session=session) is None
 
 
+# ---------- species population (scheduled populate parent cohort) ----------
+#
+# Superseded-aware, PREDICTION-cluster-free, returns ALL matching dives.
+# The distinguishing behaviour vs species-preprocessing: a dive whose
+# species rows are all superseded (post hosted-LS migration) re-enters
+# the cohort, and a live (non-superseded, real-project) row excludes it.
+
+
+async def test_needing_species_population_picks_laser_valid_without_live_species(
+    session,
+):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_dives_needing_species_population,
+    )
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    session.add_all([_dive(1), _dive(2, priority="LOW")])
+    await session.flush()
+    session.add_all([_image(11, 1), _image(21, 2)])
+    await session.flush()
+    session.add_all(
+        [
+            # dive 1: HIGH + laser-valid + no species row -> picked. No
+            # PREDICTION cluster required (unlike species-preprocessing).
+            LaserLabel(
+                image_id=11, completed=True, superseded=False, x=1.0, y=2.0,
+                label_studio_project_id=43,
+            ),
+            # dive 2: LOW priority -> excluded.
+            LaserLabel(
+                image_id=21, completed=True, superseded=False, x=1.0, y=2.0,
+                label_studio_project_id=43,
+            ),
+        ]
+    )
+    await session.flush()
+
+    assert await select_dives_needing_species_population(session=session) == [1]
+
+
+async def test_needing_species_population_reincludes_superseded_only_dive(session):
+    """The migration case: a dive whose only species rows are superseded
+    (old dead project) must re-enter the cohort — species-preprocessing
+    wrongly excludes it because its check ignores `superseded`."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_dives_needing_species_population,
+        select_next_for_species_preprocessing,
+    )
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+    )
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    session.add(DiveFrameCluster(dive_id=1, data_source=DataSource.PREDICTION))
+    session.add(
+        LaserLabel(
+            image_id=11, completed=True, superseded=False, x=1.0, y=2.0,
+            label_studio_project_id=43,
+        )
+    )
+    # only a superseded species row (dead old project 117)
+    session.add(
+        SpeciesLabel(
+            image_id=11, completed=False, superseded=True,
+            label_studio_project_id=117,
+        )
+    )
+    await session.flush()
+
+    assert await select_dives_needing_species_population(session=session) == [1]
+    # contrast: the preprocessing selector permanently excludes it
+    assert await select_next_for_species_preprocessing(session=session) is None
+
+
+async def test_needing_species_population_excludes_dive_with_live_species(session):
+    """A non-superseded, real-project species row is a live task -> the
+    image no longer needs population, so the dive drops out."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_dives_needing_species_population,
+    )
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    session.add(
+        LaserLabel(
+            image_id=11, completed=True, superseded=False, x=1.0, y=2.0,
+            label_studio_project_id=43,
+        )
+    )
+    session.add(
+        SpeciesLabel(
+            image_id=11, completed=False, superseded=False,
+            label_studio_project_id=226,
+        )
+    )
+    await session.flush()
+
+    assert await select_dives_needing_species_population(session=session) == []
+
+
+async def test_needing_species_population_excludes_invalid_laser(session):
+    """Same valid-laser gate as the other cascade cohorts."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_dives_needing_species_population,
+    )
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add_all([_image(11, 1), _image(12, 1), _image(13, 1)])
+    await session.flush()
+    session.add_all(
+        [
+            LaserLabel(image_id=11, completed=False, superseded=False, x=1.0, y=2.0),
+            LaserLabel(image_id=12, completed=True, superseded=True, x=1.0, y=2.0),
+            LaserLabel(image_id=13, completed=True, superseded=False, x=None, y=2.0),
+        ]
+    )
+    await session.flush()
+
+    assert await select_dives_needing_species_population(session=session) == []
+
+
 # ---------- stage 5.1: headtail-preprocessing ----------
 #
 # Cohort cascades from valid laser labels: any image with a "valid"


### PR DESCRIPTION
**Stacked on #308** (idempotency) — review/merge that first; this PR's base is `feat/species-populate-idempotent`.

## Why
The 12 stuck species dives (and any dive migrated off the old Label Studio) can't be (re)populated onto hosted LS:
- the `species-preprocessing` selector's `project_id IS NOT NULL` check **ignores `superseded`**, so a dive whose old-project rows were superseded is permanently excluded;
- populate only ever ran **chained off preprocess**, which skipped those dives too.

## What
A dedicated hourly parent that owns species population, decoupled from preprocess.

- **API** — `GET /api/v1/dives/needing-species-population/`: superseded-aware cohort (HIGH + laser-valid image with **no non-superseded real-project** species row), returns *all* matches; drops the PREDICTION-cluster gate (populate only needs JPEGs).
- **SDK** — `dives.get_dives_needing_species_population() -> list[int]`.
- **Worker** — `select_dives_needing_species_population_activity` + `PopulateSpeciesLabelStudioProjectParentWorkflow` (fan-out, concurrency 4, deterministic `populate-species-{id}` child id with `ALLOW_DUPLICATE` since the child is idempotent) + hourly schedule `populate-species-labels-workflow-schedule` at **+20m** (just after the +15 species-preprocess writes JPEGs), SKIP overlap.
- **JPEG gate** — the populate activity now checks `ObjectStoreClient.has_processed_jpeg` per image and **defers** any image whose stage-2 JPEG isn't in Garage yet. Critical safety: a decoupled populate must never seed a species row before the JPEG exists, or the image drops out of the preprocess cohort with a permanently-broken image.
- **Decoupling** — `PreprocessSpeciesImagesParentWorkflow` no longer chains into `PopulateSpeciesLabelStudioProjectWorkflow`; it just writes JPEGs. (laser/headtail/dive-slate populate remain preprocess-dispatched.)

## Tests (TDD)
- endpoint SQL: picks laser-valid/no-live-species, **re-includes superseded-only dives** (contrasted against the preprocessing selector), excludes live-species and invalid-laser;
- SDK list method; selector activity passthrough;
- parent contract (fan-out ids + empty-cohort no-op);
- JPEG-gate defer test; idempotency tests (from #308);
- preprocess parent test updated (no populate dispatch).
- pylint 10; all affected suites green (worker/api/sdk).

## Depends on / pairs with
- #308 — idempotency (base of this PR).
- #307 — Garage endpoint fix (must deploy for the JPEG gate + LS image URLs to resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)