### PR TITLE
test(label-studio): fix stale dedup task-count assertion (5, not 8)

### DIFF
--- a/services/fishsense-api-workflow-worker/tests/test_label_studio_integration.py
+++ b/services/fishsense-api-workflow-worker/tests/test_label_studio_integration.py
@@ -283,12 +283,18 @@ async def test_populate_skips_completed_against_real_ls(
     )
     assert n2 == 3  # only the 3 still-incomplete images
 
-    # LS now has 5 + 3 = 8 tasks. (Populate doesn't dedupe via LS — it
-    # dedupes against SQL state. Re-running with the same SQL state
-    # would push duplicates; that's why the SQL-based completed-filter
-    # is the correctness gate.)
+    # LS still has exactly 5 tasks. Populate now dedupes against LS
+    # itself: each built `s3://` URL is matched against the tasks
+    # already in the project, decoding hosted LS's per-task
+    # resolve-wrapper URLs (`/tasks/{id}/resolve/?fileuri=<b64(s3://…)>`)
+    # back to the `s3://` form first. So re-running for images that
+    # already have a task imports nothing new — no duplicate/ballooning
+    # tasks (the runaway accumulation the async-import + no-dedup bug
+    # caused). n2 == 3 counts the still-incomplete images processed
+    # (their existing task ids re-resolved and rows rewritten), not new
+    # imports.
     ls_tasks = list(ls.tasks.list(project=project_id))
-    assert len(ls_tasks) == 8
+    assert len(ls_tasks) == 5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Fixes the real-LS integration test `test_populate_skips_completed_against_real_ls`, which failed on the release PR #344 (`assert 5 == 8`) and blocked confidence in deploying v1.41.8.

## Why it failed

The test still asserted the **pre-#343** behavior — a second populate run re-imports the still-incomplete images as brand-new tasks (5 + 3 = 8), with a comment claiming *"Populate doesn't dedupe via LS."*

Since #343 (resolve-wrapper URL normalization), populate **dedupes against tasks already in the project**: each built `s3://` URL is matched against LS's per-task resolve-wrapper URLs (`/tasks/{id}/resolve/?fileuri=<b64(s3://…)>`), so the rerun imports nothing new. `n2 == 3` still holds (three incomplete images processed, rows rewritten), but LS holds **5** tasks, not 8.

`8` was exactly the ballooning #343 fixed — this is a stale test, not a code regression. The `integration-tests` label runs the real-LS suite on this PR to prove it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)