### PR TITLE
fix(sync): a Label Studio 429 is not a missing project

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/utils.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/utils.py
@@ -1,6 +1,7 @@
 """Utility functions for activities."""
 
 import asyncio
+import re
 from datetime import datetime
 from typing import Any, Awaitable, Callable
 
@@ -60,6 +61,77 @@ def _coerce_updated_at(value: Any) -> datetime | None:
         except ValueError:
             return None
     return None
+
+
+_THROTTLE_MAX_ATTEMPTS = 5
+_THROTTLE_DEFAULT_WAIT_SECONDS = 30.0
+
+
+def _throttle_wait_seconds(error: ApiError) -> float | None:
+    """Seconds to wait if `error` is a throttle, else None.
+
+    Label Studio answers 429 with `{"detail": "Request was throttled.
+    Expected available in 48 seconds."}` — honour that hint rather than
+    guessing, plus a small margin.
+    """
+    if getattr(error, "status_code", None) != 429:
+        return None
+    body = getattr(error, "body", None)
+    detail = body.get("detail", "") if isinstance(body, dict) else str(body or "")
+    match = re.search(r"(\d+(?:\.\d+)?)\s*second", str(detail))
+    return float(match.group(1)) + 2.0 if match else _THROTTLE_DEFAULT_WAIT_SECONDS
+
+
+async def _ls_project_exists(ls: LabelStudio, project_id: int, kind: str) -> bool:
+    """Whether `project_id` exists, retrying through rate limits.
+
+    A 429 is NOT a missing project. Both arrive as `ApiError`, and treating
+    them the same meant a throttled probe logged "missing" and returned —
+    silently skipping the project *and* returning before the cursor write,
+    so the skip repeated every hour forever with no error surfaced.
+
+    That is exactly what happened to project 274633 (86/86 tasks labeled in
+    LS, 0 completed in the DB, no cursor row ever written): each hourly
+    cycle probes ~46 projects across four label kinds, LS starts throttling
+    partway through, and whichever projects land after that point are
+    silently dropped. Position-dependent, so it looked non-deterministic.
+
+    Raises when still throttled after `_THROTTLE_MAX_ATTEMPTS` so the
+    activity fails and Temporal retries — a loud failure is correct here,
+    because the alternative is the silent skip this replaces.
+    """
+    for attempt in range(_THROTTLE_MAX_ATTEMPTS):
+        try:
+            await asyncio.to_thread(ls.projects.get, project_id)
+            return True
+        except ApiError as e:
+            wait = _throttle_wait_seconds(e)
+            if wait is None:
+                # 404 and friends — genuinely gone. Skipping is right.
+                activity.logger.warning(
+                    "sync_label_studio_project missing kind=%s project_id=%d error=%s",
+                    kind,
+                    project_id,
+                    e,
+                )
+                return False
+            activity.logger.info(
+                "sync_label_studio_project throttled kind=%s project_id=%d "
+                "attempt=%d/%d; backing off %.0fs",
+                kind,
+                project_id,
+                attempt + 1,
+                _THROTTLE_MAX_ATTEMPTS,
+                wait,
+            )
+            activity.heartbeat()
+            await asyncio.sleep(wait)
+
+    raise RuntimeError(
+        f"Label Studio still throttling project {project_id} (kind={kind}) after "
+        f"{_THROTTLE_MAX_ATTEMPTS} attempts — failing rather than skipping it, "
+        "so the cursor is not advanced and the next run retries."
+    )
 
 
 async def _list_ls_tasks_with_heartbeat(
@@ -196,15 +268,7 @@ async def sync_label_studio_project(
         project_id,
     )
 
-    try:
-        _ = await asyncio.to_thread(ls.projects.get, project_id)
-    except ApiError as e:
-        activity.logger.warning(
-            "sync_label_studio_project missing kind=%s project_id=%d error=%s",
-            kind,
-            project_id,
-            e,
-        )
+    if not await _ls_project_exists(ls, project_id, kind):
         return
 
     tasks = await _list_ls_tasks_with_heartbeat(ls, project_id)

--- a/services/fishsense-api-workflow-worker/tests/test_sync_throttle_handling.py
+++ b/services/fishsense-api-workflow-worker/tests/test_sync_throttle_handling.py
@@ -1,0 +1,89 @@
+"""A Label Studio 429 must never be mistaken for a missing project.
+
+`sync_label_studio_project` probes `ls.projects.get(project_id)` and treated
+any `ApiError` as "project is gone" — log a warning, return. A 429 throttle
+raises the same `ApiError` as a 404, so a rate-limited probe silently skipped
+the project AND returned before the cursor write, repeating every hour with
+no error surfaced.
+
+Observed in prod: project 274633 sat at 86/86 tasks labeled in Label Studio,
+0 completed in the DB, and no cursor row had ever been written. Each hourly
+cycle probes ~46 projects across four label kinds; LS starts throttling
+partway through and everything after that point is dropped — which is why it
+looked non-deterministic (58 and 60 synced, 59 never did).
+"""
+
+from __future__ import annotations
+
+# Tests exercise the internal throttle helpers directly.
+# pylint: disable=protected-access
+
+from unittest.mock import MagicMock
+
+import pytest
+from label_studio_sdk.core import ApiError
+from temporalio.testing import ActivityEnvironment
+
+from fishsense_api_workflow_worker.activities import utils as sut
+
+
+def _throttle(seconds: int = 48) -> ApiError:
+    return ApiError(
+        status_code=429,
+        body={"detail": f"Request was throttled. Expected available in {seconds} seconds."},
+    )
+
+
+def test_throttle_wait_honours_the_hint():
+    assert sut._throttle_wait_seconds(_throttle(48)) == 50.0  # hint + margin
+
+
+def test_throttle_wait_falls_back_when_hint_is_unparseable():
+    err = ApiError(status_code=429, body={"detail": "Request was throttled."})
+    assert sut._throttle_wait_seconds(err) == sut._THROTTLE_DEFAULT_WAIT_SECONDS
+
+
+@pytest.mark.parametrize("code", [404, 403, 500])
+def test_non_throttle_errors_are_not_treated_as_throttles(code):
+    assert sut._throttle_wait_seconds(ApiError(status_code=code, body={})) is None
+
+
+async def test_a_404_still_means_missing():
+    """Genuinely-gone projects must still be skipped — legacy ids 57-117
+    all 404 on the hosted instance and would otherwise fail every run."""
+    ls = MagicMock()
+    ls.projects.get.side_effect = ApiError(status_code=404, body={})
+
+    ran = await ActivityEnvironment().run(sut._ls_project_exists, ls, 73, "headtail")
+    assert ran is False
+
+
+async def test_a_throttle_retries_then_succeeds(monkeypatch):
+    """The 274633 case: throttled first, fine on retry — must NOT be skipped."""
+    sleeps: list[float] = []
+
+    async def _no_sleep(s):
+        sleeps.append(s)
+
+    monkeypatch.setattr(sut.asyncio, "sleep", _no_sleep)
+    ls = MagicMock()
+    ls.projects.get.side_effect = [_throttle(48), MagicMock()]
+
+    ran = await ActivityEnvironment().run(sut._ls_project_exists, ls, 274633, "headtail")
+    assert ran is True
+    assert sleeps == [50.0], "should have honoured the retry-after hint"
+
+
+async def test_persistent_throttle_raises_rather_than_skipping(monkeypatch):
+    """Failing loudly is the point: a raise leaves the cursor unadvanced so
+    the next run retries, instead of silently dropping the project."""
+    async def _no_sleep(_s):
+        return None
+
+    monkeypatch.setattr(sut.asyncio, "sleep", _no_sleep)
+    ls = MagicMock()
+    ls.projects.get.side_effect = _throttle(60)
+
+    with pytest.raises(RuntimeError, match="still throttling"):
+        await ActivityEnvironment().run(sut._ls_project_exists, ls, 274633, "headtail")
+    assert ls.projects.get.call_count == sut._THROTTLE_MAX_ATTEMPTS


### PR DESCRIPTION
## Symptom

Head/tail project **274633** (`082929_FishModels_FSL01 #59`) sat at **86/86 tasks labeled in Label Studio** but **0 completed in the DB**, so it never fell off the dashboard. Its `LabelStudioSyncCursor` row **did not exist at all** — the cursor is only written on full success, so it had never once synced.

Meanwhile 274626 and 274640 synced fine minutes earlier. That non-determinism was the clue.

## Root cause

The project-existence probe treats **any** `ApiError` as "project is gone":

```python
try:
    _ = await asyncio.to_thread(ls.projects.get, project_id)
except ApiError as e:
    activity.logger.warning("...missing...")
    return          # ← returns BEFORE the cursor write
```

A **429 throttle raises the same `ApiError` as a 404**. So a rate-limited probe silently declared the project missing, skipped it, and returned *successfully* — no error, no cursor, repeating hourly forever. Straight from the logs:

```
sync_label_studio_project missing kind=headtail project_id=274633
  error=... status_code: 429 ... 'Request was throttled. Expected available in 48 seconds.'
```

It's **position-dependent**: each hourly cycle probes ~46 projects across four label kinds, LS starts throttling partway through, and everything after that point is dropped. Which projects get hit varies run to run.

## Fix

Distinguish 429 from 404:

- **429** → back off honouring the `"available in N seconds"` hint (+2s margin), heartbeat, retry
- **404 and friends** → still "missing", still skipped — legacy ids 57–117 all 404 on the hosted instance and must not fail the run
- **Still throttled after 5 attempts** → **raise**, so the activity fails, Temporal retries, and the cursor stays unadvanced

Failing loudly is deliberate here; the alternative is precisely the silent skip being fixed.

## Tests

`test_sync_throttle_handling.py` — hint parsing (48s → 50.0), fallback when unparseable, 404/403/500 are not throttles, a 404 still means missing, a throttle retries-then-succeeds (asserting the honoured backoff), and persistent throttling raises after exactly `_THROTTLE_MAX_ATTEMPTS`.

292 worker tests pass; pylint 10.00.

## Note

This is the third distinct bug in the LS→DB sync path found today, after the annotator-dict 422 (#378) and the `put_*_label` duplicate-key 500 (#347). All three had the same shape: **an error class the code didn't anticipate, swallowed or mis-handled in a way that silently dropped work** rather than failing visibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)