### PR TITLE
fix(sync): hosted LS returns annotator dicts, not ids — 422 killed every label sync

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_dive_slate_labels_for_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_dive_slate_labels_for_label_studio_project_activity.py
@@ -21,6 +21,7 @@ from temporalio import activity
 
 from fishsense_api_workflow_worker.activities.utils import (
     SYNC_CONCURRENCY,
+    resolve_annotator_user,
     sync_label_studio_project,
 )
 from fishsense_api_workflow_worker.object_store import (
@@ -188,12 +189,12 @@ async def _update_slate_label(
     if slate_label is None:
         return
 
-    if task.annotators:
-        # Unmapped annotator (get_by_label_studio_id 404s -> None) mustn't
-        # crash the task sync — skip attribution instead.
-        user = await fs.users.get_by_label_studio_id(task.annotators[-1])
-        if user is not None:
-            slate_label.user_id = user.id
+    # Attribution is best-effort: hosted LS returns `annotators` as
+    # dicts rather than ints, and mis-handling that used to 422 and
+    # kill the whole project's sync. See resolve_annotator_user.
+    user = await resolve_annotator_user(fs, task)
+    if user is not None:
+        slate_label.user_id = user.id
 
     slate_label.label_studio_json = json.loads(task.json())
     slate_label.completed = task.is_labeled

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_headtail_labels_for_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_headtail_labels_for_label_studio_project_activity.py
@@ -8,6 +8,7 @@ from temporalio import activity
 
 from fishsense_api_workflow_worker.activities.utils import (
     SYNC_CONCURRENCY,
+    resolve_annotator_user,
     sync_label_studio_project,
 )
 
@@ -24,12 +25,12 @@ async def __update_headtail_label(fs: Client, task: Any) -> None:
     if headtail_label is None:
         return
 
-    if task.annotators:
-        # Unmapped annotator (get_by_label_studio_id 404s -> None) mustn't
-        # crash the task sync — skip attribution instead.
-        user = await fs.users.get_by_label_studio_id(task.annotators[-1])
-        if user is not None:
-            headtail_label.user_id = user.id
+    # Attribution is best-effort: hosted LS returns `annotators` as
+    # dicts rather than ints, and mis-handling that used to 422 and
+    # kill the whole project's sync. See resolve_annotator_user.
+    user = await resolve_annotator_user(fs, task)
+    if user is not None:
+        headtail_label.user_id = user.id
 
     headtail_label.label_studio_json = json.loads(task.json())
     headtail_label.completed = task.is_labeled

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_laser_labels_for_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_laser_labels_for_label_studio_project_activity.py
@@ -8,6 +8,7 @@ from temporalio import activity
 
 from fishsense_api_workflow_worker.activities.utils import (
     SYNC_CONCURRENCY,
+    resolve_annotator_user,
     sync_label_studio_project,
 )
 
@@ -26,13 +27,12 @@ async def __update_laser_label(fs: Client, task: Any) -> None:
     if laser_label is None:
         return
 
-    if task.annotators:
-        # The annotator may not be user-synced yet (get_by_label_studio_id
-        # 404s -> None), e.g. mid Label-Studio-instance transition. Skip
-        # attribution rather than crash the whole task sync.
-        user = await fs.users.get_by_label_studio_id(task.annotators[-1])
-        if user is not None:
-            laser_label.user_id = user.id
+    # Attribution is best-effort: hosted LS returns `annotators` as
+    # dicts rather than ints, and mis-handling that used to 422 and
+    # kill the whole project's sync. See resolve_annotator_user.
+    user = await resolve_annotator_user(fs, task)
+    if user is not None:
+        laser_label.user_id = user.id
 
     laser_label.label_studio_json = json.loads(task.json())
     laser_label.updated_at = task.updated_at

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_species_labels_for_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_species_labels_for_label_studio_project_activity.py
@@ -26,6 +26,7 @@ from temporalio import activity
 
 from fishsense_api_workflow_worker.activities.utils import (
     SYNC_CONCURRENCY,
+    resolve_annotator_user,
     sync_label_studio_project,
 )
 
@@ -120,12 +121,12 @@ async def _update_species_label(fs: Client, task: Any) -> None:
     if species_label is None:
         return
 
-    if task.annotators:
-        # Unmapped annotator (get_by_label_studio_id 404s -> None) mustn't
-        # crash the task sync — skip attribution instead.
-        user = await fs.users.get_by_label_studio_id(task.annotators[-1])
-        if user is not None:
-            species_label.user_id = user.id
+    # Attribution is best-effort: hosted LS returns `annotators` as
+    # dicts rather than ints, and mis-handling that used to 422 and
+    # kill the whole project's sync. See resolve_annotator_user.
+    user = await resolve_annotator_user(fs, task)
+    if user is not None:
+        species_label.user_id = user.id
 
     species_label.label_studio_json = json.loads(task.json())
     species_label.completed = task.is_labeled

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/utils.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/utils.py
@@ -96,6 +96,77 @@ async def _list_ls_tasks_with_heartbeat(
             pass
 
 
+def _coerce_label_studio_id(value: Any) -> int | None:
+    """An int id from `value`, or None. `bool` is rejected explicitly —
+    it subclasses int, and `True` must never resolve to user 1."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return None
+
+
+def resolve_annotator_label_studio_id(annotators: Any) -> int | None:
+    """Label Studio user id of the most recent annotator, or None.
+
+    Self-hosted LS returned `task.annotators` as a list of **ints**, so every
+    sync activity did `task.annotators[-1]`. Hosted LS (app.heartex.com)
+    returns a list of **dicts** instead::
+
+        [{"user_id": 141592, "id": 141592, "username": "ccrutchf", ...}]
+
+    Passing that dict straight to `get_by_label_studio_id` URL-encoded it
+    into the request path — `/api/v1/users/label-studio/%7B` — which
+    fishsense-api rejects with 422. The sync activities anticipated a 404
+    ("annotator not user-synced yet -> skip attribution"), not a 422, so the
+    error escaped the per-task TaskGroup and failed the WHOLE project's
+    sync. No completions were written back, which is why fully-labeled
+    projects never dropped off the dashboard.
+
+    Accepts either shape so a mixed/rolled-back instance still works.
+    """
+    if not annotators:
+        return None
+
+    last = annotators[-1]
+    if isinstance(last, dict):
+        # `user_id` is the annotator; `id` is the same value on hosted LS but
+        # is checked second in case a future payload separates them.
+        for key in ("user_id", "id"):
+            resolved = _coerce_label_studio_id(last.get(key))
+            if resolved is not None:
+                return resolved
+        return None
+    return _coerce_label_studio_id(last)
+
+
+async def resolve_annotator_user(fs: Client, task: Any) -> Any | None:
+    """Look up the fishsense user who annotated `task`, or None.
+
+    Attribution is best-effort on purpose: it is metadata on the label, and
+    it must never cost us the label itself. Any failure here is logged and
+    swallowed, because the 422 above proved how expensive the alternative
+    is — one unexpected annotator payload took down every task in the
+    project, on every hourly run.
+    """
+    annotator_id = resolve_annotator_label_studio_id(getattr(task, "annotators", None))
+    if annotator_id is None:
+        return None
+    try:
+        return await fs.users.get_by_label_studio_id(annotator_id)
+    except Exception as e:  # pylint: disable=broad-except
+        activity.logger.warning(
+            "could not resolve annotator label_studio_id=%s for task %s: %s; "
+            "syncing the label without attribution",
+            annotator_id,
+            getattr(task, "id", None),
+            e,
+        )
+        return None
+
+
 async def sync_label_studio_project(
     project_id: int,
     update_fn: Callable[[Client, Any], Awaitable[None]],

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_annotator_id.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_annotator_id.py
@@ -1,0 +1,59 @@
+"""Annotator-id extraction across Label Studio instance shapes.
+
+Self-hosted LS returned `task.annotators` as a list of ints; hosted LS
+(app.heartex.com) returns a list of dicts. Every sync activity did
+`annotators[-1]` and handed the result to `get_by_label_studio_id`, so on
+hosted LS a dict went into the URL path
+(`/api/v1/users/label-studio/%7B`) and came back 422 — which escaped the
+per-task TaskGroup and failed the entire project's sync.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fishsense_api_workflow_worker.activities.utils import (
+    resolve_annotator_label_studio_id as resolve,
+)
+
+_HOSTED = {
+    "user_id": 141592,
+    "annotated": True,
+    "id": 141592,
+    "username": "ccrutchf",
+    "email": "ccrutchf@ucsd.edu",
+}
+
+
+def test_hosted_ls_dict_yields_the_user_id():
+    """The prod shape that caused the 422."""
+    assert resolve([_HOSTED]) == 141592
+
+
+def test_self_hosted_int_list_still_works():
+    """Accepted too, so a rollback or mixed instance doesn't break."""
+    assert resolve([7, 42]) == 42
+
+
+def test_takes_the_most_recent_annotator():
+    assert resolve([{"user_id": 1}, {"user_id": 2}]) == 2
+
+
+@pytest.mark.parametrize(
+    "annotators",
+    [None, [], [{}], [{"username": "no-id"}], ["not-a-number"], [None]],
+    ids=["none", "empty", "empty-dict", "no-id-key", "non-numeric", "null-entry"],
+)
+def test_unusable_shapes_yield_none_rather_than_raising(annotators):
+    """None means "skip attribution" — never a value that lands in a URL."""
+    assert resolve(annotators) is None
+
+
+def test_numeric_strings_are_accepted():
+    assert resolve(["141592"]) == 141592
+    assert resolve([{"user_id": "141592"}]) == 141592
+
+
+def test_bool_is_not_treated_as_an_id():
+    """bool subclasses int; True must not become user 1."""
+    assert resolve([True]) is None

--- a/services/fishsense-api-workflow-worker/tests/test_sync_headtail_labels_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_sync_headtail_labels_activity.py
@@ -123,3 +123,107 @@ async def test_heartbeat_fires_per_completed_task(monkeypatch):
     await env.run(sut.sync_headtail_labels_for_label_studio_project_activity, 1)
 
     assert len(heartbeats) == n_tasks
+
+
+# ── Hosted-LS annotator shape ─────────────────────────────────────────
+#
+# Self-hosted LS returned `task.annotators` as a list of ints. Hosted LS
+# (app.heartex.com) returns a list of dicts:
+#
+#     [{"user_id": 141592, "id": 141592, "username": "ccrutchf", ...}]
+#
+# The activities passed `annotators[-1]` straight to
+# `get_by_label_studio_id`, which URL-encoded the dict into the path
+# (`/api/v1/users/label-studio/%7B`) and got a 422. The code anticipated a
+# 404, not a 422, so the error escaped the per-task TaskGroup and failed the
+# WHOLE project's sync — completions were never written back, and
+# fully-labeled projects never fell off the dashboard.
+
+_HOSTED_ANNOTATOR = {
+    "user_id": 141592,
+    "annotated": True,
+    "id": 141592,
+    "username": "ccrutchf",
+    "email": "ccrutchf@ucsd.edu",
+}
+
+
+def _kp(label: str, x: float, y: float) -> dict:
+    return {
+        "from_name": "kp-1",
+        "original_width": 100,
+        "original_height": 200,
+        "value": {"x": x, "y": y, "keypointlabels": [label]},
+    }
+
+
+def _labeled_task(task_id: int, annotators) -> Any:
+    """A genuinely labeled task: both keypoints placed.
+
+    The activity only writes when the task actually carries annotations, so
+    an empty `annotations` list would silently prove nothing here.
+    """
+    return SimpleNamespace(
+        id=task_id,
+        annotators=annotators,
+        annotations=[{"result": [_kp("Snout", 10, 20), _kp("Fork", 30, 40)]}],
+        is_labeled=True,
+        updated_at="2026-05-01T00:00:00Z",
+        json=lambda: "{}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_completion_syncs_when_annotators_are_hosted_ls_dicts(monkeypatch):
+    """The regression: a labeled task must reach put_headtail_label."""
+    label = SimpleNamespace(
+        image_id=7, user_id=None, label_studio_json=None,
+        completed=False, updated_at=None, head_x=None, tail_x=None,
+    )
+    fs = _make_fs_client({1: label})
+    fs.users = MagicMock()
+    fs.users.get_by_label_studio_id = AsyncMock(
+        return_value=SimpleNamespace(id=55)
+    )
+    ls = _make_ls_client([_labeled_task(1, [_HOSTED_ANNOTATOR])])
+    monkeypatch.setattr(sut_utils, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "get_ls_client", lambda: ls)
+
+    await ActivityEnvironment().run(
+        sut.sync_headtail_labels_for_label_studio_project_activity, 274633
+    )
+
+    # The dict must be unwrapped to its integer id, not passed through.
+    fs.users.get_by_label_studio_id.assert_awaited_once_with(141592)
+    fs.labels.put_headtail_label.assert_awaited_once()
+    written = fs.labels.put_headtail_label.await_args.args[1]
+    assert written.completed is True, "completion must reach the DB"
+    assert written.user_id == 55
+
+
+@pytest.mark.asyncio
+async def test_annotator_lookup_failure_does_not_lose_the_label(monkeypatch):
+    """Attribution is metadata; it must never cost us the completion.
+
+    This is the exact prod failure mode: the lookup raised and took the
+    whole project's sync with it.
+    """
+    label = SimpleNamespace(
+        image_id=7, user_id=None, label_studio_json=None,
+        completed=False, updated_at=None, head_x=None, tail_x=None,
+    )
+    fs = _make_fs_client({1: label})
+    fs.users = MagicMock()
+    fs.users.get_by_label_studio_id = AsyncMock(side_effect=RuntimeError("422"))
+    ls = _make_ls_client([_labeled_task(1, [_HOSTED_ANNOTATOR])])
+    monkeypatch.setattr(sut_utils, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "get_ls_client", lambda: ls)
+
+    await ActivityEnvironment().run(
+        sut.sync_headtail_labels_for_label_studio_project_activity, 274633
+    )
+
+    fs.labels.put_headtail_label.assert_awaited_once()
+    written = fs.labels.put_headtail_label.await_args.args[1]
+    assert written.completed is True
+    assert written.user_id is None, "attribution skipped, label still synced"


### PR DESCRIPTION
## Symptom

Completed head/tail tasks never fell off the dashboard. The dashboard lists projects with `incomplete=true`, and no completion was ever written back:

| project | LS tasks | LS annotations | DB completed |
|---|---|---|---|
| 274640 (dive 60) | 101 | **101** | 0 |
| 274626 (dive 58) | 25 | **25** | 0 |
| 274633 (dive 59) | 86 | **86** | **0** (also 0 keypoints, `updated_at` NULL) |

## Root cause

Self-hosted LS returned `task.annotators` as a list of **ints**, so all four sync activities did `get_by_label_studio_id(task.annotators[-1])`. Hosted LS returns a list of **dicts**:

```python
[{"user_id": 141592, "id": 141592, "username": "ccrutchf", ...}]
```

The dict got URL-encoded into the request path and came back 422:

```
GET http://fishsense-api:8000/api/v1/users/label-studio/%7B    ← %7B is "{"
```

The call sites anticipated a **404** ("annotator not user-synced yet → skip attribution"), not a **422**, so the error escaped the per-task `TaskGroup` and **failed the entire project's sync** — every hourly run, every project, **all four label kinds** (laser:33, headtail:30, species:126, dive-slate:194).

This is very likely the root cause behind the long-standing "labels haven't synced since the old-LS cutover" symptom.

## Fix

- `resolve_annotator_label_studio_id` unwraps either shape (dict with `user_id`/`id`, bare int, numeric string) so a rolled-back or mixed instance still works. `bool` is rejected explicitly — it subclasses `int`, and `True` must never resolve to user 1.
- `resolve_annotator_user` makes attribution **non-fatal**. It's metadata on the label and must never cost us the label itself; the 422 proved how expensive the alternative is.

## On user identity across the two instances

No change needed, and none made. `sync_users_label_studio_activity` keys on **email**, keeps the fishsense `User.id`, and repoints `label_studio_id` to whatever the current instance uses. Labels store the fishsense user id, not the LS id, so historical attribution survives the migration. Current prod: 145 users — 140 legacy ids (`<10000`), 5 hosted (`>100000`); `ccrutchf` is fishsense id 114 with `label_studio_id` already repointed to 141592. This fix is only what lets the lookup **reach** that mapping.

## Tests

`test_resolve_annotator_id.py` — hosted dict, legacy int, most-recent-wins, numeric strings, the bool trap, and six unusable shapes that must yield `None` rather than a value that lands in a URL.

Activity-level regression: a labeled task with hosted-shape annotators reaches `put_headtail_label` with `completed=True`; and a lookup that *raises* still syncs the label, just without attribution.

(The fixture initially used `annotations=[]`, which silently proved nothing — the activity only writes when a task actually carries annotations. Now it places both keypoints.)

284 worker tests pass; pylint 10.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)