### PR TITLE
fix(label-studio): resolve task ids by URL (hosted LS import is async)

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
@@ -213,6 +213,18 @@ async def build_per_dive_title(dive_id: int, suffix: str) -> str:
     return f"{name[:budget].rstrip()} {tail}"
 
 
+# Hosted LS's import is asynchronous — the created tasks are usually listable
+# immediately, but the import call returns before they're guaranteed queryable.
+# Bounded poll so a small lag doesn't force a Temporal activity retry.
+_IMPORT_VISIBILITY_ATTEMPTS = 12
+_IMPORT_VISIBILITY_INTERVAL_S = 2.0
+
+
+def _task_image_url(task: dict) -> str | None:
+    data = task.get("data", {}) or {}
+    return data.get("image") or data.get("img")
+
+
 async def import_tasks_and_record_labels(
     *,
     project_id: int,
@@ -222,37 +234,81 @@ async def import_tasks_and_record_labels(
 ) -> int:
     """Import `tasks` to LS, then PUT one label row per (item, task_id).
 
-    `record_label(item, task_id)` is the per-stage hook that builds and
-    upserts a LaserLabel/SpeciesLabel/HeadTailLabel/DiveSlateLabel row
-    via the SDK. Rows are PUT in parallel via TaskGroup matching the
-    notebook behaviour; the api PUTs are upserts so partial-failure
-    replay is safe.
+    `record_label(item, task_id)` is the per-stage hook that upserts a
+    LaserLabel/SpeciesLabel/HeadTailLabel/DiveSlateLabel row anchoring the
+    (image, LS task, project) triple. Rows are PUT in parallel via TaskGroup;
+    the api PUTs are upserts so partial-failure replay is safe.
+
+    **Hosted LS (Enterprise/heartex) imports asynchronously**: `import_tasks`
+    returns an import-job id, NOT task ids — only OSS returns task ids. The old
+    code read `imported.task_ids`, which doesn't exist on hosted LS: it crashed
+    *after* the tasks were created but *before* writing any label rows, so every
+    Temporal retry re-imported the whole batch (projects ballooned to tens of
+    thousands of tasks with zero label rows).
+
+    So we resolve task ids by listing the project's tasks and matching each
+    input task by its image URL (checksum-based, unique per image), and we
+    **dedupe against tasks already in the project before importing** — a retry
+    after a mid-activity failure then re-imports nothing and just writes the
+    missing rows.
     """
+    tasks = list(tasks)
+    items_list = list(items)
     if not tasks:
         return 0
+    if len(tasks) != len(items_list):
+        raise RuntimeError(
+            f"import_tasks_and_record_labels: {len(tasks)} tasks for "
+            f"{len(items_list)} items — the two lists must be parallel"
+        )
+
+    urls = [_task_image_url(t) for t in tasks]
+    if any(u is None for u in urls):
+        raise RuntimeError(
+            "import task missing an image URL in `data` — cannot anchor label"
+        )
 
     ls = _get_ls_client()
-    imported = await asyncio.to_thread(
-        lambda: ls.projects.import_tasks(
-            project_id, request=tasks, return_task_ids=True
-        )
-    )
-    task_ids: List[int] = list(imported.task_ids)
 
-    items_list = list(items)
-    if len(task_ids) != len(items_list):
-        raise RuntimeError(
-            f"LS import_tasks returned {len(task_ids)} task IDs for "
-            f"{len(items_list)} input items; refusing to write mismatched "
-            "label rows"
+    def _url_to_task_id() -> dict:
+        mapping: dict = {}
+        for task in ls.tasks.list(project=project_id):
+            data = getattr(task, "data", {}) or {}
+            url = data.get("image") or data.get("img")
+            if url is not None:
+                mapping[url] = task.id
+        return mapping
+
+    # Dedupe against what's already imported so a retry doesn't duplicate.
+    known = await asyncio.to_thread(_url_to_task_id)
+    to_import = [t for t, u in zip(tasks, urls) if u not in known]
+
+    if to_import:
+        await asyncio.to_thread(
+            lambda: ls.projects.import_tasks(
+                project_id, request=to_import, return_task_ids=True
+            )
         )
+        want = {u for u in urls if u not in known}
+        for _ in range(_IMPORT_VISIBILITY_ATTEMPTS):
+            known = await asyncio.to_thread(_url_to_task_id)
+            if want <= known.keys():
+                break
+            activity.heartbeat()
+            await asyncio.sleep(_IMPORT_VISIBILITY_INTERVAL_S)
+        missing = want - known.keys()
+        if missing:
+            raise RuntimeError(
+                f"{len(missing)} imported task(s) not visible in project "
+                f"{project_id} after import — retrying (dedupe prevents dupes)"
+            )
 
     async with asyncio.TaskGroup() as tg:
-        for item, task_id in zip(items_list, task_ids):
-            tg.create_task(record_label(item, task_id))
+        for item, url in zip(items_list, urls):
+            tg.create_task(record_label(item, known[url]))
             activity.heartbeat()
 
-    return len(task_ids)
+    return len(items_list)
 
 
 async def publish_label_studio_project(project_id: int) -> None:

--- a/services/fishsense-api-workflow-worker/tests/test_populate_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_dive_slate_label_studio_project_activity.py
@@ -126,11 +126,22 @@ def _make_fs_client(
 
 
 def _make_ls_client(returned_task_ids: List[int]):
+    # Fake hosted LS: import creates tasks (assigning ids from
+    # `returned_task_ids` in order) and `tasks.list` serves them back. The
+    # import response carries NO task_ids -- hosted LS imports asynchronously.
     ls = MagicMock()
     ls.projects = MagicMock()
-    ls.projects.import_tasks = MagicMock(
-        return_value=SimpleNamespace(task_ids=returned_task_ids)
-    )
+    _stored: List = []
+    _ids = iter(returned_task_ids)
+
+    def _import(project_id, request, return_task_ids=False):  # pylint: disable=unused-argument
+        for task in request:
+            _stored.append(SimpleNamespace(id=next(_ids), data=task["data"]))
+        return SimpleNamespace(import_=1)
+
+    ls.projects.import_tasks = MagicMock(side_effect=_import)
+    ls.tasks = MagicMock()
+    ls.tasks.list = MagicMock(side_effect=lambda project=None: list(_stored))
     return ls
 
 

--- a/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
@@ -153,11 +153,22 @@ def _make_fs_client(
 
 
 def _make_ls_client(returned_task_ids: List[int]):
+    # Fake hosted LS: import creates tasks (assigning ids from
+    # `returned_task_ids` in order) and `tasks.list` serves them back. The
+    # import response carries NO task_ids -- hosted LS imports asynchronously.
     ls = MagicMock()
     ls.projects = MagicMock()
-    ls.projects.import_tasks = MagicMock(
-        return_value=SimpleNamespace(task_ids=returned_task_ids)
-    )
+    _stored: List = []
+    _ids = iter(returned_task_ids)
+
+    def _import(project_id, request, return_task_ids=False):  # pylint: disable=unused-argument
+        for task in request:
+            _stored.append(SimpleNamespace(id=next(_ids), data=task["data"]))
+        return SimpleNamespace(import_=1)
+
+    ls.projects.import_tasks = MagicMock(side_effect=_import)
+    ls.tasks = MagicMock()
+    ls.tasks.list = MagicMock(side_effect=lambda project=None: list(_stored))
     return ls
 
 

--- a/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
@@ -155,11 +155,22 @@ def _make_fs_client(images: List[Image], existing_labels: List[LaserLabel]):
 
 
 def _make_ls_client(returned_task_ids: List[int]):
+    # Fake hosted LS: import creates tasks (assigning ids from
+    # `returned_task_ids` in order) and `tasks.list` serves them back. The
+    # import response carries NO task_ids -- hosted LS imports asynchronously.
     ls = MagicMock()
     ls.projects = MagicMock()
-    ls.projects.import_tasks = MagicMock(
-        return_value=SimpleNamespace(task_ids=returned_task_ids)
-    )
+    _stored: List = []
+    _ids = iter(returned_task_ids)
+
+    def _import(project_id, request, return_task_ids=False):  # pylint: disable=unused-argument
+        for task in request:
+            _stored.append(SimpleNamespace(id=next(_ids), data=task["data"]))
+        return SimpleNamespace(import_=1)
+
+    ls.projects.import_tasks = MagicMock(side_effect=_import)
+    ls.tasks = MagicMock()
+    ls.tasks.list = MagicMock(side_effect=lambda project=None: list(_stored))
     return ls
 
 
@@ -216,20 +227,32 @@ async def test_no_incomplete_images_is_a_no_op(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_aborts_when_import_tasks_returns_wrong_count(monkeypatch):
+async def test_rerun_does_not_reimport_existing_tasks(monkeypatch):
+    """Hosted LS import is async and returns no task ids; the activity resolves
+    ids by listing tasks and dedupes against ones already in the project. A
+    second run (e.g. after a mid-activity failure) must NOT re-import — that is
+    what stops the runaway task accumulation the old `imported.task_ids` crash
+    caused."""
     images = [_image(1, "a"), _image(2, "b")]
     fs = _make_fs_client(images, existing_labels=[])
-    ls = _make_ls_client(returned_task_ids=[999])  # only 1 ID for 2 tasks
+    ls = _make_ls_client(returned_task_ids=[1001, 1002])
 
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
     monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
 
-    with pytest.raises(Exception):
-        await ActivityEnvironment().run(
-            sut.populate_laser_label_studio_project_activity, 42, 73
-        )
+    n1 = await ActivityEnvironment().run(
+        sut.populate_laser_label_studio_project_activity, 42, 73
+    )
+    n2 = await ActivityEnvironment().run(
+        sut.populate_laser_label_studio_project_activity, 42, 73
+    )
 
-    fs.labels.put_laser_label.assert_not_called()
+    assert n1 == 2 and n2 == 2
+    # Imported exactly once: the rerun found both tasks already present and
+    # only re-resolved their ids to (re-)write the rows.
+    assert ls.projects.import_tasks.call_count == 1
+    written = [c.args[1] for c in fs.labels.put_laser_label.await_args_list]
+    assert {label.label_studio_task_id for label in written} == {1001, 1002}
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_activity.py
@@ -189,11 +189,22 @@ def _make_fs_client(
 
 
 def _make_ls_client(returned_task_ids: List[int]):
+    # Fake hosted LS: import creates tasks (assigning ids from
+    # `returned_task_ids` in order) and `tasks.list` serves them back. The
+    # import response carries NO task_ids -- hosted LS imports asynchronously.
     ls = MagicMock()
     ls.projects = MagicMock()
-    ls.projects.import_tasks = MagicMock(
-        return_value=SimpleNamespace(task_ids=returned_task_ids)
-    )
+    _stored: List = []
+    _ids = iter(returned_task_ids)
+
+    def _import(project_id, request, return_task_ids=False):  # pylint: disable=unused-argument
+        for task in request:
+            _stored.append(SimpleNamespace(id=next(_ids), data=task["data"]))
+        return SimpleNamespace(import_=1)
+
+    ls.projects.import_tasks = MagicMock(side_effect=_import)
+    ls.tasks = MagicMock()
+    ls.tasks.list = MagicMock(side_effect=lambda project=None: list(_stored))
     return ls
 
 


### PR DESCRIPTION
## The bug (the runaway re-import)

Hosted LS (Enterprise/heartex) imports tasks **asynchronously**: `import_tasks` returns an import-*job* id, not task ids — only OSS/community returns them. `import_tasks_and_record_labels` read `imported.task_ids`:

```
'ImportTasksProjectsResponse' object has no attribute 'task_ids'
```

So it created the tasks in LS, then **crashed before writing any label row**. Temporal retried → re-imported the whole batch → repeat. That's why projects ballooned (274243: 22,745 tasks / 0 rows; dive 439's fresh post-rename project: 6,954 / 0) and never seeded the anchoring rows.

Verified live: the failed `populate-species-439` activity error was exactly that AttributeError; a throwaway import probe confirmed the hosted response carries `import_: <id>` and **no** `task_ids` (not even in extras), while the tasks *were* created and listable.

## The fix

`import_tasks_and_record_labels` no longer reads `task_ids`. It:
- **resolves** each task's id by listing the project's tasks and matching on the image URL in the task data (checksum-based → unique per image);
- **dedupes** against tasks already in the project *before* importing, so a retry after a mid-activity failure re-imports nothing and just writes the missing rows — this is what stops the runaway;
- **bounded-polls** for the async import to become listable (usually immediate).

Works for both hosted (async) and OSS (sync) LS.

## Tests

The 4 populate fakes now model hosted LS: `import_tasks` stores tasks and returns a response with **no** `task_ids`; `tasks.list` serves them back. New `test_rerun_does_not_reimport_existing_tasks` pins the dedup (second run → `import_tasks` call_count stays 1). **256 passed**, pylint 10.

## Rollout

This is the last blocker for stable labeling. After deploy, freshly-created `#{id}` projects will import once, persist rows, and stop re-importing — so they won't balloon. (LS cleanup already done; the empty projects were deleted.)