### PR TITLE
fix: use krg's Garage buckets (scratch vs labels split) + publish LS projects only when complete

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_dive_slate_label_studio_project_activity.py
@@ -19,6 +19,7 @@ from temporalio import activity
 from fishsense_api_workflow_worker.activities.populate_utils import (
     build_image_url,
     import_tasks_and_record_labels,
+    publish_label_studio_project,
 )
 from fishsense_api_workflow_worker.activities.utils import get_fs_client
 
@@ -121,5 +122,14 @@ async def populate_dive_slate_label_studio_project_activity(
             old.superseded = True
             await fs.labels.put_dive_slate_label(old.image_id, old)
             activity.heartbeat()
+
+        # Slate imports its whole selection in one pass (no JPEG deferral),
+        # so the project's task set is complete. Publish iff it actually
+        # holds tasks so an empty project isn't shown to labelers.
+        if new_count > 0 or any(
+            label.label_studio_project_id == project_id
+            for label in existing_slate
+        ):
+            await publish_label_studio_project(project_id)
 
         return new_count

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_headtail_label_studio_project_activity.py
@@ -33,6 +33,7 @@ from temporalio import activity
 from fishsense_api_workflow_worker.activities.populate_utils import (
     build_image_url,
     import_tasks_and_record_labels,
+    publish_label_studio_project,
 )
 from fishsense_api_workflow_worker.activities.utils import get_fs_client
 
@@ -162,5 +163,14 @@ async def populate_headtail_label_studio_project_activity(
             old.superseded = True
             await fs.labels.put_headtail_label(old.image_id, old)
             activity.heartbeat()
+
+        # Headtail imports its whole selection in one pass (no JPEG
+        # deferral), so the project's task set is complete. Publish iff it
+        # actually holds tasks so an empty project isn't shown to labelers.
+        if new_count > 0 or any(
+            label.label_studio_project_id == project_id
+            for label in existing_headtail
+        ):
+            await publish_label_studio_project(project_id)
 
         return new_count

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_laser_label_studio_project_activity.py
@@ -16,6 +16,7 @@ from temporalio import activity
 from fishsense_api_workflow_worker.activities.populate_utils import (
     build_image_url,
     import_tasks_and_record_labels,
+    publish_label_studio_project,
 )
 from fishsense_api_workflow_worker.activities.utils import get_fs_client
 
@@ -79,6 +80,15 @@ async def populate_laser_label_studio_project_activity(
                 "nothing to import",
                 dive_id,
             )
+            # No image needs a task, so the task set is complete. Publish
+            # iff this project already holds tasks — a genuinely empty
+            # project (grandfathered dive whose rows point at an old
+            # project) is left as a hidden draft.
+            if any(
+                label.label_studio_project_id == project_id
+                for label in existing_labels
+            ):
+                await publish_label_studio_project(project_id)
             return 0
 
         tasks = [_build_task(image) for image in unlabeled]
@@ -100,9 +110,13 @@ async def populate_laser_label_studio_project_activity(
             )
             await fs.labels.put_laser_label(image.id, label)
 
-        return await import_tasks_and_record_labels(
+        imported = await import_tasks_and_record_labels(
             project_id=project_id,
             tasks=tasks,
             record_label=_record,
             items=unlabeled,
         )
+        # Laser imports its whole selection in one pass (no JPEG deferral),
+        # so the project's task set is now complete — safe to publish.
+        await publish_label_studio_project(project_id)
+        return imported

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_species_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_species_label_studio_project_activity.py
@@ -30,6 +30,7 @@ from temporalio import activity
 from fishsense_api_workflow_worker.activities.populate_utils import (
     build_image_url,
     import_tasks_and_record_labels,
+    publish_label_studio_project,
 )
 from fishsense_api_workflow_worker.activities.utils import get_fs_client
 from fishsense_api_workflow_worker.object_store import open_object_store_client
@@ -156,13 +157,14 @@ async def populate_species_label_studio_project_activity(
             if image is not None:
                 images_by_id[image.id] = image
 
-        targets = _select_target_images(
+        selected = _select_target_images(
             laser_labels, images_by_id, existing_species, project_id
         )
         # Only import tasks for images whose species JPEG is already in
         # Garage (see `_gate_on_jpeg_presence`). Deferred images stay in
         # the cohort and are picked up on a later run.
-        targets = await _gate_on_jpeg_presence(targets)
+        targets = await _gate_on_jpeg_presence(selected)
+        deferred = len(selected) - len(targets)
 
         new_count = 0
         if targets:
@@ -221,5 +223,18 @@ async def populate_species_label_studio_project_activity(
             old.superseded = True
             await fs.labels.put_species_label(old.image_id, old)
             activity.heartbeat()
+
+        # Publish only when the project's task set is COMPLETE. Species tasks
+        # trickle in as stage-2 JPEGs are processed, so a run that deferred
+        # any image (JPEG not yet in Garage) leaves the project a hidden
+        # draft — never shown to annotators half-populated. Once nothing is
+        # deferred, publish iff the project holds tasks (this run's imports or
+        # a prior run's non-superseded rows for this project).
+        already_in_project = any(
+            label.label_studio_project_id == project_id and not label.superseded
+            for label in existing_species
+        )
+        if deferred == 0 and (new_count > 0 or already_in_project):
+            await publish_label_studio_project(project_id)
 
         return new_count

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
@@ -136,19 +136,6 @@ async def create_or_get_label_studio_project(
                 matches[0].id,
             )
         project_id = matches[0].id
-        # Self-heal drafts created before publish-on-create landed: if the
-        # existing project isn't published, publish it so labelers can see
-        # it. `is_published is False` (not falsy) avoids a needless update
-        # when the SDK omits the field.
-        if getattr(matches[0], "is_published", None) is False:
-            await asyncio.to_thread(
-                lambda: ls.projects.update(id=project_id, is_published=True)
-            )
-            activity.logger.info(
-                "Published existing draft LS project %r (id=%d)",
-                project_title,
-                project_id,
-            )
         await ensure_label_studio_s3_storage(project_id)
         return project_id
 
@@ -160,15 +147,16 @@ async def create_or_get_label_studio_project(
             "Interface -> Code) into the corresponding constant."
         )
 
-    # `is_published=True` so annotators can see the project immediately.
-    # On LS Enterprise a project created without it defaults to draft and
-    # stays invisible until an admin publishes it by hand.
+    # Created as a draft (is_published left at the LS default). Per-dive
+    # projects are only published once their task set is complete — see
+    # `publish_label_studio_project`, called by the populate activities —
+    # so a still-filling or JPEG-deferred project stays hidden from
+    # annotators until every intended task exists.
     project = await asyncio.to_thread(
         ls.projects.create,
         title=project_title,
         label_config=labeling_config_xml,
         workspace=workspace_id,
-        is_published=True,
     )
     activity.logger.info(
         "Created LS project %r (id=%d)", project_title, project.id
@@ -251,6 +239,25 @@ async def import_tasks_and_record_labels(
             activity.heartbeat()
 
     return len(task_ids)
+
+
+async def publish_label_studio_project(project_id: int) -> None:
+    """Idempotently publish an LS project so annotators can see it.
+
+    Called by the populate activities **only once a project's task set is
+    complete** — never at create time. On LS Enterprise a project is created
+    as a draft (invisible to annotators); publishing is deferred until every
+    intended task exists so a still-filling project (e.g. species images
+    whose stage-2 JPEGs haven't been processed yet, which the JPEG gate
+    defers) is never shown half-populated. `projects.update` with
+    `is_published=True` is idempotent, so re-running populate on an
+    already-complete project is a harmless no-op.
+    """
+    ls = _get_ls_client()
+    await asyncio.to_thread(
+        lambda: ls.projects.update(id=project_id, is_published=True)
+    )
+    activity.logger.info("Published LS project id=%d", project_id)
 
 
 def _get_ls_client() -> LabelStudio:

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
@@ -41,9 +41,16 @@ def build_image_url(folder: str, checksum: str) -> str:
     at. There's no virtual->physical rewrite layer anymore, which is
     why the old nginx alias mismatch (issue #113) is gone by
     construction.
+
+    JPEGs live in the **labels** bucket (LS-facing) under the optional
+    `labels_prefix`, separate from the raw/slate scratch `bucket`. Falls
+    back to `bucket`/no-prefix for single-bucket layouts.
     """
-    bucket = settings.object_store.bucket
-    return f"s3://{bucket}/{folder}/{checksum}.JPG"
+    obj = settings.object_store
+    bucket = obj.get("labels_bucket", None) or obj.bucket
+    prefix = (obj.get("labels_prefix", "") or "").strip("/")
+    key = f"{prefix}/{folder}/{checksum}.JPG" if prefix else f"{folder}/{checksum}.JPG"
+    return f"s3://{bucket}/{key}"
 
 
 def _ls_s3_presign_credentials() -> tuple[str, str]:
@@ -70,7 +77,12 @@ async def ensure_label_studio_s3_storage(project_id: int) -> None:
     exists only to enable presigning.
     """
     ls = _get_ls_client()
-    bucket = settings.object_store.bucket
+    obj = settings.object_store
+    # LS serves JPEGs from the labels bucket; register storage against it
+    # (not the scratch bucket). Prefix scopes it within the shared labels
+    # bucket, mirroring the coral-gardeners layout.
+    bucket = obj.get("labels_bucket", None) or obj.bucket
+    prefix = (obj.get("labels_prefix", "") or "").strip("/")
 
     existing = await asyncio.to_thread(
         lambda: list(ls.import_storage.s3.list(project=project_id))
@@ -83,19 +95,20 @@ async def ensure_label_studio_s3_storage(project_id: int) -> None:
             return
 
     access_key, secret_key = _ls_s3_presign_credentials()
-    await asyncio.to_thread(
-        lambda: ls.import_storage.s3.create(
-            project=project_id,
-            title=LS_S3_STORAGE_TITLE,
-            bucket=bucket,
-            s3endpoint=settings.object_store.endpoint_url,
-            region_name=settings.object_store.region,
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_key,
-            presign=True,
-            use_blob_urls=False,
-        )
+    create_kwargs = dict(
+        project=project_id,
+        title=LS_S3_STORAGE_TITLE,
+        bucket=bucket,
+        s3endpoint=settings.object_store.endpoint_url,
+        region_name=settings.object_store.region,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        presign=True,
+        use_blob_urls=False,
     )
+    if prefix:
+        create_kwargs["prefix"] = prefix
+    await asyncio.to_thread(lambda: ls.import_storage.s3.create(**create_kwargs))
     activity.logger.info(
         "registered LS S3 storage project_id=%d bucket=%s", project_id, bucket
     )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
@@ -95,17 +95,17 @@ async def ensure_label_studio_s3_storage(project_id: int) -> None:
             return
 
     access_key, secret_key = _ls_s3_presign_credentials()
-    create_kwargs = dict(
-        project=project_id,
-        title=LS_S3_STORAGE_TITLE,
-        bucket=bucket,
-        s3endpoint=settings.object_store.endpoint_url,
-        region_name=settings.object_store.region,
-        aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
-        presign=True,
-        use_blob_urls=False,
-    )
+    create_kwargs = {
+        "project": project_id,
+        "title": LS_S3_STORAGE_TITLE,
+        "bucket": bucket,
+        "s3endpoint": settings.object_store.endpoint_url,
+        "region_name": settings.object_store.region,
+        "aws_access_key_id": access_key,
+        "aws_secret_access_key": secret_key,
+        "presign": True,
+        "use_blob_urls": False,
+    }
     if prefix:
         create_kwargs["prefix"] = prefix
     await asyncio.to_thread(lambda: ls.import_storage.s3.create(**create_kwargs))

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/config.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/config.py
@@ -99,7 +99,14 @@ _VALIDATORS = [
         condition=url_condition,
     ),
     Validator("object_store.region", required=True, cast=str, default="garage"),
+    # `bucket` holds the raw/slate **scratch** (raw/, slate_pdf/). Processed
+    # JPEGs that Label Studio serves live in `labels_bucket` under
+    # `labels_prefix` — a separate bucket so scratch never lands in the
+    # LS-facing labels bucket. `labels_bucket` defaults to `bucket` (single-
+    # bucket layouts keep working); `labels_prefix` defaults to "" (no prefix).
     Validator("object_store.bucket", required=True, cast=str),
+    Validator("object_store.labels_bucket", cast=str),
+    Validator("object_store.labels_prefix", cast=str, default=""),
     Validator("object_store.access_key", required=True, cast=str),
     Validator("object_store.secret_key", required=True, cast=str),
     # Optional read-only key handed to Label Studio when registering the

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/object_store.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/object_store.py
@@ -56,14 +56,18 @@ def slate_pdf_key(slate_id: int) -> str:
     return f"{SLATE_PDF_PREFIX}/{slate_id}.pdf"
 
 
-def processed_jpeg_key(folder: str, checksum: str) -> str:
+def processed_jpeg_key(folder: str, checksum: str, prefix: str = "") -> str:
     """Physical Garage key for a data-worker-written processed JPEG.
 
     `folder` is the per-stage prefix (`preprocess_groups_jpeg`,
     `preprocess_jpeg`, `preprocess_headtail_jpeg`,
-    `preprocess_slate_images_jpeg`) — the exact key the JPEG lives at.
+    `preprocess_slate_images_jpeg`). `prefix` is the optional
+    `labels_prefix` that partitions our JPEGs within the shared labels
+    bucket (mirrors the coral-gardeners prefix); empty → no prefix.
     """
-    return f"{folder}/{checksum}.JPG"
+    base = f"{folder}/{checksum}.JPG"
+    prefix = (prefix or "").strip("/")
+    return f"{prefix}/{base}" if prefix else base
 
 
 def build_s3_client(
@@ -105,22 +109,36 @@ def open_object_store_client() -> "ObjectStoreClient":
         access_key=settings.object_store.access_key,
         secret_key=settings.object_store.secret_key,
     )
-    return ObjectStoreClient(s3, settings.object_store.bucket)
+    return ObjectStoreClient(
+        s3,
+        settings.object_store.bucket,
+        labels_bucket=settings.object_store.get("labels_bucket", None),
+        labels_prefix=settings.object_store.get("labels_prefix", "") or "",
+    )
 
 
 class ObjectStoreClient:
     """Thin async wrapper over a boto3 S3 client for the api-worker's
     staging + scratch-cleanup needs. Constructed per-activity-call; the
-    boto3 client is injected so tests can pass a moto-backed one."""
+    boto3 client is injected so tests can pass a moto-backed one.
 
-    def __init__(self, s3, bucket: str):
+    Staging (raw/slate) lives in ``bucket`` (scratch); processed JPEGs that
+    Label Studio serves live in ``labels_bucket`` under ``labels_prefix``.
+    ``labels_bucket`` defaults to ``bucket`` so single-bucket layouts keep
+    working unchanged."""
+
+    def __init__(self, s3, bucket: str, labels_bucket=None, labels_prefix=""):
         self._s3 = s3
         self._bucket = bucket
+        self._labels_bucket = labels_bucket or bucket
+        self._labels_prefix = labels_prefix or ""
 
-    async def _exists(self, key: str) -> bool:
+    async def _exists(self, key: str, bucket: str | None = None) -> bool:
+        target = bucket or self._bucket
+
         def _do() -> bool:
             try:
-                self._s3.head_object(Bucket=self._bucket, Key=key)
+                self._s3.head_object(Bucket=target, Key=key)
                 return True
             except ClientError as exc:
                 code = exc.response.get("Error", {}).get("Code", "")
@@ -153,8 +171,12 @@ class ObjectStoreClient:
         activity to gate task import on the JPEG existing (a decoupled
         populate must never seed rows for an image whose JPEG isn't
         written yet — that would drop the dive out of the preprocess
-        cohort with a broken image)."""
-        return await self._exists(processed_jpeg_key(folder, checksum))
+        cohort with a broken image). Checks the **labels** bucket/prefix
+        where the data-worker writes JPEGs."""
+        return await self._exists(
+            processed_jpeg_key(folder, checksum, self._labels_prefix),
+            bucket=self._labels_bucket,
+        )
 
     async def upload_raw(self, checksum: str, data: bytes) -> None:
         await self._put(raw_key(checksum), data)

--- a/services/fishsense-api-workflow-worker/tests/test_create_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_create_laser_label_studio_project_activity.py
@@ -101,7 +101,6 @@ async def test_creates_project_when_no_match_and_xml_present(monkeypatch):
         title=expected_title,
         label_config="<View><Image/></View>",
         workspace=None,
-        is_published=True,
     )
 
 
@@ -146,7 +145,6 @@ async def test_falls_back_to_dive_id_when_name_missing(monkeypatch):
         title=expected_title,
         label_config="<View/>",
         workspace=None,
-        is_published=True,
     )
 
 
@@ -178,7 +176,6 @@ async def test_falls_back_to_dive_id_when_name_too_long(monkeypatch):
         title=expected_title,
         label_config="<View/>",
         workspace=None,
-        is_published=True,
     )
 
 

--- a/services/fishsense-api-workflow-worker/tests/test_object_store.py
+++ b/services/fishsense-api-workflow-worker/tests/test_object_store.py
@@ -41,6 +41,12 @@ def _keys(s3) -> set[str]:
 def test_key_helpers():
     assert sut.raw_key("abc123") == "raw/abc123.ORF"
     assert sut.slate_pdf_key(7) == "slate_pdf/7.pdf"
+    assert sut.processed_jpeg_key("preprocess_jpeg", "abc") == (
+        "preprocess_jpeg/abc.JPG"
+    )
+    assert sut.processed_jpeg_key("preprocess_jpeg", "abc", "fishsense-lite") == (
+        "fishsense-lite/preprocess_jpeg/abc.JPG"
+    )
 
 
 def test_build_s3_client_uses_path_style_addressing_for_garage():
@@ -110,3 +116,50 @@ async def test_delete_raw_removes_scratch_object_and_is_idempotent(s3):
     assert first is True
     assert second is True
     assert _keys(s3) == set()
+
+
+@pytest.mark.asyncio
+async def test_has_processed_jpeg_checks_labels_bucket_and_prefix(s3):
+    # JPEGs live in the labels bucket under labels_prefix; has_processed_jpeg
+    # must look there, not in the scratch bucket.
+    labels = "labels-fishsense-test"
+    s3.create_bucket(Bucket=labels)
+    client = sut.ObjectStoreClient(
+        s3, BUCKET, labels_bucket=labels, labels_prefix="fishsense-lite"
+    )
+
+    async def _before():
+        return await client.has_processed_jpeg("preprocess_groups_jpeg", "caf")
+
+    assert await ActivityEnvironment().run(_before) is False
+
+    # Writing it into the scratch bucket must NOT count.
+    s3.put_object(
+        Bucket=BUCKET, Key="fishsense-lite/preprocess_groups_jpeg/caf.JPG", Body=b"x"
+    )
+    assert await ActivityEnvironment().run(_before) is False
+
+    # Only the labels bucket at the prefixed key counts.
+    s3.put_object(
+        Bucket=labels, Key="fishsense-lite/preprocess_groups_jpeg/caf.JPG", Body=b"x"
+    )
+    assert await ActivityEnvironment().run(_before) is True
+
+
+@pytest.mark.asyncio
+async def test_staging_uses_scratch_bucket_even_with_labels_configured(s3):
+    # Raw staging always targets the scratch bucket, never the labels bucket.
+    labels = "labels-fishsense-test"
+    s3.create_bucket(Bucket=labels)
+    client = sut.ObjectStoreClient(
+        s3, BUCKET, labels_bucket=labels, labels_prefix="fishsense-lite"
+    )
+
+    async def _run():
+        await client.upload_raw("abc123", b"RAW")
+        return await client.has_raw("abc123")
+
+    assert await ActivityEnvironment().run(_run) is True
+    assert _body(s3, "raw/abc123.ORF") == b"RAW"
+    # nothing written to the labels bucket
+    assert s3.list_objects_v2(Bucket=labels).get("Contents", []) == []

--- a/services/fishsense-api-workflow-worker/tests/test_populate_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_dive_slate_label_studio_project_activity.py
@@ -178,3 +178,42 @@ async def test_no_slate_marked_images_is_a_no_op(monkeypatch):
     assert n == 0
     ls.projects.import_tasks.assert_not_called()
     fs.labels.put_dive_slate_label.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_publishes_project_after_import(monkeypatch):
+    # Slate imports its whole selection in one pass -> project complete
+    # after import -> publish.
+    species = [
+        _species_label(1, content=sut.SLATE_CONTENT_MARKER),
+        _species_label(3, content=sut.SLATE_CONTENT_MARKER),
+    ]
+    images_by_id = {1: _image(1, "a"), 3: _image(3, "c")}
+    fs = _make_fs_client(species, existing_slate=[], images_by_id=images_by_id)
+    ls = _make_ls_client(returned_task_ids=[4001, 4002])
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+
+    await ActivityEnvironment().run(
+        sut.populate_dive_slate_label_studio_project_activity, 42, 66
+    )
+
+    ls.projects.update.assert_called_once_with(id=66, is_published=True)
+
+
+@pytest.mark.asyncio
+async def test_does_not_publish_empty_project(monkeypatch):
+    # No slate-marked images and no existing rows -> stay a hidden draft.
+    species = [_species_label(1, content="Fish")]
+    fs = _make_fs_client(species, existing_slate=[], images_by_id={})
+    ls = _make_ls_client(returned_task_ids=[])
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+
+    await ActivityEnvironment().run(
+        sut.populate_dive_slate_label_studio_project_activity, 42, 66
+    )
+
+    ls.projects.update.assert_not_called()

--- a/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
@@ -230,3 +230,40 @@ async def test_no_valid_laser_targets_skips_import_but_still_supersedes(monkeypa
     fs.labels.put_headtail_label.assert_awaited_once()
     written = fs.labels.put_headtail_label.await_args.args[1]
     assert written.superseded is True
+
+
+@pytest.mark.asyncio
+async def test_publishes_project_after_import(monkeypatch):
+    # Headtail imports its whole selection in one pass -> project complete
+    # after import -> publish.
+    laser = [_laser(1), _laser(2)]
+    images_by_id = {1: _image(1, "a"), 2: _image(2, "b")}
+    fs = _make_fs_client(laser, [], images_by_id)
+    ls = _make_ls_client(returned_task_ids=[3001, 3002])
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+
+    await ActivityEnvironment().run(
+        sut.populate_headtail_label_studio_project_activity, 42, 71
+    )
+
+    ls.projects.update.assert_called_once_with(id=71, is_published=True)
+
+
+@pytest.mark.asyncio
+async def test_does_not_publish_empty_project(monkeypatch):
+    # No laser-valid images and no existing rows -> stay a hidden draft.
+    laser = [_laser(1, completed=False)]
+    images_by_id = {1: _image(1, "a")}
+    fs = _make_fs_client(laser, [], images_by_id)
+    ls = _make_ls_client(returned_task_ids=[])
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+
+    await ActivityEnvironment().run(
+        sut.populate_headtail_label_studio_project_activity, 42, 71
+    )
+
+    ls.projects.update.assert_not_called()

--- a/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
@@ -230,3 +230,41 @@ async def test_aborts_when_import_tasks_returns_wrong_count(monkeypatch):
         )
 
     fs.labels.put_laser_label.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_publishes_project_after_import(monkeypatch):
+    # Laser imports its whole selection in one pass, so the project is
+    # complete after import -> publish it.
+    images = [_image(1, "a"), _image(2, "b")]
+    fs = _make_fs_client(images, [])
+    ls = _make_ls_client(returned_task_ids=[1001, 1002])
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+
+    await ActivityEnvironment().run(
+        sut.populate_laser_label_studio_project_activity, 42, 73
+    )
+
+    ls.projects.update.assert_called_once_with(id=73, is_published=True)
+
+
+@pytest.mark.asyncio
+async def test_does_not_publish_empty_project(monkeypatch):
+    # Fully-labeled dive whose only rows point at an OLD project (99): the
+    # fresh per-dive project (73) gets no tasks and must stay a hidden draft.
+    images = [_image(1, "a")]
+    existing = [_label(1, completed=True, project_id=99)]
+    fs = _make_fs_client(images, existing)
+    ls = _make_ls_client(returned_task_ids=[])
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+
+    n = await ActivityEnvironment().run(
+        sut.populate_laser_label_studio_project_activity, 42, 73
+    )
+
+    assert n == 0
+    ls.projects.update.assert_not_called()

--- a/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_activity.py
@@ -364,3 +364,68 @@ async def test_writes_label_with_image_url_and_groups_jpeg_folder(monkeypatch):
     assert written.image_url is not None
     assert "preprocess_groups_jpeg" in written.image_url
     assert "abc123" in written.image_url
+
+
+@pytest.mark.asyncio
+async def test_publishes_when_no_images_deferred(monkeypatch):
+    # All laser-valid images have their JPEG (autouse fixture) -> nothing
+    # deferred -> project task set complete -> publish.
+    laser = [_laser(1), _laser(2)]
+    images_by_id = {1: _image(1, "a"), 2: _image(2, "b")}
+    fs = _make_fs_client(laser, [], images_by_id)
+    ls = _make_ls_client(returned_task_ids=[1, 2])
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+
+    await ActivityEnvironment().run(
+        sut.populate_species_label_studio_project_activity, 42, 70
+    )
+
+    ls.projects.update.assert_called_once_with(id=70, is_published=True)
+
+
+@pytest.mark.asyncio
+async def test_does_not_publish_when_an_image_is_deferred(monkeypatch):
+    # Image 2's JPEG isn't in Garage yet -> deferred -> project incomplete ->
+    # stay a hidden draft even though image 1's task imported.
+    laser = [_laser(1), _laser(2)]
+    images_by_id = {1: _image(1, "aaa"), 2: _image(2, "bbb")}
+    fs = _make_fs_client(laser, [], images_by_id)
+    ls = _make_ls_client(returned_task_ids=[9001])
+
+    store = MagicMock()
+
+    async def _has(_folder, checksum):
+        return checksum == "aaa"
+
+    store.has_processed_jpeg = AsyncMock(side_effect=_has)
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+    monkeypatch.setattr(sut, "open_object_store_client", lambda: store)
+
+    await ActivityEnvironment().run(
+        sut.populate_species_label_studio_project_activity, 42, 70
+    )
+
+    ls.projects.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_does_not_publish_empty_project(monkeypatch):
+    # No laser-valid images and no existing rows -> nothing to task ->
+    # stay a hidden draft.
+    laser = [_laser(1, completed=False)]
+    images_by_id = {1: _image(1, "a")}
+    fs = _make_fs_client(laser, [], images_by_id)
+    ls = _make_ls_client(returned_task_ids=[])
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+
+    await ActivityEnvironment().run(
+        sut.populate_species_label_studio_project_activity, 42, 70
+    )
+
+    ls.projects.update.assert_not_called()

--- a/services/fishsense-api-workflow-worker/tests/test_populate_utils_workspace.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_utils_workspace.py
@@ -99,51 +99,10 @@ async def test_create_idempotent_finds_existing_in_workspace(monkeypatch):
     ls.projects.create.assert_not_called()
 
 
-async def test_create_publishes_existing_draft_project(monkeypatch):
-    # An already-created but still-draft per-dive project must be published
-    # on the next idempotent hit so labelers aren't blocked waiting for a
-    # manual toggle.
-    monkeypatch.setenv("E4EFS_LABEL_STUDIO__WORKSPACE", "FishSense")
-    cfg.settings.reload()
-    existing = MagicMock()
-    existing.id = 55
-    existing.title = "X - Laser Labeling"
-    existing.is_published = False
-    ls = _fake_ls(workspaces=[_workspace(7, "FishSense")], existing_projects=[existing])
-    monkeypatch.setattr(pu, "_get_ls_client", lambda: ls)
-    monkeypatch.setattr(pu, "ensure_label_studio_s3_storage", _noop)
-
-    pid = await pu.create_or_get_label_studio_project(
-        project_title="X - Laser Labeling", labeling_config_xml="<View/>"
-    )
-
-    assert pid == 55
-    ls.projects.create.assert_not_called()
-    ls.projects.update.assert_called_once_with(id=55, is_published=True)
-
-
-async def test_create_leaves_published_existing_project_untouched(monkeypatch):
-    monkeypatch.setenv("E4EFS_LABEL_STUDIO__WORKSPACE", "FishSense")
-    cfg.settings.reload()
-    existing = MagicMock()
-    existing.id = 55
-    existing.title = "X - Laser Labeling"
-    existing.is_published = True
-    ls = _fake_ls(workspaces=[_workspace(7, "FishSense")], existing_projects=[existing])
-    monkeypatch.setattr(pu, "_get_ls_client", lambda: ls)
-    monkeypatch.setattr(pu, "ensure_label_studio_s3_storage", _noop)
-
-    await pu.create_or_get_label_studio_project(
-        project_title="X - Laser Labeling", labeling_config_xml="<View/>"
-    )
-
-    ls.projects.update.assert_not_called()
-
-
-async def test_create_publishes_new_project(monkeypatch):
-    # On LS Enterprise a project created without is_published defaults to
-    # draft — invisible to annotators. Per-dive projects must be created
-    # published so labelers can pick them up without a manual toggle.
+async def test_create_does_not_publish(monkeypatch):
+    # Projects are created as drafts (no is_published on create) and never
+    # published from the create path — publishing is deferred to the populate
+    # activities once the task set is complete (see publish_label_studio_project).
     monkeypatch.delenv("E4EFS_LABEL_STUDIO__WORKSPACE", raising=False)
     cfg.settings.reload()
     ls = _fake_ls(workspaces=[], existing_projects=[])
@@ -155,7 +114,17 @@ async def test_create_publishes_new_project(monkeypatch):
     )
 
     _, kwargs = ls.projects.create.call_args
-    assert kwargs["is_published"] is True
+    assert "is_published" not in kwargs
+    ls.projects.update.assert_not_called()
+
+
+async def test_publish_label_studio_project_sets_is_published(monkeypatch):
+    ls = _fake_ls()
+    monkeypatch.setattr(pu, "_get_ls_client", lambda: ls)
+
+    await pu.publish_label_studio_project(55)
+
+    ls.projects.update.assert_called_once_with(id=55, is_published=True)
 
 
 async def test_create_without_workspace_uses_default(monkeypatch):

--- a/services/fishsense-api-workflow-worker/tests/test_populate_utils_workspace.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_utils_workspace.py
@@ -142,3 +142,40 @@ async def test_create_without_workspace_uses_default(monkeypatch):
     ls.projects.list.assert_called_once_with()  # no workspace filter
     _, kwargs = ls.projects.create.call_args
     assert kwargs["workspace"] is None
+
+
+def test_build_image_url_single_bucket_fallback(monkeypatch):
+    # No labels_bucket configured -> falls back to `bucket`, no prefix.
+    monkeypatch.delenv("E4EFS_OBJECT_STORE__LABELS_BUCKET", raising=False)
+    monkeypatch.delenv("E4EFS_OBJECT_STORE__LABELS_PREFIX", raising=False)
+    cfg.settings.reload()
+    assert (
+        pu.build_image_url("preprocess_jpeg", "abc")
+        == "s3://fishsense-test/preprocess_jpeg/abc.JPG"
+    )
+
+
+def test_build_image_url_uses_labels_bucket_and_prefix(monkeypatch):
+    monkeypatch.setenv("E4EFS_OBJECT_STORE__LABELS_BUCKET", "labels-fishsense-lite")
+    monkeypatch.setenv("E4EFS_OBJECT_STORE__LABELS_PREFIX", "fishsense-lite")
+    cfg.settings.reload()
+    assert (
+        pu.build_image_url("preprocess_groups_jpeg", "caf")
+        == "s3://labels-fishsense-lite/fishsense-lite/preprocess_groups_jpeg/caf.JPG"
+    )
+
+
+async def test_ensure_s3_storage_registers_labels_bucket_and_prefix(monkeypatch):
+    monkeypatch.setenv("E4EFS_OBJECT_STORE__LABELS_BUCKET", "labels-fishsense-lite")
+    monkeypatch.setenv("E4EFS_OBJECT_STORE__LABELS_PREFIX", "fishsense-lite")
+    cfg.settings.reload()
+    ls = MagicMock()
+    ls.import_storage.s3.list.return_value = []
+    monkeypatch.setattr(pu, "_get_ls_client", lambda: ls)
+
+    await pu.ensure_label_studio_s3_storage(999)
+
+    _, kwargs = ls.import_storage.s3.create.call_args
+    assert kwargs["bucket"] == "labels-fishsense-lite"
+    assert kwargs["prefix"] == "fishsense-lite"
+    assert kwargs["presign"] is True

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/config.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/config.py
@@ -51,7 +51,12 @@ _VALIDATORS = [
         condition=url_condition,
     ),
     Validator("object_store.region", required=True, cast=str, default="garage"),
+    # `bucket` = raw/slate **scratch** (read here). Processed JPEGs are
+    # written to `labels_bucket` under `labels_prefix` — the LS-facing bucket.
+    # `labels_bucket` defaults to `bucket`; `labels_prefix` defaults to "".
     Validator("object_store.bucket", required=True, cast=str),
+    Validator("object_store.labels_bucket", cast=str),
+    Validator("object_store.labels_prefix", cast=str, default=""),
     Validator("object_store.access_key", required=True, cast=str),
     Validator("object_store.secret_key", required=True, cast=str),
 ]

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/object_store.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/object_store.py
@@ -47,8 +47,10 @@ def slate_pdf_key(slate_id: int) -> str:
     return f"{SLATE_PDF_PREFIX}/{slate_id}.pdf"
 
 
-def jpeg_key(folder: str, checksum: str) -> str:
-    return f"{folder}/{checksum}.JPG"
+def jpeg_key(folder: str, checksum: str, prefix: str = "") -> str:
+    base = f"{folder}/{checksum}.JPG"
+    prefix = (prefix or "").strip("/")
+    return f"{prefix}/{base}" if prefix else base
 
 
 def build_s3_client(
@@ -88,17 +90,29 @@ def open_object_store_client() -> "ObjectStoreClient":
         access_key=settings.object_store.access_key,
         secret_key=settings.object_store.secret_key,
     )
-    return ObjectStoreClient(s3, settings.object_store.bucket)
+    return ObjectStoreClient(
+        s3,
+        settings.object_store.bucket,
+        labels_bucket=settings.object_store.get("labels_bucket", None),
+        labels_prefix=settings.object_store.get("labels_prefix", "") or "",
+    )
 
 
 class ObjectStoreClient:
     """Thin async wrapper over a boto3 S3 client for the data-worker's
     read + JPEG-write needs. Constructed per-activity-call; the boto3
-    client is injected so tests can pass a moto-backed one."""
+    client is injected so tests can pass a moto-backed one.
 
-    def __init__(self, s3, bucket: str):
+    Reads raw/slate **scratch** from ``bucket``; writes processed JPEGs to
+    ``labels_bucket`` (the LS-facing bucket) under ``labels_prefix``.
+    ``labels_bucket`` defaults to ``bucket`` so single-bucket layouts keep
+    working unchanged."""
+
+    def __init__(self, s3, bucket: str, labels_bucket=None, labels_prefix=""):
         self._s3 = s3
         self._bucket = bucket
+        self._labels_bucket = labels_bucket or bucket
+        self._labels_prefix = labels_prefix or ""
 
     async def _get(self, key: str) -> bytes:
         def _do() -> bytes:
@@ -125,7 +139,7 @@ class ObjectStoreClient:
     ) -> None:
         await asyncio.to_thread(
             self._s3.put_object,
-            Bucket=self._bucket,
-            Key=jpeg_key(folder, checksum),
+            Bucket=self._labels_bucket,
+            Key=jpeg_key(folder, checksum, self._labels_prefix),
             Body=data,
         )

--- a/services/fishsense-data-processing-workflow-worker/tests/test_object_store.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_object_store.py
@@ -35,6 +35,13 @@ def test_key_helpers():
     assert sut.jpeg_key("preprocess_groups_jpeg", "cafef00d") == (
         "preprocess_groups_jpeg/cafef00d.JPG"
     )
+    # labels_prefix partitions our JPEGs within the shared labels bucket.
+    assert sut.jpeg_key("preprocess_groups_jpeg", "cafef00d", "fishsense-lite") == (
+        "fishsense-lite/preprocess_groups_jpeg/cafef00d.JPG"
+    )
+    assert sut.jpeg_key("preprocess_jpeg", "x", "/fishsense-lite/") == (
+        "fishsense-lite/preprocess_jpeg/x.JPG"
+    )
 
 
 def test_build_s3_client_uses_path_style_addressing_for_garage():
@@ -92,6 +99,32 @@ async def test_upload_processed_jpeg_writes_folder_checksum_key(s3, folder):
 
     key = f"{folder}/cafef00d.JPG"
     assert s3.get_object(Bucket=BUCKET, Key=key)["Body"].read() == b"JPEGBYTES"
+
+
+@pytest.mark.asyncio
+async def test_split_buckets_read_scratch_write_labels(s3):
+    # Two-bucket layout: raw scratch is read from `bucket`, JPEGs are written
+    # to `labels_bucket` under `labels_prefix`.
+    labels = "labels-fishsense-test"
+    s3.create_bucket(Bucket=labels)
+    s3.put_object(Bucket=BUCKET, Key="raw/deadbeef.ORF", Body=b"RAW")
+    client = sut.ObjectStoreClient(
+        s3, BUCKET, labels_bucket=labels, labels_prefix="fishsense-lite"
+    )
+
+    async def _run():
+        raw = await client.download_raw("deadbeef")
+        await client.upload_processed_jpeg(
+            folder="preprocess_groups_jpeg", checksum="cafef00d", data=b"JPG"
+        )
+        return raw
+
+    assert await ActivityEnvironment().run(_run) == b"RAW"
+    # JPEG lands in the labels bucket, under the prefix; NOT the scratch bucket.
+    key = "fishsense-lite/preprocess_groups_jpeg/cafef00d.JPG"
+    assert s3.get_object(Bucket=labels, Key=key)["Body"].read() == b"JPG"
+    with pytest.raises(ClientError):
+        s3.get_object(Bucket=BUCKET, Key=key)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

Chasing down why no images show in Label Studio, two our-side root causes surfaced (heartex is **not** at fault):

1. **Wrong bucket.** Config pointed `object_store.bucket` at `fishsense`, which **does not exist** for our Garage key (`NoSuchBucket`). krg-infra provisioned two buckets — `fishsense-lite` (empty, ours) and `labels-fishsense-lite` (LS-facing; the working Coral Gardeners project already reads from it by prefix). Because `fishsense` returns NoSuchBucket, hosted LS 500'd on S3 storage-create *and* JPEG writes/reads would fail. Verified: same credentials → `fishsense` 404/NoSuchBucket, `labels-fishsense-lite` head+list OK; storage-create matrix → every `fishsense` combo 500, every `labels-fishsense-lite` combo OK (including our exact presign/blob flags).

2. **Publish timing regression.** #321 merged the earlier *publish-on-create* commit; the *publish-when-complete* correction never landed, so `main` publishes empty projects at create time. This restores the intended behavior.

## What

**Two-bucket split** (matches krg's naming; you chose this):
- New `object_store.labels_bucket` (defaults to `bucket`) + `object_store.labels_prefix` (defaults to `""`) on both workers — backward compatible.
- Raw/slate **scratch** stays in `bucket`; LS-served **JPEGs** write to / read from `labels_bucket` under `labels_prefix`.
- `build_image_url` emits `s3://{labels_bucket}/{prefix}/…`; `ensure_label_studio_s3_storage` registers the LS source storage against the labels bucket (+ prefix), mirroring coral-gardeners.

**Publish only when complete** (re-applies the lost correction):
- Projects created as drafts; each populate activity publishes only once its task set is complete (species: only when nothing JPEG-deferred). Empty projects stay hidden drafts.

## Ops action required to activate (config, not in repo)
Set on the api-worker slot config **and** the data-worker k8s config:
```
object_store.bucket        = fishsense-lite
object_store.labels_bucket = labels-fishsense-lite
object_store.labels_prefix = fishsense-lite
```

## Tests
TDD. Two-bucket: key-prefix helpers, split read-scratch/write-labels, `has_processed_jpeg` checks the labels bucket, `build_image_url`/storage-registration use labels bucket+prefix, plus single-bucket backward-compat. Publish-when-complete: per-activity publishes-when-complete / stays-draft-when-empty / (species) stays-draft-when-deferred. api-worker **250 passed**; data-worker **92 passed** (opencv module deselected — needs libgl, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)