### PR TITLE
feat(label-studio): new Fish Model choices + self-healing labeling config

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/create_species_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/create_species_label_studio_project_activity.py
@@ -31,8 +31,13 @@ SPECIES_PROJECT_TITLE_SUFFIX = "Species Labeling"
 #     their own dedicated project (stage 0.1).
 #   - `<Choices name="slate">` ("Slate upside down") removed.
 #   - Slate branch expanded with H-Slate, Tic-Tac-Toe 1..6, V-Slate 1..4.
-#   - Fish Model branch added (George, Purple Angel, Purple Ant,
-#     Yellow Ant, Yellow Anthias, Snook).
+#   - Fish Model branch added; its choices were replaced wholesale on
+#     2026-07-21 with the current model set (Weasly Fish, Snook, Grouper,
+#     Shark, Gray Anthias, Purple Angel, Yellow Anthias). Editing this
+#     constant is enough — `create_or_get_label_studio_project` pushes a
+#     changed config onto already-created projects, so existing per-dive
+#     projects converge on the next populate run rather than keeping the
+#     config they were born with.
 SPECIES_LABELING_CONFIG_XML = """\
 <View>
   <Choices name="grouping" toName="image">
@@ -85,12 +90,13 @@ SPECIES_LABELING_CONFIG_XML = """\
       <Choice value="Other (Identifiable but Nontarget)"/>
     </Choice>
     <Choice value="Fish Model">
-      <Choice value="George"/>
-      <Choice value="Purple Angel"/>
-	  <Choice value="Purple Ant"/>
-      <Choice value="Yellow Ant"/>
-	  <Choice value="Yellow Anthias"/>
+      <Choice value="Weasly Fish"/>
       <Choice value="Snook"/>
+      <Choice value="Grouper"/>
+      <Choice value="Shark"/>
+      <Choice value="Gray Anthias"/>
+      <Choice value="Purple Angel"/>
+      <Choice value="Yellow Anthias"/>
     </Choice>
   </Taxonomy>
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_utils.py
@@ -15,9 +15,11 @@ import asyncio
 import base64
 import binascii
 import urllib.parse
+import xml.etree.ElementTree as ET
 from typing import Any, Awaitable, Callable, Iterable, List
 
 from label_studio_sdk.client import LabelStudio
+from label_studio_sdk.core import ApiError
 from temporalio import activity
 
 from fishsense_api_workflow_worker.activities.utils import (
@@ -117,6 +119,88 @@ async def ensure_label_studio_s3_storage(project_id: int) -> None:
     )
 
 
+def _canonical_label_config(config: str | None) -> str | None:
+    """Structure-only form of a labeling-config XML, or None if unparseable.
+
+    LS reformats `label_config` server-side (indentation, self-closing
+    style, attribute order), so a raw string compare reports drift on every
+    single run and would re-PATCH the project hourly forever. Comparing
+    parsed structure instead means we only write when the *choices* really
+    changed.
+    """
+    if not config or not isinstance(config, str):
+        return None
+    try:
+        root = ET.fromstring(config)
+    except ET.ParseError:
+        return None
+
+    def _node(element):
+        return (
+            element.tag,
+            tuple(sorted((k, (v or "").strip()) for k, v in element.attrib.items())),
+            tuple(_node(child) for child in element),
+        )
+
+    return repr(_node(root))
+
+
+def _label_config_differs(current: str | None, desired: str) -> bool:
+    """True when `current` needs to be replaced by `desired`."""
+    canonical_current = _canonical_label_config(current)
+    canonical_desired = _canonical_label_config(desired)
+    if canonical_current is None or canonical_desired is None:
+        # Unparseable on either side — fall back to a whitespace-normalized
+        # compare rather than guessing (and rather than looping on a PATCH
+        # that can never converge).
+        raw_current = current if isinstance(current, str) else ""
+        return " ".join(raw_current.split()) != " ".join(desired.split())
+    return canonical_current != canonical_desired
+
+
+async def heal_labeling_config(ls: LabelStudio, project: Any, desired_xml: str) -> bool:
+    """Push `desired_xml` onto an already-created project when it drifted.
+
+    Without this, editing a `<STAGE>_LABELING_CONFIG_XML` constant only
+    affects projects created *after* the deploy — every existing per-dive
+    project keeps the config it was born with, so a taxonomy change (e.g.
+    swapping the Fish Model choices) silently never reaches annotators.
+
+    Returns True when the config was rewritten.
+    """
+    current = getattr(project, "label_config", None)
+    if not isinstance(current, str):
+        # `projects.list` may omit the config; fetch the detail view.
+        detail = await asyncio.to_thread(lambda: ls.projects.get(id=project.id))
+        current = getattr(detail, "label_config", None)
+
+    if not _label_config_differs(current, desired_xml):
+        return False
+
+    try:
+        await asyncio.to_thread(
+            lambda: ls.projects.update(id=project.id, label_config=desired_xml)
+        )
+    except ApiError as e:
+        # LS rejects a config that would invalidate existing annotations
+        # (e.g. dropping a choice value someone already used). Keep the old
+        # config and keep populating rather than failing the whole stage.
+        activity.logger.warning(
+            "Could not update labeling config for LS project id=%d: %s. "
+            "Project keeps its previous config; reconcile by hand if the "
+            "taxonomy change is required.",
+            project.id,
+            e,
+        )
+        return False
+
+    activity.logger.info(
+        "Updated labeling config for LS project id=%d (config drift healed)",
+        project.id,
+    )
+    return True
+
+
 async def create_or_get_label_studio_project(
     *,
     project_title: str,
@@ -152,6 +236,11 @@ async def create_or_get_label_studio_project(
                 matches[0].id,
             )
         project_id = matches[0].id
+        # Self-heal: converge an already-created project onto the current
+        # labeling-config constant. Editing the constant is otherwise a
+        # no-op for every project that already exists.
+        if labeling_config_xml:
+            await heal_labeling_config(ls, matches[0], labeling_config_xml)
         await ensure_label_studio_s3_storage(project_id)
         return project_id
 

--- a/services/fishsense-api-workflow-worker/tests/test_populate_utils_workspace.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_utils_workspace.py
@@ -234,3 +234,110 @@ def test_normalize_image_url_decodes_hosted_ls_resolve_wrapper():
     assert pu._normalize_image_url("/tasks/1/resolve/?fileuri=!!bad") == (
         "/tasks/1/resolve/?fileuri=!!bad"             # undecodable → returned as-is
     )
+
+
+# ── Labeling-config self-heal ─────────────────────────────────────────
+#
+# Editing a `<STAGE>_LABELING_CONFIG_XML` constant used to affect only
+# projects created after the deploy: `create_or_get_label_studio_project`
+# found the existing project by title and returned its id untouched, so
+# every already-created per-dive project kept the config it was born with.
+# A taxonomy change (e.g. swapping the Fish Model choices) therefore never
+# reached annotators. These pin the converge-on-drift behavior.
+
+
+def _project(pid: int, title: str, label_config=None):
+    p = MagicMock()
+    p.id = pid
+    p.title = title
+    p.label_config = label_config
+    return p
+
+
+_CFG_A = '<View><Choices name="x"><Choice value="Old"/></Choices></View>'
+_CFG_B = '<View><Choices name="x"><Choice value="New"/></Choices></View>'
+
+
+async def test_heal_rewrites_config_when_choices_changed():
+    ls = _fake_ls()
+    changed = await pu.heal_labeling_config(ls, _project(5, "T", _CFG_A), _CFG_B)
+
+    assert changed is True
+    ls.projects.update.assert_called_once_with(id=5, label_config=_CFG_B)
+
+
+async def test_heal_is_noop_when_only_formatting_differs():
+    """The anti-churn guard. LS reformats `label_config` server-side, so a
+    raw string compare would report drift forever and re-PATCH every project
+    on every hourly run."""
+    reformatted = (
+        '<View>\n'
+        '  <Choices   name="x">\n'
+        '    <Choice value="Old"></Choice>\n'
+        '  </Choices>\n'
+        '</View>\n'
+    )
+    ls = _fake_ls()
+    changed = await pu.heal_labeling_config(ls, _project(5, "T", reformatted), _CFG_A)
+
+    assert changed is False
+    ls.projects.update.assert_not_called()
+
+
+async def test_heal_fetches_detail_when_list_omits_config():
+    ls = _fake_ls()
+    ls.projects.get.return_value = _project(5, "T", _CFG_A)
+
+    changed = await pu.heal_labeling_config(ls, _project(5, "T", None), _CFG_B)
+
+    ls.projects.get.assert_called_once_with(id=5)
+    assert changed is True
+
+
+async def test_heal_survives_ls_rejecting_the_config():
+    """LS refuses a config that would invalidate existing annotations. That
+    must not fail the whole populate stage."""
+    from label_studio_sdk.core import ApiError  # pylint: disable=import-outside-toplevel
+
+    ls = _fake_ls()
+    ls.projects.update.side_effect = ApiError(status_code=400, body="in use")
+
+    changed = await pu.heal_labeling_config(ls, _project(5, "T", _CFG_A), _CFG_B)
+
+    assert changed is False  # swallowed, not raised
+
+
+async def test_create_or_get_heals_existing_project_config(monkeypatch):
+    """End of the wiring: an existing per-dive project converges on the
+    current constant instead of keeping its birth config."""
+    monkeypatch.delenv("E4EFS_LABEL_STUDIO__WORKSPACE", raising=False)
+    cfg.settings.reload()
+    existing = _project(55, "X - Species Labeling", _CFG_A)
+    ls = _fake_ls(workspaces=[], existing_projects=[existing])
+    monkeypatch.setattr(pu, "_get_ls_client", lambda: ls)
+    monkeypatch.setattr(pu, "ensure_label_studio_s3_storage", _noop)
+
+    pid = await pu.create_or_get_label_studio_project(
+        project_title="X - Species Labeling", labeling_config_xml=_CFG_B
+    )
+
+    assert pid == 55
+    ls.projects.create.assert_not_called()
+    ls.projects.update.assert_called_once_with(id=55, label_config=_CFG_B)
+
+
+def test_species_xml_carries_the_current_fish_model_set():
+    """The Fish Model choices are the thing operators actually edit."""
+    from fishsense_api_workflow_worker.activities import (  # pylint: disable=import-outside-toplevel
+        create_species_label_studio_project_activity as species_sut,
+    )
+
+    xml = species_sut.SPECIES_LABELING_CONFIG_XML
+    for fish in (
+        "Weasly Fish", "Snook", "Grouper", "Shark",
+        "Gray Anthias", "Purple Angel", "Yellow Anthias",
+    ):
+        assert f'<Choice value="{fish}"/>' in xml, fish
+    # Retired model names must be gone, or annotators keep seeing them.
+    for gone in ("George", "Purple Ant", "Yellow Ant"):
+        assert f'<Choice value="{gone}"/>' not in xml, gone


### PR DESCRIPTION
## New Fish Model set

Replaces the Fish Model taxonomy branch with the requested models:

| New | Retired |
|---|---|
| Weasly Fish, Snook, Grouper, Shark, Gray Anthias, Purple Angel, Yellow Anthias | George, Purple Ant, Yellow Ant |

## Why the XML edit alone wasn't enough

The species projects **already exist**. `create_or_get_label_studio_project` matched them by title and returned the id **untouched**, so a changed constant only applied to projects created *after* the deploy. Every existing per-dive project would have kept the config it was born with, and the new fish would silently never appear in the labeling UI.

## Self-healing config

When an existing project is found, its `label_config` is now compared against the constant and **rewritten on drift**. It lives in the shared helper, so it covers **all four stages** — any `<STAGE>_LABELING_CONFIG_XML` edit converges on the next populate run, no manual LS surgery.

Two details that make it safe to run hourly:

- **Structural comparison, not textual.** LS reformats `label_config` server-side (indentation, self-closing style, attribute order). A raw string compare reports drift on *every* run and would re-PATCH every project forever. Verified directly:
  ```
  naive string compare says drift : True     <- would churn hourly
  canonical compare says drift    : False    <- correct
  real choice change detected     : True     <- still catches real edits
  ```
- **LS rejection is swallowed with a warning.** LS refuses a config that would invalidate existing annotations (e.g. dropping a choice value already in use). That must not take down the populate stage — the project keeps its old config and the log says so.

The 12 species projects currently hold **0 annotations**, so this applies cleanly to all of them on the next populate run.

## Tests

Six new tests: rewrite-on-change, **no-op on reformat** (the anti-churn guard), detail-fetch when `projects.list` omits the config, `ApiError` swallowed, end-to-end wiring through `create_or_get_label_studio_project`, and a check that the XML carries all 7 new fish and none of the 3 retired names.

Worker suite **263 passed**, 3 skipped; pylint 10.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)