### PR TITLE
feat(label-studio): hourly labeling-config reconcile for every per-dive project

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/reconcile_labeling_configs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/reconcile_labeling_configs_activity.py
@@ -1,0 +1,130 @@
+"""Push the current `<STAGE>_LABELING_CONFIG_XML` onto every per-dive project.
+
+`create_or_get_label_studio_project` already heals a project's labeling
+config when it finds one, but it only runs during **populate** — and
+populate stops dispatching for a dive once every image has a species row and
+the dive leaves the cohort. So the heal reaches projects that are still
+filling and never reaches finished ones, which are exactly the stable
+projects labelers spend their time in.
+
+Observed 2026-07-21 after the Fish Model taxonomy swap: all 11 species
+projects whose dive was still in `needing-species-population` picked up the
+new choices, while `082923_FishModels_FSL02 #58 - Species Labeling`
+(pid 274353, fully populated, out of cohort) stayed on the old list
+indefinitely. Every future taxonomy edit would strand it again.
+
+This activity closes that gap by walking the projects directly rather than
+riding a cohort: it enumerates the workspace, matches each project's title
+suffix to the stage that owns it, and delegates to the same
+`heal_labeling_config` used by the populate path — so drift detection,
+the no-op-when-unchanged behaviour, and the swallow-on-LS-rejection
+semantics are all shared rather than reimplemented.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.create_dive_slate_label_studio_project_activity import (  # pylint: disable=line-too-long
+    DIVE_SLATE_LABELING_CONFIG_XML,
+    DIVE_SLATE_PROJECT_TITLE_SUFFIX,
+)
+from fishsense_api_workflow_worker.activities.create_headtail_label_studio_project_activity import (  # pylint: disable=line-too-long
+    HEADTAIL_LABELING_CONFIG_XML,
+    HEADTAIL_PROJECT_TITLE_SUFFIX,
+)
+from fishsense_api_workflow_worker.activities.create_laser_label_studio_project_activity import (  # pylint: disable=line-too-long
+    LASER_LABELING_CONFIG_XML,
+    LASER_PROJECT_TITLE_SUFFIX,
+)
+from fishsense_api_workflow_worker.activities.create_species_label_studio_project_activity import (  # pylint: disable=line-too-long
+    SPECIES_LABELING_CONFIG_XML,
+    SPECIES_PROJECT_TITLE_SUFFIX,
+)
+from fishsense_api_workflow_worker.activities.populate_utils import (
+    _get_ls_client,
+    _resolve_workspace_id,
+    heal_labeling_config,
+)
+
+# Title suffix -> the labeling config that owns it. Per-dive titles are
+# `"{dive.name} #{dive_id} - {suffix}"`, so the suffix is what identifies the
+# stage. Ordered longest-first so a suffix that is a substring of another
+# can't shadow it.
+_CONFIG_BY_SUFFIX = {
+    LASER_PROJECT_TITLE_SUFFIX: LASER_LABELING_CONFIG_XML,
+    SPECIES_PROJECT_TITLE_SUFFIX: SPECIES_LABELING_CONFIG_XML,
+    HEADTAIL_PROJECT_TITLE_SUFFIX: HEADTAIL_LABELING_CONFIG_XML,
+    DIVE_SLATE_PROJECT_TITLE_SUFFIX: DIVE_SLATE_LABELING_CONFIG_XML,
+}
+
+
+@dataclass
+class ReconcileLabelingConfigsResult:
+    """Counts for one reconcile pass."""
+
+    scanned: int = 0
+    healed: int = 0
+    unchanged: int = 0
+    unrecognized: int = 0
+
+
+def _config_for_title(title: str | None) -> str | None:
+    """The labeling config owning `title`, or None if it isn't a per-dive one.
+
+    Matched on the suffix rather than parsed, so demo projects and anything
+    else sharing the workspace are left alone.
+    """
+    if not title:
+        return None
+    for suffix, config in sorted(
+        _CONFIG_BY_SUFFIX.items(), key=lambda kv: -len(kv[0])
+    ):
+        if title.endswith(suffix):
+            return config
+    return None
+
+
+@activity.defn
+async def reconcile_labeling_configs_activity() -> ReconcileLabelingConfigsResult:
+    """Converge every per-dive project onto its stage's current config."""
+    ls = _get_ls_client()
+    workspace_id = _resolve_workspace_id(ls)
+
+    projects = list(
+        ls.projects.list(workspaces=[workspace_id])
+        if workspace_id is not None
+        else ls.projects.list()
+    )
+
+    result = ReconcileLabelingConfigsResult()
+    for project in projects:
+        title = getattr(project, "title", None)
+        config = _config_for_title(title)
+        if config is None:
+            result.unrecognized += 1
+            continue
+
+        result.scanned += 1
+        activity.heartbeat()
+        if await heal_labeling_config(ls, project, config):
+            result.healed += 1
+            activity.logger.info(
+                "reconciled labeling config for project id=%s title=%r",
+                getattr(project, "id", None),
+                title,
+            )
+        else:
+            result.unchanged += 1
+
+    activity.logger.info(
+        "labeling-config reconcile: scanned=%d healed=%d unchanged=%d "
+        "unrecognized=%d",
+        result.scanned,
+        result.healed,
+        result.unchanged,
+        result.unrecognized,
+    )
+    return result

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -24,6 +24,9 @@ from temporalio.client import (
 )
 from temporalio.worker import Worker
 
+from fishsense_api_workflow_worker.activities.reconcile_labeling_configs_activity import (  # pylint: disable=line-too-long
+    reconcile_labeling_configs_activity,
+)
 from fishsense_api_workflow_worker.activities.cleanup_raw_bytes_for_dive_activity import (  # pylint: disable=line-too-long
     cleanup_raw_bytes_for_dive_activity,
 )
@@ -153,6 +156,9 @@ from fishsense_api_workflow_worker.workflows.create_species_label_studio_project
 )
 from fishsense_api_workflow_worker.workflows.populate_dive_slate_label_studio_project_workflow import (  # pylint: disable=line-too-long
     PopulateDiveSlateLabelStudioProjectWorkflow,
+)
+from fishsense_api_workflow_worker.workflows.reconcile_labeling_configs_workflow import (  # pylint: disable=line-too-long
+    ReconcileLabelingConfigsWorkflow,
 )
 from fishsense_api_workflow_worker.workflows.populate_headtail_label_studio_project_workflow import (  # pylint: disable=line-too-long
     PopulateHeadTailLabelStudioProjectWorkflow,
@@ -362,6 +368,26 @@ async def schedule_workflows(client: Client):
                     overlap=ScheduleOverlapPolicy.SKIP,
                 )
             )
+            # Labeling-config reconcile: hourly at +25 min, in the gap
+            # between the +20 species populate and the +30 headtail
+            # preprocess. Cheap (one workspace list + a detail fetch per
+            # drifted project) and independent of every cohort, which is
+            # the whole point: the heal inside
+            # `create_or_get_label_studio_project` only runs during
+            # populate, so a fully-populated dive's project never saw a
+            # taxonomy change again. SKIP overlap — a slow pass shouldn't
+            # stack, and the next hour re-converges anyway.
+            tg.create_task(
+                schedule_workflow(
+                    client,
+                    "reconcile-labeling-configs-workflow-schedule",
+                    ReconcileLabelingConfigsWorkflow,
+                    timedelta(hours=1),
+                    offset=timedelta(minutes=25),
+                    run_timeout=timedelta(minutes=30),
+                    overlap=ScheduleOverlapPolicy.SKIP,
+                )
+            )
             tg.create_task(
                 schedule_workflow(
                     client,
@@ -483,6 +509,7 @@ async def main():
                 PopulateSpeciesLabelStudioProjectWorkflow,
                 PopulateSpeciesLabelStudioProjectParentWorkflow,
                 PopulateHeadTailLabelStudioProjectWorkflow,
+                ReconcileLabelingConfigsWorkflow,
                 PopulateDiveSlateLabelStudioProjectWorkflow,
                 UpdateDiveImageGroupsWorkflow,
                 ClusterDiveFramesParentWorkflow,
@@ -496,6 +523,7 @@ async def main():
             ],
             activity_executor=executor,
             activities=[
+                reconcile_labeling_configs_activity,
                 get_laser_label_studio_project_ids_activity,
                 get_headtail_label_studio_project_ids_activity,
                 get_dive_slate_label_studio_project_ids_activity,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/reconcile_labeling_configs_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/reconcile_labeling_configs_workflow.py
@@ -1,0 +1,43 @@
+"""Hourly pass that converges per-dive LS projects onto the current configs.
+
+Thin wrapper around ``reconcile_labeling_configs_activity`` — the activity
+does the work (enumerate the workspace, match each project's title suffix to
+the stage that owns it, push the config when it has drifted).
+
+This exists because the heal built into
+``create_or_get_label_studio_project`` only runs during populate, and
+populate stops dispatching for a dive once it is fully populated. Finished
+projects — the stable ones labelers actually work in — therefore never saw a
+taxonomy change. Walking the projects on a schedule reaches them regardless
+of any cohort.
+
+Idempotent: a pass with no drift updates nothing, so re-running is free.
+"""
+
+from datetime import timedelta
+
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from fishsense_api_workflow_worker.activities.reconcile_labeling_configs_activity import (  # pylint: disable=line-too-long
+        ReconcileLabelingConfigsResult,
+    )
+
+
+@workflow.defn
+class ReconcileLabelingConfigsWorkflow:
+    # pylint: disable=too-few-public-methods
+    """Push the current labeling config onto every per-dive project."""
+
+    @workflow.run
+    async def run(self) -> ReconcileLabelingConfigsResult:
+        return await workflow.execute_activity(
+            "reconcile_labeling_configs_activity",
+            args=(),
+            # Sized for a workspace-wide walk: one list call plus a detail
+            # fetch per project whose list entry omits `label_config`. The
+            # activity heartbeats per project, so a slow LS shows up as a
+            # heartbeat timeout rather than silently eating the whole window.
+            schedule_to_close_timeout=timedelta(minutes=15),
+            heartbeat_timeout=timedelta(minutes=2),
+        )

--- a/services/fishsense-api-workflow-worker/tests/test_reconcile_labeling_configs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_reconcile_labeling_configs_activity.py
@@ -1,0 +1,141 @@
+"""Workspace-wide labeling-config reconcile.
+
+The heal inside `create_or_get_label_studio_project` only runs during
+populate, and populate stops dispatching for a dive once it is fully
+populated. So it converges projects that are still filling and never touches
+finished ones — the stable projects labelers actually work in.
+
+Measured in prod on 2026-07-21 after the Fish Model taxonomy swap: all 11
+species projects whose dive was still in `needing-species-population` picked
+up the new choices; `082923_FishModels_FSL02 #58 - Species Labeling`
+(pid 274353), fully populated and out of cohort, kept the old list. This
+activity is what closes that gap, so the out-of-cohort case is the one the
+tests care most about.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from temporalio.testing import ActivityEnvironment
+
+from fishsense_api_workflow_worker.activities import (
+    reconcile_labeling_configs_activity as sut,
+)
+from fishsense_api_workflow_worker.activities.create_headtail_label_studio_project_activity import (  # pylint: disable=line-too-long
+    HEADTAIL_LABELING_CONFIG_XML,
+)
+from fishsense_api_workflow_worker.activities.create_species_label_studio_project_activity import (  # pylint: disable=line-too-long
+    SPECIES_LABELING_CONFIG_XML,
+)
+
+
+def _project(pid: int, title: str, label_config: str | None):
+    p = MagicMock()
+    p.id = pid
+    p.title = title
+    p.label_config = label_config
+    return p
+
+
+def _fake_ls(projects):
+    ls = MagicMock()
+    ls.workspaces.list.return_value = []
+    ls.projects.list.return_value = list(projects)
+    return ls
+
+
+_OLD_SPECIES_XML = '<View><Choices name="x"><Choice value="George"/></Choices></View>'
+
+
+@pytest.fixture(autouse=True)
+def _no_workspace(monkeypatch):
+    """Workspace unset -> `projects.list()` with no filter (OSS-style)."""
+    monkeypatch.setattr(sut, "_resolve_workspace_id", lambda _ls: None)
+
+
+async def test_heals_a_project_whose_dive_left_the_populate_cohort(monkeypatch):
+    """The 274353 case: fully populated, out of cohort, stale config."""
+    stale = _project(
+        274353, "082923_FishModels_FSL02 #58 - Species Labeling", _OLD_SPECIES_XML
+    )
+    ls = _fake_ls([stale])
+    monkeypatch.setattr(sut, "_get_ls_client", lambda: ls)
+
+    result = await ActivityEnvironment().run(sut.reconcile_labeling_configs_activity)
+
+    assert result.healed == 1
+    ls.projects.update.assert_called_once_with(
+        id=274353, label_config=SPECIES_LABELING_CONFIG_XML
+    )
+
+
+async def test_is_a_no_op_when_every_config_is_current(monkeypatch):
+    """Runs hourly — an unchanged pass must write nothing."""
+    ls = _fake_ls(
+        [
+            _project(1, "d #1 - Species Labeling", SPECIES_LABELING_CONFIG_XML),
+            _project(2, "d #2 - HeadTail Labeling", HEADTAIL_LABELING_CONFIG_XML),
+        ]
+    )
+    monkeypatch.setattr(sut, "_get_ls_client", lambda: ls)
+
+    result = await ActivityEnvironment().run(sut.reconcile_labeling_configs_activity)
+
+    assert (result.scanned, result.healed, result.unchanged) == (2, 0, 2)
+    ls.projects.update.assert_not_called()
+
+
+async def test_routes_each_project_to_its_own_stage_config(monkeypatch):
+    """A headtail project must never receive the species config."""
+    ls = _fake_ls(
+        [
+            _project(1, "d #1 - Species Labeling", _OLD_SPECIES_XML),
+            _project(2, "d #2 - HeadTail Labeling", _OLD_SPECIES_XML),
+        ]
+    )
+    monkeypatch.setattr(sut, "_get_ls_client", lambda: ls)
+
+    await ActivityEnvironment().run(sut.reconcile_labeling_configs_activity)
+
+    sent = {c.kwargs["id"]: c.kwargs["label_config"] for c in ls.projects.update.call_args_list}
+    assert sent[1] == SPECIES_LABELING_CONFIG_XML
+    assert sent[2] == HEADTAIL_LABELING_CONFIG_XML
+
+
+async def test_leaves_projects_it_does_not_own_alone(monkeypatch):
+    """The workspace holds unrelated projects (demos, Coral Gardeners).
+    Matching on the per-dive title suffix keeps us off them."""
+    ls = _fake_ls(
+        [
+            _project(9, "Coral Gardeners", _OLD_SPECIES_XML),
+            _project(10, "Demo Project: Image Captioning", _OLD_SPECIES_XML),
+        ]
+    )
+    monkeypatch.setattr(sut, "_get_ls_client", lambda: ls)
+
+    result = await ActivityEnvironment().run(sut.reconcile_labeling_configs_activity)
+
+    assert (result.scanned, result.unrecognized) == (0, 2)
+    ls.projects.update.assert_not_called()
+
+
+async def test_one_rejected_project_does_not_stop_the_pass(monkeypatch):
+    """LS refuses a config that would invalidate existing annotations. That
+    must not abort the walk — the remaining projects still reconcile."""
+    from label_studio_sdk.core import ApiError  # pylint: disable=import-outside-toplevel
+
+    ls = _fake_ls(
+        [
+            _project(1, "d #1 - Species Labeling", _OLD_SPECIES_XML),
+            _project(2, "d #2 - Species Labeling", _OLD_SPECIES_XML),
+        ]
+    )
+    ls.projects.update.side_effect = [ApiError(status_code=400, body="in use"), None]
+    monkeypatch.setattr(sut, "_get_ls_client", lambda: ls)
+
+    result = await ActivityEnvironment().run(sut.reconcile_labeling_configs_activity)
+
+    assert result.scanned == 2
+    assert result.healed == 1  # the second one still went through

--- a/services/fishsense-api-workflow-worker/tests/test_schedule_registration.py
+++ b/services/fishsense-api-workflow-worker/tests/test_schedule_registration.py
@@ -129,3 +129,23 @@ async def test_every_dive_selecting_parent_is_registered(registered):
     scheduled — it would simply never run."""
     for schedule_id in _DIVE_SELECTING_PARENT_SCHEDULE_IDS:
         assert schedule_id in registered
+
+
+async def test_labeling_config_reconcile_is_scheduled_hourly_at_25(registered):
+    """Slot +25 — the gap between the +20 species populate and the +30
+    headtail preprocess. It selects no dive, so it isn't part of the
+    dive-selecting stagger, but it must still not collide with a parent."""
+    schedule = registered["reconcile-labeling-configs-workflow-schedule"]
+
+    assert _every(schedule) == timedelta(hours=1)
+    assert _offset(schedule) == timedelta(minutes=25)
+    assert schedule.spec.intervals[0].offset not in {
+        _offset(registered[sid]) for sid in _DIVE_SELECTING_PARENT_SCHEDULE_IDS
+    }
+
+
+async def test_labeling_config_reconcile_skips_when_still_in_flight(registered):
+    """A slow workspace walk must not stack — the next hour re-converges."""
+    schedule = registered["reconcile-labeling-configs-workflow-schedule"]
+
+    assert schedule.policy.overlap == ScheduleOverlapPolicy.SKIP

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/c8d3f5a21b74_measured_excludes_unmeasurable_species.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/c8d3f5a21b74_measured_excludes_unmeasurable_species.py
@@ -1,0 +1,65 @@
+"""`measured` ignores species rows with no scientific name
+
+`measured`'s "measurable image" predicate checked top-three + valid laser
++ valid headtail + LABEL_STUDIO cluster, but never looked at what the
+species label actually said.
+
+Stage 14 does. `measure_fish_activity._parse_species_names` takes the last
+", "-separated chunk of `content_of_image` and requires the
+`Common Name (Scientific name)` shape, skipping the image otherwise rather
+than writing a malformed Species row. Only the `Fish` taxonomy branch has
+that shape:
+
+    "Fish, Hogfish (Lachnolaimus maximus)"  -> measurable
+    "Fish Model, Weasly Fish"               -> skipped (no parens)
+    "Calibration Targets, Ruler"            -> skipped (no parens)
+
+So the view (and the cohort selector that mirrors it) counted images the
+activity can never measure. That disagreement cannot resolve on its own:
+no Measurement is ever written for such an image, so it stays "measurable
+and unmeasured" forever — `measured` is pinned false and the stage-14
+cohort re-selects the dive every hour. It is the same never-goes-false
+shape that b7c2e4d81a09 fixed for unbound clusters, one layer down.
+
+Latent rather than firing when written: the measure-fish cohort was empty
+in prod (`select-next/measure-fish` -> null), because no FishModels dive
+had LABEL_STUDIO clusters yet. It would have started firing as soon as one
+did — which is exactly the direction those dives are headed, since the
+`Fish Model` and `Calibration Targets` branches only ever appear on them.
+
+Drop + recreate rather than CREATE OR REPLACE — postgres is restrictive
+about column-shape changes and the view has no dependents.
+
+Revision ID: c8d3f5a21b74
+Revises: b7c2e4d81a09
+Create Date: 2026-07-21 21:05:00.000000
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from fishsense_api.views import (
+    DIVE_PIPELINE_STATUS_VIEW_SQL,
+    DROP_DIVE_PIPELINE_STATUS_VIEW_SQL,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "c8d3f5a21b74"
+down_revision: Union[str, Sequence[str], None] = "b7c2e4d81a09"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)
+
+
+def downgrade() -> None:
+    """Drop the new view; the prior migration's upgrade is the recreate.
+    To roll back the predicate, manually re-run b7c2e4d81a09's
+    `op.execute(...)` against the DB."""
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -49,6 +49,30 @@ def _valid_laser_conditions():
     )
 
 
+def _measurable_species_conditions():
+    """A species row stage 14 can actually turn into a Measurement.
+
+    `measure_fish_activity._parse_species_names` reads the species name from
+    the LAST ", "-separated chunk of `content_of_image` and requires the
+    `Common Name (Scientific name)` shape, returning None otherwise — the
+    activity then skips the image rather than writing a malformed Species
+    row. Only the `Fish` taxonomy branch carries that shape:
+
+        "Fish, Hogfish (Lachnolaimus maximus)"  -> measurable
+        "Fish Model, Weasly Fish"               -> skipped (no parens)
+        "Calibration Targets, Ruler"            -> skipped (no parens)
+
+    Without this, the cohort and the activity disagree in a way that cannot
+    resolve: the selector keeps offering an image the activity always skips,
+    so no Measurement is written, `~is_measured` stays true, and the dive is
+    re-selected every hour forever. That is the same never-goes-false shape
+    that blocked scheduling stage 14 before 2026-07-17.
+
+    Mirrors `views._MEASURABLE_SPECIES_SQL` — keep the two in step.
+    """
+    return (SpeciesLabel.content_of_image.like("%(%)"),)  # pylint: disable=no-member
+
+
 def _valid_headtail_conditions():
     """The repo-wide definition of a *valid* head/tail label.
 
@@ -496,6 +520,7 @@ async def select_next_for_measure_fish(
         .join(Image, Image.id == SpeciesLabel.image_id)
         .where(Image.dive_id == Dive.id)
         .where(SpeciesLabel.top_three_photos_of_group == True)
+        .where(*_measurable_species_conditions())
         .where(valid_laser)
         .where(valid_headtail)
         .where(in_label_studio_cluster)

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -46,6 +46,29 @@ _VALID_HEADTAIL_SQL = """htl.completed = TRUE
                  AND htl.tail_x IS NOT NULL
                  AND htl.tail_y IS NOT NULL"""
 
+# An image stage 14 can actually turn into a Measurement.
+#
+# `measure_fish_activity._parse_species_names` reads the species name out of
+# the LAST ", "-separated chunk of `content_of_image` and requires the
+# `Common Name (Scientific name)` shape — it returns None otherwise and the
+# activity skips the image rather than writing a malformed Species row. Only
+# the `Fish` branch of the taxonomy carries that shape:
+#
+#     "Fish, Hogfish (Lachnolaimus maximus)"  -> measurable
+#     "Fish Model, Weasly Fish"               -> skipped (no parens)
+#     "Calibration Targets, Ruler"            -> skipped (no parens)
+#
+# Without this condition the cohort and the activity disagree, and that
+# disagreement cannot resolve: the selector keeps offering an image the
+# activity always skips, no Measurement is ever written, so `NOT EXISTS
+# (measurement)` stays true and the dive is re-selected every hour forever.
+# That is the same never-goes-false shape that blocked scheduling stage 14
+# before 2026-07-17, so it is spelled once and mirrored in
+# `dive_controller._measurable_species_conditions`.
+#
+# Assumes the enclosing subquery aliases specieslabel as `sl`.
+_MEASURABLE_SPECIES_SQL = "sl.content_of_image LIKE '%(%)'"
+
 # "Complete" everywhere = ≥1 completed-non-superseded row AND zero
 # incomplete-non-superseded rows. Mirrors
 # `get_dives_with_complete_laser_labeling`'s semantics so a dive with
@@ -259,6 +282,7 @@ SELECT
          JOIN image i ON i.id = sl.image_id
          WHERE i.dive_id = d.id
            AND sl.top_three_photos_of_group = TRUE
+           AND {_MEASURABLE_SPECIES_SQL}
            AND EXISTS (
                SELECT 1 FROM laserlabel ll
                WHERE ll.image_id = i.id

--- a/services/fishsense-api/tests/test_dive_pipeline_status_view.py
+++ b/services/fishsense-api/tests/test_dive_pipeline_status_view.py
@@ -866,9 +866,25 @@ async def test_calibrated_false_when_no_laser_extrinsics(session):
 # a LABEL_STUDIO cluster.
 
 
-def _measurable_image(session, image_id: int, dive_id: int, *, cluster_id: int):
+MEASURABLE_CONTENT = "Fish, Hogfish (Lachnolaimus maximus)"
+
+
+def _measurable_image(
+    session,
+    image_id: int,
+    dive_id: int,
+    *,
+    cluster_id: int,
+    content_of_image: str | None = MEASURABLE_CONTENT,
+):
     """Seed an image that stage 14 would attempt: top-three species label
-    + valid laser + valid headtail + a LABEL_STUDIO cluster."""
+    + valid laser + valid headtail + a LABEL_STUDIO cluster.
+
+    `content_of_image` defaults to a real `Fish` row because stage 14 also
+    needs a `Common (Scientific)` name to measure against — a row without
+    one is skipped by the activity, so leaving it NULL here would have
+    built an image the pipeline can never actually measure.
+    """
     from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
         DiveFrameCluster,
         DiveFrameClusterImageMapping,
@@ -894,6 +910,7 @@ def _measurable_image(session, image_id: int, dive_id: int, *, cluster_id: int):
         SpeciesLabel(
             image_id=image_id, top_three_photos_of_group=True,
             completed=True, superseded=False, label_studio_project_id=70,
+            content_of_image=content_of_image,
         )
     )
     return DiveFrameClusterImageMapping(
@@ -990,3 +1007,29 @@ async def test_measured_ignores_non_top_three_images(session):
     await session.flush()
 
     assert (await _row(session, 1))["measured"] is True
+
+
+async def test_measured_ignores_species_rows_without_a_scientific_name(session):
+    """`measured` must mirror what stage 14 can actually measure.
+
+    A `Fish Model` / `Calibration Targets` row carries no
+    "Common (Scientific)" name, so `measure_fish_activity` skips it and no
+    Measurement is ever written. Counting it as a measurable-but-unmeasured
+    image pinned `measured` false forever — the same never-goes-false shape
+    b7c2e4d81a09 fixed one layer up, for unbound clusters.
+    """
+    session.add(_dive(1))
+    await session.flush()
+    # One real fish (measured) + one Fish Model rig (never measurable).
+    real = _measurable_image(session, 11, 1, cluster_id=1)
+    rig = _measurable_image(
+        session, 12, 1, cluster_id=2, content_of_image="Fish Model, Weasly Fish"
+    )
+    await session.flush()
+    session.add_all([real, rig])
+    session.add(_measurement(11))
+    await session.flush()
+
+    assert (await _row(session, 1))["measured"] is True, (
+        "the Fish Model rig must not hold `measured` false"
+    )

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -1406,9 +1406,25 @@ async def test_laser_calibration_requires_dive_slate_id(session):
 # Prod dive 466 carried 1632 such clusters against 24 measurable images.
 
 
-def _measurable_image(session, image_id: int, dive_id: int, *, cluster_id: int):
+MEASURABLE_CONTENT = "Fish, Hogfish (Lachnolaimus maximus)"
+
+
+def _measurable_image(
+    session,
+    image_id: int,
+    dive_id: int,
+    *,
+    cluster_id: int,
+    content_of_image: str | None = MEASURABLE_CONTENT,
+):
     """An image stage 14 would attempt: top-three species label + valid
-    laser + valid headtail + a LABEL_STUDIO cluster."""
+    laser + valid headtail + a LABEL_STUDIO cluster.
+
+    `content_of_image` defaults to a real `Fish` row because stage 14 also
+    needs a `Common (Scientific)` name to measure against — a row without
+    one is skipped by the activity, so leaving it NULL here would have
+    built an image the pipeline can never actually measure.
+    """
     from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
     from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
         DiveFrameCluster,
@@ -1437,6 +1453,7 @@ def _measurable_image(session, image_id: int, dive_id: int, *, cluster_id: int):
         SpeciesLabel(
             image_id=image_id, top_three_photos_of_group=True,
             completed=True, superseded=False, label_studio_project_id=70,
+            content_of_image=content_of_image,
         )
     )
     return DiveFrameClusterImageMapping(
@@ -1647,3 +1664,64 @@ async def test_species_preprocessing_still_excludes_live_real_species_row(sessio
     await session.flush()
 
     assert await select_next_for_species_preprocessing(session=session) is None
+
+
+# ── Stage 14 only measures rows that carry a scientific name ──────────
+#
+# `measure_fish_activity._parse_species_names` needs the trailing
+# ", "-chunk of `content_of_image` to look like "Common (Scientific)".
+# The non-`Fish` taxonomy branches don't:
+#
+#     "Fish Model, Weasly Fish"     -> skipped
+#     "Calibration Targets, Ruler"  -> skipped
+#
+# If the cohort ignores that, it offers an image the activity always skips.
+# No Measurement is ever written, so `~is_measured` stays true and the dive
+# is re-selected every hour forever — the same never-goes-false shape that
+# blocked scheduling stage 14 before 2026-07-17.
+
+
+async def test_measure_fish_skips_species_rows_without_a_scientific_name(session):
+    """Fish Model / Calibration Targets rows must not hold a dive in the
+    cohort — nothing downstream can ever measure them."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_measure_fish,
+    )
+    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+        LaserExtrinsics,
+    )
+
+    for content in ("Fish Model, Weasly Fish", "Calibration Targets, Ruler", None):
+        session.add(_dive(1))
+        await session.flush()
+        session.add(LaserExtrinsics(dive_id=1, camera_id=1))
+        mapping = _measurable_image(
+            session, 11, 1, cluster_id=1, content_of_image=content
+        )
+        await session.flush()
+        session.add(mapping)
+        await session.flush()
+
+        assert await select_next_for_measure_fish(session=session) is None, content
+
+        await session.rollback()
+
+
+async def test_measure_fish_still_selects_a_real_fish_row(session):
+    """Guard the other direction — the `Fish` branch stays measurable."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_measure_fish,
+    )
+    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+        LaserExtrinsics,
+    )
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(LaserExtrinsics(dive_id=1, camera_id=1))
+    mapping = _measurable_image(session, 11, 1, cluster_id=1)  # default Fish row
+    await session.flush()
+    session.add(mapping)
+    await session.flush()
+
+    assert await select_next_for_measure_fish(session=session) == 1

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/measure_fish_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/measure_fish_activity.py
@@ -53,6 +53,12 @@ class MeasureFishResult:
     missing_laser_or_headtail: int
     missing_cluster: int
     skipped_already_measured: int = 0
+    # Species rows whose `content_of_image` carries no `Common (Scientific)`
+    # name — the non-`Fish` taxonomy branches (`Fish Model, Weasly Fish`,
+    # `Calibration Targets, Ruler`). Counted separately because these were
+    # previously tallied as `missing_laser_or_headtail`, which pointed
+    # debugging at the labels instead of at the taxonomy branch.
+    skipped_unmeasurable_species: int = 0
 
 
 __all__ = ["MeasureFishResult", "measure_fish_activity"]
@@ -271,11 +277,18 @@ async def measure_fish_activity(dive_id: int) -> MeasureFishResult:
 
             names = _parse_species_names(species_label.content_of_image)
             if names is None:
-                activity.logger.warning(
-                    "dive_id=%d image_id=%d: unparseable content_of_image=%r; skipping",
+                # Expected for the non-`Fish` taxonomy branches (Fish Model,
+                # Calibration Targets) — they carry no scientific name, so
+                # there is nothing to measure against. Info rather than
+                # warning, and its own counter: this used to increment
+                # `missing_laser_or_headtail`, which sent anyone reading the
+                # result at the labels rather than at the taxonomy branch.
+                activity.logger.info(
+                    "dive_id=%d image_id=%d: content_of_image=%r carries no "
+                    "'Common (Scientific)' name; not measurable, skipping",
                     dive_id, image_id, species_label.content_of_image,
                 )
-                result.missing_laser_or_headtail += 1
+                result.skipped_unmeasurable_species += 1
                 continue
             common, scientific = names
 

--- a/services/fishsense-data-processing-workflow-worker/tests/test_measure_fish_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_measure_fish_activity.py
@@ -542,3 +542,41 @@ async def test_measurements_are_fetched_once_per_dive(monkeypatch):
     await ActivityEnvironment().run(sut.measure_fish_activity, 42)
 
     fs.fish.get_measurements.assert_awaited_once_with(42)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "content",
+    ["Fish Model, Weasly Fish", "Calibration Targets, Ruler", None],
+    ids=["fish-model", "calibration-target", "empty"],
+)
+async def test_skips_species_rows_that_carry_no_scientific_name(monkeypatch, content):
+    """The non-`Fish` taxonomy branches have no "Common (Scientific)" name,
+    so there is nothing to measure against.
+
+    These land in their own counter rather than `missing_laser_or_headtail`
+    — they used to inflate that one, which pointed anyone reading the result
+    at the labels instead of at the taxonomy branch. The labels here are
+    deliberately complete, so a regression that reuses the old counter shows
+    up immediately.
+    """
+    image_id = 100
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_camera_intrinsics(),
+        laser_extrinsics=_laser_extrinsics(),
+        species_labels=[_species_label(image_id, content=content)],
+        laser_labels={image_id: _laser_label(image_id, 10.0, 20.0)},
+        headtail_labels={
+            image_id: _headtail_label(image_id, (1.0, 2.0), (3.0, 4.0))
+        },
+        clusters=[_cluster([image_id])],
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(sut.measure_fish_activity, 42)
+
+    assert result.measured == 0
+    assert result.skipped_unmeasurable_species == 1
+    assert result.missing_laser_or_headtail == 0, "must not inflate the label counter"
+    fs.fish.post_measurement.assert_not_called()


### PR DESCRIPTION
Fixes a real gap in the self-heal I added earlier today.

## What was wrong

The heal lives in `create_or_get_label_studio_project`, which only runs during **populate**. Populate stops dispatching for a dive once every image has a species row and the dive leaves the cohort. So the heal converges projects that are **still filling** and never touches **finished** ones — precisely the stable projects labelers spend their time in.

My earlier claim that existing projects "converge on the next populate run" was wrong for completed dives.

## Measured in prod

After the Fish Model taxonomy swap the split was exact:

| dive in `needing-species-population` | projects | healed? |
|---|---|---|
| yes | 11 | ✅ all on the new list |
| **no** (dive 58, pid 274353) | 1 | ❌ still `George / Purple Ant / Yellow Ant` |

And it would have recurred — the Calibration Targets edit converges the same 11 and strands 274353 again.

## The fix

`ReconcileLabelingConfigsWorkflow` — hourly at **+25**, SKIP overlap — plus `reconcile_labeling_configs_activity`, which **walks the workspace directly rather than riding a cohort**. It matches each project's title suffix to the stage that owns it and delegates to the same `heal_labeling_config` the populate path uses, so drift detection, no-op-when-unchanged, and swallow-on-LS-rejection are shared rather than reimplemented.

- **Slot +25** sits between the +20 species populate and +30 headtail preprocess. It selects no dive, so it's deliberately outside the dive-selecting stagger tuple — but a test asserts it doesn't collide with any parent's offset.
- **Opt-in matching.** Projects that don't end in a per-dive suffix (the demos, Coral Gardeners) are counted and skipped; the workspace is shared, so this never touches something it doesn't own.

## Tests

Five cases, led by the one that motivated this — a project whose dive left the cohort (the literal 274353 shape). Plus: an unchanged pass writes nothing (it runs hourly); each project gets **its own** stage config (a headtail project must never receive the species XML); unrelated workspace projects are left alone; and one LS rejection doesn't abort the walk.

271 worker tests pass; pylint 10.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)