### PR TITLE
fix(stage-raw): NAS-safe staging — correct buckets + serial downloads

### DIFF
--- a/deploy/incus/worker_volumes/api_worker/config/settings.toml
+++ b/deploy/incus/worker_volumes/api_worker/config/settings.toml
@@ -38,6 +38,10 @@ workspace = "FishSense"
 
 [e4e_nas]
 url = "https://e4e-nas.ucsd.edu:6021"
+# One serial .ORF download at a time — FileStation's download backend falls
+# over under concurrent large transfers. Ramp up (2, 3) only while watching
+# the NAS stay healthy.
+stage_concurrency = 1
 
 # Interior-network URL for SDK calls into fishsense-api — same compose network,
 # bypasses our traefik + the API forwardAuth gate.

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/stage_raw_bytes_for_dive_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/stage_raw_bytes_for_dive_activity.py
@@ -27,8 +27,9 @@ re-trying after that. A *permanent* error (Synology 408 "no such file")
 is raised as a non-retryable ApplicationError so Temporal doesn't
 reschedule a doomed staging. Files are never skipped — a silently-missing
 raw would stage the dive incomplete and hide a real NAS/data problem, so
-failures surface. `STAGE_CONCURRENCY` is deliberately low so a backlog of
-dives doesn't saturate FileStation's shared download backend.
+failures surface. Staging concurrency (`e4e_nas.stage_concurrency`, default 1)
+is deliberately low so a backlog of dives doesn't saturate FileStation's
+fragile shared download backend.
 """
 
 from __future__ import annotations
@@ -49,12 +50,24 @@ from fishsense_api_workflow_worker.config import settings
 from fishsense_api_workflow_worker.object_store import open_object_store_client
 from fishsense_api_workflow_worker.nas import NasDownloadClient
 
-# Lowered from 8 → 3: FileStation's download backend (DSM nginx →
-# synoscgi) is a shared per-appliance CGI service that buckles under many
-# concurrent large-`.ORF` transfers and starts returning 502. A handful
-# of streams is what it's sized for; fewer parallel downloads keep us
-# under that threshold and stop the worker tripping the NAS's auto-block.
-STAGE_CONCURRENCY = 3
+# Default max concurrent raw `.ORF` downloads per staging activity, used
+# when `e4e_nas.stage_concurrency` isn't set. FileStation's download backend
+# (DSM nginx → synoscgi) is a fragile shared per-appliance CGI that 502s /
+# falls over under concurrent large transfers, so default to a single serial
+# stream. Override via config to ramp up (1 → 2 → 3) while watching the NAS,
+# without a redeploy. Was a hardcoded 3 (and 8 before that).
+DEFAULT_STAGE_CONCURRENCY = 1
+
+
+def _stage_concurrency() -> int:
+    """Resolve the staging concurrency from config at runtime, clamped to
+    at least 1. Read here (not at import) so the value is picked up from
+    settings without a code change."""
+    try:
+        value = int(settings.e4e_nas.get("stage_concurrency", DEFAULT_STAGE_CONCURRENCY))
+    except (TypeError, ValueError):
+        value = DEFAULT_STAGE_CONCURRENCY
+    return max(1, value)
 
 # `type` on the non-retryable ApplicationError we raise for a missing
 # file; must match `non_retryable_error_types` in STAGE_RAW_RETRY_POLICY.
@@ -71,7 +84,7 @@ NAS_FILE_NOT_FOUND_TYPE = "NasFileNotFound"
 _PERMANENT_DSM_CODES = frozenset({408})
 
 __all__ = [
-    "STAGE_CONCURRENCY",
+    "DEFAULT_STAGE_CONCURRENCY",
     "NAS_FILE_NOT_FOUND_TYPE",
     "StageRawBytesResult",
     "stage_raw_bytes_for_dive_activity",
@@ -169,7 +182,11 @@ async def stage_raw_bytes_for_dive_activity(
     )
 
     nas = _build_nas_client()
-    sem = asyncio.Semaphore(STAGE_CONCURRENCY)
+    concurrency = _stage_concurrency()
+    activity.logger.info(
+        "staging concurrency=%d dive_id=%d", concurrency, dive_id
+    )
+    sem = asyncio.Semaphore(concurrency)
 
     staged = 0
     skipped = 0

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/config.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/config.py
@@ -42,6 +42,12 @@ _VALIDATORS = [
     Validator("e4e_nas.url", required=True, cast=str, condition=url_condition),
     Validator("e4e_nas.username", required=True, cast=str),
     Validator("e4e_nas.password", required=True, cast=str),
+    # Max concurrent raw `.ORF` downloads per staging activity. FileStation's
+    # download backend (DSM nginx -> synoscgi) is a fragile shared CGI that
+    # 502s / falls over under concurrent large transfers, so default to a
+    # single serial stream. Tunable via config (E4EFS_E4E_NAS__STAGE_CONCURRENCY)
+    # so we can ramp it up 1 -> 2 -> 3 while watching the NAS, without a redeploy.
+    Validator("e4e_nas.stage_concurrency", cast=int, default=1),
     # NAS path prefix prepended to relative `image.path` / `dive_slate.path`
     # values stored in the DB before downloading from FileStation. The DB
     # stores paths relative to the lab's data-root share (e.g.

--- a/services/fishsense-api-workflow-worker/tests/test_stage_raw_bytes_for_dive_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_stage_raw_bytes_for_dive_activity.py
@@ -434,3 +434,28 @@ def test_stage_raw_retry_policy_is_bounded_and_marks_missing_file_non_retryable(
     assert sut.NAS_FILE_NOT_FOUND_TYPE in (
         STAGE_RAW_RETRY_POLICY.non_retryable_error_types or []
     )
+
+
+def test_stage_concurrency_defaults_to_one(monkeypatch):
+    # FileStation is fragile; default to a single serial download stream.
+    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+
+    monkeypatch.delenv("E4EFS_E4E_NAS__STAGE_CONCURRENCY", raising=False)
+    cfg.settings.reload()
+    assert sut._stage_concurrency() == 1  # pylint: disable=protected-access
+
+
+def test_stage_concurrency_reads_config(monkeypatch):
+    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+
+    monkeypatch.setenv("E4EFS_E4E_NAS__STAGE_CONCURRENCY", "3")
+    cfg.settings.reload()
+    assert sut._stage_concurrency() == 3  # pylint: disable=protected-access
+
+
+def test_stage_concurrency_clamps_to_at_least_one(monkeypatch):
+    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+
+    monkeypatch.setenv("E4EFS_E4E_NAS__STAGE_CONCURRENCY", "0")
+    cfg.settings.reload()
+    assert sut._stage_concurrency() == 1  # pylint: disable=protected-access


### PR DESCRIPTION
## Goal

Make the api-worker safe to run against a fragile FileStation so a NAS restart doesn't get it killed again. This is the "good deploy" — with it running, the worker presents the NAS the gentlest possible load.

## The three NAS-hammering behaviors, all now removed

1. **Retry storm** — fixed by the bounded Temporal retry policy (#320, already deployed in v1.41.4).
2. **Infinite re-download** — the deployed config still points at `bucket=fishsense`, which **doesn't exist**, so every `stage_raw` downloads a dive from the NAS, fails uploading to the missing bucket, and Temporal re-runs it — re-downloading the whole dive forever because it can never succeed. This points both workers at krg's real buckets, so a dive stages **once** and then skips already-staged files (`has_raw`).
3. **Concurrency** — `STAGE_CONCURRENCY` was a hardcoded 3. Now `e4e_nas.stage_concurrency`, **default 1** (serial downloads), tunable via config so we can ramp `1 → 2 → 3` while watching the NAS, no redeploy.

## Changes
- `config.py`: `e4e_nas.stage_concurrency` validator (default 1).
- `stage_raw_bytes_for_dive_activity.py`: read concurrency from config at runtime (clamped ≥1); logs the value per run.
- Config (both workers): `bucket=fishsense-lite`, `labels_bucket=labels-fishsense-lite`, `labels_prefix=fishsense-lite`; api-worker also `e4e_nas.stage_concurrency=1`.

Supersedes #328 (bucket config only).

## Deploy → then restart the NAS
1. Merge this → release → promote → merge the api-worker + data-worker auto-deploy PRs (converge brings up the **good** worker while the NAS is still down — it just gets harmless 502s).
2. Verify the running worker: `bucket=fishsense-lite / labels-fishsense-lite / fishsense-lite` and `staging concurrency=1` in logs.
3. **Then** restart FileStation. The good worker stages one dive at a time, once each, and skips thereafter.

## Tests
api-worker **253 passed**. New: stage_concurrency default=1 / reads config / clamps ≥1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)