### PR TITLE
fix(api): stage-14 cohort must skip species rows with no scientific name

### DIFF
--- a/services/fishsense-api/src/fishsense_api/alembic/versions/c8d3f5a21b74_measured_excludes_unmeasurable_species.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/c8d3f5a21b74_measured_excludes_unmeasurable_species.py
@@ -1,0 +1,65 @@
+"""`measured` ignores species rows with no scientific name
+
+`measured`'s "measurable image" predicate checked top-three + valid laser
++ valid headtail + LABEL_STUDIO cluster, but never looked at what the
+species label actually said.
+
+Stage 14 does. `measure_fish_activity._parse_species_names` takes the last
+", "-separated chunk of `content_of_image` and requires the
+`Common Name (Scientific name)` shape, skipping the image otherwise rather
+than writing a malformed Species row. Only the `Fish` taxonomy branch has
+that shape:
+
+    "Fish, Hogfish (Lachnolaimus maximus)"  -> measurable
+    "Fish Model, Weasly Fish"               -> skipped (no parens)
+    "Calibration Targets, Ruler"            -> skipped (no parens)
+
+So the view (and the cohort selector that mirrors it) counted images the
+activity can never measure. That disagreement cannot resolve on its own:
+no Measurement is ever written for such an image, so it stays "measurable
+and unmeasured" forever — `measured` is pinned false and the stage-14
+cohort re-selects the dive every hour. It is the same never-goes-false
+shape that b7c2e4d81a09 fixed for unbound clusters, one layer down.
+
+Latent rather than firing when written: the measure-fish cohort was empty
+in prod (`select-next/measure-fish` -> null), because no FishModels dive
+had LABEL_STUDIO clusters yet. It would have started firing as soon as one
+did — which is exactly the direction those dives are headed, since the
+`Fish Model` and `Calibration Targets` branches only ever appear on them.
+
+Drop + recreate rather than CREATE OR REPLACE — postgres is restrictive
+about column-shape changes and the view has no dependents.
+
+Revision ID: c8d3f5a21b74
+Revises: b7c2e4d81a09
+Create Date: 2026-07-21 21:05:00.000000
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from fishsense_api.views import (
+    DIVE_PIPELINE_STATUS_VIEW_SQL,
+    DROP_DIVE_PIPELINE_STATUS_VIEW_SQL,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "c8d3f5a21b74"
+down_revision: Union[str, Sequence[str], None] = "b7c2e4d81a09"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)
+
+
+def downgrade() -> None:
+    """Drop the new view; the prior migration's upgrade is the recreate.
+    To roll back the predicate, manually re-run b7c2e4d81a09's
+    `op.execute(...)` against the DB."""
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -49,6 +49,30 @@ def _valid_laser_conditions():
     )
 
 
+def _measurable_species_conditions():
+    """A species row stage 14 can actually turn into a Measurement.
+
+    `measure_fish_activity._parse_species_names` reads the species name from
+    the LAST ", "-separated chunk of `content_of_image` and requires the
+    `Common Name (Scientific name)` shape, returning None otherwise — the
+    activity then skips the image rather than writing a malformed Species
+    row. Only the `Fish` taxonomy branch carries that shape:
+
+        "Fish, Hogfish (Lachnolaimus maximus)"  -> measurable
+        "Fish Model, Weasly Fish"               -> skipped (no parens)
+        "Calibration Targets, Ruler"            -> skipped (no parens)
+
+    Without this, the cohort and the activity disagree in a way that cannot
+    resolve: the selector keeps offering an image the activity always skips,
+    so no Measurement is written, `~is_measured` stays true, and the dive is
+    re-selected every hour forever. That is the same never-goes-false shape
+    that blocked scheduling stage 14 before 2026-07-17.
+
+    Mirrors `views._MEASURABLE_SPECIES_SQL` — keep the two in step.
+    """
+    return (SpeciesLabel.content_of_image.like("%(%)"),)  # pylint: disable=no-member
+
+
 def _valid_headtail_conditions():
     """The repo-wide definition of a *valid* head/tail label.
 
@@ -496,6 +520,7 @@ async def select_next_for_measure_fish(
         .join(Image, Image.id == SpeciesLabel.image_id)
         .where(Image.dive_id == Dive.id)
         .where(SpeciesLabel.top_three_photos_of_group == True)
+        .where(*_measurable_species_conditions())
         .where(valid_laser)
         .where(valid_headtail)
         .where(in_label_studio_cluster)

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -46,6 +46,29 @@ _VALID_HEADTAIL_SQL = """htl.completed = TRUE
                  AND htl.tail_x IS NOT NULL
                  AND htl.tail_y IS NOT NULL"""
 
+# An image stage 14 can actually turn into a Measurement.
+#
+# `measure_fish_activity._parse_species_names` reads the species name out of
+# the LAST ", "-separated chunk of `content_of_image` and requires the
+# `Common Name (Scientific name)` shape — it returns None otherwise and the
+# activity skips the image rather than writing a malformed Species row. Only
+# the `Fish` branch of the taxonomy carries that shape:
+#
+#     "Fish, Hogfish (Lachnolaimus maximus)"  -> measurable
+#     "Fish Model, Weasly Fish"               -> skipped (no parens)
+#     "Calibration Targets, Ruler"            -> skipped (no parens)
+#
+# Without this condition the cohort and the activity disagree, and that
+# disagreement cannot resolve: the selector keeps offering an image the
+# activity always skips, no Measurement is ever written, so `NOT EXISTS
+# (measurement)` stays true and the dive is re-selected every hour forever.
+# That is the same never-goes-false shape that blocked scheduling stage 14
+# before 2026-07-17, so it is spelled once and mirrored in
+# `dive_controller._measurable_species_conditions`.
+#
+# Assumes the enclosing subquery aliases specieslabel as `sl`.
+_MEASURABLE_SPECIES_SQL = "sl.content_of_image LIKE '%(%)'"
+
 # "Complete" everywhere = ≥1 completed-non-superseded row AND zero
 # incomplete-non-superseded rows. Mirrors
 # `get_dives_with_complete_laser_labeling`'s semantics so a dive with
@@ -259,6 +282,7 @@ SELECT
          JOIN image i ON i.id = sl.image_id
          WHERE i.dive_id = d.id
            AND sl.top_three_photos_of_group = TRUE
+           AND {_MEASURABLE_SPECIES_SQL}
            AND EXISTS (
                SELECT 1 FROM laserlabel ll
                WHERE ll.image_id = i.id

--- a/services/fishsense-api/tests/test_dive_pipeline_status_view.py
+++ b/services/fishsense-api/tests/test_dive_pipeline_status_view.py
@@ -866,9 +866,25 @@ async def test_calibrated_false_when_no_laser_extrinsics(session):
 # a LABEL_STUDIO cluster.
 
 
-def _measurable_image(session, image_id: int, dive_id: int, *, cluster_id: int):
+MEASURABLE_CONTENT = "Fish, Hogfish (Lachnolaimus maximus)"
+
+
+def _measurable_image(
+    session,
+    image_id: int,
+    dive_id: int,
+    *,
+    cluster_id: int,
+    content_of_image: str | None = MEASURABLE_CONTENT,
+):
     """Seed an image that stage 14 would attempt: top-three species label
-    + valid laser + valid headtail + a LABEL_STUDIO cluster."""
+    + valid laser + valid headtail + a LABEL_STUDIO cluster.
+
+    `content_of_image` defaults to a real `Fish` row because stage 14 also
+    needs a `Common (Scientific)` name to measure against — a row without
+    one is skipped by the activity, so leaving it NULL here would have
+    built an image the pipeline can never actually measure.
+    """
     from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
         DiveFrameCluster,
         DiveFrameClusterImageMapping,
@@ -894,6 +910,7 @@ def _measurable_image(session, image_id: int, dive_id: int, *, cluster_id: int):
         SpeciesLabel(
             image_id=image_id, top_three_photos_of_group=True,
             completed=True, superseded=False, label_studio_project_id=70,
+            content_of_image=content_of_image,
         )
     )
     return DiveFrameClusterImageMapping(
@@ -990,3 +1007,29 @@ async def test_measured_ignores_non_top_three_images(session):
     await session.flush()
 
     assert (await _row(session, 1))["measured"] is True
+
+
+async def test_measured_ignores_species_rows_without_a_scientific_name(session):
+    """`measured` must mirror what stage 14 can actually measure.
+
+    A `Fish Model` / `Calibration Targets` row carries no
+    "Common (Scientific)" name, so `measure_fish_activity` skips it and no
+    Measurement is ever written. Counting it as a measurable-but-unmeasured
+    image pinned `measured` false forever — the same never-goes-false shape
+    b7c2e4d81a09 fixed one layer up, for unbound clusters.
+    """
+    session.add(_dive(1))
+    await session.flush()
+    # One real fish (measured) + one Fish Model rig (never measurable).
+    real = _measurable_image(session, 11, 1, cluster_id=1)
+    rig = _measurable_image(
+        session, 12, 1, cluster_id=2, content_of_image="Fish Model, Weasly Fish"
+    )
+    await session.flush()
+    session.add_all([real, rig])
+    session.add(_measurement(11))
+    await session.flush()
+
+    assert (await _row(session, 1))["measured"] is True, (
+        "the Fish Model rig must not hold `measured` false"
+    )

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -1406,9 +1406,25 @@ async def test_laser_calibration_requires_dive_slate_id(session):
 # Prod dive 466 carried 1632 such clusters against 24 measurable images.
 
 
-def _measurable_image(session, image_id: int, dive_id: int, *, cluster_id: int):
+MEASURABLE_CONTENT = "Fish, Hogfish (Lachnolaimus maximus)"
+
+
+def _measurable_image(
+    session,
+    image_id: int,
+    dive_id: int,
+    *,
+    cluster_id: int,
+    content_of_image: str | None = MEASURABLE_CONTENT,
+):
     """An image stage 14 would attempt: top-three species label + valid
-    laser + valid headtail + a LABEL_STUDIO cluster."""
+    laser + valid headtail + a LABEL_STUDIO cluster.
+
+    `content_of_image` defaults to a real `Fish` row because stage 14 also
+    needs a `Common (Scientific)` name to measure against — a row without
+    one is skipped by the activity, so leaving it NULL here would have
+    built an image the pipeline can never actually measure.
+    """
     from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
     from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
         DiveFrameCluster,
@@ -1437,6 +1453,7 @@ def _measurable_image(session, image_id: int, dive_id: int, *, cluster_id: int):
         SpeciesLabel(
             image_id=image_id, top_three_photos_of_group=True,
             completed=True, superseded=False, label_studio_project_id=70,
+            content_of_image=content_of_image,
         )
     )
     return DiveFrameClusterImageMapping(
@@ -1647,3 +1664,64 @@ async def test_species_preprocessing_still_excludes_live_real_species_row(sessio
     await session.flush()
 
     assert await select_next_for_species_preprocessing(session=session) is None
+
+
+# ── Stage 14 only measures rows that carry a scientific name ──────────
+#
+# `measure_fish_activity._parse_species_names` needs the trailing
+# ", "-chunk of `content_of_image` to look like "Common (Scientific)".
+# The non-`Fish` taxonomy branches don't:
+#
+#     "Fish Model, Weasly Fish"     -> skipped
+#     "Calibration Targets, Ruler"  -> skipped
+#
+# If the cohort ignores that, it offers an image the activity always skips.
+# No Measurement is ever written, so `~is_measured` stays true and the dive
+# is re-selected every hour forever — the same never-goes-false shape that
+# blocked scheduling stage 14 before 2026-07-17.
+
+
+async def test_measure_fish_skips_species_rows_without_a_scientific_name(session):
+    """Fish Model / Calibration Targets rows must not hold a dive in the
+    cohort — nothing downstream can ever measure them."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_measure_fish,
+    )
+    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+        LaserExtrinsics,
+    )
+
+    for content in ("Fish Model, Weasly Fish", "Calibration Targets, Ruler", None):
+        session.add(_dive(1))
+        await session.flush()
+        session.add(LaserExtrinsics(dive_id=1, camera_id=1))
+        mapping = _measurable_image(
+            session, 11, 1, cluster_id=1, content_of_image=content
+        )
+        await session.flush()
+        session.add(mapping)
+        await session.flush()
+
+        assert await select_next_for_measure_fish(session=session) is None, content
+
+        await session.rollback()
+
+
+async def test_measure_fish_still_selects_a_real_fish_row(session):
+    """Guard the other direction — the `Fish` branch stays measurable."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_measure_fish,
+    )
+    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+        LaserExtrinsics,
+    )
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(LaserExtrinsics(dive_id=1, camera_id=1))
+    mapping = _measurable_image(session, 11, 1, cluster_id=1)  # default Fish row
+    await session.flush()
+    session.add(mapping)
+    await session.flush()
+
+    assert await select_next_for_measure_fish(session=session) == 1

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/measure_fish_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/measure_fish_activity.py
@@ -53,6 +53,12 @@ class MeasureFishResult:
     missing_laser_or_headtail: int
     missing_cluster: int
     skipped_already_measured: int = 0
+    # Species rows whose `content_of_image` carries no `Common (Scientific)`
+    # name — the non-`Fish` taxonomy branches (`Fish Model, Weasly Fish`,
+    # `Calibration Targets, Ruler`). Counted separately because these were
+    # previously tallied as `missing_laser_or_headtail`, which pointed
+    # debugging at the labels instead of at the taxonomy branch.
+    skipped_unmeasurable_species: int = 0
 
 
 __all__ = ["MeasureFishResult", "measure_fish_activity"]
@@ -271,11 +277,18 @@ async def measure_fish_activity(dive_id: int) -> MeasureFishResult:
 
             names = _parse_species_names(species_label.content_of_image)
             if names is None:
-                activity.logger.warning(
-                    "dive_id=%d image_id=%d: unparseable content_of_image=%r; skipping",
+                # Expected for the non-`Fish` taxonomy branches (Fish Model,
+                # Calibration Targets) — they carry no scientific name, so
+                # there is nothing to measure against. Info rather than
+                # warning, and its own counter: this used to increment
+                # `missing_laser_or_headtail`, which sent anyone reading the
+                # result at the labels rather than at the taxonomy branch.
+                activity.logger.info(
+                    "dive_id=%d image_id=%d: content_of_image=%r carries no "
+                    "'Common (Scientific)' name; not measurable, skipping",
                     dive_id, image_id, species_label.content_of_image,
                 )
-                result.missing_laser_or_headtail += 1
+                result.skipped_unmeasurable_species += 1
                 continue
             common, scientific = names
 

--- a/services/fishsense-data-processing-workflow-worker/tests/test_measure_fish_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_measure_fish_activity.py
@@ -542,3 +542,41 @@ async def test_measurements_are_fetched_once_per_dive(monkeypatch):
     await ActivityEnvironment().run(sut.measure_fish_activity, 42)
 
     fs.fish.get_measurements.assert_awaited_once_with(42)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "content",
+    ["Fish Model, Weasly Fish", "Calibration Targets, Ruler", None],
+    ids=["fish-model", "calibration-target", "empty"],
+)
+async def test_skips_species_rows_that_carry_no_scientific_name(monkeypatch, content):
+    """The non-`Fish` taxonomy branches have no "Common (Scientific)" name,
+    so there is nothing to measure against.
+
+    These land in their own counter rather than `missing_laser_or_headtail`
+    — they used to inflate that one, which pointed anyone reading the result
+    at the labels instead of at the taxonomy branch. The labels here are
+    deliberately complete, so a regression that reuses the old counter shows
+    up immediately.
+    """
+    image_id = 100
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_camera_intrinsics(),
+        laser_extrinsics=_laser_extrinsics(),
+        species_labels=[_species_label(image_id, content=content)],
+        laser_labels={image_id: _laser_label(image_id, 10.0, 20.0)},
+        headtail_labels={
+            image_id: _headtail_label(image_id, (1.0, 2.0), (3.0, 4.0))
+        },
+        clusters=[_cluster([image_id])],
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(sut.measure_fish_activity, 42)
+
+    assert result.measured == 0
+    assert result.skipped_unmeasurable_species == 1
+    assert result.missing_laser_or_headtail == 0, "must not inflate the label counter"
+    fs.fish.post_measurement.assert_not_called()


### PR DESCRIPTION
Follow-up to #371 (Calibration Targets). Started as "make measurement skip calibration targets" and turned up a latent never-goes-false loop that also covers `Fish Model`.

## The disagreement

The cohort and `dive_pipeline_status.measured` call an image measurable on top-three + valid laser + valid headtail + LABEL_STUDIO cluster — **without looking at what the species label says**.

Stage 14 does look. `_parse_species_names` reads the last `", "`-separated chunk of `content_of_image` and requires `Common Name (Scientific name)`, skipping otherwise rather than writing a malformed Species row. Only the `Fish` branch has that shape:

| content_of_image | activity |
|---|---|
| `Fish, Hogfish (Lachnolaimus maximus)` | measures |
| `Fish Model, Weasly Fish` | **skips** — no parens |
| `Calibration Targets, Ruler` | **skips** — no parens |

## Why that can't resolve itself

The selector keeps offering an image the activity always skips → no `Measurement` is ever written → `NOT EXISTS (measurement)` stays true → **the dive is re-selected every hour forever**, with `measured` pinned false. Same never-goes-false shape `b7c2e4d81a09` fixed one layer up for unbound clusters.

**Latent, not firing.** `select-next/measure-fish` returned `null` in prod when I checked — no FishModels dive has LABEL_STUDIO clusters yet. It starts the moment one does, and the `Fish Model` / `Calibration Targets` branches only ever appear on exactly those dives.

## Changes

- `views._MEASURABLE_SPECIES_SQL` + `dive_controller._measurable_species_conditions` — the predicate, spelled once per side and cross-referenced, per the "keep the two in step" rule
- alembic `c8d3f5a21b74` — drop/recreate the view (the documented pattern)
- `measure_fish_activity` — own `skipped_unmeasurable_species` counter. It previously incremented `missing_laser_or_headtail`, pointing debugging at the labels instead of the taxonomy branch, and logged at *warning* for what is entirely expected on a models dive

## Test-fixture correction worth calling out

Both `_measurable_image` helpers seeded a `SpeciesLabel` with **no `content_of_image`** — an image stage 14 could never actually measure. They now default to a real `Fish` row (with an override), so the fixtures describe something the pipeline can complete. All 83 pre-existing tests still pass against the corrected helpers.

New tests: selector and view both reject `Fish Model` / `Calibration Targets` / NULL and still accept a real `Fish` row; the activity's counter is parametrized over all three and asserts `missing_laser_or_headtail == 0` so a regression reusing the old counter fails loudly.

180 api + 96 data-worker tests pass; pylint 10.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)