### PR TITLE
fix(web): hosted-LS JWT auth + tolerate unresolvable project ids

### DIFF
--- a/apps/fishsense-lite-web/lib/env.ts
+++ b/apps/fishsense-lite-web/lib/env.ts
@@ -32,18 +32,27 @@ export const env: Env = new Proxy({} as Env, {
 
 const TRUTHY = new Set(["true", "1", "yes"]);
 
-// Kill-switch for the Label Studio integration. **Defaults to off.**
+// Kill-switch for the Label Studio integration. **Defaults to off**, but
+// both original blockers are fixed as of 2026-07-21, so prod sets
+// `LABEL_STUDIO_ENABLED=true` (see deploy/incus/compose.yml).
 //
-// The hosted instance (app.heartex.com) rejects the legacy
-// `Authorization: Token <key>` scheme this app sends, so every
-// `/api/projects/<id>` fetch 401s. `getProject` throws on a non-OK
-// response and `getProjects` fans them out through `Promise.all`, so a
-// single bad ID rejected out of the server component and 500'd the whole
-// landing page. Disabled, `getActiveProjects` returns empty buckets and
-// `buildSections` collapses the four labeling sections.
+// What used to break:
+//   1. Auth — this app sent `Authorization: Token <key>` and every
+//      `/api/projects/<id>` fetch 401'd. The hosted instance
+//      (app.heartex.com) treats `LABEL_STUDIO_API_KEY` as a *refresh*
+//      token: it must be exchanged at `/api/token/refresh` for a
+//      short-lived access JWT sent as `Bearer`. `lib/label-studio.ts`
+//      now does that (and caches/dedupes the exchange).
+//   2. Blast radius — `getProject` throws on non-OK and `getProjects`
+//      fanned out under `Promise.all`, so one dead ID rejected out of the
+//      server component and 500'd the whole landing page. fishsense-api
+//      still stores legacy ids (57-117) that all 404 on the hosted
+//      instance, so that was guaranteed. `getProjects` now uses
+//      `Promise.allSettled` and drops what it can't resolve.
 //
-// Re-enable with `LABEL_STUDIO_ENABLED=true` once the new instance's auth
-// scheme and project IDs are reconciled with what fishsense-api stores.
+// Kept as a switch so the integration can still be cut fast if the hosted
+// instance misbehaves. Disabled, `getActiveProjects` returns empty buckets
+// and `buildSections` collapses the four labeling sections.
 //
 // Compared explicitly against a truthy allowlist rather than
 // `Boolean(process.env.X)` — the latter reads the literal string "false"

--- a/apps/fishsense-lite-web/lib/label-studio.test.ts
+++ b/apps/fishsense-lite-web/lib/label-studio.test.ts
@@ -1,17 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getProject, getProjects } from "./label-studio";
+import { __resetTokenCache, getAccessToken, getProject, getProjects } from "./label-studio";
 
 beforeEach(() => {
   vi.stubEnv("FISHSENSE_API_URL", "http://api.test");
   vi.stubEnv("FISHSENSE_API_USERNAME", "u");
   vi.stubEnv("FISHSENSE_API_PASSWORD", "p");
   vi.stubEnv("LABEL_STUDIO_URL", "http://ls.test");
-  vi.stubEnv("LABEL_STUDIO_API_KEY", "ls-key-123");
+  vi.stubEnv("LABEL_STUDIO_API_KEY", "ls-refresh-token");
+  __resetTokenCache();
 });
 
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.unstubAllGlobals();
+  __resetTokenCache();
 });
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
@@ -25,38 +27,91 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
 type NextFetchInit = RequestInit & { next?: { revalidate?: number } };
 type FetchSig = (input: string, init?: NextFetchInit) => Promise<Response>;
 
+const REFRESH_URL = "http://ls.test/api/token/refresh";
+
+/** Routes token refreshes to a JWT and project GETs to `onProject`. */
+function stubFetch(
+  onProject: (url: string, init?: NextFetchInit) => Promise<Response>,
+  accessToken = "jwt-abc",
+) {
+  const fetchMock = vi.fn<FetchSig>(async (url, init) => {
+    if (url === REFRESH_URL) return jsonResponse({ access: accessToken });
+    return onProject(url, init);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("getAccessToken", () => {
+  it("exchanges the API key as a refresh token for an access JWT", async () => {
+    const fetchMock = stubFetch(async () => jsonResponse({}));
+
+    const token = await getAccessToken();
+
+    expect(token).toBe("jwt-abc");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(REFRESH_URL);
+    expect(init?.method).toBe("POST");
+    // The configured key is the *refresh* token, not a bearer credential.
+    expect(JSON.parse(String(init?.body))).toEqual({ refresh: "ls-refresh-token" });
+  });
+
+  it("caches the token instead of refreshing per request", async () => {
+    const fetchMock = stubFetch(async (url) => {
+      const id = Number(url.split("/").pop());
+      return jsonResponse({ id, title: `p${id}` });
+    });
+
+    await getProjects([1, 2, 3], 60);
+
+    const refreshCalls = fetchMock.mock.calls.filter(([url]) => url === REFRESH_URL);
+    expect(refreshCalls).toHaveLength(1);
+  });
+});
+
 describe("getProject", () => {
-  it("calls /api/projects/{id} with Token auth and returns id+title", async () => {
-    const fetchMock = vi.fn<FetchSig>(async () =>
+  it("calls /api/projects/{id} with Bearer JWT auth and returns id+title", async () => {
+    const fetchMock = stubFetch(async () =>
       jsonResponse({ id: 42, title: "REEF Laser High Priority", extra: "ignored" }),
     );
-    vi.stubGlobal("fetch", fetchMock);
 
     const project = await getProject(42, 60);
 
     expect(project).toEqual({ id: 42, title: "REEF Laser High Priority" });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe("http://ls.test/api/projects/42");
-    const headers = init?.headers as Record<string, string>;
-    expect(headers.Authorization).toBe("Token ls-key-123");
+    const projectCall = fetchMock.mock.calls.find(([url]) => url !== REFRESH_URL)!;
+    expect(projectCall[0]).toBe("http://ls.test/api/projects/42");
+    const headers = projectCall[1]?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer jwt-abc");
   });
 
   it("forwards revalidate to fetch's next option", async () => {
-    const fetchMock = vi.fn<FetchSig>(async () => jsonResponse({ id: 1, title: "x" }));
-    vi.stubGlobal("fetch", fetchMock);
+    const fetchMock = stubFetch(async () => jsonResponse({ id: 1, title: "x" }));
 
     await getProject(1, 999);
 
-    const [, init] = fetchMock.mock.calls[0];
-    expect(init?.next?.revalidate).toBe(999);
+    const projectCall = fetchMock.mock.calls.find(([url]) => url !== REFRESH_URL)!;
+    expect(projectCall[1]?.next?.revalidate).toBe(999);
+  });
+
+  it("refreshes once and retries when a cached JWT has gone stale", async () => {
+    let projectCalls = 0;
+    const fetchMock = stubFetch(async () => {
+      projectCalls += 1;
+      if (projectCalls === 1) {
+        return new Response("stale", { status: 401, statusText: "Unauthorized" });
+      }
+      return jsonResponse({ id: 7, title: "recovered" });
+    });
+
+    const project = await getProject(7, 60);
+
+    expect(project).toEqual({ id: 7, title: "recovered" });
+    const refreshCalls = fetchMock.mock.calls.filter(([url]) => url === REFRESH_URL);
+    expect(refreshCalls).toHaveLength(2); // initial + forced retry
   });
 
   it("throws on non-OK response with status in the message", async () => {
-    const fetchMock = vi.fn<FetchSig>(
-      async () => new Response("nope", { status: 404, statusText: "Not Found" }),
-    );
-    vi.stubGlobal("fetch", fetchMock);
+    stubFetch(async () => new Response("nope", { status: 404, statusText: "Not Found" }));
 
     await expect(getProject(99, 60)).rejects.toThrow(/Label Studio project 99.*404/);
   });
@@ -76,7 +131,7 @@ describe("getProjects", () => {
   it("fetches each ID in parallel and preserves order", async () => {
     let inFlight = 0;
     let maxInFlight = 0;
-    const fetchMock = vi.fn<FetchSig>(async (url) => {
+    stubFetch(async (url) => {
       inFlight += 1;
       maxInFlight = Math.max(maxInFlight, inFlight);
       await new Promise((r) => setTimeout(r, 5));
@@ -84,7 +139,6 @@ describe("getProjects", () => {
       const id = Number(url.split("/").pop());
       return jsonResponse({ id, title: `project-${id}` });
     });
-    vi.stubGlobal("fetch", fetchMock);
 
     const projects = await getProjects([1, 2, 3], 60);
 
@@ -94,5 +148,26 @@ describe("getProjects", () => {
       { id: 3, title: "project-3" },
     ]);
     expect(maxInFlight).toBe(3);
+  });
+
+  it("drops unresolvable IDs instead of failing the whole page", async () => {
+    // The prod shape: fishsense-api still hands out legacy ids (57-117) from
+    // the retired self-hosted instance and every one 404s. Under Promise.all
+    // one of these 500'd the entire landing page.
+    stubFetch(async (url) => {
+      const id = Number(url.split("/").pop());
+      if (id === 73) return new Response("gone", { status: 404, statusText: "Not Found" });
+      return jsonResponse({ id, title: `project-${id}` });
+    });
+
+    const projects = await getProjects([73, 274558], 60);
+
+    expect(projects).toEqual([{ id: 274558, title: "project-274558" }]);
+  });
+
+  it("returns an empty list rather than throwing when every ID is dead", async () => {
+    stubFetch(async () => new Response("gone", { status: 404, statusText: "Not Found" }));
+
+    await expect(getProjects([57, 73, 117], 60)).resolves.toEqual([]);
   });
 });

--- a/apps/fishsense-lite-web/lib/label-studio.ts
+++ b/apps/fishsense-lite-web/lib/label-studio.ts
@@ -5,21 +5,118 @@ export type LabelStudioProject = {
   title: string;
 };
 
+// Hosted Label Studio (app.heartex.com) does NOT accept the configured key
+// as a bearer credential. `LABEL_STUDIO_API_KEY` is a *personal access
+// token* — a refresh token — which must be exchanged at
+// `/api/token/refresh` for a short-lived access JWT that is then sent as
+// `Authorization: Bearer <jwt>`.
+//
+// This is why the integration was originally kill-switched off: the app
+// sent `Authorization: Token <key>`, which 401s on every request. Verified
+// against prod 2026-07-21 — `Token <key>` and `Bearer <key>` both 401,
+// while refresh -> `Bearer <jwt>` returns 200.
+const DEFAULT_TOKEN_TTL_SECONDS = 240;
+const EXPIRY_SKEW_SECONDS = 30;
+
+type CachedToken = { token: string; expiresAtMs: number };
+let cachedToken: CachedToken | null = null;
+// Deduplicates concurrent refreshes. `getProjects` fans out over every id at
+// once, so without this each one races on an empty cache and fires its own
+// refresh POST — a dozen redundant round trips per page render.
+let inFlightRefresh: Promise<string> | null = null;
+
+/** Seconds until a JWT expires, from its `exp` claim; null if unreadable. */
+function jwtLifetimeSeconds(token: string): number | null {
+  const payload = token.split(".")[1];
+  if (!payload) return null;
+  try {
+    const json = JSON.parse(
+      Buffer.from(payload.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString(
+        "utf8",
+      ),
+    ) as { exp?: number };
+    if (typeof json.exp !== "number") return null;
+    return json.exp - Math.floor(Date.now() / 1000);
+  } catch {
+    return null;
+  }
+}
+
+async function refreshAccessToken(): Promise<string> {
+  const url = `${env.labelStudioUrl}/api/token/refresh`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ refresh: env.labelStudioApiKey }),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Label Studio token refresh failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const data = (await response.json()) as { access?: string };
+  if (!data.access) {
+    throw new Error("Label Studio token refresh returned no access token");
+  }
+
+  const lifetime = jwtLifetimeSeconds(data.access) ?? DEFAULT_TOKEN_TTL_SECONDS;
+  const ttl = Math.max(lifetime - EXPIRY_SKEW_SECONDS, 1);
+  cachedToken = { token: data.access, expiresAtMs: Date.now() + ttl * 1000 };
+  return data.access;
+}
+
+export async function getAccessToken(forceRefresh = false): Promise<string> {
+  if (!forceRefresh && cachedToken && cachedToken.expiresAtMs > Date.now()) {
+    return cachedToken.token;
+  }
+  if (!forceRefresh && inFlightRefresh) {
+    return inFlightRefresh;
+  }
+
+  const pending = refreshAccessToken();
+  inFlightRefresh = pending;
+  try {
+    return await pending;
+  } finally {
+    if (inFlightRefresh === pending) {
+      inFlightRefresh = null;
+    }
+  }
+}
+
+/** Test seam — drops the cached access token and any in-flight refresh. */
+export function __resetTokenCache(): void {
+  cachedToken = null;
+  inFlightRefresh = null;
+}
+
 export async function getProject(
   id: number,
   revalidate: number,
 ): Promise<LabelStudioProject> {
   const url = `${env.labelStudioUrl}/api/projects/${id}`;
-  const response = await fetch(url, {
-    headers: { Authorization: `Token ${env.labelStudioApiKey}` },
-    next: { revalidate },
-  });
+
+  const attempt = async (token: string) =>
+    fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+      next: { revalidate },
+    });
+
+  let response = await attempt(await getAccessToken());
+  if (response.status === 401 || response.status === 403) {
+    // Cached JWT went stale early (or was revoked) — refresh once.
+    response = await attempt(await getAccessToken(true));
+  }
 
   if (!response.ok) {
-    console.error(
-      `[label-studio] project ${id} fetch failed`,
-      { url, status: response.status, statusText: response.statusText },
-    );
+    console.error(`[label-studio] project ${id} fetch failed`, {
+      url,
+      status: response.status,
+      statusText: response.statusText,
+    });
     throw new Error(
       `Label Studio project ${id} fetch failed: ${response.status} ${response.statusText}`,
     );
@@ -33,5 +130,29 @@ export async function getProjects(
   ids: number[],
   revalidate: number,
 ): Promise<LabelStudioProject[]> {
-  return Promise.all(ids.map((id) => getProject(id, revalidate)));
+  // Tolerate individual failures. fishsense-api still stores legacy project
+  // ids (57-117) from the retired self-hosted instance, and every one of
+  // them 404s on the hosted one. Under `Promise.all` a single dead id
+  // rejected out of the server component and 500'd the entire landing page,
+  // which is the other half of why this integration got kill-switched off.
+  // Drop what we can't resolve and render the rest.
+  const settled = await Promise.allSettled(ids.map((id) => getProject(id, revalidate)));
+
+  const projects: LabelStudioProject[] = [];
+  const failedIds: number[] = [];
+  settled.forEach((result, index) => {
+    if (result.status === "fulfilled") {
+      projects.push(result.value);
+    } else {
+      failedIds.push(ids[index]);
+    }
+  });
+
+  if (failedIds.length > 0) {
+    console.warn(
+      `[label-studio] skipped ${failedIds.length} unresolvable project id(s): ${failedIds.join(", ")}`,
+    );
+  }
+
+  return projects;
 }


### PR DESCRIPTION
Restores the landing page's Label Studio project cards. They're currently hidden because `LABEL_STUDIO_ENABLED` defaults to **off** — the integration was broken two independent ways against the hosted instance. Both are fixed here.

## 1. Auth — the API key is a *refresh* token

The app sent `Authorization: Token <key>`; every `/api/projects/<id>` 401'd. app.heartex.com wants the key exchanged for a short-lived access JWT. Verified against prod:

```
Token  <key> -> 401   (even for a live project)
Bearer <key> -> 401
POST /api/token/refresh {"refresh": <key>} -> 200, access JWT
GET  /api/projects/274558  Bearer <jwt>    -> 200
     "101624_AlligatorDeep_FSL06 #439 - Species Labeling"
```

The exchange is **cached** (expiry from the JWT `exp` claim, minus skew) and **de-duplicated across concurrent callers** — `getProjects` fans out over every id simultaneously, so without dedup each one races an empty cache and fires its own refresh. A 401/403 on a project fetch forces one refresh and retries.

## 2. Blast radius — one dead id took down the page

`getProject` throws on non-OK and `getProjects` fanned out under `Promise.all`, so a single unresolvable id rejected out of the server component and 500'd the entire landing page. fishsense-api still stores legacy ids (57–117) from the retired self-hosted instance, all of which 404 on the hosted one — guaranteed, not theoretical. Now `Promise.allSettled`: keep what resolved, log what was skipped.

## What renders after this

Checked against prod right now (`incomplete=true` per kind, intersected with live hosted projects):

| kind | ids | resolvable |
|---|---|---|
| laser | 0 | 0 |
| species | 2 | **2** (274353, 274558) |
| headtail | 3 | **3** (274619, 274626, 274633) |
| dive-slate | 0 | 0 |

→ **5 project cards.**

## Deliberately does NOT flip the flag

Enabling `LABEL_STUDIO_ENABLED` must land in the **same converge** as the image containing this code. If it merged to main now, a converge fired for any *other* package (e.g. the api-workflow-worker release already in flight) would enable the integration against the **old** image — Token auth + `Promise.all` — and break the public landing page. The env change will ride along with the image pin bump instead.

## Tests

Rewritten for the real auth flow plus new coverage: refresh-token exchange, token caching (asserts exactly one refresh across a fan-out), Bearer header, stale-JWT refresh-and-retry, dropping unresolvable ids, and all-dead-ids returning `[]` rather than throwing.

Node isn't available in my environment, so I could not execute vitest locally — the CI `vitest (apps/fishsense-lite-web)` job is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)