### PR TITLE
fix(preprocess): child uses ALLOW_DUPLICATE so a dive can reprocess new images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,17 +208,26 @@ one replica):
   `overlap=ScheduleOverlapPolicy.SKIP` — a previous run still in
   flight blocks the next firing, so two selectors can't race past
   the same `dives.get()` and pick the same dive.
-* Child workflow id is deterministic (`preprocess-laser-{dive_id}`)
-  and dispatched with
-  `id_reuse_policy=ALLOW_DUPLICATE_FAILED_ONLY`. If a parent run
-  *does* race past the schedule guard (e.g. manual trigger
-  overlapping a scheduled one), the second `start_child_workflow`
-  raises `WorkflowAlreadyStartedError` which the parent catches —
-  archive + cleanup + populate then still run, so a child-then-parent
-  split failure self-heals on the next firing without redoing
-  per-image work. **Note:** temporalio's default child
-  `id_reuse_policy` is `ALLOW_DUPLICATE`, which lets duplicates
-  through silently — the explicit setting is required.
+* Child workflow id is deterministic (`preprocess-laser-{dive_id}`).
+  The **preprocess** child is dispatched with
+  `id_reuse_policy=ALLOW_DUPLICATE` (changed from
+  `ALLOW_DUPLICATE_FAILED_ONLY` on 2026-07-23). FAILED_ONLY meant a
+  *completed* child id could never re-dispatch, so a dive could never
+  be reprocessed to pick up images that became processable after its
+  first successful run — a laser validated after one-shot stage-1
+  clustering, or an orphan later assigned a cluster. Those images'
+  JPEGs were never produced and populate deferred them forever (prod
+  dives 59/439). ALLOW_DUPLICATE is safe here: the resolver returns
+  only images that still need work (finished images aren't redone) and
+  the per-image activities are idempotent (S3 overwrite). A
+  `WorkflowAlreadyStartedError` is now only raised when a prior child
+  with the same id is still *running* (manual run overlapping the
+  schedule); the parent catches it and continues to cleanup.
+  The **populate** child (laser/headtail/slate parents) keeps
+  `ALLOW_DUPLICATE_FAILED_ONLY` — duplicate LS `import_tasks` is the
+  task-ballooning bug, so its dedup must stay. **Note:** temporalio's
+  default child `id_reuse_policy` is `ALLOW_DUPLICATE`, so the populate
+  child's FAILED_ONLY is set explicitly.
 * Per-image activities are idempotent: S3 PutObject overwrites,
   SDK upserts.
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_headtail_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_headtail_images_parent_workflow.py
@@ -93,7 +93,12 @@ class PreprocessHeadtailImagesParentWorkflow:
                 id=f"preprocess-headtail-{dive_id}",
                 task_queue=DATA_PROCESSING_TASK_QUEUE,
                 execution_timeout=timedelta(hours=1),
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+                # ALLOW_DUPLICATE so a dive can reprocess images that became
+                # processable after its first successful run (see the species
+                # parent for the full rationale). Safe: the resolver returns only
+                # still-needed images and per-image work is idempotent. The populate
+                # child below keeps FAILED_ONLY to dedupe LS task imports.
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
             )
         except WorkflowAlreadyStartedError:
             workflow.logger.info(

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_laser_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_laser_images_parent_workflow.py
@@ -135,7 +135,12 @@ class PreprocessLaserImagesParentWorkflow:
                 id=f"preprocess-laser-{dive_id}",
                 task_queue=DATA_PROCESSING_TASK_QUEUE,
                 execution_timeout=timedelta(hours=1),
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+                # ALLOW_DUPLICATE so a dive can reprocess images that became
+                # processable after its first successful run (see the species
+                # parent for the full rationale). Safe: the resolver returns only
+                # still-needed images and per-image work is idempotent. The populate
+                # child below keeps FAILED_ONLY to dedupe LS task imports.
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
             )
         except WorkflowAlreadyStartedError:
             workflow.logger.info(

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_slate_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_slate_images_parent_workflow.py
@@ -102,7 +102,12 @@ class PreprocessSlateImagesParentWorkflow:
                 id=f"preprocess-slate-{dive_id}",
                 task_queue=DATA_PROCESSING_TASK_QUEUE,
                 execution_timeout=timedelta(hours=1),
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+                # ALLOW_DUPLICATE so a dive can reprocess images that became
+                # processable after its first successful run (see the species
+                # parent for the full rationale). Safe: the resolver returns only
+                # still-needed images and per-image work is idempotent. The populate
+                # child below keeps FAILED_ONLY to dedupe LS task imports.
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
             )
         except WorkflowAlreadyStartedError:
             workflow.logger.info(

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_species_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_species_images_parent_workflow.py
@@ -106,13 +106,28 @@ class PreprocessSpeciesImagesParentWorkflow:
                 id=f"preprocess-species-{dive_id}",
                 task_queue=DATA_PROCESSING_TASK_QUEUE,
                 execution_timeout=timedelta(hours=2),
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+                # ALLOW_DUPLICATE, not ALLOW_DUPLICATE_FAILED_ONLY: the child
+                # must be able to re-run on a dive it already processed, to
+                # pick up images that became processable AFTER that run — a
+                # laser validated after one-shot stage-1 clustering, or an
+                # orphan later assigned a cluster. FAILED_ONLY permanently
+                # blocked that (a completed id can never re-dispatch), so such
+                # images' JPEGs were never produced and populate deferred them
+                # forever. Safe: the resolver returns only images that still
+                # need work (finished images aren't redone) and the per-image
+                # activities are idempotent (S3 overwrite). (Species populate
+                # is decoupled — the scheduled populate parent owns dedup of
+                # LS imports — so there is no populate child here to worry
+                # about; laser/headtail/slate keep FAILED_ONLY on theirs.)
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
             )
         except WorkflowAlreadyStartedError:
+            # Only reachable now if a prior child with this id is still
+            # RUNNING (e.g. a manual run overlapping the schedule). The
+            # in-flight run is doing the work; continue to cleanup.
             workflow.logger.info(
-                "preprocess-species-%d already ran successfully in a "
-                "prior firing; skipping data-worker dispatch and continuing "
-                "to cleanup + populate",
+                "preprocess-species-%d already running; skipping duplicate "
+                "dispatch and continuing to cleanup",
                 dive_id,
             )
 

--- a/services/fishsense-api-workflow-worker/tests/test_preprocess_species_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preprocess_species_images_parent_workflow.py
@@ -235,3 +235,59 @@ async def test_skips_child_dispatch_when_no_clusters():
     assert result == 440
     assert not child_runs
     assert not populate_runs
+
+
+@pytest.mark.asyncio
+async def test_child_redispatches_after_a_prior_successful_run():
+    """The preprocess child must re-run on a dive it already processed.
+
+    A dive's image set grows after its first successful child run — a laser
+    validated after one-shot stage-1 clustering, or an orphan later given a
+    cluster. Under ALLOW_DUPLICATE_FAILED_ONLY the deterministic child id
+    (`preprocess-species-{dive}`) was permanently spent once it completed, so
+    those new images' JPEGs were never produced and populate deferred them
+    forever. With ALLOW_DUPLICATE the child re-dispatches; the resolver
+    returns only still-needed images and per-image work is idempotent, so
+    re-running is safe.
+
+    Two parent runs on the same dive → the child (same deterministic id) must
+    run BOTH times.
+    """
+    inputs = PreprocessSpeciesImagesInput(
+        dive_id=59,
+        clusters=[["orphan-checksum"]],
+        camera_matrix=_K,
+        distortion_coefficients=_D,
+    )
+    activities, _, _ = _make_stubs(59, inputs)
+    child_runs: List[tuple] = []
+    populate_runs: List[tuple] = []
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-stage2-redispatch",
+            workflows=[
+                PreprocessSpeciesImagesParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[
+                *activities,
+                _make_populate_recording_activity(populate_runs),
+            ],
+        ), Worker(
+            env.client,
+            task_queue=DATA_PROCESSING_TASK_QUEUE,
+            workflows=[_StubChildWorkflow],
+            activities=[_make_recording_activity(child_runs)],
+        ):
+            for _ in range(2):
+                await env.client.execute_workflow(
+                    PreprocessSpeciesImagesParentWorkflow.run,
+                    id=f"test-stage2-redispatch-parent-{uuid.uuid4()}",
+                    task_queue="test-stage2-redispatch",
+                )
+
+    # Same deterministic child id both times; both must have run.
+    assert len(child_runs) == 2, "child must re-dispatch on the second parent run"
+    assert {c[0] for c in child_runs} == {"preprocess-species-59"}


### PR DESCRIPTION
## The bug (found while verifying #390 in prod)

After #390 + the orphan-cluster data fix, the species selector correctly offered dive 59 (`clusters=1 images=1`) — but the parent logged:

```
dispatching species preprocess dive_id=59 clusters=1 images=1
preprocess-species-59 already ran successfully … skipping dispatch
```

The child id is deterministic (`preprocess-{stage}-{dive_id}`) with `ALLOW_DUPLICATE_FAILED_ONLY`. **A completed child id can never re-dispatch** under that policy (and you can't terminate a *completed* workflow to free it — `RPCError`). So once a dive's preprocess child succeeded, the dive can never reprocess to pick up images that became processable **later**:

- a laser validated after one-shot stage-1 clustering, or
- an orphan image later assigned a cluster (the 2026-07-22 fix).

Their JPEGs are never produced → JPEG-gated populate defers them forever. All **four** preprocess parents shared this.

## Fix

Switch the **preprocess** child to `ALLOW_DUPLICATE`. Safe because:
- the **resolver already returns only images that still need work**, so re-running never redoes finished images;
- per-image activities are **idempotent** (S3 overwrite).

`WorkflowAlreadyStartedError` is now only raised when a prior child with the same id is still *running* (a manual run overlapping the schedule) — still caught, still continues to cleanup.

The **populate** child (laser/headtail/slate) keeps `ALLOW_DUPLICATE_FAILED_ONLY` — duplicate `import_tasks` is the task-ballooning bug, so that dedup stays. Species has no populate child (decoupled).

## Test

Two parent runs on the same dive must **both** dispatch the child (same deterministic id). Verified it **fails under `FAILED_ONLY`** (second run skipped) and passes under `ALLOW_DUPLICATE`.

293 worker tests pass; pylint 10.00. CLAUDE.md updated.

## After deploy

Dives 59 and 439 reprocess on the next species-preprocess cycle and their 2 orphan JPEGs get produced — no manual intervention. The other 36 orphans already process (their children never ran). Closes the remaining half of the "nothing populating" investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)