### PR TITLE
feat(web): only surface published Label Studio projects on the landing page

### DIFF
--- a/apps/fishsense-lite-web/lib/active-projects.test.ts
+++ b/apps/fishsense-lite-web/lib/active-projects.test.ts
@@ -36,7 +36,7 @@ describe("getActiveProjects", () => {
       "dive-slate": [66],
     });
     projectsMock.mockImplementation(async (ids) =>
-      ids.map((id) => ({ id, title: `p-${id}` })),
+      ids.map((id) => ({ id, title: `p-${id}`, isPublished: true })),
     );
 
     const result = await getActiveProjects(60);
@@ -50,12 +50,12 @@ describe("getActiveProjects", () => {
 
     expect(result).toEqual({
       laser: [
-        { id: 42, title: "p-42" },
-        { id: 43, title: "p-43" },
+        { id: 42, title: "p-42", isPublished: true },
+        { id: 43, title: "p-43", isPublished: true },
       ],
-      species: [{ id: 70, title: "p-70" }],
-      headtail: [{ id: 44, title: "p-44" }],
-      slate: [{ id: 66, title: "p-66" }],
+      species: [{ id: 70, title: "p-70", isPublished: true }],
+      headtail: [{ id: 44, title: "p-44", isPublished: true }],
+      slate: [{ id: 66, title: "p-66", isPublished: true }],
     });
   });
 
@@ -129,5 +129,65 @@ describe("getActiveProjects (Label Studio disabled)", () => {
 
     expect(idsMock).not.toHaveBeenCalled();
     expect(projectsMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("getActiveProjects — publish filtering", () => {
+  it("hides unpublished projects from the landing page", async () => {
+    // The real case: laser project 274728 was unpublished in Label Studio to
+    // hold it back from labelers, but the id list comes from fishsense-api
+    // (derived from label rows) and knows nothing about publish state — so
+    // without this filter the held project stays linked from the landing page.
+    idsMock.mockResolvedValue({
+      laser: [274728, 73],
+      species: [],
+      headtail: [],
+      "dive-slate": [],
+    });
+    projectsMock.mockImplementation(async (ids) =>
+      ids.map((id) => ({
+        id,
+        title: `p-${id}`,
+        isPublished: id !== 274728,
+      })),
+    );
+
+    const result = await getActiveProjects(60);
+
+    expect(result.laser).toEqual([{ id: 73, title: "p-73", isPublished: true }]);
+  });
+
+  it("filters every kind, not just laser", async () => {
+    idsMock.mockResolvedValue({
+      laser: [1],
+      species: [2],
+      headtail: [3],
+      "dive-slate": [4],
+    });
+    projectsMock.mockImplementation(async (ids) =>
+      ids.map((id) => ({ id, title: `p-${id}`, isPublished: false })),
+    );
+
+    const result = await getActiveProjects(60);
+
+    expect(result).toEqual({ laser: [], species: [], headtail: [], slate: [] });
+  });
+
+  it("keeps drafts out while a project is still being populated", async () => {
+    // Per-dive projects are created as drafts and only published once their
+    // task set is complete, so a half-filled project must not appear either.
+    idsMock.mockResolvedValue({
+      laser: [],
+      species: [100, 101],
+      headtail: [],
+      "dive-slate": [],
+    });
+    projectsMock.mockImplementation(async (ids) =>
+      ids.map((id) => ({ id, title: `p-${id}`, isPublished: id === 100 })),
+    );
+
+    const result = await getActiveProjects(60);
+
+    expect(result.species.map((p) => p.id)).toEqual([100]);
   });
 });

--- a/apps/fishsense-lite-web/lib/active-projects.ts
+++ b/apps/fishsense-lite-web/lib/active-projects.ts
@@ -18,6 +18,23 @@ const noActiveProjects = (): ActiveProjects => ({
   slate: [],
 });
 
+/** Drop unpublished projects.
+ *
+ * The id list comes from fishsense-api (`label-studio-project-ids?incomplete=true`),
+ * which is derived from label rows and knows nothing about Label Studio's
+ * publish state. So a project that is a draft — still being populated — or one
+ * deliberately unpublished to hold it back from labelers would still be linked
+ * from the landing page. Publish state lives in LS, so it's filtered here,
+ * after the per-project fetch that already tells us.
+ */
+function published(projects: LabelStudioProject[]): LabelStudioProject[] {
+  // `!== false` rather than truthiness: only an explicit unpublished flag
+  // hides a card. `getProject` already normalizes a missing `is_published`
+  // to true, and failing open here too means a Label Studio response change
+  // can never silently blank the landing page.
+  return projects.filter((project) => project.isPublished !== false);
+}
+
 export async function getActiveProjects(revalidate = 300): Promise<ActiveProjects> {
   // Label Studio is off by default — see `labelStudioEnabled`. Short-circuit
   // before the fishsense-api call too: the project IDs it returns are only
@@ -34,5 +51,10 @@ export async function getActiveProjects(revalidate = 300): Promise<ActiveProject
     getProjects(ids.headtail, revalidate),
     getProjects(ids["dive-slate"], revalidate),
   ]);
-  return { laser, species, headtail, slate };
+  return {
+    laser: published(laser),
+    species: published(species),
+    headtail: published(headtail),
+    slate: published(slate),
+  };
 }

--- a/apps/fishsense-lite-web/lib/label-studio.test.ts
+++ b/apps/fishsense-lite-web/lib/label-studio.test.ts
@@ -77,7 +77,7 @@ describe("getProject", () => {
 
     const project = await getProject(42, 60);
 
-    expect(project).toEqual({ id: 42, title: "REEF Laser High Priority" });
+    expect(project).toEqual({ id: 42, title: "REEF Laser High Priority", isPublished: true });
     const projectCall = fetchMock.mock.calls.find(([url]) => url !== REFRESH_URL)!;
     expect(projectCall[0]).toBe("http://ls.test/api/projects/42");
     const headers = projectCall[1]?.headers as Record<string, string>;
@@ -105,7 +105,7 @@ describe("getProject", () => {
 
     const project = await getProject(7, 60);
 
-    expect(project).toEqual({ id: 7, title: "recovered" });
+    expect(project).toEqual({ id: 7, title: "recovered", isPublished: true });
     const refreshCalls = fetchMock.mock.calls.filter(([url]) => url === REFRESH_URL);
     expect(refreshCalls).toHaveLength(2); // initial + forced retry
   });
@@ -143,9 +143,9 @@ describe("getProjects", () => {
     const projects = await getProjects([1, 2, 3], 60);
 
     expect(projects).toEqual([
-      { id: 1, title: "project-1" },
-      { id: 2, title: "project-2" },
-      { id: 3, title: "project-3" },
+      { id: 1, title: "project-1", isPublished: true },
+      { id: 2, title: "project-2", isPublished: true },
+      { id: 3, title: "project-3", isPublished: true },
     ]);
     expect(maxInFlight).toBe(3);
   });
@@ -162,7 +162,7 @@ describe("getProjects", () => {
 
     const projects = await getProjects([73, 274558], 60);
 
-    expect(projects).toEqual([{ id: 274558, title: "project-274558" }]);
+    expect(projects).toEqual([{ id: 274558, title: "project-274558", isPublished: true }]);
   });
 
   it("returns an empty list rather than throwing when every ID is dead", async () => {

--- a/apps/fishsense-lite-web/lib/label-studio.ts
+++ b/apps/fishsense-lite-web/lib/label-studio.ts
@@ -3,6 +3,13 @@ import { env } from "./env";
 export type LabelStudioProject = {
   id: number;
   title: string;
+  /** LS publish state. Unpublished projects are drafts or deliberately held
+   *  and must not be surfaced — see `getActiveProjects`.
+   *
+   *  Optional because only `getProject` sources it; consumers that merely
+   *  render id/title (e.g. `buildSections`) shouldn't have to carry it.
+   *  Absent is treated as published, so filtering fails open. */
+  isPublished?: boolean;
 };
 
 // Hosted Label Studio (app.heartex.com) does NOT accept the configured key
@@ -122,8 +129,19 @@ export async function getProject(
     );
   }
 
-  const data = (await response.json()) as { id: number; title: string };
-  return { id: data.id, title: data.title };
+  const data = (await response.json()) as {
+    id: number;
+    title: string;
+    is_published?: boolean;
+  };
+  // A missing `is_published` counts as published: the landing page should
+  // fail OPEN (show the card) rather than silently hide real labeling work
+  // if LS ever stops returning the field.
+  return {
+    id: data.id,
+    title: data.title,
+    isPublished: data.is_published !== false,
+  };
 }
 
 export async function getProjects(


### PR DESCRIPTION
## Why

The landing page builds its cards from `label-studio-project-ids?incomplete=true`, which fishsense-api derives from **label rows** — it knows nothing about Label Studio's publish state. Two classes of project therefore leaked onto the public page:

- **Drafts.** Per-dive projects are created unpublished and only published once their task set is complete (the `deferred == 0` gate). A half-populated project appeared as soon as its first sentinel rows existed.
- **Deliberately held projects.** Laser project **274728** was unpublished in LS to reserve its 70 images for the detector model — and remained linked from the landing page regardless. That's the concrete case that prompted this.

## Approach

Filtered in the web app, not the API: publish state lives in Label Studio, and the app **already fetches each project**, so the flag comes for free. fishsense-api could only do this by mirroring state it doesn't own.

- `getProject` now reads `is_published`
- `getActiveProjects` drops unpublished across **all four kinds**

## Two deliberate details

**`isPublished` is optional on `LabelStudioProject`.** Only `getProject` sources it; consumers that merely render id/title (`buildSections`) shouldn't have to carry it. Making it required forced ~10 unrelated fixtures in `sections.test.ts` to be edited for a field they never exercise — churn that obscures the change.

**Both the parse and the filter fail OPEN** (`is_published !== false`). Only an explicit unpublished flag hides a card, so a Label Studio response change can never silently blank the landing page. Hiding real labeling work is the worse failure here than showing one card too many.

## Tests

Three new cases: the literal 274728 hold, filtering applied to every kind (not just laser), and a still-populating draft being kept out. Existing assertions updated where `getProject`'s return shape legitimately changed.

**58 tests pass; lint, typecheck and `next build` all clean** (verified in a node:24 container matching CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)