### PR TITLE
feat(calibration): borrow another dive's laser calibration via calibration_dive_id

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,7 +249,7 @@ dives). Per-stage cohort:
 | 5.1 | HIGH-priority + at least one image with a *valid* `LaserLabel` whose image carries no non-sentinel `HeadTailLabel` row |
 | 9   | HIGH-priority + `dive_slate_id` set + at least one `SpeciesLabel.content_of_image='Slate, Laser on slate'` whose image carries no `DiveSlateLabel` row at all |
 | 13  | HIGH-priority + `dive_slate_id` set + no `LaserExtrinsics` + ≥2 completed `DiveSlateLabel` rows (matches the data-worker activity's `MIN_LASER_POINTS=2` precondition) |
-| 14  | HIGH-priority + has `LaserExtrinsics` + at least one *measurable* image with no `Measurement` (same predicate as the view's `measured`; keep the two in step) |
+| 14  | HIGH-priority + has `LaserExtrinsics` (own **or borrowed** via `Dive.calibration_dive_id`) + at least one *measurable* image with no `Measurement` (same predicate as the view's `measured`; keep the two in step) |
 
 Stages 1, 2, and 5.1 all cascade from the same "valid laser" gate.
 Stage 1 lands PREDICTION clusters that stage 2 then consumes; stage
@@ -335,7 +335,7 @@ Backs Superset dashboards reading the fishsense Postgres connection.
 | `slate_applicable` | `dive_slate_id IS NOT NULL` |
 | `slate_preprocessed` | every image with `SpeciesLabel.content_of_image='Slate, Laser on slate'` has a non-sentinel `DiveSlateLabel` row |
 | `slate_labeling_complete` | ≥1 completed `DiveSlateLabel` AND zero incomplete |
-| `calibrated` | dive has a `LaserExtrinsics` row |
+| `calibrated` | dive has a `LaserExtrinsics` row **of its own, or borrows one** via `Dive.calibration_dive_id` (see "Borrowed laser calibration" below) |
 | `measured` | ≥1 `Measurement` for the dive AND zero *measurable* images without one. "Measurable" = a `top_three_photos_of_group` `SpeciesLabel` whose image has a valid laser label, a valid head/tail label, and a LABEL_STUDIO cluster — i.e. what `measure_fish_activity` actually attempts. Rescoped 2026-07-17; see the stage-14 notes. |
 
 **"Complete" semantics throughout** mirror
@@ -383,6 +383,31 @@ activity calls (selector → `start_child_workflow`); the data-worker
 keeps SDK fetches inline because the math kernels need opencv +
 fishsense-core, so splitting fetch/math across workers would add 5+
 activity handoffs per dive for no gain.
+
+**Borrowed laser calibration (`Dive.calibration_dive_id`).** Laser
+calibration (`LaserExtrinsics`) is physically a property of the
+camera+laser rig, not the dive — one slate calibration holds for every
+dive shot with the same rig until it's disturbed. But stage 13 computes
+`LaserExtrinsics` *per dive* from that dive's own slate labels, so a
+fish-only dive with no slate frames (the slate was shot in a separate
+calibration dive) can never self-calibrate and stage 14 can never
+measure it. The self-referential FK `Dive.calibration_dive_id` lets such
+a dive **borrow** a sibling slate dive's calibration. Resolution order,
+own-wins-then-link, is centralized in `get_laser_extrinsics_for_dive`
+(the endpoint `measure_fish_activity` reads via
+`fs.dives.get_laser_extrinsics(dive_id)`), so the data-worker needs no
+change — it transparently gets the borrowed row. Three predicates mirror
+each other and must stay in step: the endpoint's fallback, the stage-14
+`select_next_for_measure_fish` cohort (`has_laser_extrinsics` = own
+`OR` linked), and the view's `calibrated` flag. Stage 13 is unchanged:
+a linked fish dive has no `dive_slate_id`/slate labels so it's naturally
+excluded from self-calibration, and a dive with its own slate always
+self-calibrates (own wins). Set/clear the link via
+`PUT|DELETE /api/v1/dives/{id}/calibration-source/{source_id}` (SDK:
+`dives.set_calibration_source` / `clear_calibration_source`). The
+management UI is the authenticated `/portal` dashboard (a follow-up to
+the backend). NULL link = self-calibrate (the default for every
+slate-bearing dive).
 
 **Stage 14 became idempotent and got a schedule on 2026-07-17** (hourly,
 +40 min). It used to be non-idempotent — `post_measurement` was a plain

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/client_base.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/client_base.py
@@ -95,12 +95,25 @@ class ClientBase(ABC):
             )
 
     @retry(exceptions=httpx.HTTPStatusError, tries=3, delay=2, backoff=2)
-    async def _put(self, endpoint: str, json: dict) -> httpx.Response:
+    async def _put(self, endpoint: str, json: dict | None = None) -> httpx.Response:
         async with self.semaphore:
             self.logger.debug("PUT request to %s with payload: %s", endpoint, json)
             return await self.__client.put(
                 endpoint,
                 json=json,
+                headers=(
+                    {"Authorization": f"Basic {self.__token.decode('utf-8')}"}
+                    if self.__token
+                    else {}
+                ),
+            )
+
+    @retry(exceptions=httpx.HTTPStatusError, tries=3, delay=2, backoff=2)
+    async def _delete(self, endpoint: str) -> httpx.Response:
+        async with self.semaphore:
+            self.logger.debug("DELETE request to %s", endpoint)
+            return await self.__client.delete(
+                endpoint,
                 headers=(
                     {"Authorization": f"Basic {self.__token.decode('utf-8')}"}
                     if self.__token

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
@@ -148,3 +148,38 @@ class DiveClient(ClientBase):
         response.raise_for_status()
 
         return response.json()
+
+    async def set_calibration_source(
+        self, dive_id: int, source_dive_id: int
+    ) -> int:
+        """Link a dive to borrow another dive's laser calibration.
+
+        Use for a fish-only dive with no slate frames of its own — point
+        it at a sibling slate/calibration dive shot with the same
+        camera+laser rig. Laser-extrinsics resolution then falls back to
+        the source dive when this dive has no calibration of its own.
+
+        Args:
+            dive_id (int): The dive that will borrow calibration.
+            source_dive_id (int): The dive whose calibration to borrow.
+
+        Returns:
+            int: The linked dive's id.
+        """
+        response = await self._put(
+            f"/api/v1/dives/{dive_id}/calibration-source/{source_dive_id}"
+        )
+        response.raise_for_status()
+
+        return response.json()
+
+    async def clear_calibration_source(self, dive_id: int) -> None:
+        """Unlink a dive from any borrowed calibration source (idempotent).
+
+        Args:
+            dive_id (int): The dive to unlink.
+        """
+        response = await self._delete(
+            f"/api/v1/dives/{dive_id}/calibration-source/"
+        )
+        response.raise_for_status()

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
@@ -268,6 +268,7 @@ class Dive(BaseModel):
     flip_dive_slate: bool | None = Field(False, title='Flip Dive Slate')
     camera_id: int | None = Field(None, title='Camera Id')
     dive_slate_id: int | None = Field(None, title='Dive Slate Id')
+    calibration_dive_id: int | None = Field(None, title='Calibration Dive Id')
 
 
 class HTTPValidationError(BaseModel):

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/dive.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/dive.py
@@ -18,3 +18,4 @@ class Dive(ModelBase):
 
     camera_id: int | None
     dive_slate_id: int | None
+    calibration_dive_id: int | None

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/dive.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/dive.py
@@ -18,4 +18,7 @@ class Dive(ModelBase):
 
     camera_id: int | None
     dive_slate_id: int | None
-    calibration_dive_id: int | None
+    # Defaulted (unlike the fields above) so consumers built before this
+    # column existed — older API responses, worker test fixtures — still
+    # validate. A newly-added optional column must be optional on the wire.
+    calibration_dive_id: int | None = None

--- a/libs/fishsense-api-sdk/tests/clients/test_dive_client.py
+++ b/libs/fishsense-api-sdk/tests/clients/test_dive_client.py
@@ -32,6 +32,7 @@ def _dive_payload(dive_id: int = 1, name: str = "test-dive") -> dict:
         "flip_dive_slate": False,
         "camera_id": 12,
         "dive_slate_id": None,
+        "calibration_dive_id": None,
     }
 
 
@@ -248,6 +249,40 @@ class TestDiveClient:
                 assert payload["camera_id"] == 12
                 assert payload["laser_position"] == [1.0, 2.0, 3.0]
                 assert payload["laser_axis"] == [0.0, 0.0, 1.0]
+
+    async def test_set_calibration_source_puts_to_link_endpoint(self):
+        """Links a dive to a calibration source via the path-param PUT."""
+        client = _make_client()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = 2
+        mock_response.raise_for_status = Mock()
+
+        with patch.object(client, "_put", new_callable=AsyncMock) as mock_put:
+            mock_put.return_value = mock_response
+
+            async with client:
+                returned = await client.set_calibration_source(2, 1)
+                assert returned == 2
+                mock_put.assert_awaited_once_with(
+                    "/api/v1/dives/2/calibration-source/1"
+                )
+
+    async def test_clear_calibration_source_deletes_the_link(self):
+        """Unlinks a dive via DELETE on the calibration-source endpoint."""
+        client = _make_client()
+        mock_response = Mock()
+        mock_response.status_code = 204
+        mock_response.raise_for_status = Mock()
+
+        with patch.object(client, "_delete", new_callable=AsyncMock) as mock_delete:
+            mock_delete.return_value = mock_response
+
+            async with client:
+                await client.clear_calibration_source(2)
+                mock_delete.assert_awaited_once_with(
+                    "/api/v1/dives/2/calibration-source/"
+                )
 
     async def test_get_dives_needing_species_population_returns_list(self):
         """Returns the full list of dive ids from the population endpoint."""

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/e1a4c9f7d2b3_add_calibration_dive_id_to_dive.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/e1a4c9f7d2b3_add_calibration_dive_id_to_dive.py
@@ -1,0 +1,44 @@
+"""add calibration_dive_id self-link to dive
+
+Lets a dive borrow another dive's laser calibration. Laser calibration is
+physically a property of the camera+laser rig, not the dive, so a fish-only
+dive with no slate frames can point at a sibling slate/calibration dive shot
+with the same rig. NULL (the default) means "self-calibrate from my own slate
+labels".
+
+Revision ID: e1a4c9f7d2b3
+Revises: d4e9a1c7b520
+Create Date: 2026-07-22 00:00:00.000000
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e1a4c9f7d2b3"
+down_revision: Union[str, Sequence[str], None] = "d4e9a1c7b520"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "dive",
+        sa.Column(
+            "calibration_dive_id",
+            sa.Integer(),
+            sa.ForeignKey("dive.id", name="fk_dive_calibration_dive_id"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint("fk_dive_calibration_dive_id", "dive", type_="foreignkey")
+    op.drop_column("dive", "calibration_dive_id")

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/f2b5d0c8e3a1_calibrated_counts_borrowed_calibration.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/f2b5d0c8e3a1_calibrated_counts_borrowed_calibration.py
@@ -1,0 +1,45 @@
+"""`calibrated` counts borrowed calibration via calibration_dive_id
+
+The stage-13 `calibrated` flag checked only "dive has its own LaserExtrinsics
+row". With the new `Dive.calibration_dive_id` self-link, a fish-only dive can
+borrow a sibling slate dive's calibration, and `get_laser_extrinsics_for_dive`
++ the stage-14 cohort now resolve through that link. The view lagged, so a
+linked dive read `calibrated = false` on the dashboard even though it was
+measurable. `calibrated` now ORs in the linked source dive's extrinsics.
+
+Drop + recreate rather than CREATE OR REPLACE — postgres is restrictive about
+column-shape changes and the view has no dependents.
+
+Revision ID: f2b5d0c8e3a1
+Revises: e1a4c9f7d2b3
+Create Date: 2026-07-22 00:05:00.000000
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from fishsense_api.views import (
+    DIVE_PIPELINE_STATUS_VIEW_SQL,
+    DROP_DIVE_PIPELINE_STATUS_VIEW_SQL,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "f2b5d0c8e3a1"
+down_revision: Union[str, Sequence[str], None] = "e1a4c9f7d2b3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)
+
+
+def downgrade() -> None:
+    """Drop the new view; the prior migration's upgrade is the recreate.
+    To roll back the predicate, manually re-run d4e9a1c7b520's
+    `op.execute(...)` against the DB."""
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -6,7 +6,7 @@ from typing import List
 
 from fastapi import Depends, HTTPException
 from fastapi.encoders import jsonable_encoder
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -504,10 +504,17 @@ async def select_next_for_measure_fish(
     (image_id, fish_id) and the activity skips already-measured images —
     so this cohort drains and the workflow is safe to schedule.
     """
-    has_laser_extrinsics = (
+    # Own calibration, or a sibling dive's via `calibration_dive_id`.
+    # When the link is NULL the borrowed EXISTS never matches (no
+    # LaserExtrinsics row has dive_id = NULL), so it reduces to the own
+    # check. Mirrors `dive_pipeline_status.calibrated`.
+    has_laser_extrinsics = or_(
         select(LaserExtrinsics.id)
         .where(LaserExtrinsics.dive_id == Dive.id)
-        .exists()
+        .exists(),
+        select(LaserExtrinsics.id)
+        .where(LaserExtrinsics.dive_id == Dive.calibration_dive_id)
+        .exists(),
     )
     valid_laser = (
         select(LaserLabel.id)
@@ -572,14 +579,9 @@ async def get_dive(
     return dive
 
 
-@app.get("/api/v1/dives/{dive_id}/laser-extrinsics/")
-async def get_laser_extrinsics_for_dive(
-    dive_id: int, session: AsyncSession = Depends(get_async_session)
-) -> LaserExtrinsics | None:
-    """Retrieve all laser extrinsics for a given dive ID."""
-    logger.debug("Retrieving laser extrinsics for dive with id=%d", dive_id)
-    # With max date filter
-    query = (
+def _latest_extrinsics_query(dive_id: int):
+    """The most-recently-created `LaserExtrinsics` row for a dive."""
+    return (
         select(LaserExtrinsics)
         .where(LaserExtrinsics.dive_id == dive_id)
         .where(
@@ -592,7 +594,42 @@ async def get_laser_extrinsics_for_dive(
         )
     )
 
-    laser_extrinsics = (await session.exec(query)).first()
+
+@app.get("/api/v1/dives/{dive_id}/laser-extrinsics/")
+async def get_laser_extrinsics_for_dive(
+    dive_id: int, session: AsyncSession = Depends(get_async_session)
+) -> LaserExtrinsics | None:
+    """Retrieve the laser extrinsics that apply to a dive.
+
+    A dive's *own* calibration wins; if it has none but is linked to a
+    calibration-source dive (`Dive.calibration_dive_id`), the source
+    dive's extrinsics are returned instead. This lets a fish-only dive
+    with no slate frames borrow the calibration of a sibling slate dive
+    shot with the same camera+laser rig. The `laser_position` /
+    `laser_axis` are all stage 14 consumes, so the returned row's
+    `dive_id` (the source dive) is inconsequential to callers.
+    """
+    logger.debug("Retrieving laser extrinsics for dive with id=%d", dive_id)
+
+    laser_extrinsics = (
+        await session.exec(_latest_extrinsics_query(dive_id))
+    ).first()
+
+    if laser_extrinsics is None:
+        dive = await session.get(Dive, dive_id)
+        if dive is not None and dive.calibration_dive_id is not None:
+            logger.debug(
+                "dive id=%d has no own extrinsics; borrowing from "
+                "calibration_dive_id=%d",
+                dive_id,
+                dive.calibration_dive_id,
+            )
+            laser_extrinsics = (
+                await session.exec(
+                    _latest_extrinsics_query(dive.calibration_dive_id)
+                )
+            ).first()
+
     if laser_extrinsics is None:
         logger.warning("Laser extrinsics for dive with id=%d not found", dive_id)
         raise HTTPException(status_code=404, detail="Laser extrinsics not found")
@@ -616,3 +653,67 @@ async def put_laser_extrinsics_for_dive(
     extrinsics_id = extrinsics.id
 
     return extrinsics_id
+
+
+@app.put("/api/v1/dives/{dive_id}/calibration-source/{source_dive_id}")
+async def set_dive_calibration_source(
+    dive_id: int,
+    source_dive_id: int,
+    session: AsyncSession = Depends(get_async_session),
+) -> int:
+    """Link `dive_id` to borrow `source_dive_id`'s laser calibration.
+
+    For a fish-only dive with no slate frames of its own: point it at a
+    sibling slate/calibration dive shot with the same camera+laser rig.
+    Laser-extrinsics resolution and the `calibrated` gate then fall back
+    to the source dive when this dive has no calibration of its own.
+
+    Returns the linked dive's id. 404 if either dive is missing; 400 on a
+    self-link (a dive is never its own calibration source).
+    """
+    logger.debug(
+        "Linking dive id=%d to calibration source dive id=%d",
+        dive_id,
+        source_dive_id,
+    )
+    if dive_id == source_dive_id:
+        raise HTTPException(
+            status_code=400,
+            detail="A dive cannot be its own calibration source",
+        )
+
+    dive = await session.get(Dive, dive_id)
+    if dive is None:
+        raise HTTPException(status_code=404, detail="Dive not found")
+
+    source = await session.get(Dive, source_dive_id)
+    if source is None:
+        raise HTTPException(
+            status_code=404, detail="Calibration source dive not found"
+        )
+
+    dive.calibration_dive_id = source_dive_id
+    session.add(dive)
+    await session.flush()
+
+    return dive_id
+
+
+@app.delete("/api/v1/dives/{dive_id}/calibration-source/", status_code=204)
+async def clear_dive_calibration_source(
+    dive_id: int,
+    session: AsyncSession = Depends(get_async_session),
+) -> None:
+    """Unlink `dive_id` from any borrowed calibration source (idempotent).
+
+    404 only if the dive itself is missing; clearing an already-null link
+    is a no-op.
+    """
+    logger.debug("Clearing calibration source link for dive id=%d", dive_id)
+    dive = await session.get(Dive, dive_id)
+    if dive is None:
+        raise HTTPException(status_code=404, detail="Dive not found")
+
+    dive.calibration_dive_id = None
+    session.add(dive)
+    await session.flush()

--- a/services/fishsense-api/src/fishsense_api/models/dive.py
+++ b/services/fishsense-api/src/fishsense_api/models/dive.py
@@ -20,3 +20,12 @@ class Dive(ModelBase, table=True):
 
     camera_id: int | None = Field(default=None, foreign_key="camera.id")
     dive_slate_id: int | None = Field(default=None, foreign_key="diveslate.id")
+
+    # Self-referential link to the dive whose laser calibration this dive
+    # borrows. Laser calibration is physically a property of the camera+laser
+    # rig, not the dive, so a dive with no slate frames of its own (e.g. a
+    # fish-only dive) can point at a sibling slate/calibration dive shot with
+    # the same rig. When set, laser-extrinsics resolution and the
+    # `calibrated` gate fall back to this dive's LaserExtrinsics. NULL means
+    # "self-calibrate from my own slate labels" (the default).
+    calibration_dive_id: int | None = Field(default=None, foreign_key="dive.id")

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -271,11 +271,18 @@ SELECT
            AND (dsl.completed = FALSE OR dsl.completed IS NULL)
      )) AS slate_labeling_complete,
 
-    -- Stage 13: dive has a LaserExtrinsics row.
-    EXISTS (
+    -- Stage 13: calibration is available for the dive — either its own
+    -- LaserExtrinsics row, or a borrowed one via `calibration_dive_id`
+    -- (a fish-only dive pointing at a sibling slate dive shot with the
+    -- same rig). Mirrors `get_laser_extrinsics_for_dive`'s resolution and
+    -- the stage-14 cohort's `has_laser_extrinsics`.
+    (EXISTS (
         SELECT 1 FROM laserextrinsics le
         WHERE le.dive_id = d.id
-    ) AS calibrated,
+    ) OR EXISTS (
+        SELECT 1 FROM laserextrinsics le
+        WHERE le.dive_id = d.calibration_dive_id
+    )) AS calibrated,
 
     -- Stage 14: ≥1 measurement for the dive AND no measurable image left
     -- unmeasured. "Measurable" mirrors what measure_fish_activity

--- a/services/fishsense-api/tests/test_calibration_source_endpoints.py
+++ b/services/fishsense-api/tests/test_calibration_source_endpoints.py
@@ -1,0 +1,220 @@
+"""Tests for the dive calibration-source link.
+
+`Dive.calibration_dive_id` lets a fish-only dive (no slate frames of its
+own) borrow a sibling slate dive's laser calibration. These pin down:
+
+  * `get_laser_extrinsics_for_dive` resolves own calibration first, then
+    falls back through the link, then 404s.
+  * `set_dive_calibration_source` / `clear_dive_calibration_source`
+    manage the link (with self-link + missing-dive guards).
+
+FK-less in-memory sqlite, same as test_select_next_dive_endpoints.py — we
+exercise the controller functions directly, not referential integrity.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+def _dive(dive_id: int, *, calibration_dive_id=None):
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+
+    return Dive(
+        id=dive_id,
+        path=f"/dev/null/{dive_id}",
+        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        priority=Priority.HIGH,
+        calibration_dive_id=calibration_dive_id,
+    )
+
+
+def _extrinsics(dive_id: int, *, position, created_at):
+    from fishsense_api.models.laser_extrinsics import LaserExtrinsics  # pylint: disable=import-outside-toplevel
+
+    return LaserExtrinsics(
+        dive_id=dive_id,
+        camera_id=1,
+        laser_position=position,
+        laser_axis=[0.0, 0.0, 1.0],
+        created_at=created_at,
+    )
+
+
+# ---------- resolution ----------
+
+
+async def test_own_extrinsics_win_over_the_link(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        get_laser_extrinsics_for_dive,
+    )
+
+    session.add_all([_dive(1), _dive(2, calibration_dive_id=1)])
+    await session.flush()
+    session.add(
+        _extrinsics(1, position=[9.0, 9.0, 9.0],
+                    created_at=datetime(2025, 1, 1, tzinfo=timezone.utc))
+    )
+    session.add(
+        _extrinsics(2, position=[2.0, 2.0, 2.0],
+                    created_at=datetime(2025, 1, 2, tzinfo=timezone.utc))
+    )
+    await session.flush()
+
+    result = await get_laser_extrinsics_for_dive(2, session=session)
+    assert result.laser_position == [2.0, 2.0, 2.0]  # dive 2's own, not dive 1's
+
+
+async def test_falls_back_to_linked_source_when_no_own_extrinsics(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        get_laser_extrinsics_for_dive,
+    )
+
+    session.add_all([_dive(1), _dive(2, calibration_dive_id=1)])
+    await session.flush()
+    session.add(
+        _extrinsics(1, position=[1.0, 1.0, 1.0],
+                    created_at=datetime(2025, 1, 1, tzinfo=timezone.utc))
+    )
+    await session.flush()
+
+    result = await get_laser_extrinsics_for_dive(2, session=session)
+    assert result.laser_position == [1.0, 1.0, 1.0]  # borrowed from dive 1
+
+
+async def test_404_when_neither_own_nor_linked_extrinsics(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        get_laser_extrinsics_for_dive,
+    )
+
+    session.add_all([_dive(1), _dive(2, calibration_dive_id=1)])
+    await session.flush()
+
+    with pytest.raises(HTTPException) as exc:
+        await get_laser_extrinsics_for_dive(2, session=session)
+    assert exc.value.status_code == 404
+
+
+async def test_no_link_and_no_own_extrinsics_is_404(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        get_laser_extrinsics_for_dive,
+    )
+
+    session.add(_dive(1))
+    await session.flush()
+
+    with pytest.raises(HTTPException) as exc:
+        await get_laser_extrinsics_for_dive(1, session=session)
+    assert exc.value.status_code == 404
+
+
+# ---------- set / clear ----------
+
+
+async def test_set_calibration_source_links_the_dives(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        set_dive_calibration_source,
+    )
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+
+    session.add_all([_dive(1), _dive(2)])
+    await session.flush()
+
+    returned = await set_dive_calibration_source(2, 1, session=session)
+    assert returned == 2
+    assert (await session.get(Dive, 2)).calibration_dive_id == 1
+
+
+async def test_set_calibration_source_rejects_self_link(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        set_dive_calibration_source,
+    )
+
+    session.add(_dive(1))
+    await session.flush()
+
+    with pytest.raises(HTTPException) as exc:
+        await set_dive_calibration_source(1, 1, session=session)
+    assert exc.value.status_code == 400
+
+
+async def test_set_calibration_source_404_when_source_missing(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        set_dive_calibration_source,
+    )
+
+    session.add(_dive(1))
+    await session.flush()
+
+    with pytest.raises(HTTPException) as exc:
+        await set_dive_calibration_source(1, 999, session=session)
+    assert exc.value.status_code == 404
+
+
+async def test_set_calibration_source_404_when_dive_missing(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        set_dive_calibration_source,
+    )
+
+    session.add(_dive(1))
+    await session.flush()
+
+    with pytest.raises(HTTPException) as exc:
+        await set_dive_calibration_source(999, 1, session=session)
+    assert exc.value.status_code == 404
+
+
+async def test_clear_calibration_source_unlinks(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        clear_dive_calibration_source,
+    )
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+
+    session.add_all([_dive(1), _dive(2, calibration_dive_id=1)])
+    await session.flush()
+
+    await clear_dive_calibration_source(2, session=session)
+    assert (await session.get(Dive, 2)).calibration_dive_id is None
+
+
+async def test_clear_calibration_source_is_idempotent(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        clear_dive_calibration_source,
+    )
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+
+    await clear_dive_calibration_source(1, session=session)  # already null
+    assert (await session.get(Dive, 1)).calibration_dive_id is None
+
+
+async def test_clear_calibration_source_404_when_dive_missing(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        clear_dive_calibration_source,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await clear_dive_calibration_source(999, session=session)
+    assert exc.value.status_code == 404

--- a/services/fishsense-api/tests/test_dive_pipeline_status_view.py
+++ b/services/fishsense-api/tests/test_dive_pipeline_status_view.py
@@ -49,7 +49,9 @@ async def session():
     await engine.dispose()
 
 
-def _dive(dive_id: int, *, priority: str = "HIGH", dive_slate_id=None):
+def _dive(
+    dive_id: int, *, priority: str = "HIGH", dive_slate_id=None, calibration_dive_id=None
+):
     from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
     from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
 
@@ -59,6 +61,7 @@ def _dive(dive_id: int, *, priority: str = "HIGH", dive_slate_id=None):
         dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
         priority=Priority[priority],
         dive_slate_id=dive_slate_id,
+        calibration_dive_id=calibration_dive_id,
     )
 
 
@@ -865,6 +868,31 @@ async def test_calibrated_false_when_no_laser_extrinsics(session):
     await session.flush()
 
     assert (await _row(session, 1))["calibrated"] is False
+
+
+async def test_calibrated_true_when_borrowed_via_calibration_dive_id(session):
+    """A fish-only dive linked to a slate dive that owns extrinsics reads
+    calibrated=true even though it has none of its own."""
+    from fishsense_api.models.laser_extrinsics import LaserExtrinsics  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))  # slate dive: owns the calibration
+    session.add(_dive(2, calibration_dive_id=1))  # fish dive: borrows it
+    await session.flush()
+    session.add(LaserExtrinsics(dive_id=1, camera_id=1))
+    await session.flush()
+
+    assert (await _row(session, 1))["calibrated"] is True
+    assert (await _row(session, 2))["calibrated"] is True
+
+
+async def test_calibrated_false_when_linked_source_has_no_extrinsics(session):
+    """A link to a source that isn't itself calibrated doesn't fabricate
+    calibration."""
+    session.add(_dive(1))
+    session.add(_dive(2, calibration_dive_id=1))
+    await session.flush()
+
+    assert (await _row(session, 2))["calibrated"] is False
 
 
 # ---------- measured (stage 14) ----------

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -34,7 +34,7 @@ async def session():
     await engine.dispose()
 
 
-def _dive(dive_id: int, *, priority="HIGH", dive_slate_id=None):
+def _dive(dive_id: int, *, priority="HIGH", dive_slate_id=None, calibration_dive_id=None):
     from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
     from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
 
@@ -44,6 +44,7 @@ def _dive(dive_id: int, *, priority="HIGH", dive_slate_id=None):
         dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
         priority=Priority[priority],
         dive_slate_id=dive_slate_id,
+        calibration_dive_id=calibration_dive_id,
     )
 
 
@@ -1560,6 +1561,48 @@ async def test_measure_fish_ignores_unbound_clusters_with_no_measurable_image(se
             id=99, dive_id=1, data_source=DataSource.LABEL_STUDIO, fish_id=None
         )
     )
+    await session.flush()
+
+    assert await select_next_for_measure_fish(session=session) is None
+
+
+async def test_measure_fish_selects_dive_with_borrowed_calibration(session):
+    """A fish dive with no extrinsics of its own is still measurable when it
+    links to a slate dive that owns extrinsics via `calibration_dive_id`."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_measure_fish,
+    )
+    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+        LaserExtrinsics,
+    )
+
+    # dive 1: the slate/calibration dive — owns extrinsics, no fish images.
+    # dive 2: the fish dive — borrows dive 1's calibration, has an
+    # unmeasured measurable image. Without the link it would be excluded
+    # (no extrinsics); with it, it is selected.
+    session.add_all([_dive(1), _dive(2, calibration_dive_id=1)])
+    await session.flush()
+    session.add(LaserExtrinsics(dive_id=1, camera_id=1))
+    mapping = _measurable_image(session, 21, 2, cluster_id=2)
+    await session.flush()
+    session.add(mapping)
+    await session.flush()
+
+    assert await select_next_for_measure_fish(session=session) == 2
+
+
+async def test_measure_fish_link_to_uncalibrated_source_does_not_select(session):
+    """A link to a source that owns no extrinsics doesn't fabricate
+    calibration — the fish dive stays out of the cohort."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_measure_fish,
+    )
+
+    session.add_all([_dive(1), _dive(2, calibration_dive_id=1)])
+    await session.flush()
+    mapping = _measurable_image(session, 21, 2, cluster_id=2)
+    await session.flush()
+    session.add(mapping)
     await session.flush()
 
     assert await select_next_for_measure_fish(session=session) is None


### PR DESCRIPTION
## Problem

The FishModels dives (08/29 & 08/30/2023) have **no slate frames of their own** — the slate was shot in a separate calibration dive. Today that leaves them permanently uncalibrated and unmeasurable:

- Stage 13 computes `LaserExtrinsics` **per dive** from that dive's own slate labels (`select-next/laser-calibration` requires `dive_slate_id` + completed `DiveSlateLabel` rows).
- Everything downstream reads extrinsics **strictly by `dive_id`** (`get_laser_extrinsics_for_dive`, the stage-14 cohort, the `calibrated` view flag).
- A dive with no slate → no calibration → stuck at `calibrated=false`, never measured.

But laser calibration is physically a property of the **camera+laser rig**, not the dive. One slate calibration holds for every dive shot with the same rig.

## Change

Add a self-referential FK **`Dive.calibration_dive_id`** so a fish-only dive can **borrow** a sibling slate/calibration dive's `LaserExtrinsics`.

- **Resolution centralized** in `get_laser_extrinsics_for_dive` — own calibration wins, else follow the link, else 404. `measure_fish_activity` reads via `fs.dives.get_laser_extrinsics(dive_id)`, so the data-worker transparently gets the borrowed row — **no data-worker change**.
- **Three predicates kept in step**: the endpoint fallback, the stage-14 `select_next_for_measure_fish` cohort (`has_laser_extrinsics` = own `OR` linked), and the view's `calibrated` flag.
- **New endpoints + SDK methods** to manage the link:
  - `PUT /api/v1/dives/{dive_id}/calibration-source/{source_dive_id}` (self-link → 400, missing dive → 404)
  - `DELETE /api/v1/dives/{dive_id}/calibration-source/` (idempotent)
  - SDK: `dives.set_calibration_source` / `dives.clear_calibration_source`
- **Stage 13 unchanged**: a linked fish dive has no `dive_slate_id`/slate labels, so it's naturally excluded from self-calibration; a dive with its own slate always self-calibrates (own wins).

Two alembic migrations: add the column (`e1a4c9f7d2b3`), then drop/recreate the `dive_pipeline_status` view for the new `calibrated` predicate (`f2b5d0c8e3a1`). Chain: `d4e9a1c7b520 → e1a4c9f7d2b3 → f2b5d0c8e3a1`.

## Tests (TDD)

- `test_calibration_source_endpoints.py` (new): own-wins-over-link, link fallback, 404 when neither, set/clear with self-link + missing-dive guards, idempotent clear.
- `test_dive_pipeline_status_view.py`: `calibrated` true when borrowed, false when the linked source itself has no extrinsics.
- `test_select_next_dive_endpoints.py`: stage-14 selects a fish dive with borrowed calibration; does not select when the source is uncalibrated.
- SDK `test_dive_client.py`: `set_calibration_source` / `clear_calibration_source` hit the right endpoints; payload helper gains the new field.
- Drift guard (`test_sdk_drift.py`) covers the SDK↔API mirror automatically.

api: 199 passed · sdk: 112 passed · pylint 10.00.

## Follow-up

Backend-first per design — the **`/portal` dashboard UI** to browse dives and set slate links is the next PR. Until then links can be set via the SDK/endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)