### PR TITLE
fix(label-studio): normalize resolve-wrapper task URLs so dedup matches

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
@@ -12,6 +12,9 @@ target project ID and then push tasks into it.
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
+import urllib.parse
 from typing import Any, Awaitable, Callable, Iterable, List
 
 from label_studio_sdk.client import LabelStudio
@@ -225,6 +228,30 @@ def _task_image_url(task: dict) -> str | None:
     return data.get("image") or data.get("img")
 
 
+def _normalize_image_url(url: str | None) -> str | None:
+    """Reduce an LS task image URL to a stable comparison key (the s3 URI).
+
+    Freshly-built task data carries `s3://…`, but when hosted LS *lists* tasks
+    it returns `data.image` as a per-task presign resolve-wrapper
+    `/tasks/{task_id}/resolve/?fileuri=<base64(s3://…)>`. The embedded task_id
+    makes that string unique per task, so comparing it raw against the built
+    `s3://` URL never matched — silently defeating dedup and re-importing the
+    whole batch every run (projects ballooned to thousands of tasks, 0 rows).
+    Decode the `fileuri` back to the s3 URI so both forms compare equal.
+    """
+    if not url or url.startswith("s3://"):
+        return url
+    if "fileuri=" in url:
+        query = urllib.parse.urlparse(url).query
+        fileuri = urllib.parse.parse_qs(query).get("fileuri", [None])[0]
+        if fileuri:
+            try:
+                return base64.b64decode(fileuri).decode("utf-8")
+            except (binascii.Error, ValueError, UnicodeDecodeError):
+                return url
+    return url
+
+
 async def import_tasks_and_record_labels(
     *,
     project_id: int,
@@ -262,7 +289,7 @@ async def import_tasks_and_record_labels(
             f"{len(items_list)} items — the two lists must be parallel"
         )
 
-    urls = [_task_image_url(t) for t in tasks]
+    urls = [_normalize_image_url(_task_image_url(t)) for t in tasks]
     if any(u is None for u in urls):
         raise RuntimeError(
             "import task missing an image URL in `data` — cannot anchor label"
@@ -274,7 +301,7 @@ async def import_tasks_and_record_labels(
         mapping: dict = {}
         for task in ls.tasks.list(project=project_id):
             data = getattr(task, "data", {}) or {}
-            url = data.get("image") or data.get("img")
+            url = _normalize_image_url(data.get("image") or data.get("img"))
             if url is not None:
                 mapping[url] = task.id
         return mapping

--- a/services/fishsense-api-workflow-worker/tests/test_populate_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_dive_slate_label_studio_project_activity.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import List
@@ -136,7 +138,17 @@ def _make_ls_client(returned_task_ids: List[int]):
 
     def _import(project_id, request, return_task_ids=False):  # pylint: disable=unused-argument
         for task in request:
-            _stored.append(SimpleNamespace(id=next(_ids), data=task["data"]))
+            _tid = next(_ids)
+            _s3 = task["data"].get("image") or task["data"].get("img")
+            _fileuri = base64.b64encode(_s3.encode()).decode()
+            # hosted LS lists tasks with a per-task presign resolve-wrapper,
+            # NOT the imported s3:// URL — mirror that so dedup is exercised.
+            _stored.append(
+                SimpleNamespace(
+                    id=_tid,
+                    data={"image": f"/tasks/{_tid}/resolve/?fileuri={_fileuri}"},
+                )
+            )
         return SimpleNamespace(import_=1)
 
     ls.projects.import_tasks = MagicMock(side_effect=_import)

--- a/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
@@ -12,6 +12,8 @@ Two correctness invariants particular to stage 5.3:
 
 from __future__ import annotations
 
+import base64
+
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import List, Optional
@@ -163,7 +165,17 @@ def _make_ls_client(returned_task_ids: List[int]):
 
     def _import(project_id, request, return_task_ids=False):  # pylint: disable=unused-argument
         for task in request:
-            _stored.append(SimpleNamespace(id=next(_ids), data=task["data"]))
+            _tid = next(_ids)
+            _s3 = task["data"].get("image") or task["data"].get("img")
+            _fileuri = base64.b64encode(_s3.encode()).decode()
+            # hosted LS lists tasks with a per-task presign resolve-wrapper,
+            # NOT the imported s3:// URL — mirror that so dedup is exercised.
+            _stored.append(
+                SimpleNamespace(
+                    id=_tid,
+                    data={"image": f"/tasks/{_tid}/resolve/?fileuri={_fileuri}"},
+                )
+            )
         return SimpleNamespace(import_=1)
 
     ls.projects.import_tasks = MagicMock(side_effect=_import)

--- a/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
@@ -10,6 +10,8 @@ rows.
 
 from __future__ import annotations
 
+import base64
+
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import List
@@ -165,7 +167,17 @@ def _make_ls_client(returned_task_ids: List[int]):
 
     def _import(project_id, request, return_task_ids=False):  # pylint: disable=unused-argument
         for task in request:
-            _stored.append(SimpleNamespace(id=next(_ids), data=task["data"]))
+            _tid = next(_ids)
+            _s3 = task["data"].get("image") or task["data"].get("img")
+            _fileuri = base64.b64encode(_s3.encode()).decode()
+            # hosted LS lists tasks with a per-task presign resolve-wrapper,
+            # NOT the imported s3:// URL — mirror that so dedup is exercised.
+            _stored.append(
+                SimpleNamespace(
+                    id=_tid,
+                    data={"image": f"/tasks/{_tid}/resolve/?fileuri={_fileuri}"},
+                )
+            )
         return SimpleNamespace(import_=1)
 
     ls.projects.import_tasks = MagicMock(side_effect=_import)

--- a/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_activity.py
@@ -14,6 +14,8 @@ project's own in-progress rows.
 
 from __future__ import annotations
 
+import base64
+
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import List, Optional
@@ -199,7 +201,17 @@ def _make_ls_client(returned_task_ids: List[int]):
 
     def _import(project_id, request, return_task_ids=False):  # pylint: disable=unused-argument
         for task in request:
-            _stored.append(SimpleNamespace(id=next(_ids), data=task["data"]))
+            _tid = next(_ids)
+            _s3 = task["data"].get("image") or task["data"].get("img")
+            _fileuri = base64.b64encode(_s3.encode()).decode()
+            # hosted LS lists tasks with a per-task presign resolve-wrapper,
+            # NOT the imported s3:// URL — mirror that so dedup is exercised.
+            _stored.append(
+                SimpleNamespace(
+                    id=_tid,
+                    data={"image": f"/tasks/{_tid}/resolve/?fileuri={_fileuri}"},
+                )
+            )
         return SimpleNamespace(import_=1)
 
     ls.projects.import_tasks = MagicMock(side_effect=_import)

--- a/services/fishsense-api-workflow-worker/tests/test_populate_utils_workspace.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_utils_workspace.py
@@ -219,3 +219,18 @@ async def test_title_truncates_long_name_but_keeps_id(monkeypatch):
 async def test_title_nameless_dive_is_id_and_suffix(monkeypatch):
     t = await _title_for(monkeypatch, 7, None, "Species Labeling")
     assert t == "#7 - Species Labeling"
+
+
+def test_normalize_image_url_decodes_hosted_ls_resolve_wrapper():
+    import base64  # pylint: disable=import-outside-toplevel
+
+    s3 = "s3://labels-fishsense-lite/fishsense-lite/preprocess_groups_jpeg/abc.JPG"
+    wrapper = "/tasks/999/resolve/?fileuri=" + base64.b64encode(s3.encode()).decode()
+    # Hosted LS lists tasks with the resolve-wrapper; must decode back to s3://
+    # so dedup/resolve match the built s3:// URLs (else re-import every run).
+    assert pu._normalize_image_url(wrapper) == s3
+    assert pu._normalize_image_url(s3) == s3          # raw s3:// passes through
+    assert pu._normalize_image_url(None) is None
+    assert pu._normalize_image_url("/tasks/1/resolve/?fileuri=!!bad") == (
+        "/tasks/1/resolve/?fileuri=!!bad"             # undecodable → returned as-is
+    )


### PR DESCRIPTION
## Why (found while watching #336/#339 in prod)

After #336 deployed, projects **still ballooned** — 439's project hit **2,440 tasks for 122 images, 0 rows**. Root cause: #336 dedups/resolves task ids by matching the built `s3://` URL against the URL from `tasks.list`, but **hosted LS lists tasks with `data.image` = a per-task presign resolve-wrapper**:

```
/tasks/277831166/resolve/?fileuri=czM6Ly9sYWJlbHM…   (base64 of the s3:// URI, and the {task_id} makes it unique per task)
```

vs the built `s3://labels-fishsense-lite/…`. They never match → dedup misses every run → re-imports the whole batch → the visibility poll (`want <= known`) never satisfies → activity fails → **rows never persist** → re-import next run.

My #336 test fake returned the raw `s3://` from `tasks.list`, so the bug slipped through.

## Fix

`_normalize_image_url` decodes the resolve-wrapper's `fileuri` back to the `s3://` URI (raw `s3://` passes through, undecodable → returned as-is). Both the built URLs and the listed URLs are normalized before matching, so **dedup, the visibility poll, and id resolution all compare like-for-like**.

## Tests

- The 4 populate fakes now emit the **resolve-wrapper** form from `tasks.list` (matching hosted LS) — regression guard: without normalization the rerun/dedup tests fail.
- Direct `_normalize_image_url` unit test (decode wrapper, s3:// passthrough, None, undecodable).
- 257 passed; changed files lint 10.00.

## Post-deploy cleanup

The re-ballooned projects (274496 ≈2,440, 274504 ≈420, both 0 rows) should be deleted after this deploys so they regenerate clean. Separately, #339's `cap=4` was borderline (2 OOMs on the backlog burst before stabilizing) — may want a lower cap or more memory if OOMs recur.