### PR TITLE
fix(stage-raw): retry NAS downloads with backoff + lower concurrency

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/stage_raw_bytes_for_dive_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/stage_raw_bytes_for_dive_activity.py
@@ -16,12 +16,18 @@ this activity prepends `e4e_nas.raw_root_path` (default
 prefix, FileStation's download endpoint fails with a 502 (it surfaces
 unresolved paths as Bad Gateway on the download API specifically).
 
-Failure semantics: any per-image failure (NAS missing, HTTP error)
-raises and aborts the whole activity. The schedule's `overlap=SKIP`
-will not retry within the firing, but the next firing of the parent
-schedule retries from scratch — staging is bounded by the dive's
-image count and skip-on-present makes the retry cheap for already-
-staged work.
+Failure semantics: a transient `TransportError` (502 Bad Gateway from
+FileStation's download backend) on a single file is retried with
+exponential backoff (`NAS_DOWNLOAD_MAX_ATTEMPTS`); anything still
+failing after that — or any non-transient error — raises and aborts
+the whole activity. Files are never skipped: a silently-missing raw
+would stage the dive incomplete and hide a real NAS/data problem, so a
+persistent failure is surfaced, not swallowed. The next firing of the
+parent schedule retries from scratch — skip-on-present makes that cheap
+for already-staged work. `STAGE_CONCURRENCY` is deliberately low so a
+backlog of dives doesn't saturate FileStation's download backend (which
+502s under concurrent large-`.ORF` load, and can auto-block a client
+that hammers it).
 """
 
 from __future__ import annotations
@@ -32,6 +38,7 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
+from synology_filestation import TransportError
 from temporalio import activity
 
 from fishsense_api_workflow_worker.activities.utils import get_fs_client
@@ -39,10 +46,25 @@ from fishsense_api_workflow_worker.config import settings
 from fishsense_api_workflow_worker.object_store import open_object_store_client
 from fishsense_api_workflow_worker.nas import NasDownloadClient
 
-STAGE_CONCURRENCY = 8
+# Lowered from 8 → 3: FileStation's download backend (DSM nginx →
+# synoscgi) buckles under many concurrent large-`.ORF` transfers and
+# starts returning 502; fewer parallel downloads keep us under that
+# threshold and stop the worker from tripping the NAS's auto-block.
+STAGE_CONCURRENCY = 3
+
+# Per-file download retry. `TransportError` is what the Synology client
+# raises for a 502 Bad Gateway (DSM's nginx couldn't reach its own
+# FileStation download backend) — usually transient, so retry with
+# backoff instead of failing the whole dive on the first blip. We never
+# *skip* a file after exhaustion: a silently-missing raw would yield an
+# incomplete dive, so exhaustion re-raises and the activity fails loudly.
+NAS_DOWNLOAD_MAX_ATTEMPTS = 4
+NAS_DOWNLOAD_RETRY_INITIAL_SECONDS = 2.0
+NAS_DOWNLOAD_RETRY_BACKOFF = 2.0
 
 __all__ = [
     "STAGE_CONCURRENCY",
+    "NAS_DOWNLOAD_MAX_ATTEMPTS",
     "StageRawBytesResult",
     "stage_raw_bytes_for_dive_activity",
 ]
@@ -66,6 +88,41 @@ def _build_nas_client() -> NasDownloadClient:
     )
 
 
+
+
+async def _download_with_retry(nas, *, src_path: str, dest_dir: str) -> None:
+    """Download one file, retrying a transient `TransportError` (502 Bad
+    Gateway from FileStation's download backend) with exponential
+    backoff.
+
+    Re-raises on the final attempt — callers must NOT swallow it. Skipping
+    a file that can't be fetched would stage the dive incomplete (missing
+    raws → missing preprocessed images) and hide a real NAS/data problem;
+    a hard failure surfaces it. The backoff also throttles our request
+    rate so we stop hammering an already-struggling NAS.
+    """
+    delay = NAS_DOWNLOAD_RETRY_INITIAL_SECONDS
+    for attempt in range(1, NAS_DOWNLOAD_MAX_ATTEMPTS + 1):
+        try:
+            await asyncio.to_thread(
+                nas.download_to, src_path=src_path, dest_dir=dest_dir
+            )
+            return
+        except TransportError as exc:
+            if attempt >= NAS_DOWNLOAD_MAX_ATTEMPTS:
+                raise
+            activity.logger.warning(
+                "nas download transient failure src=%s attempt=%d/%d: %s; "
+                "backing off %.1fs",
+                src_path,
+                attempt,
+                NAS_DOWNLOAD_MAX_ATTEMPTS,
+                exc,
+                delay,
+            )
+            activity.heartbeat()
+            await asyncio.sleep(delay)
+            delay *= NAS_DOWNLOAD_RETRY_BACKOFF
 
 
 def _resolve_nas_path(relative_path: str) -> str:
@@ -121,10 +178,8 @@ async def stage_raw_bytes_for_dive_activity(
 
             with tempfile.TemporaryDirectory() as tmpdir:
                 src_path = _resolve_nas_path(image.path)
-                await asyncio.to_thread(
-                    nas.download_to,
-                    src_path=src_path,
-                    dest_dir=tmpdir,
+                await _download_with_retry(
+                    nas, src_path=src_path, dest_dir=tmpdir
                 )
                 local_path = Path(tmpdir) / os.path.basename(src_path)
                 data = await asyncio.to_thread(local_path.read_bytes)

--- a/services/fishsense-api-workflow-worker/tests/test_stage_raw_bytes_for_dive_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_stage_raw_bytes_for_dive_activity.py
@@ -33,6 +33,7 @@ from unittest.mock import AsyncMock, MagicMock
 import boto3
 import pytest
 from moto import mock_aws
+from synology_filestation import TransportError
 from temporalio.testing import ActivityEnvironment
 
 from fishsense_api_sdk.models.image import Image
@@ -341,3 +342,55 @@ async def test_relative_image_paths_get_prefixed_before_nas_download(monkeypatch
         )
         # Object-store PUT still keys on checksum, not the rewritten path.
         assert _raw_keys(s3) == {raw_key("aaa")}
+
+
+@pytest.mark.asyncio
+async def test_retries_transient_transport_error_then_succeeds(monkeypatch):
+    """A 502 (TransportError) that clears on retry stages successfully —
+    one flaky FileStation download must not fail the whole dive."""
+    monkeypatch.setattr(sut, "NAS_DOWNLOAD_RETRY_INITIAL_SECONDS", 0.0)
+    images = [_image(1, checksum="aaa")]
+    fs = _make_fs(images)
+    nas = _make_nas()
+    nas.download_to.side_effect = [
+        TransportError("download HTTP 502 Bad Gateway"),
+        TransportError("download HTTP 502 Bad Gateway"),
+        None,  # third attempt succeeds
+    ]
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut, "_build_nas_client", lambda: nas)
+    _patch_tempfile_read(monkeypatch, b"raw-bytes")
+
+    with _moto_store(monkeypatch) as s3:
+        result = await ActivityEnvironment().run(
+            sut.stage_raw_bytes_for_dive_activity, 42
+        )
+
+        assert result.staged == 1
+        assert nas.download_to.call_count == 3
+        assert _raw_keys(s3) == {raw_key("aaa")}
+
+
+@pytest.mark.asyncio
+async def test_persistent_502_exhausts_retries_and_never_skips(monkeypatch):
+    """A persistent 502 exhausts the retries and fails the activity — the
+    file is NOT skipped. Skipping would stage the dive incomplete (a
+    missing raw) and hide a real NAS/data problem, so the failure must
+    surface."""
+    monkeypatch.setattr(sut, "NAS_DOWNLOAD_RETRY_INITIAL_SECONDS", 0.0)
+    images = [_image(1, checksum="aaa")]
+    fs = _make_fs(images)
+    nas = _make_nas()
+    nas.download_to.side_effect = TransportError("download HTTP 502 Bad Gateway")
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut, "_build_nas_client", lambda: nas)
+
+    with _moto_store(monkeypatch) as s3:
+        with pytest.raises((ExceptionGroup, TransportError)):
+            await ActivityEnvironment().run(
+                sut.stage_raw_bytes_for_dive_activity, 42
+            )
+
+        assert nas.download_to.call_count == sut.NAS_DOWNLOAD_MAX_ATTEMPTS
+        # nothing partially staged
+        assert _raw_keys(s3) == set()


### PR DESCRIPTION
## Why
FileStation's download backend (DSM nginx → `synoscgi`) returns **502 Bad Gateway** under concurrent large-`.ORF` load. Today a single 502 fails the whole `stage_raw_bytes_for_dive_activity`, which Temporal retries in a tight loop — the same files were observed requested **200–250× each**, hammering the NAS hard enough to trip its **auto-block** (authenticated ops then started returning Synology error **407 "Operation not permitted"** on *every* path, incl. the share root). Every preprocess parent (headtail/species/slate) has been failing on this.

Full diagnosis + NAS-side fix tracked in **KastnerRG/krg-infra#501**. This PR stops the worker from *aggravating* it.

## Change
- **Per-file retry with exponential backoff** on the transient `TransportError` (the 502) in `_stage_one`, so one flaky download doesn't fail the whole dive (`NAS_DOWNLOAD_MAX_ATTEMPTS=4`, 2s→4s→8s).
- **Never skip after exhaustion** — a persistent failure re-raises and fails the activity. Skipping would stage the dive *incomplete* (a missing raw → missing preprocessed image) and hide a real NAS/data problem, so the failure must surface.
- **`STAGE_CONCURRENCY` 8 → 3** to stay under FileStation's concurrency threshold and stop hammering the NAS.

## Tests (TDD)
- `test_retries_transient_transport_error_then_succeeds`: two 502s then success → staged, `download_to` called 3×.
- `test_persistent_502_exhausts_retries_and_never_skips`: permanent 502 → activity raises after `NAS_DOWNLOAD_MAX_ATTEMPTS` attempts, nothing staged (no partial/incomplete write).
- pylint 10, full `stage_raw` suite green (9 passed).

## Note
This does not *fix* the NAS being unreachable — while the 407/502 persists (krg-infra#501), staging still fails, but now it fails after a few well-spaced attempts at low concurrency instead of a retry storm. Once the NAS auto-block / permissions are cleared, staging recovers on the next hourly firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)