### PR TITLE
feat(label-studio): add Calibration Targets branch (Ruler, E4E Checkerboard)

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/create_species_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/create_species_label_studio_project_activity.py
@@ -33,11 +33,17 @@ SPECIES_PROJECT_TITLE_SUFFIX = "Species Labeling"
 #   - Slate branch expanded with H-Slate, Tic-Tac-Toe 1..6, V-Slate 1..4.
 #   - Fish Model branch added; its choices were replaced wholesale on
 #     2026-07-21 with the current model set (Weasly Fish, Snook, Grouper,
-#     Shark, Gray Anthias, Purple Angel, Yellow Anthias). Editing this
-#     constant is enough — `create_or_get_label_studio_project` pushes a
-#     changed config onto already-created projects, so existing per-dive
-#     projects converge on the next populate run rather than keeping the
-#     config they were born with.
+#     Shark, Gray Anthias, Purple Angel, Yellow Anthias).
+#   - `Calibration Targets` top-level branch added 2026-07-21 (Ruler,
+#     E4E Checkerboard). Kept as its own sibling of `Fish Model` rather
+#     than folded into it because they aren't fish — `content_of_image`
+#     records the taxonomy path, so these read as
+#     "Calibration Targets, Ruler" and stay trivially separable from the
+#     fish-model rows downstream. Editing this constant is enough —
+#     `create_or_get_label_studio_project` pushes a changed config onto
+#     already-created projects, so existing per-dive projects converge on
+#     the next populate run rather than keeping the config they were born
+#     with.
 SPECIES_LABELING_CONFIG_XML = """\
 <View>
   <Choices name="grouping" toName="image">
@@ -97,6 +103,10 @@ SPECIES_LABELING_CONFIG_XML = """\
       <Choice value="Gray Anthias"/>
       <Choice value="Purple Angel"/>
       <Choice value="Yellow Anthias"/>
+    </Choice>
+    <Choice value="Calibration Targets">
+      <Choice value="Ruler"/>
+      <Choice value="E4E Checkerboard"/>
     </Choice>
   </Taxonomy>
 

--- a/services/fishsense-api-workflow-worker/tests/test_populate_utils_workspace.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_utils_workspace.py
@@ -326,18 +326,56 @@ async def test_create_or_get_heals_existing_project_config(monkeypatch):
     ls.projects.update.assert_called_once_with(id=55, label_config=_CFG_B)
 
 
-def test_species_xml_carries_the_current_fish_model_set():
-    """The Fish Model choices are the thing operators actually edit."""
+def _species_taxonomy_branch(label: str) -> list[str]:
+    """Child choice values under a top-level species-taxonomy branch.
+
+    Parsed rather than substring-matched so the assertions are about
+    structure — a value nested under the wrong parent would still satisfy
+    an `in xml` check.
+    """
+    import xml.etree.ElementTree as ET  # pylint: disable=import-outside-toplevel
+
     from fishsense_api_workflow_worker.activities import (  # pylint: disable=import-outside-toplevel
         create_species_label_studio_project_activity as species_sut,
     )
 
-    xml = species_sut.SPECIES_LABELING_CONFIG_XML
-    for fish in (
-        "Weasly Fish", "Snook", "Grouper", "Shark",
-        "Gray Anthias", "Purple Angel", "Yellow Anthias",
-    ):
-        assert f'<Choice value="{fish}"/>' in xml, fish
+    root = ET.fromstring(species_sut.SPECIES_LABELING_CONFIG_XML)
+    for choice in root.iter("Choice"):
+        if choice.get("value") == label:
+            return [child.get("value") for child in choice]
+    raise AssertionError(f"no top-level taxonomy branch {label!r}")
+
+
+def test_species_xml_carries_the_current_fish_model_set():
+    """The Fish Model choices are the thing operators actually edit."""
+    assert _species_taxonomy_branch("Fish Model") == [
+        "Weasly Fish",
+        "Snook",
+        "Grouper",
+        "Shark",
+        "Gray Anthias",
+        "Purple Angel",
+        "Yellow Anthias",
+    ]
     # Retired model names must be gone, or annotators keep seeing them.
+    from fishsense_api_workflow_worker.activities import (  # pylint: disable=import-outside-toplevel
+        create_species_label_studio_project_activity as species_sut,
+    )
+
     for gone in ("George", "Purple Ant", "Yellow Ant"):
-        assert f'<Choice value="{gone}"/>' not in xml, gone
+        assert f'<Choice value="{gone}"/>' not in species_sut.SPECIES_LABELING_CONFIG_XML
+
+
+def test_species_xml_has_calibration_targets_as_its_own_branch():
+    """Ruler / E4E Checkerboard are not fish.
+
+    Kept a sibling of `Fish Model` rather than folded into it so
+    `content_of_image` (which stores the joined taxonomy path) reads as
+    "Calibration Targets, Ruler" and stays separable from fish-model rows.
+    """
+    assert _species_taxonomy_branch("Calibration Targets") == [
+        "Ruler",
+        "E4E Checkerboard",
+    ]
+    # ...and they must NOT also linger under Fish Model.
+    assert "Ruler" not in _species_taxonomy_branch("Fish Model")


### PR DESCRIPTION
Adds a **`Calibration Targets`** top-level branch to the species taxonomy:

```
species taxonomy: None | Slate | Fish | Fish Model | Calibration Targets
  Fish Model:          Weasly Fish, Snook, Grouper, Shark,
                       Gray Anthias, Purple Angel, Yellow Anthias
  Calibration Targets: Ruler, E4E Checkerboard
```

## Why a sibling branch, not more Fish Model entries

They aren't fish. `content_of_image` stores the **joined taxonomy path**, so these persist as `"Calibration Targets, Ruler"` and stay trivially separable from fish-model rows downstream — the same property the existing `Slate, Laser on slate` marker already relies on for the stage-9 cohort.

## No sync change required

Checked rather than assumed: `_content_of_image` in the species sync is `", ".join(taxonomy[0])` — it joins whatever path LS returns instead of mapping against a known category list, so a brand-new top-level branch flows through with no code change.

## No LS-side action required

The labeling-config **self-heal** added earlier today pushes the changed config onto already-created per-dive projects on their next populate run, so the existing species projects pick this up on their own.

## Tests

The assertions **parse the XML and check branch membership** rather than substring-matching the raw string — a choice nested under the wrong parent would still satisfy an `in xml` check, so structure is what's pinned. Also asserts Ruler is *not* left behind under Fish Model.

264 worker tests pass; pylint 10.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)