### PR TITLE
fix(data-worker): cap max_concurrent_activities to stop OOM crash-loop

### DIFF
--- a/deploy/k8s/data-worker/settings.toml
+++ b/deploy/k8s/data-worker/settings.toml
@@ -24,6 +24,10 @@
 
 [general]
 max_workers = 8
+# Cap concurrent activities so peak memory (each per-image activity does a
+# ~1-2 GB rawpy decode) stays under the pod's 12 Gi limit. Uncapped (SDK
+# default 100) OOMKilled the pod → CrashLoopBackOff. Raise cautiously.
+max_concurrent_activities = 4
 
 # Shared krg-prod Temporal (mTLS). MUST match the api-worker's cluster +
 # TLS server-name — the two workers share the `fishsense_data_processing_queue`

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/config.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/config.py
@@ -24,6 +24,16 @@ _VALIDATORS = [
         default=4,
         condition=lambda x: x > 0,
     ),
+    # Max activities run concurrently. Bounds peak memory: the per-image
+    # activities each do a ~1-2 GB rawpy decode, so an uncapped worker OOMs the
+    # 12 Gi pod. Keep low; raise cautiously while watching `kubectl top pod`.
+    Validator(
+        "general.max_concurrent_activities",
+        required=True,
+        cast=int,
+        default=4,
+        condition=lambda x: x > 0,
+    ),
     Validator("temporal.host", required=True, cast=str, condition=validators.hostname),
     Validator("temporal.port", required=True, cast=int, default=7233),
     Validator("temporal.tls", required=True, cast=bool, default=False),

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
@@ -1,3 +1,10 @@
+"""Data-worker Temporal worker construction and run loop.
+
+Single ``build_worker`` construction point (shared with tests) plus the
+``main`` scale-to-zero-friendly run loop. Caps activity concurrency to keep
+the CPU-heavy per-image rectify/decode work under the pod's memory limit.
+"""
+
 import asyncio
 import logging
 import signal
@@ -68,6 +75,15 @@ TASK_QUEUE_NAME = "fishsense_data_processing_queue"
 # The k8s Deployment's terminationGracePeriodSeconds must be >= this.
 GRACEFUL_SHUTDOWN_TIMEOUT = timedelta(seconds=30)
 
+# Cap on activities executed at once. The per-image activities are async and
+# offload full-res rawpy decode + opencv rectify via `asyncio.to_thread`, each
+# peaking at ~1-2 GB. The Temporal SDK default (100) let a burst run ~8-9
+# decodes concurrently, which blew the pod's 12 Gi limit → OOMKilled →
+# CrashLoopBackOff (the whole worker died on startup within seconds, so nothing
+# drained). Cap it low so peak memory stays bounded; tune via
+# `general.max_concurrent_activities`.
+DEFAULT_MAX_CONCURRENT_ACTIVITIES = 4
+
 
 async def schedule_workflows(_: Client):
     """Schedule workflows for the worker.
@@ -79,16 +95,21 @@ async def schedule_workflows(_: Client):
     """
 
 
-def build_worker(client: Client, activity_executor: ThreadPoolExecutor) -> Worker:
+def build_worker(
+    client: Client,
+    activity_executor: ThreadPoolExecutor,
+    max_concurrent_activities: int = DEFAULT_MAX_CONCURRENT_ACTIVITIES,
+) -> Worker:
     """Construct the data-worker Temporal worker.
 
     Single construction point so the worker config (workflows, activities,
-    graceful-shutdown window) is exercised by tests without standing up
-    the full ``main`` loop.
+    graceful-shutdown window, activity concurrency cap) is exercised by tests
+    without standing up the full ``main`` loop.
     """
     return Worker(
         client,
         task_queue=TASK_QUEUE_NAME,
+        max_concurrent_activities=max_concurrent_activities,
         workflows=[
             DiveFrameClusteringWorkflow,
             MeasureFishWorkflow,
@@ -140,7 +161,13 @@ async def main():
         loop.add_signal_handler(sig, interrupt_event.set)
 
     with ThreadPoolExecutor(max_workers=settings.general.max_workers) as executor:
-        async with build_worker(client, executor):
+        async with build_worker(
+            client,
+            executor,
+            settings.general.get(
+                "max_concurrent_activities", DEFAULT_MAX_CONCURRENT_ACTIVITIES
+            ),
+        ):
             log.info("Worker started, scheduling workflows...")
             await schedule_workflows(client)
             await interrupt_event.wait()

--- a/services/fishsense-data-processing-workflow-worker/tests/test_worker.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_worker.py
@@ -17,6 +17,7 @@ import pytest
 from temporalio.testing import WorkflowEnvironment
 
 from fishsense_data_processing_workflow_worker.worker import (
+    DEFAULT_MAX_CONCURRENT_ACTIVITIES,
     GRACEFUL_SHUTDOWN_TIMEOUT,
     TASK_QUEUE_NAME,
     build_worker,
@@ -36,3 +37,16 @@ async def test_build_worker_wires_graceful_shutdown_and_task_queue():
             config = worker.config()
             assert config["task_queue"] == TASK_QUEUE_NAME
             assert config["graceful_shutdown_timeout"] == GRACEFUL_SHUTDOWN_TIMEOUT
+            # Default concurrency cap bounds peak memory (rawpy OOM guard).
+            assert (
+                config["max_concurrent_activities"]
+                == DEFAULT_MAX_CONCURRENT_ACTIVITIES
+            )
+
+
+@pytest.mark.asyncio
+async def test_build_worker_honors_explicit_concurrency_cap():
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            worker = build_worker(env.client, executor, max_concurrent_activities=2)
+            assert worker.config()["max_concurrent_activities"] == 2


### PR DESCRIPTION
## Root cause (confirmed on the live pod via kubectl)

The data-worker was in **CrashLoopBackOff**, killing the entire pipeline: no stage-2 JPEGs → species populate JPEG-gates to 0 → every LS project empty.

- `Last State: Terminated, Reason: OOMKilled, Exit Code: 137`, **9 restarts**, dying ~17s after startup.
- Crash log at OOM: ~**9 `preprocess_headtail_image`** activities running concurrently (plus a `validate_laser_labels` burst).

The per-image activities are `async def` and offload full-res rawpy decode + opencv rectify via `asyncio.to_thread` (~1–2 GB peak each). The Worker set **no `max_concurrent_activities`**, so the SDK default (100) let ~8–9 decodes run at once → blew the pod's 12 Gi limit → OOM → restart → same backlog → crash-loop. It worked earlier (a 122-image species batch drained fully) only when no such burst coincided.

## Fix

Cap concurrent activities via `Worker(max_concurrent_activities=…)`, configurable as `general.max_concurrent_activities` (**default 4**). 4 concurrent decodes ≈ 6–8 GB, comfortably under 12 Gi, while the worker stays up and drains.

**Why not lower `general.max_workers`?** That's the Temporal *sync* activity executor — unused here, since our activities are async and their `to_thread` work runs on asyncio's default executor. `max_concurrent_activities` is the only correct bound.

## Tests

`test_worker.py`: assert the default cap is wired into the Worker config, and that an explicit cap propagates. Both pass locally; each changed file lints 10.00.

## Deploy + immediate relief

This is the last blocker for the whole pipeline. After deploy (data-worker chain → `kubectl apply -k`), the worker stops OOMing and drains stage-2 → JPEGs → tasks. For **immediate relief before the deploy**, bump the pod memory limit so it survives the current burst:
`kubectl -n e4e-fishsense patch deployment fishsense-data-processing-workflow-worker --type=json -p='[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"24Gi"}]'`
(reverts on the next converge; the cap makes 12 Gi safe again).