### PR TITLE
fix(api): upsert put_*_label on natural key, not blind INSERT

### DIFF
--- a/services/fishsense-api/src/fishsense_api/controllers/label_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/label_controller.py
@@ -106,6 +106,23 @@ async def put_dive_slate_label(
     label = DiveSlateLabel.model_validate(jsonable_encoder(label))
     label.image_id = image_id
 
+    # Natural-key upsert: merge on id=None always INSERTs, violating
+    # uq_dive_slate_image_project on a populate retry. Resolve to the
+    # existing (image_id, project) row first (see put_headtail_label).
+    if label.id is None and label.label_studio_project_id is not None:
+        existing = (
+            await session.exec(
+                select(DiveSlateLabel)
+                .where(DiveSlateLabel.image_id == image_id)
+                .where(
+                    DiveSlateLabel.label_studio_project_id
+                    == label.label_studio_project_id
+                )
+            )
+        ).first()
+        if existing is not None:
+            label.id = existing.id
+
     label = await session.merge(label)
     await session.flush()
 
@@ -227,6 +244,26 @@ async def put_headtail_label(
     logger.debug("Creating or updating head-tail label for image with id=%d", image_id)
     label = HeadTailLabel.model_validate(jsonable_encoder(label))
     label.image_id = image_id
+
+    # session.merge keys on the primary key alone, so a body with id=None
+    # always INSERTs — which violates uq_headtail_image_project when the
+    # populate activity retries and re-writes a sentinel row that already
+    # exists for this (image_id, project). Resolve the natural key to the
+    # existing row id first so the merge becomes an UPDATE (see
+    # post_measurement / uq_measurement_image_fish for the precedent).
+    if label.id is None and label.label_studio_project_id is not None:
+        existing = (
+            await session.exec(
+                select(HeadTailLabel)
+                .where(HeadTailLabel.image_id == image_id)
+                .where(
+                    HeadTailLabel.label_studio_project_id
+                    == label.label_studio_project_id
+                )
+            )
+        ).first()
+        if existing is not None:
+            label.id = existing.id
 
     label = await session.merge(label)
     await session.flush()
@@ -429,6 +466,23 @@ async def put_laser_label(
     label = LaserLabel.model_validate(jsonable_encoder(label))
     label.image_id = image_id
 
+    # Natural-key upsert: merge on id=None always INSERTs, violating
+    # uq_laser_image_project on a populate retry. Resolve to the existing
+    # (image_id, project) row first (see put_headtail_label).
+    if label.id is None and label.label_studio_project_id is not None:
+        existing = (
+            await session.exec(
+                select(LaserLabel)
+                .where(LaserLabel.image_id == image_id)
+                .where(
+                    LaserLabel.label_studio_project_id
+                    == label.label_studio_project_id
+                )
+            )
+        ).first()
+        if existing is not None:
+            label.id = existing.id
+
     label = await session.merge(label)
     await session.flush()
 
@@ -522,6 +576,23 @@ async def put_species_label(
     logger.debug("Creating or updating species label for image with id=%d", image_id)
     label = SpeciesLabel.model_validate(jsonable_encoder(label))
     label.image_id = image_id
+
+    # Natural-key upsert: merge on id=None always INSERTs, violating
+    # uq_species_image_project on a populate retry. Resolve to the existing
+    # (image_id, project) row first (see put_headtail_label).
+    if label.id is None and label.label_studio_project_id is not None:
+        existing = (
+            await session.exec(
+                select(SpeciesLabel)
+                .where(SpeciesLabel.image_id == image_id)
+                .where(
+                    SpeciesLabel.label_studio_project_id
+                    == label.label_studio_project_id
+                )
+            )
+        ).first()
+        if existing is not None:
+            label.id = existing.id
 
     label = await session.merge(label)
     await session.flush()

--- a/services/fishsense-api/tests/test_label_upsert_endpoint.py
+++ b/services/fishsense-api/tests/test_label_upsert_endpoint.py
@@ -1,0 +1,113 @@
+"""put_*_label endpoints upsert on the natural key, not blind-INSERT.
+
+Every label model carries a `uq_<kind>_image_project` unique constraint on
+`(image_id, label_studio_project_id)`. The handlers used a plain
+`session.merge(label)` which keys on the primary key alone, so a body with
+`id=None` always INSERTs. That is fine on the first write but blows up with
+a duplicate-key 500 on the *second* — exactly what happens when the populate
+activity retries and re-writes the sentinel rows it already created (observed
+in prod on headtail dive 347 after the LS import dedup fix stopped masking it
+by crashing earlier).
+
+Same failure mode and same fix as `post_measurement` /
+`uq_measurement_image_fish`: resolve the natural key to the existing row id
+first so the merge becomes an UPDATE. Parametrized across all four label
+kinds because all four handlers shared the bug.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+def _cases():
+    from fishsense_api.controllers.label_controller import (  # pylint: disable=import-outside-toplevel
+        put_dive_slate_label,
+        put_headtail_label,
+        put_laser_label,
+        put_species_label,
+    )
+    from fishsense_api.models.dive_slate_label import (  # pylint: disable=import-outside-toplevel
+        DiveSlateLabel,
+    )
+    from fishsense_api.models.head_tail_label import (  # pylint: disable=import-outside-toplevel
+        HeadTailLabel,
+    )
+    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+        LaserLabel,
+    )
+    from fishsense_api.models.species_label import (  # pylint: disable=import-outside-toplevel
+        SpeciesLabel,
+    )
+
+    return [
+        pytest.param(put_headtail_label, HeadTailLabel, id="headtail"),
+        pytest.param(put_laser_label, LaserLabel, id="laser"),
+        pytest.param(put_species_label, SpeciesLabel, id="species"),
+        pytest.param(put_dive_slate_label, DiveSlateLabel, id="dive_slate"),
+    ]
+
+
+def _label(model, *, task_id, project_id, completed):
+    return model(
+        id=None,
+        label_studio_task_id=task_id,
+        label_studio_project_id=project_id,
+        completed=completed,
+    )
+
+
+@pytest.mark.parametrize("put_fn,model", _cases())
+async def test_put_label_creates_then_upserts_on_retry(session, put_fn, model):
+    """First PUT inserts; a second PUT for the same (image, project) with
+    id=None must UPDATE the same row — not raise duplicate-key."""
+    first_id = await put_fn(
+        11, _label(model, task_id=500, project_id=73, completed=False), session=session
+    )
+    await session.flush()
+
+    # The populate retry: same task, same (image, project), still id=None.
+    second_id = await put_fn(
+        11, _label(model, task_id=500, project_id=73, completed=True), session=session
+    )
+    await session.flush()
+
+    rows = (await session.exec(select(model))).all()
+    assert len(rows) == 1, "retry must upsert on (image_id, project), not duplicate"
+    assert first_id == second_id
+    assert rows[0].completed is True, "latest write wins"
+
+
+@pytest.mark.parametrize("put_fn,model", _cases())
+async def test_put_label_distinct_projects_same_image_both_persist(
+    session, put_fn, model
+):
+    """The natural key includes the project — the same image in two
+    different per-dive projects is two legitimate rows."""
+    await put_fn(
+        11, _label(model, task_id=600, project_id=73, completed=False), session=session
+    )
+    await session.flush()
+    await put_fn(
+        11, _label(model, task_id=601, project_id=99, completed=False), session=session
+    )
+    await session.flush()
+
+    rows = (await session.exec(select(model))).all()
+    assert len(rows) == 2


### PR DESCRIPTION
## Summary

All four `put_*_label` handlers (laser, species, headtail, dive-slate) did a plain `session.merge(label)`. `merge` keys on the **primary key** alone, so a body with `id=None` always **INSERTs** — fine on the first write, but a **duplicate-key 500** on the second, because every label model has a `uq_<kind>_image_project` unique constraint on `(image_id, label_studio_project_id)`.

## How it surfaced (prod)

The populate activity's `record_label` TaskGroup hits this on **retry**: attempt 1 writes the sentinel rows and fails partway; attempt 2 re-writes rows that now already exist → 500 → the activity never finishes → the per-dive project never publishes and the dive never drains from the cohort.

Observed live on **headtail dive 347** right after the LS-import dedup fix (**v1.41.8 / #343**) stopped *masking* this — the old `imported.task_ids` crash used to abort before the writeback ever ran:

```
asyncpg UniqueViolationError: duplicate key value violates unique
constraint "uq_headtail_image_project"
  at label_controller.py:232 in put_headtail_label
```

## Fix

Same failure mode and same remedy as `post_measurement` / `uq_measurement_image_fish` (2026-07-17): resolve the natural key `(image_id, project_id)` to the existing row id before `merge`, turning it into an UPDATE. Guarded on `label_studio_project_id is not None` so NULL-project sentinel rows (which Postgres treats as distinct) keep insert-always behavior.

Fixes **all four** handlers — laser/species/dive-slate share the identical latent bug and would 500 the same way on their own retries.

## Tests

`tests/test_label_upsert_endpoint.py`, parametrized over all four label kinds:
- a second `id=None` PUT for the same `(image, project)` **upserts** (1 row, latest wins) instead of duplicating
- the same image in two different projects still yields two rows

Verified the test **fails on the pre-fix blind merge** and passes after. Full api suite: 174 passed. Pylint 10.00.

## Deploy note

No data cleanup needed — self-heals: once deployed, the next headtail populate for dive 347 dedups the import (v1.41.8) and the writeback now upserts, so the activity completes and publishes project 274550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)