### PR TITLE
fix(label-studio): include dive_id in per-dive project titles

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
@@ -178,25 +178,23 @@ async def create_or_get_label_studio_project(
     return project.id
 
 
-# LS rejects `Project.title` over 50 characters with a 400. The
-# longest stage suffix ("Laser Calibration Labeling") is 26 chars, so
-# many real dive names blow the budget. `build_per_dive_title` keeps
-# titles within this cap by falling back to the `Dive {id}` form when
-# the dive's own name doesn't fit — that form is always under 50 chars
-# for any reasonable dive_id and uniquely identifies the dive.
+# LS rejects `Project.title` over 50 characters with a 400.
 LS_PROJECT_TITLE_MAX = 50
 
 
 async def build_per_dive_title(dive_id: int, suffix: str) -> str:
-    """Build a per-dive LS project title in the form
-    `"{dive.name} - {suffix}"`. Used by the four create-LS-project
-    activities so each dive ends up with its own project rather than
-    sharing one canonical project per stage.
+    """Build a per-dive LS project title `"{dive.name} #{dive_id} - {suffix}"`.
 
-    Falls back to `f"Dive {dive_id}"` when the dive has no `name` or
-    when `dive.name` would push the full title past LS's 50-char cap.
-    The fallback is keyed by `dive_id` rather than truncated name so
-    two long-named dives can't collide on the same truncated title.
+    Used by the four create-LS-project activities so each dive gets its own
+    project. `#{dive_id}` is **always** included so dives that share a `name`
+    still get distinct projects — dive names are NOT unique in prod (mislabeled
+    captures, duplicate-named dives, and same-site/same-camera repeats all
+    exist), so keying the title on the name alone silently merged two dives
+    into one project.
+
+    `dive.name` is truncated (never the `#{dive_id}` tail) to fit LS's 50-char
+    cap, so the id-based uniqueness survives even for long names. A nameless
+    dive yields `"#{dive_id} - {suffix}"`.
     """
     async with get_fs_client() as fs:
         dive = await fs.dives.get(dive_id=dive_id)
@@ -205,11 +203,14 @@ async def build_per_dive_title(dive_id: int, suffix: str) -> str:
             f"Cannot build LS project title for dive_id={dive_id}: "
             "no such dive found via the API"
         )
-    dive_label = dive.name or f"Dive {dive_id}"
-    title = f"{dive_label} - {suffix}"
-    if len(title) > LS_PROJECT_TITLE_MAX:
-        title = f"Dive {dive_id} - {suffix}"
-    return title
+    tail = f"#{dive_id} - {suffix}"
+    name = (dive.name or "").strip()
+    if not name:
+        return tail[:LS_PROJECT_TITLE_MAX]
+    budget = LS_PROJECT_TITLE_MAX - len(tail) - 1  # 1 for the space before tail
+    if budget < 1:
+        return tail[:LS_PROJECT_TITLE_MAX]
+    return f"{name[:budget].rstrip()} {tail}"
 
 
 async def import_tasks_and_record_labels(

--- a/services/fishsense-api-workflow-worker/tests/test_create_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_create_laser_label_studio_project_activity.py
@@ -62,7 +62,7 @@ def _patch_dive_lookup(monkeypatch, *, dive_name: str | None):
 @pytest.mark.asyncio
 async def test_returns_existing_project_id_by_title_match(monkeypatch):
     _patch_dive_lookup(monkeypatch, dive_name="dive-alpha")
-    expected_title = "dive-alpha - Laser Calibration Labeling"
+    expected_title = "dive-alpha #393 - Laser Calibration Labeling"
 
     ls = _make_ls(
         list_result=[
@@ -83,7 +83,7 @@ async def test_returns_existing_project_id_by_title_match(monkeypatch):
 @pytest.mark.asyncio
 async def test_creates_project_when_no_match_and_xml_present(monkeypatch):
     _patch_dive_lookup(monkeypatch, dive_name="dive-alpha")
-    expected_title = "dive-alpha - Laser Calibration Labeling"
+    expected_title = "dive-alpha #393 - Laser Calibration Labeling"
     monkeypatch.setattr(sut, "LASER_LABELING_CONFIG_XML", "<View><Image/></View>")
 
     ls = _make_ls(
@@ -123,11 +123,10 @@ async def test_raises_when_no_match_and_xml_constant_empty(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_falls_back_to_dive_id_when_name_missing(monkeypatch):
-    """A dive with a NULL name still gets a unique title — fall back
-    to `f"Dive {dive_id}"` so the create call doesn't generate an
-    empty-prefix title that would collide across nameless dives."""
+    """A dive with a NULL name still gets a unique title from the
+    `#{dive_id}` tail alone."""
     _patch_dive_lookup(monkeypatch, dive_name=None)
-    expected_title = "Dive 393 - Laser Calibration Labeling"
+    expected_title = "#393 - Laser Calibration Labeling"
     monkeypatch.setattr(sut, "LASER_LABELING_CONFIG_XML", "<View/>")
 
     ls = _make_ls(
@@ -150,14 +149,13 @@ async def test_falls_back_to_dive_id_when_name_missing(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_falls_back_to_dive_id_when_name_too_long(monkeypatch):
-    """LS caps `Project.title` at 50 chars. When a real dive's name
-    plus the stage suffix would exceed the cap, `build_per_dive_title`
-    must fall back to the `f"Dive {dive_id}"` form rather than
-    truncating — truncation could collide two long-named dives."""
+    """LS caps `Project.title` at 50 chars. A long dive name is
+    truncated to fit, but the `#{dive_id}` tail is always preserved so
+    two long-named dives can't collide on a truncated title."""
     long_name = "2024-08-21 Florida Keys reef survey dive 03 (cohort A)"
     assert len(long_name) > sut_utils.LS_PROJECT_TITLE_MAX
     _patch_dive_lookup(monkeypatch, dive_name=long_name)
-    expected_title = "Dive 393 - Laser Calibration Labeling"
+    expected_title = "2024-08-21 Flori #393 - Laser Calibration Labeling"
     monkeypatch.setattr(sut, "LASER_LABELING_CONFIG_XML", "<View/>")
 
     ls = _make_ls(

--- a/services/fishsense-api-workflow-worker/tests/test_populate_utils_workspace.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_utils_workspace.py
@@ -179,3 +179,43 @@ async def test_ensure_s3_storage_registers_labels_bucket_and_prefix(monkeypatch)
     assert kwargs["bucket"] == "labels-fishsense-lite"
     assert kwargs["prefix"] == "fishsense-lite"
     assert kwargs["presign"] is True
+
+
+async def _title_for(monkeypatch, dive_id, name, suffix):
+    from contextlib import asynccontextmanager  # pylint: disable=import-outside-toplevel
+    from types import SimpleNamespace  # pylint: disable=import-outside-toplevel
+
+    fake = MagicMock()
+
+    async def _get(**_k):
+        return SimpleNamespace(id=dive_id, name=name)
+
+    fake.dives.get = _get
+
+    @asynccontextmanager
+    async def _client():
+        yield fake
+
+    monkeypatch.setattr(pu, "get_fs_client", _client)
+    return await pu.build_per_dive_title(dive_id, suffix)
+
+
+async def test_same_named_dives_get_distinct_titles(monkeypatch):
+    # Real prod case: dives 439 and 440 share the (mislabeled) name. The
+    # #dive_id tail must keep their LS projects distinct.
+    t439 = await _title_for(monkeypatch, 439, "101624_AlligatorDeep_FSL02", "Species Labeling")
+    t440 = await _title_for(monkeypatch, 440, "101624_AlligatorDeep_FSL02", "Species Labeling")
+    assert t439 != t440
+    assert "#439" in t439 and "#440" in t440
+    assert len(t439) <= pu.LS_PROJECT_TITLE_MAX
+
+
+async def test_title_truncates_long_name_but_keeps_id(monkeypatch):
+    t = await _title_for(monkeypatch, 393, "x" * 80, "Laser Calibration Labeling")
+    assert len(t) <= pu.LS_PROJECT_TITLE_MAX
+    assert "#393 - Laser Calibration Labeling" in t
+
+
+async def test_title_nameless_dive_is_id_and_suffix(monkeypatch):
+    t = await _title_for(monkeypatch, 7, None, "Species Labeling")
+    assert t == "#7 - Species Labeling"


### PR DESCRIPTION
## Why

Dive names are **not unique** in prod — mislabeled captures, duplicate-named dives, and same-site/same-camera repeats all share names. `build_per_dive_title` keyed the LS project title on `dive.name` alone, so two distinct dives with the same name **silently merged into one project**.

Observed live: dives 439 and 440 (both named `101624_AlligatorDeep_FSL02`, different cameras, 0 shared images) landed in one project (274243), which then re-imported to **22,745 tasks with 0 label rows**. Even after canonical-dive filtering, ~8 same-name/same-camera canonical pairs remain that would collide.

## What

`build_per_dive_title` now always includes `#{dive_id}`:

```
"{name} #{dive_id} - {suffix}"
```

- The `#{dive_id}` tail is **always** present → one project per dive, guaranteed.
- The **name** is truncated (never the id tail) to fit LS's 50-char cap, so uniqueness survives long names.
- A nameless dive yields `"#{dive_id} - {suffix}"`.

## Note on rollout

Every per-dive title changes, so on next populate each dive creates a **fresh** project (old ones orphaned). That's fine given the current state — there is ~no real labeling in the existing per-dive projects (all empty/collided), so this is a clean-slate moment. Complements the direct-DB dive-name corrections (13 dives fixed separately).

## Tests

- New: two same-named dives (439/440) get distinct titles; long name truncates but keeps `#id`; nameless dive → `#id - suffix`.
- Updated the create-activity title assertions for the new format.
- api-worker **256 passed**, pylint 10.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)