### PR TITLE
chore(config): point workers at krg Garage buckets

### DIFF
--- a/deploy/incus/worker_volumes/api_worker/config/settings.toml
+++ b/deploy/incus/worker_volumes/api_worker/config/settings.toml
@@ -49,7 +49,11 @@ url = "http://fishsense-api:8000"
 [object_store]
 endpoint_url = "https://s3.e4e.ucsd.edu"
 region = "garage"
-bucket = "fishsense"
+# `bucket` = raw/slate scratch; `labels_bucket` = the LS-facing bucket where
+# processed JPEGs live (under `labels_prefix`). krg-infra provisioned both.
+bucket = "fishsense-lite"
+labels_bucket = "labels-fishsense-lite"
+labels_prefix = "fishsense-lite"
 
 # NRP data-worker scale-to-zero. The api-worker scales the data-worker
 # Deployment (ns `e4e-fishsense`) 0 <-> active_replicas on demand.

--- a/deploy/k8s/data-worker/settings.toml
+++ b/deploy/k8s/data-worker/settings.toml
@@ -61,7 +61,11 @@ url = "https://api.fishsense.e4e.ucsd.edu"
 [object_store]
 endpoint_url = "https://s3.e4e.ucsd.edu"
 region = "garage"
-bucket = "fishsense"
+# `bucket` = raw/slate scratch (read); `labels_bucket` = LS-facing bucket where
+# this worker writes processed JPEGs (under `labels_prefix`).
+bucket = "fishsense-lite"
+labels_bucket = "labels-fishsense-lite"
+labels_prefix = "fishsense-lite"
 
 # No NAS access from the data-worker by design — the api-worker is the
 # only side that touches the NAS, and it stages all bytes the


### PR DESCRIPTION
The code for the scratch/labels bucket split shipped in #324 (v1.41.4 / v2.7.4), but the **config commit didn't make it onto main** (it landed on the branch after #324 was squash-merged). So the deployed workers still read `bucket = "fishsense"` (which doesn't exist) → `labels_bucket` falls back to it → hosted LS still 500s on S3 storage-create.

This sets the values the #324 code needs, on both workers:
```
[object_store]
bucket        = "fishsense-lite"          # raw/slate scratch
labels_bucket = "labels-fishsense-lite"   # LS-served JPEGs
labels_prefix = "fishsense-lite"
```

- `deploy/incus/worker_volumes/api_worker/config/settings.toml`
- `deploy/k8s/data-worker/settings.toml`

**Deploy note:** config-only changes cut no release, so no auto-deploy PR opens. After merge, converge manually:
- api-worker: `deploy.yml` workflow_dispatch `target: incus` (or hand-converge).
- data-worker: `deploy.yml` workflow_dispatch `target: data-worker` (kustomize regenerates the settings ConfigMap → rolls the Deployment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)