### PR TITLE
fix(api): make preprocess cohort gates superseded-aware

### DIFF
--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -221,9 +221,17 @@ async def select_next_for_species_preprocessing(
     `validate_laser_labels_for_dive_activity._positive_xy`, and the
     headtail cohort.
 
-    "Non-sentinel" species = `project_id IS NOT NULL`. See the laser
-    cohort docstring for the rationale (sentinels predate the new
-    flow and every other discovery query already filters them out).
+    "Non-sentinel" species = `project_id IS NOT NULL` AND not
+    superseded. See the laser cohort docstring for the sentinel
+    rationale (sentinels predate the new flow and every other discovery
+    query already filters them out).
+
+    The superseded half was added 2026-07-21: a dead-lettered row is not
+    evidence the work is done, and treating it as such deadlocked the
+    stage against `needing-species-population` (which is superseded-
+    aware). 1,826 species and 1,761 headtail images were stranded — their
+    JPEGs never regenerated, so populate deferred them forever and no
+    per-dive species project could publish.
     """
     has_prediction_cluster = (
         select(DiveFrameCluster.id)
@@ -240,6 +248,12 @@ async def select_next_for_species_preprocessing(
             ~select(SpeciesLabel.id)
             .where(SpeciesLabel.image_id == Image.id)
             .where(SpeciesLabel.label_studio_project_id != None)
+            # A superseded row is a dead letter, not evidence the work is
+            # done. Without this, an image whose only species row was
+            # dead-lettered (retired old-LS project) never gets its stage-2
+            # JPEG regenerated, so populate defers it forever and the
+            # per-dive project never publishes.
+            .where(SpeciesLabel.superseded == False)
             .exists()
         )
         .exists()
@@ -268,11 +282,15 @@ async def select_dives_needing_species_population(
     count, which is exactly what lets a dive whose old-project rows were
     superseded (e.g. after the hosted-LS migration) re-enter the cohort.
 
-    Unlike `select-next/species-preprocessing`, this is superseded-aware
-    (that endpoint's `project_id IS NOT NULL` check ignores supersede,
-    so it permanently excludes migrated dives) and drops the
-    PREDICTION-cluster gate — populate only needs the species JPEGs to
-    exist, which the populate activity gates per-image against Garage.
+    `select-next/species-preprocessing` is superseded-aware too, as of
+    2026-07-21 — it previously ignored supersede, which permanently
+    excluded migrated dives from stage 2 while this endpoint kept
+    re-selecting them for populate. The two disagreeing was a deadlock:
+    populate deferred every image whose JPEG preprocess would never
+    regenerate, so `deferred > 0` and the project never published.
+    This endpoint still drops the PREDICTION-cluster gate — populate
+    only needs the species JPEGs to exist, which the populate activity
+    gates per-image against Garage.
     The activity is idempotent + JPEG-gated, so this coarse candidate
     set is safe to over-select.
 
@@ -334,6 +352,8 @@ async def select_next_for_headtail_preprocessing(
             ~select(HeadTailLabel.id)
             .where(HeadTailLabel.image_id == Image.id)
             .where(HeadTailLabel.label_studio_project_id != None)
+            # Dead letters don't count as done — see the species cohort.
+            .where(HeadTailLabel.superseded == False)
             .exists()
         )
         .exists()
@@ -368,6 +388,11 @@ async def select_next_for_slate_preprocessing(
             ~select(DiveSlateLabel.id)
             .where(DiveSlateLabel.image_id == Image.id)
             .where(DiveSlateLabel.label_studio_project_id != None)
+            # Dead letters don't count as done — see the species cohort.
+            # No slate rows are superseded today; this keeps the three
+            # preprocess gates spelled identically so the next supersede
+            # pass can't strand slate images the way it stranded species.
+            .where(DiveSlateLabel.superseded == False)
             .exists()
         )
         .exists()

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -885,8 +885,9 @@ async def test_needing_species_population_picks_laser_valid_without_live_species
 
 async def test_needing_species_population_reincludes_superseded_only_dive(session):
     """The migration case: a dive whose only species rows are superseded
-    (old dead project) must re-enter the cohort — species-preprocessing
-    wrongly excludes it because its check ignores `superseded`."""
+    (old dead project) must re-enter BOTH cohorts. species-preprocessing
+    used to exclude it (its check ignored `superseded`); the two
+    selectors disagreeing deadlocked the stage — fixed 2026-07-21."""
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         select_dives_needing_species_population,
         select_next_for_species_preprocessing,
@@ -918,8 +919,12 @@ async def test_needing_species_population_reincludes_superseded_only_dive(sessio
     await session.flush()
 
     assert await select_dives_needing_species_population(session=session) == [1]
-    # contrast: the preprocessing selector permanently excludes it
-    assert await select_next_for_species_preprocessing(session=session) is None
+    # The preprocessing selector MUST agree. It used to return None here
+    # (its check ignored `superseded`), and that disagreement was a
+    # deadlock: populate kept re-selecting the dive but every image was
+    # deferred on a JPEG that preprocess would never regenerate, so
+    # `deferred > 0` and the per-dive project never published.
+    assert await select_next_for_species_preprocessing(session=session) == 1
 
 
 async def test_needing_species_population_excludes_dive_with_live_species(session):
@@ -1525,3 +1530,120 @@ async def test_measure_fish_ignores_unbound_clusters_with_no_measurable_image(se
     await session.flush()
 
     assert await select_next_for_measure_fish(session=session) is None
+
+
+# ── Superseded rows must not permanently strand an image ──────────────
+#
+# The breach-recovery pass dead-lettered ~1.9k species and ~1.9k headtail
+# rows that pointed at retired old-LS projects. `needing-species-population`
+# is superseded-aware, so those dives re-enter *populate* — but the
+# preprocess selectors' existence gates were not, so the same images read as
+# "already labeled" and never got their stage-2 JPEG regenerated. Populate
+# then defers them forever (`deferred > 0`), so the per-dive project never
+# publishes. Measured in prod on 2026-07-21: 1,826 species and 1,761 headtail
+# images blocked this way, across the 12 dives that own every species project.
+#
+# A superseded row is a dead letter, not evidence the work is done.
+
+
+async def test_species_preprocessing_reenters_dive_with_only_superseded_species(
+    session,
+):
+    """A superseded real-project SpeciesLabel must NOT gate the image out."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_species_preprocessing,
+    )
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+    )
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add(DiveFrameCluster(dive_id=1, data_source=DataSource.PREDICTION))
+    session.add_all(
+        [
+            LaserLabel(
+                image_id=11, completed=True, superseded=False,
+                x=100.0, y=200.0, label_studio_project_id=43,
+            ),
+            # Dead-lettered row pointing at a retired project.
+            SpeciesLabel(
+                image_id=11, completed=False, superseded=True,
+                label_studio_project_id=117,
+            ),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_species_preprocessing(session=session) == 1
+
+
+async def test_headtail_preprocessing_reenters_dive_with_only_superseded_headtail(
+    session,
+):
+    """Same dead-letter rule for the head/tail cohort."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_headtail_preprocessing,
+    )
+    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add_all(
+        [
+            LaserLabel(
+                image_id=11, completed=True, superseded=False,
+                x=100.0, y=200.0, label_studio_project_id=43,
+            ),
+            HeadTailLabel(
+                image_id=11, completed=False, superseded=True,
+                label_studio_project_id=71,
+            ),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_headtail_preprocessing(session=session) == 1
+
+
+async def test_species_preprocessing_still_excludes_live_real_species_row(session):
+    """Guard the other direction: a LIVE (non-superseded) real-project row
+    must still drop the dive, or preprocess would loop forever."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_species_preprocessing,
+    )
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+    )
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add(DiveFrameCluster(dive_id=1, data_source=DataSource.PREDICTION))
+    session.add_all(
+        [
+            LaserLabel(
+                image_id=11, completed=True, superseded=False,
+                x=100.0, y=200.0, label_studio_project_id=43,
+            ),
+            SpeciesLabel(
+                image_id=11, completed=False, superseded=False,
+                label_studio_project_id=70,
+            ),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_species_preprocessing(session=session) is None


### PR DESCRIPTION
## The bug

The stage-2/5.1/9 preprocess selectors asked *"does this image already have a non-sentinel label row?"* using only `project_id IS NOT NULL` — **no supersede filter**. A superseded row is a **dead letter**, not evidence the work is done. So any image whose only real-project row had been dead-lettered read as "already labeled" and never re-entered preprocessing.

## Why that deadlocked species labeling

`needing-species-population` **is** superseded-aware, so it kept re-selecting those dives. Populate ran, but every candidate image was **deferred** on a stage-2 JPEG that preprocess would never regenerate → `deferred > 0` → the activity never reached its publish call:

```python
if deferred == 0 and (new_count > 0 or already_in_project):
    await publish_label_studio_project(project_id)
```

The two selectors disagreeing is the whole bug. The asymmetry was even documented (*"Unlike `select-next/species-preprocessing`, this is superseded-aware"*) — the consequence just wasn't foreseen.

**Net effect in prod:** all 12 per-dive species projects stuck as unpublished drafts, 11 with zero tasks.

## Measured impact (2026-07-21)

| Stage | Images stranded (superseded-only) |
|---|---|
| Species | **1,826** |
| Headtail | **1,761** |
| Slate | 0 (no superseded slate rows yet) |

…across exactly the 12 dives that own every species project. Dive 439 is the clean example: **119 of 120 tasks imported**, blocked from publishing by one image (122040) whose sole species row was superseded against retired project 117 — `select_next_for_species_preprocessing` returned `null` despite the dive being HIGH priority with 71 PREDICTION clusters and a valid laser label on that image.

## Fix

Add `superseded == False` to the species, headtail and dive-slate preprocess gates so all three match the population cohort. Slate is a no-op today but is spelled identically so the next supersede pass can't strand it the way it stranded species.

## Tests

Three new tests (species + headtail re-enter on a superseded-only row; a **live** real-project row must still exclude, so preprocess can't loop forever). Verified they **fail before the fix** (`assert None == 1`).

`test_needing_species_population_reincludes_superseded_only_dive` asserted the old behavior as a deliberate "contrast" — its docstring literally called it *wrongly* excluded. It now asserts the two selectors agree.

Full api suite **177 passed**; pylint 10.00.

## After deploy

The 12 dives re-enter stage 2, JPEGs regenerate, populate imports the remaining tasks, `deferred` reaches 0, and the species projects publish on their own. This is a real reprocessing load (~1.8k images) — it'll grind through at one dive per hourly cycle on the data-worker (now 2 replicas × concurrency 2 after #351).

🤖 Generated with [Claude Code](https://claude.com/claude-code)