### PR TITLE
feat(web): portal UI to link dives to a slate calibration source

### DIFF
--- a/apps/fishsense-lite-web/app/portal/actions.ts
+++ b/apps/fishsense-lite-web/app/portal/actions.ts
@@ -1,0 +1,46 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { auth } from "@/auth";
+import { clearCalibrationSource, setCalibrationSource } from "@/lib/dives";
+
+export type ActionResult = { ok: true } | { ok: false; error: string };
+
+/** Server actions are public endpoints — re-check the session on every call
+ * rather than trusting that the client only renders for signed-in users. */
+async function requireSession(): Promise<void> {
+  const session = await auth();
+  if (!session?.user) {
+    throw new Error("Not authenticated");
+  }
+}
+
+export async function setCalibrationSourceAction(
+  diveId: number,
+  sourceId: number,
+): Promise<ActionResult> {
+  try {
+    await requireSession();
+    if (diveId === sourceId) {
+      return { ok: false, error: "A dive cannot be its own calibration source" };
+    }
+    await setCalibrationSource(diveId, sourceId);
+    revalidatePath("/portal");
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : "Failed" };
+  }
+}
+
+export async function clearCalibrationSourceAction(
+  diveId: number,
+): Promise<ActionResult> {
+  try {
+    await requireSession();
+    await clearCalibrationSource(diveId);
+    revalidatePath("/portal");
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : "Failed" };
+  }
+}

--- a/apps/fishsense-lite-web/app/portal/calibration-links.tsx
+++ b/apps/fishsense-lite-web/app/portal/calibration-links.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import type { Dive } from "@/lib/dives";
+import {
+  clearCalibrationSourceAction,
+  setCalibrationSourceAction,
+} from "./actions";
+
+function diveLabel(dive: Dive): string {
+  return `${dive.name?.trim() || `Dive ${dive.id}`} #${dive.id}`;
+}
+
+function diveDate(dive: Dive): string {
+  if (!dive.dive_datetime) return "—";
+  const date = new Date(dive.dive_datetime);
+  return Number.isNaN(date.getTime())
+    ? "—"
+    : date.toISOString().slice(0, 10);
+}
+
+type RowProps = {
+  dive: Dive;
+  sources: Dive[];
+  sourceLabel: (id: number) => string;
+};
+
+function CalibrationRow({ dive, sources, sourceLabel }: RowProps) {
+  const persisted = dive.calibration_dive_id;
+  const [selected, setSelected] = useState<number | "">(persisted ?? "");
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const dirty = (selected === "" ? null : selected) !== persisted;
+
+  function save() {
+    setError(null);
+    if (selected === "") return;
+    const sourceId = selected;
+    startTransition(async () => {
+      const result = await setCalibrationSourceAction(dive.id, sourceId);
+      if (!result.ok) setError(result.error);
+    });
+  }
+
+  function clear() {
+    setError(null);
+    setSelected("");
+    startTransition(async () => {
+      const result = await clearCalibrationSourceAction(dive.id);
+      if (!result.ok) setError(result.error);
+    });
+  }
+
+  return (
+    <tr className="border-t border-slate-200 dark:border-slate-800">
+      <td className="py-2 pr-4 align-top">
+        <div className="font-medium">{diveLabel(dive)}</div>
+        <div className="text-xs text-slate-500">{diveDate(dive)}</div>
+      </td>
+      <td className="py-2 pr-4 align-top text-center">
+        {dive.dive_slate_id != null ? (
+          <span title="Has its own slate — self-calibrates">✓</span>
+        ) : (
+          <span className="text-slate-400">—</span>
+        )}
+      </td>
+      <td className="py-2 pr-4 align-top">
+        <select
+          value={selected}
+          disabled={pending}
+          onChange={(event) =>
+            setSelected(event.target.value === "" ? "" : Number(event.target.value))
+          }
+          className="w-full max-w-xs rounded-md border border-slate-300 bg-white px-2 py-1 text-sm shadow-sm disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900"
+        >
+          <option value="">— none (self-calibrate) —</option>
+          {sources
+            .filter((source) => source.id !== dive.id)
+            .map((source) => (
+              <option key={source.id} value={source.id}>
+                {sourceLabel(source.id)}
+              </option>
+            ))}
+        </select>
+        {error ? (
+          <div className="mt-1 text-xs text-red-600 dark:text-red-400">{error}</div>
+        ) : null}
+      </td>
+      <td className="py-2 align-top">
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={save}
+            disabled={pending || !dirty || selected === ""}
+            className="rounded-md border border-slate-300 bg-white px-3 py-1 text-sm font-medium shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800"
+          >
+            {pending ? "Saving…" : "Save"}
+          </button>
+          <button
+            type="button"
+            onClick={clear}
+            disabled={pending || persisted == null}
+            className="rounded-md border border-slate-300 bg-white px-3 py-1 text-sm font-medium shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800"
+          >
+            Clear
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+export function CalibrationLinks({ dives }: { dives: Dive[] }) {
+  const [query, setQuery] = useState("");
+  const [onlyNeedingLink, setOnlyNeedingLink] = useState(true);
+
+  // Sources are slate-bearing dives — the ones stage 13 can calibrate and so
+  // the only ones worth borrowing from.
+  const sources = useMemo(
+    () =>
+      dives
+        .filter((dive) => dive.dive_slate_id != null)
+        .sort((a, b) => a.id - b.id),
+    [dives],
+  );
+
+  const sourceLabelById = useMemo(() => {
+    const map = new Map<number, string>();
+    for (const dive of dives) {
+      map.set(dive.id, `${diveLabel(dive)} — ${diveDate(dive)}`);
+    }
+    return map;
+  }, [dives]);
+
+  const rows = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return dives
+      .filter((dive) => {
+        if (onlyNeedingLink && dive.dive_slate_id != null) return false;
+        if (!needle) return true;
+        return (
+          diveLabel(dive).toLowerCase().includes(needle) ||
+          String(dive.id).includes(needle)
+        );
+      })
+      .sort((a, b) => {
+        // Newest first when we have dates; fall back to id.
+        const at = a.dive_datetime ? Date.parse(a.dive_datetime) : 0;
+        const bt = b.dive_datetime ? Date.parse(b.dive_datetime) : 0;
+        return bt - at || b.id - a.id;
+      });
+  }, [dives, query, onlyNeedingLink]);
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-wrap items-center gap-4">
+        <input
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search dives by name or id…"
+          className="w-64 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm shadow-sm dark:border-slate-700 dark:bg-slate-900"
+        />
+        <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
+          <input
+            type="checkbox"
+            checked={onlyNeedingLink}
+            onChange={(event) => setOnlyNeedingLink(event.target.checked)}
+          />
+          Only dives without their own slate
+        </label>
+        <span className="text-xs text-slate-500">
+          {rows.length} dive{rows.length === 1 ? "" : "s"} · {sources.length} slate
+          dive{sources.length === 1 ? "" : "s"} available as sources
+        </span>
+      </div>
+
+      {sources.length === 0 ? (
+        <p className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200">
+          No slate-bearing dives found to borrow calibration from.
+        </p>
+      ) : null}
+
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[640px] text-sm">
+          <thead>
+            <tr className="text-left text-xs uppercase tracking-wide text-slate-500">
+              <th className="pb-2 pr-4 font-medium">Dive</th>
+              <th className="pb-2 pr-4 text-center font-medium">Own slate</th>
+              <th className="pb-2 pr-4 font-medium">Calibration source</th>
+              <th className="pb-2 font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((dive) => (
+              <CalibrationRow
+                key={dive.id}
+                dive={dive}
+                sources={sources}
+                sourceLabel={(id) => sourceLabelById.get(id) ?? `Dive ${id}`}
+              />
+            ))}
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="py-6 text-center text-slate-500">
+                  No dives match.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/fishsense-lite-web/app/portal/page.tsx
+++ b/apps/fishsense-lite-web/app/portal/page.tsx
@@ -1,5 +1,7 @@
 import { redirect } from "next/navigation";
 import { auth, signOut } from "@/auth";
+import { getDives } from "@/lib/dives";
+import { CalibrationLinks } from "./calibration-links";
 
 export const dynamic = "force-dynamic";
 
@@ -10,44 +12,54 @@ export default async function PortalPage() {
   }
   const user = session.user;
 
+  let dives: Awaited<ReturnType<typeof getDives>> = [];
+  let divesError: string | null = null;
+  try {
+    dives = await getDives();
+  } catch (error) {
+    divesError = error instanceof Error ? error.message : "Failed to load dives";
+  }
+
   return (
-    <main className="mx-auto max-w-4xl px-6 py-12">
+    <main className="mx-auto max-w-5xl px-6 py-12">
       <header className="mb-8 flex items-center justify-between">
         <h1 className="text-3xl font-semibold tracking-tight">Portal</h1>
-        <form
-          action={async () => {
-            "use server";
-            await signOut({ redirectTo: "/" });
-          }}
-        >
-          <button
-            type="submit"
-            className="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium shadow-sm transition hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800"
+        <div className="flex items-center gap-4">
+          <span className="text-sm text-slate-500">{user?.email ?? user?.name}</span>
+          <form
+            action={async () => {
+              "use server";
+              await signOut({ redirectTo: "/" });
+            }}
           >
-            Sign out
-          </button>
-        </form>
+            <button
+              type="submit"
+              className="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium shadow-sm transition hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
       </header>
 
       <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-        <h2 className="text-lg font-medium">Signed in as</h2>
-        <dl className="mt-3 grid grid-cols-[max-content_1fr] gap-x-4 gap-y-2 text-sm">
-          <dt className="text-slate-500">Name</dt>
-          <dd>{user?.name ?? "—"}</dd>
-          <dt className="text-slate-500">Email</dt>
-          <dd>{user?.email ?? "—"}</dd>
-          <dt className="text-slate-500">Groups</dt>
-          <dd>{user?.groups?.length ? user.groups.join(", ") : "—"}</dd>
-        </dl>
-      </section>
+        <h2 className="text-lg font-medium">Dive calibration links</h2>
+        <p className="mt-1 max-w-3xl text-sm text-slate-600 dark:text-slate-400">
+          Link a dive that has no slate of its own to a sibling slate dive shot
+          with the same camera and laser rig. The dive then borrows that dive&apos;s
+          laser calibration, so it can be measured without a slate in-frame. A
+          dive with its own slate self-calibrates and needs no link.
+        </p>
 
-      <section className="mt-6 rounded-lg border border-amber-300 bg-amber-50 p-6 text-xs dark:border-amber-700 dark:bg-amber-950">
-        <h2 className="mb-2 text-sm font-medium text-amber-900 dark:text-amber-200">
-          Debug: raw session
-        </h2>
-        <pre className="overflow-x-auto whitespace-pre-wrap break-all text-amber-900 dark:text-amber-200">
-          {JSON.stringify(session, null, 2)}
-        </pre>
+        <div className="mt-6">
+          {divesError ? (
+            <p className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-700 dark:border-red-700 dark:bg-red-950 dark:text-red-300">
+              Could not load dives: {divesError}
+            </p>
+          ) : (
+            <CalibrationLinks dives={dives} />
+          )}
+        </div>
       </section>
     </main>
   );

--- a/apps/fishsense-lite-web/lib/dives.test.ts
+++ b/apps/fishsense-lite-web/lib/dives.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearCalibrationSource,
+  getDives,
+  setCalibrationSource,
+} from "./dives";
+
+beforeEach(() => {
+  vi.stubEnv("FISHSENSE_API_URL", "http://api.test");
+  vi.stubEnv("FISHSENSE_API_USERNAME", "alice");
+  vi.stubEnv("FISHSENSE_API_PASSWORD", "secret");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+const EXPECTED_AUTH = `Basic ${Buffer.from("alice:secret").toString("base64")}`;
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    statusText: init.statusText ?? "OK",
+    headers: { "content-type": "application/json", ...(init.headers ?? {}) },
+  });
+}
+
+type NextFetchInit = RequestInit & { next?: { revalidate?: number } };
+type FetchSig = (input: string, init?: NextFetchInit) => Promise<Response>;
+
+describe("getDives", () => {
+  it("GETs the dives list with Basic auth and returns the parsed body", async () => {
+    const dives = [
+      { id: 1, name: "slate dive", dive_slate_id: 5, calibration_dive_id: null },
+      { id: 2, name: "fish dive", dive_slate_id: null, calibration_dive_id: 1 },
+    ];
+    const fetchMock = vi.fn<FetchSig>(async () => jsonResponse(dives));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getDives(30);
+
+    expect(result).toEqual(dives);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://api.test/api/v1/dives/");
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(EXPECTED_AUTH);
+    expect(init?.next?.revalidate).toBe(30);
+  });
+
+  it("throws on a non-OK response", async () => {
+    const fetchMock = vi.fn<FetchSig>(async () =>
+      new Response("nope", { status: 500, statusText: "Server Error" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getDives()).rejects.toThrow(/dives list failed: 500/);
+  });
+});
+
+describe("setCalibrationSource", () => {
+  it("PUTs to the path-param endpoint with Basic auth", async () => {
+    const fetchMock = vi.fn<FetchSig>(async () => jsonResponse(2));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await setCalibrationSource(2, 1);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://api.test/api/v1/dives/2/calibration-source/1");
+    expect(init?.method).toBe("PUT");
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(EXPECTED_AUTH);
+  });
+
+  it("throws on a non-OK response", async () => {
+    const fetchMock = vi.fn<FetchSig>(async () =>
+      new Response("bad", { status: 400, statusText: "Bad Request" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(setCalibrationSource(1, 1)).rejects.toThrow(
+      /set calibration source failed: 400/,
+    );
+  });
+});
+
+describe("clearCalibrationSource", () => {
+  it("DELETEs the calibration-source endpoint with Basic auth", async () => {
+    const fetchMock = vi.fn<FetchSig>(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await clearCalibrationSource(2);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://api.test/api/v1/dives/2/calibration-source/");
+    expect(init?.method).toBe("DELETE");
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(EXPECTED_AUTH);
+  });
+
+  it("throws on a non-OK response", async () => {
+    const fetchMock = vi.fn<FetchSig>(async () =>
+      new Response("nope", { status: 404, statusText: "Not Found" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(clearCalibrationSource(9)).rejects.toThrow(
+      /clear calibration source failed: 404/,
+    );
+  });
+});

--- a/apps/fishsense-lite-web/lib/dives.ts
+++ b/apps/fishsense-lite-web/lib/dives.ts
@@ -1,0 +1,86 @@
+import { env } from "./env";
+
+/** The dive fields the portal needs. The API returns more (path, camera_id,
+ * flip_dive_slate); we only type what we render or act on. */
+export type Dive = {
+  id: number;
+  name: string | null;
+  dive_datetime: string | null;
+  priority: string | null;
+  dive_slate_id: number | null;
+  calibration_dive_id: number | null;
+};
+
+function basicAuthHeader(): string {
+  const token = Buffer.from(
+    `${env.fishsenseApiUsername}:${env.fishsenseApiPassword}`,
+  ).toString("base64");
+  return `Basic ${token}`;
+}
+
+/** Every dive, for the calibration-linking table. */
+export async function getDives(revalidate = 0): Promise<Dive[]> {
+  const url = `${env.fishsenseApiUrl}/api/v1/dives/`;
+  const response = await fetch(url, {
+    headers: { Authorization: basicAuthHeader() },
+    next: { revalidate },
+  });
+
+  if (!response.ok) {
+    console.error("[dives] list fetch failed", {
+      url,
+      status: response.status,
+      statusText: response.statusText,
+    });
+    throw new Error(
+      `fishsense-api dives list failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return (await response.json()) as Dive[];
+}
+
+/** Link `diveId` to borrow `sourceId`'s laser calibration. */
+export async function setCalibrationSource(
+  diveId: number,
+  sourceId: number,
+): Promise<void> {
+  const url = `${env.fishsenseApiUrl}/api/v1/dives/${diveId}/calibration-source/${sourceId}`;
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: { Authorization: basicAuthHeader() },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    console.error("[dives] set calibration source failed", {
+      url,
+      status: response.status,
+      statusText: response.statusText,
+    });
+    throw new Error(
+      `set calibration source failed: ${response.status} ${response.statusText}`,
+    );
+  }
+}
+
+/** Remove any borrowed-calibration link from `diveId` (idempotent). */
+export async function clearCalibrationSource(diveId: number): Promise<void> {
+  const url = `${env.fishsenseApiUrl}/api/v1/dives/${diveId}/calibration-source/`;
+  const response = await fetch(url, {
+    method: "DELETE",
+    headers: { Authorization: basicAuthHeader() },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    console.error("[dives] clear calibration source failed", {
+      url,
+      status: response.status,
+      statusText: response.statusText,
+    });
+    throw new Error(
+      `clear calibration source failed: ${response.status} ${response.statusText}`,
+    );
+  }
+}


### PR DESCRIPTION
Stacked on #399 (base = `feat/dive-calibration-source-link`). This is the portal-first-was-backend follow-up: the UI that manages the `Dive.calibration_dive_id` links #399 introduced.

## What it does

Adds a **Dive calibration links** table to the authenticated `/portal` dashboard so an operator can point a fish-only dive (no slate in-frame — the slate was shot in a separate dive) at a sibling slate dive shot with the same camera+laser rig. The dive then borrows that dive's laser calibration and becomes measurable.

![flow] Dive → pick calibration source → Save. A dive with its own slate self-calibrates and needs no link.

## Structure

- **`lib/dives.ts`** — `getDives`, `setCalibrationSource`, `clearCalibrationSource`; basic-auth to fishsense-api, same pattern as `lib/fishsense-api.ts`.
- **`app/portal/actions.ts`** — `"use server"` wrappers that **re-check the session** (server actions are public endpoints, not gated by the page's redirect) and `revalidatePath("/portal")`.
- **`app/portal/calibration-links.tsx`** — client table: per-row source `<select>` + Save/Clear (`useTransition`, inline errors), a search box, and a default-on filter **"only dives without their own slate"** (the dives that actually need a link). Source options are **slate-bearing dives** — the only ones stage 13 can calibrate, so the only ones worth borrowing from.
- **`app/portal/page.tsx`** — replaces the old debug session dump with the table; keeps sign-out.

## Verification

- `lib/dives.test.ts` (6 new): correct endpoints, Basic-auth header, `revalidate` forwarding, error paths for all three calls.
- Full web suite: **64 passed** · `tsc --noEmit` clean · `next build` OK (`/portal` builds as a dynamic route) · eslint clean (only the pre-existing `postcss.config.mjs` warning).

## Notes

- Functionally depends on #399's `/api/v1/dives/{id}/calibration-source/{source_id}` endpoints — merge after #399 (GitHub will retarget this to `main` when #399 merges).
- First-cut UI: a flat table with search + filter. If you'd rather group by dive date/session (to make "same-day rig" links obvious), easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)