### PR TITLE
fix(data-worker): halve activity concurrency, raise mem, run 2 replicas

### DIFF
--- a/deploy/incus/worker_volumes/api_worker/config/settings.toml
+++ b/deploy/incus/worker_volumes/api_worker/config/settings.toml
@@ -77,5 +77,11 @@ labels_prefix = "fishsense-lite"
 kubeconfig_path = "/run/tenant/nrp/kubeconfig"
 namespace = "e4e-fishsense"
 deployment_name = "fishsense-data-processing-workflow-worker"
-active_replicas = 1
+# 2 replicas (clamped range is [1, 4]). Deliberate operator choice, paired
+# with dropping the data-worker's `general.max_concurrent_activities` 4 -> 2
+# after the 2026-07-21 OOM CrashLoopBackOff: per-pod peak memory is halved,
+# and the lost throughput is recovered horizontally instead of by packing
+# more concurrent full-res rawpy decodes into one pod. Also buys active-window
+# resilience on a preemption-prone cluster.
+active_replicas = 2
 idle_cooldown_minutes = 15

--- a/deploy/k8s/data-worker/deployment.yaml
+++ b/deploy/k8s/data-worker/deployment.yaml
@@ -109,15 +109,24 @@ spec:
             # Tune from `kubectl top pod` once it's running. The CPU
             # limit must stay in lockstep with `general.max_workers` in
             # settings.toml (the ThreadPoolExecutor size for the
-            # CPU-bound rectify activities) — currently 8. Memory
-            # headroom is for ~8 concurrent full-res rawpy decodes.
+            # CPU-bound rectify activities) — currently 8.
+            #
+            # Memory is sized against `general.max_concurrent_activities`
+            # (currently 2), NOT max_workers: each in-flight per-image
+            # activity peaks at ~1-3 GB for a full-res rawpy decode +
+            # opencv rectify. At a cap of 4 this pod OOMKilled (exit 137)
+            # ~22s after start and CrashLoopBackOff'd 17 times, which
+            # starved the queue and timed out the ValidateLaserLabels
+            # children. Cap 2 x ~3 GB leaves real headroom under 16Gi;
+            # throughput is recovered with a second replica instead
+            # (`kubernetes.active_replicas` on the api-worker).
             requests:
               cpu: "4"
               memory: 6Gi
               ephemeral-storage: 2Gi
             limits:
               cpu: "8"
-              memory: 12Gi
+              memory: 16Gi
               # >= the sum of the emptyDir sizeLimits below
               # (logs 1Gi + cache 2Gi + scratch 4Gi = 7Gi) so a volume
               # can fill to its own cap without tripping the container's

--- a/deploy/k8s/data-worker/settings.toml
+++ b/deploy/k8s/data-worker/settings.toml
@@ -27,7 +27,7 @@ max_workers = 8
 # Cap concurrent activities so peak memory (each per-image activity does a
 # ~1-2 GB rawpy decode) stays under the pod's 12 Gi limit. Uncapped (SDK
 # default 100) OOMKilled the pod → CrashLoopBackOff. Raise cautiously.
-max_concurrent_activities = 4
+max_concurrent_activities = 2
 
 # Shared krg-prod Temporal (mTLS). MUST match the api-worker's cluster +
 # TLS server-name — the two workers share the `fishsense_data_processing_queue`

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
@@ -77,12 +77,18 @@ GRACEFUL_SHUTDOWN_TIMEOUT = timedelta(seconds=30)
 
 # Cap on activities executed at once. The per-image activities are async and
 # offload full-res rawpy decode + opencv rectify via `asyncio.to_thread`, each
-# peaking at ~1-2 GB. The Temporal SDK default (100) let a burst run ~8-9
-# decodes concurrently, which blew the pod's 12 Gi limit → OOMKilled →
+# peaking at ~1-3 GB. The Temporal SDK default (100) let a burst run ~8-9
+# decodes concurrently, which blew the pod's memory limit → OOMKilled →
 # CrashLoopBackOff (the whole worker died on startup within seconds, so nothing
-# drained). Cap it low so peak memory stays bounded; tune via
+# drained). A cap of 4 was still too high: on 2026-07-21 headtail preprocessing
+# OOMKilled (exit 137) ~22s after start and CrashLoopBackOff'd 17 times, which
+# starved `fishsense_data_processing_queue` and timed out the
+# ValidateLaserLabelsForDive children after 17 min. It cannot self-heal —
+# Temporal redelivers the same heavy tasks on restart. Keep this low so peak
+# memory stays bounded and scale throughput horizontally instead
+# (`kubernetes.active_replicas` on the api-worker); tune via
 # `general.max_concurrent_activities`.
-DEFAULT_MAX_CONCURRENT_ACTIVITIES = 4
+DEFAULT_MAX_CONCURRENT_ACTIVITIES = 2
 
 
 async def schedule_workflows(_: Client):


### PR DESCRIPTION
## Symptom

A burst of Temporal errors: `ValidateLaserLabelsForDiveWorkflow` **7 FAILED + 1 TIMED_OUT** in one cycle. Children started `16:00:08` and died at `16:17:08` (exactly 17 min) with **"Activity task timed out"**. Everything else — all four sync workflows, all 12 populate workflows, every preprocess/measure/calibration parent — completed fine.

## Root cause

The data-worker was **OOMKilled (exit 137) ~22s after every start**, in **CrashLoopBackOff with 17 restarts**. So `fishsense_data_processing_queue` was never drained and the validate children timed out waiting.

`general.max_concurrent_activities = 4` against a **12Gi** limit is over budget: each in-flight per-image activity offloads a full-res rawpy decode + opencv rectify peaking at **~1–3 GB**, and the crashed run showed exactly 4 concurrent `preprocess_headtail_image` decodes. The cap was working as configured — it was just set too high.

**It cannot self-heal:** Temporal redelivers the same heavy activity tasks on restart, so it OOMs again immediately. (The earlier "borderline, stabilized" reading was only because the worker was idle.)

## Fix

- **`max_concurrent_activities` 4 → 2** — in the deployed ConfigMap *and* the in-code default, so a ConfigMap missing the key can't reintroduce the OOM. Halves peak memory to ~6GB.
- **memory limit 12Gi → 16Gi** — headroom for an unusually large dive. `requests` stays 6Gi so the pod remains schedulable on NRP.
- **`kubernetes.active_replicas` 1 → 2** (api-worker) — recovers the throughput lost to the lower cap **horizontally** (2 replicas × cap 2 = the old aggregate) instead of packing more concurrent decodes into one pod. Also buys active-window resilience on a preemption-prone cluster. Remains an explicit operator choice inside the clamped `[1, 4]` range.

Also rewrites the `resources` comment, which sized memory against `max_workers` (the ThreadPoolExecutor) when the binding constraint is `max_concurrent_activities`.

## Verification

`test_worker.py` 3 passed; data-worker unit suite **93 passed**; pylint 10.00. (`test_composite_slate_with_image.py` fails to collect locally on a missing `libxcb.so.1` — pre-existing local env gap, CI installs the opencv system libs.)

## Deploy

Two targets: `kubectl apply -k deploy/k8s/data-worker` for the ConfigMap/limits, and an incus converge for the api-worker's `active_replicas`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)