### PR TITLE
fix(api): species preprocess requires the qualifying image be in a PREDICTION cluster

### DIFF
--- a/services/fishsense-api/src/fishsense_api/alembic/versions/d4e9a1c7b520_species_preprocessed_requires_in_cluster.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/d4e9a1c7b520_species_preprocessed_requires_in_cluster.py
@@ -1,0 +1,62 @@
+"""`dive_images_preprocessed` counts only in-cluster, live-labeled images
+
+The stage-2 `dive_images_preprocessed` flag checked "dive has a PREDICTION
+cluster" and "every valid-laser image has a non-sentinel species row" as two
+independent, dive-wide conditions. But `resolve_species_preprocess_inputs_activity`
+only makes JPEGs for a qualifying image that is *in* a PREDICTION cluster (it
+needs the cluster for the "image i of N" overlay), and
+`select_next_for_species_preprocessing` was tightened to match on 2026-07-22.
+
+The view lagged, so it diverged from the selector two ways:
+
+* An image with a valid laser but in no cluster (a laser validated after
+  one-shot stage-1 clustering) counted against "preprocessed", leaving the
+  dive forever incomplete on the dashboard while the selector — correctly —
+  never re-fired on it. In prod this was the poison pill: such a dive sat at
+  the front of the one-per-hour selector queue resolving to zero and starving
+  every productive dive behind it.
+* The species existence check ignored `superseded`, so a dive whose only
+  species rows were dead-lettered read as preprocessed=true. The selector
+  became superseded-aware in b7c... / the 2026-07-21 preprocess-cohort fix;
+  the view did not.
+
+Both are now defined identically to the selector: a "processable" image is
+valid-laser AND in a PREDICTION cluster, and only a live (non-superseded)
+non-sentinel species row marks it done.
+
+Drop + recreate rather than CREATE OR REPLACE — postgres is restrictive about
+column-shape changes and the view has no dependents.
+
+Revision ID: d4e9a1c7b520
+Revises: c8d3f5a21b74
+Create Date: 2026-07-22 23:55:00.000000
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from fishsense_api.views import (
+    DIVE_PIPELINE_STATUS_VIEW_SQL,
+    DROP_DIVE_PIPELINE_STATUS_VIEW_SQL,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "d4e9a1c7b520"
+down_revision: Union[str, Sequence[str], None] = "c8d3f5a21b74"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)
+
+
+def downgrade() -> None:
+    """Drop the new view; the prior migration's upgrade is the recreate.
+    To roll back the predicate, manually re-run c8d3f5a21b74's
+    `op.execute(...)` against the DB."""
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -256,14 +256,20 @@ async def select_next_for_species_preprocessing(
     aware). 1,826 species and 1,761 headtail images were stranded — their
     JPEGs never regenerated, so populate deferred them forever and no
     per-dive species project could publish.
+
+    The PREDICTION-cluster gate is checked on the SAME image as the laser
+    gate, not dive-wide (fixed 2026-07-22). `resolve_species_preprocess_inputs_activity`
+    only dispatches per-image work for a qualifying image that is *in* a
+    PREDICTION cluster (it needs the cluster for the "image i of N" overlay).
+    The selector used to check "dive has some cluster" and "dive has some
+    qualifying image" independently, so a dive whose one qualifying image
+    was NOT clustered (a laser validated after stage-1 clustering, which is
+    one-shot per dive) got selected while the resolver returned zero. Since
+    the parent drains one dive per hour ordered by id, such a dive sat at the
+    front forever, resolving to nothing and starving every productive dive
+    behind it — dives 59 and 439 did exactly this, blocking 60/61/66/76/…
     """
-    has_prediction_cluster = (
-        select(DiveFrameCluster.id)
-        .where(DiveFrameCluster.dive_id == Dive.id)
-        .where(DiveFrameCluster.data_source == DataSource.PREDICTION)
-        .exists()
-    )
-    has_valid_laser_image_without_real_species = (
+    has_valid_laser_image_in_cluster_without_real_species = (
         select(LaserLabel.id)
         .join(Image, Image.id == LaserLabel.image_id)
         .where(Image.dive_id == Dive.id)
@@ -280,13 +286,26 @@ async def select_next_for_species_preprocessing(
             .where(SpeciesLabel.superseded == False)
             .exists()
         )
+        # The qualifying image must itself be in a PREDICTION cluster — this
+        # is what the resolver requires, so checking it here keeps the two in
+        # step. Subsumes the old dive-wide "has any PREDICTION cluster" gate.
+        .where(
+            select(DiveFrameClusterImageMapping.image_id)
+            .join(
+                DiveFrameCluster,
+                DiveFrameCluster.id
+                == DiveFrameClusterImageMapping.dive_frame_cluster_id,
+            )
+            .where(DiveFrameClusterImageMapping.image_id == Image.id)
+            .where(DiveFrameCluster.data_source == DataSource.PREDICTION)
+            .exists()
+        )
         .exists()
     )
     query = (
         select(Dive.id)
         .where(Dive.priority == Priority.HIGH)
-        .where(has_prediction_cluster)
-        .where(has_valid_laser_image_without_real_species)
+        .where(has_valid_laser_image_in_cluster_without_real_species)
         .order_by(Dive.id)
         .limit(1)
     )

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -160,34 +160,54 @@ SELECT
           AND dfc.data_source = 'PREDICTION'
     ) AS has_prediction_clusters,
 
-    -- Stage 2: has PREDICTION clusters AND every image carrying a
-    -- valid laser label (completed, not superseded, x/y both set) has
-    -- a non-sentinel SpeciesLabel row. ≥1 such laser-valid image must
-    -- exist (otherwise the predicate would be vacuously true for dives
-    -- with no laser work yet — same convention as headtail_preprocessed).
-    -- Cohort flipped 2026-05-05 from "every image" → "every laser-valid
-    -- image" so species labeling now mirrors head/tail (per-image
-    -- cascade from valid lasers) while keeping the cluster gate.
+    -- Stage 2: every "processable" image has a non-sentinel, non-superseded
+    -- SpeciesLabel row, and ≥1 processable image exists (else vacuously true
+    -- for dives with no laser work yet — same convention as
+    -- headtail_preprocessed).
+    --
+    -- "Processable" = carries a valid laser label (completed, not superseded,
+    -- x/y both set) AND is itself in a PREDICTION cluster. Both halves mirror
+    -- `select_next_for_species_preprocessing` exactly, and the drift-guard
+    -- test pins the two together:
+    --   * in-cluster (2026-07-22): the resolver only makes JPEGs for a
+    --     qualifying image that is in a cluster (it needs the cluster for the
+    --     "image i of N" overlay). An image with a valid laser but no cluster
+    --     — a laser validated after one-shot stage-1 clustering — is not
+    --     processable, so it must not count against "preprocessed" (it would
+    --     otherwise read as forever-incomplete while the selector, correctly,
+    --     never re-fired on it).
+    --   * superseded (2026-07-22): a dead-lettered species row is not
+    --     evidence the work is done — matches the selector's superseded gate.
     (EXISTS (
-         SELECT 1 FROM diveframecluster dfc
-         WHERE dfc.dive_id = d.id
-           AND dfc.data_source = 'PREDICTION'
-     )
-     AND EXISTS (
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
          WHERE i.dive_id = d.id
            AND {_VALID_LASER_SQL}
+           AND EXISTS (
+               SELECT 1 FROM diveframeclusterimagemapping mm
+               JOIN diveframecluster dfc
+                 ON dfc.id = mm.dive_frame_cluster_id
+               WHERE mm.image_id = i.id
+                 AND dfc.data_source = 'PREDICTION'
+           )
      )
      AND NOT EXISTS (
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
          WHERE i.dive_id = d.id
            AND {_VALID_LASER_SQL}
+           AND EXISTS (
+               SELECT 1 FROM diveframeclusterimagemapping mm
+               JOIN diveframecluster dfc
+                 ON dfc.id = mm.dive_frame_cluster_id
+               WHERE mm.image_id = i.id
+                 AND dfc.data_source = 'PREDICTION'
+           )
            AND NOT EXISTS (
                SELECT 1 FROM specieslabel sl
                WHERE sl.image_id = i.id
                  AND sl.label_studio_project_id IS NOT NULL
+                 AND sl.superseded = FALSE
            )
      )) AS dive_images_preprocessed,
 

--- a/services/fishsense-api/tests/test_dive_pipeline_status_view.py
+++ b/services/fishsense-api/tests/test_dive_pipeline_status_view.py
@@ -475,7 +475,10 @@ async def test_dive_images_preprocessed_requires_clusters_and_laser_valid_specie
 ):
     """Predicate (post 2026-05-05): PREDICTION cluster present AND
     every laser-valid image has a non-sentinel SpeciesLabel row."""
-    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+        DiveFrameClusterImageMapping,
+    )
     from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
     from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
 
@@ -484,12 +487,13 @@ async def test_dive_images_preprocessed_requires_clusters_and_laser_valid_specie
     session.add_all([_image(11, 1), _image(12, 1)])
     await session.flush()
     session.add(
-        DiveFrameCluster(
-            dive_id=1, data_source="PREDICTION", index=0,
-        )
+        DiveFrameCluster(id=820, dive_id=1, data_source="PREDICTION", index=0)
     )
+    await session.flush()
     session.add_all(
         [
+            DiveFrameClusterImageMapping(dive_frame_cluster_id=820, image_id=11),
+            DiveFrameClusterImageMapping(dive_frame_cluster_id=820, image_id=12),
             LaserLabel(
                 image_id=11, completed=True, superseded=False,
                 x=100.0, y=200.0, label_studio_project_id=43,
@@ -591,7 +595,10 @@ async def test_dive_images_preprocessed_ignores_images_without_valid_laser(sessi
     species row on it doesn't fail dive_images_preprocessed. As long
     as the laser-valid image (11) has a species row, the predicate
     holds."""
-    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+        DiveFrameClusterImageMapping,
+    )
     from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
     from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
 
@@ -600,12 +607,13 @@ async def test_dive_images_preprocessed_ignores_images_without_valid_laser(sessi
     session.add_all([_image(11, 1), _image(12, 1)])
     await session.flush()
     session.add(
-        DiveFrameCluster(
-            dive_id=1, data_source="PREDICTION", index=0,
-        )
+        DiveFrameCluster(id=830, dive_id=1, data_source="PREDICTION", index=0)
     )
+    await session.flush()
     session.add_all(
         [
+            DiveFrameClusterImageMapping(dive_frame_cluster_id=830, image_id=11),
+            DiveFrameClusterImageMapping(dive_frame_cluster_id=830, image_id=12),
             LaserLabel(
                 image_id=11, completed=True, superseded=False,
                 x=100.0, y=200.0, label_studio_project_id=43,
@@ -641,12 +649,13 @@ async def test_view_and_selector_agree_on_species_predicate(session):
     )
     from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
         DiveFrameCluster,
+        DiveFrameClusterImageMapping,
     )
     from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
     from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
 
-    # dive 1 (Case A): PREDICTION cluster + valid laser + no species → cohort.
-    # dive 2 (Case B): PREDICTION cluster + valid laser + species labeled → done.
+    # dive 1 (Case A): valid laser IN a cluster + no species → cohort.
+    # dive 2 (Case B): valid laser IN a cluster + species labeled → done.
     # dive 3 (Case C): PREDICTION cluster + no valid laser → ineligible.
     session.add_all([_dive(1), _dive(2), _dive(3)])
     await session.flush()
@@ -654,9 +663,17 @@ async def test_view_and_selector_agree_on_species_predicate(session):
     await session.flush()
     session.add_all(
         [
-            DiveFrameCluster(dive_id=1, data_source="PREDICTION", index=0),
-            DiveFrameCluster(dive_id=2, data_source="PREDICTION", index=0),
-            DiveFrameCluster(dive_id=3, data_source="PREDICTION", index=0),
+            DiveFrameCluster(id=801, dive_id=1, data_source="PREDICTION", index=0),
+            DiveFrameCluster(id=802, dive_id=2, data_source="PREDICTION", index=0),
+            DiveFrameCluster(id=803, dive_id=3, data_source="PREDICTION", index=0),
+        ]
+    )
+    await session.flush()
+    session.add_all(
+        [
+            # Qualifying images must be IN their cluster (view + selector).
+            DiveFrameClusterImageMapping(dive_frame_cluster_id=801, image_id=11),
+            DiveFrameClusterImageMapping(dive_frame_cluster_id=802, image_id=21),
             LaserLabel(
                 image_id=11, completed=True, superseded=False,
                 x=100.0, y=200.0, label_studio_project_id=43,
@@ -1033,3 +1050,85 @@ async def test_measured_ignores_species_rows_without_a_scientific_name(session):
     assert (await _row(session, 1))["measured"] is True, (
         "the Fish Model rig must not hold `measured` false"
     )
+
+
+async def test_dive_images_preprocessed_ignores_unclustered_and_superseded(session):
+    """`dive_images_preprocessed` must count only *processable* images —
+    valid laser AND in a PREDICTION cluster — with a live species row, so it
+    stays in step with `select_next_for_species_preprocessing`.
+
+    Two images: image 11 is clustered and labeled (done); image 12 has a
+    valid laser but is NOT in any cluster, so it is unprocessable and must not
+    drag the flag to False. Otherwise the dashboard reads "stage 2 stuck"
+    forever on a dive the selector correctly never re-fires on (the prod
+    poison pill).
+    """
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+        DiveFrameClusterImageMapping,
+    )
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add_all([_image(11, 1), _image(12, 1)])
+    await session.flush()
+    session.add(DiveFrameCluster(id=810, dive_id=1, data_source=DataSource.PREDICTION))
+    await session.flush()
+    session.add(DiveFrameClusterImageMapping(dive_frame_cluster_id=810, image_id=11))
+    session.add_all(
+        [
+            LaserLabel(
+                image_id=11, completed=True, superseded=False,
+                x=1.0, y=2.0, label_studio_project_id=43,
+            ),
+            LaserLabel(
+                image_id=12, completed=True, superseded=False,
+                x=3.0, y=4.0, label_studio_project_id=43,
+            ),
+            SpeciesLabel(
+                image_id=11, completed=False, superseded=False,
+                label_studio_project_id=70,
+            ),
+        ]
+    )
+    await session.flush()
+
+    # image 12 is unclustered → not processable → doesn't count against done.
+    assert (await _row(session, 1))["dive_images_preprocessed"] is True
+
+
+async def test_dive_images_preprocessed_false_when_only_species_row_superseded(session):
+    """A dead-lettered species row is not evidence the work is done."""
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+        DiveFrameClusterImageMapping,
+    )
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add(DiveFrameCluster(id=811, dive_id=1, data_source=DataSource.PREDICTION))
+    await session.flush()
+    session.add(DiveFrameClusterImageMapping(dive_frame_cluster_id=811, image_id=11))
+    session.add_all(
+        [
+            LaserLabel(
+                image_id=11, completed=True, superseded=False,
+                x=1.0, y=2.0, label_studio_project_id=43,
+            ),
+            SpeciesLabel(
+                image_id=11, completed=False, superseded=True,
+                label_studio_project_id=117,
+            ),
+        ]
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["dive_images_preprocessed"] is False

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -620,19 +620,25 @@ async def test_species_preprocessing_requires_prediction_cluster_and_valid_laser
     from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
         DiveFrameCluster,
     )
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameClusterImageMapping,
+    )
     from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
 
     # dive 1: no PREDICTION cluster -> excluded.
     # dive 2: PREDICTION cluster but no laser-valid image -> excluded.
-    # dive 3: PREDICTION cluster + laser-valid image without species label -> picked.
+    # dive 3: PREDICTION cluster + laser-valid image IN that cluster,
+    #         without a species label -> picked.
     session.add_all([_dive(1), _dive(2), _dive(3)])
     await session.flush()
     session.add_all([_image(11, 1), _image(21, 2), _image(31, 3)])
     await session.flush()
     session.add_all(
         [
-            DiveFrameCluster(dive_id=2, data_source=DataSource.PREDICTION),
-            DiveFrameCluster(dive_id=3, data_source=DataSource.PREDICTION),
+            DiveFrameCluster(id=902, dive_id=2, data_source=DataSource.PREDICTION),
+            DiveFrameCluster(id=903, dive_id=3, data_source=DataSource.PREDICTION),
+            # The qualifying image must be IN the cluster, matching the resolver.
+            DiveFrameClusterImageMapping(dive_frame_cluster_id=903, image_id=31),
             LaserLabel(
                 image_id=11, completed=True, superseded=False,
                 x=100.0, y=200.0, label_studio_project_id=43,
@@ -749,10 +755,16 @@ async def test_species_preprocessing_ignores_null_project_species_sentinels(sess
     from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
     from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
 
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameClusterImageMapping,
+    )
+
     session.add(_dive(1))
     await session.flush()
     session.add(_image(11, 1))
-    session.add(DiveFrameCluster(dive_id=1, data_source=DataSource.PREDICTION))
+    session.add(DiveFrameCluster(id=910, dive_id=1, data_source=DataSource.PREDICTION))
+    await session.flush()
+    session.add(DiveFrameClusterImageMapping(dive_frame_cluster_id=910, image_id=11))
     session.add(
         LaserLabel(
             image_id=11, completed=True, superseded=False,
@@ -895,6 +907,7 @@ async def test_needing_species_population_reincludes_superseded_only_dive(sessio
     from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
     from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
         DiveFrameCluster,
+        DiveFrameClusterImageMapping,
     )
     from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
     from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
@@ -902,7 +915,10 @@ async def test_needing_species_population_reincludes_superseded_only_dive(sessio
     session.add(_dive(1))
     await session.flush()
     session.add(_image(11, 1))
-    session.add(DiveFrameCluster(dive_id=1, data_source=DataSource.PREDICTION))
+    session.add(DiveFrameCluster(id=950, dive_id=1, data_source=DataSource.PREDICTION))
+    await session.flush()
+    # image 11 is IN the cluster — the preprocessing selector requires this.
+    session.add(DiveFrameClusterImageMapping(dive_frame_cluster_id=950, image_id=11))
     session.add(
         LaserLabel(
             image_id=11, completed=True, superseded=False, x=1.0, y=2.0,
@@ -1577,11 +1593,17 @@ async def test_species_preprocessing_reenters_dive_with_only_superseded_species(
     from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
     from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
 
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameClusterImageMapping,
+    )
+
     session.add(_dive(1))
     await session.flush()
     session.add(_image(11, 1))
     await session.flush()
-    session.add(DiveFrameCluster(dive_id=1, data_source=DataSource.PREDICTION))
+    session.add(DiveFrameCluster(id=920, dive_id=1, data_source=DataSource.PREDICTION))
+    await session.flush()
+    session.add(DiveFrameClusterImageMapping(dive_frame_cluster_id=920, image_id=11))
     session.add_all(
         [
             LaserLabel(
@@ -1725,3 +1747,96 @@ async def test_measure_fish_still_selects_a_real_fish_row(session):
     await session.flush()
 
     assert await select_next_for_measure_fish(session=session) == 1
+
+
+async def test_species_preprocessing_skips_qualifying_image_not_in_a_cluster(session):
+    """The 2026-07-22 poison pill.
+
+    A dive can have PREDICTION clusters AND a valid-laser image with no
+    species row, yet that image not be in any cluster — e.g. its laser was
+    validated after stage-1 clustering (one-shot per dive). The selector used
+    to check the two conditions dive-wide and independently, so it picked such
+    a dive; the resolver, which only dispatches per-image work for images IN a
+    cluster, then returned zero. Ordered by id and drained one dive per hour,
+    that dive sat at the front forever and starved every productive dive
+    behind it (dives 59 and 439 in prod).
+
+    So a qualifying image that is NOT clustered must not select the dive.
+    """
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_species_preprocessing,
+    )
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+        DiveFrameClusterImageMapping,
+    )
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    # image 11 is clustered but already handled; image 12 qualifies but is NOT
+    # in any cluster — the exact poison-pill shape.
+    session.add_all([_image(11, 1), _image(12, 1)])
+    await session.flush()
+    session.add(DiveFrameCluster(id=930, dive_id=1, data_source=DataSource.PREDICTION))
+    await session.flush()
+    session.add(DiveFrameClusterImageMapping(dive_frame_cluster_id=930, image_id=11))
+    session.add_all(
+        [
+            LaserLabel(
+                image_id=11, completed=True, superseded=False,
+                x=1.0, y=2.0, label_studio_project_id=43,
+            ),
+            LaserLabel(
+                image_id=12, completed=True, superseded=False,
+                x=3.0, y=4.0, label_studio_project_id=43,
+            ),
+        ]
+    )
+    await session.flush()
+
+    # image 11 (clustered) has no species row either, so on its own it WOULD
+    # select the dive; give it one so the only *unlabeled* image is the
+    # unclustered 12. Now nothing processable remains.
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(
+        SpeciesLabel(image_id=11, completed=False, label_studio_project_id=70)
+    )
+    await session.flush()
+
+    assert await select_next_for_species_preprocessing(session=session) is None
+
+
+async def test_species_preprocessing_picks_dive_with_a_clustered_qualifying_image(
+    session,
+):
+    """Guard the other direction: when the qualifying image IS clustered, the
+    dive is still selected — the fix must not over-exclude."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_species_preprocessing,
+    )
+    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+        DiveFrameCluster,
+        DiveFrameClusterImageMapping,
+    )
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(_image(11, 1))
+    await session.flush()
+    session.add(DiveFrameCluster(id=940, dive_id=1, data_source=DataSource.PREDICTION))
+    await session.flush()
+    session.add(DiveFrameClusterImageMapping(dive_frame_cluster_id=940, image_id=11))
+    session.add(
+        LaserLabel(
+            image_id=11, completed=True, superseded=False,
+            x=1.0, y=2.0, label_studio_project_id=43,
+        )
+    )
+    await session.flush()
+
+    assert await select_next_for_species_preprocessing(session=session) == 1


### PR DESCRIPTION
## Symptom

**Nothing was populating.** The species preprocess parent completed every hour but dispatched **no data-worker child** — so no stage-2 JPEGs were written, and every species populate deferred `"JPEG not yet in Garage"` on all **471** pending images. All workflows showed COMPLETED; the failure was silent.

## Root cause — selector and resolver disagree

`select_next_for_species_preprocessing` checked two conditions **independently and dive-wide**:
- dive has *a* PREDICTION cluster
- dive has *a* valid-laser image with no live species row

But `resolve_species_preprocess_inputs_activity` only emits per-image work for a qualifying image that is **in** a PREDICTION cluster (it needs the cluster for the "image i of N" overlay). So a dive whose one qualifying image is **not** clustered — a laser validated *after* one-shot stage-1 clustering — gets selected while the resolver returns **zero**:

```
dispatching species preprocess to data-worker dive_id=59 clusters=0 images=0
```

`select-next` orders by dive id and the parent drains **one dive per hour**, so that dive sits at the front forever, resolving to nothing and **starving every productive dive behind it**. Measured in prod:

| dive | qualifying imgs | …in a cluster |
|---|---|---|
| **59** | 1 | **0** ← poison pill (lowest id, picked every hour) |
| **439** | 1 | **0** ← poison pill |
| 60 | 101 | 98 |
| 61 / 66 / 76 / 393 / 427 / 436 / 437 / 440 | 69–926 | nearly all |

Dive 59 blocked hundreds of processable images across nine dives.

## Fix

Fold cluster membership into the selector's qualifying-image test, so it means exactly what the resolver processes: **valid laser AND in a PREDICTION cluster AND no live non-sentinel species row**. Poison-pill dives drop out; the selector advances to real work.

`dive_pipeline_status.dive_images_preprocessed` mirrors this predicate — there's a **drift-guard test** pinning the view and selector together — so it gets the same change via a drop/recreate migration. While there, the view's species check was also made **superseded-aware**: the selector became so on 2026-07-21 (#353) but the view didn't, a latent divergence the guard's three cases never exercised. Both halves now match.

## Tests

- selector: qualifying-but-unclustered image ⇒ not selected (the poison pill); clustered qualifying image ⇒ still selected (no over-exclusion). Three existing selection tests updated to map their qualifying image into the cluster (they encoded the old dive-wide behavior).
- view: unclustered/superseded images don't count against `dive_images_preprocessed`; a superseded-only dive reads False.
- both cross-check tests (`view↔selector`, `needing-population↔preprocess`) updated and green.

184 api tests pass; pylint 10.00; single alembic head.

## Follow-up (not this PR)

The orphan images themselves — 2 in prod, valid laser but no cluster — still can't be species-labeled in this pipeline (stage-1 clustering is one-shot per dive). They no longer block anything; making them processable needs a re-cluster path. Worth a tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)