### PR TITLE
fix(web): render user name + groups on portal (fixes release integration test)

### DIFF
--- a/apps/fishsense-lite-web/app/portal/page.tsx
+++ b/apps/fishsense-lite-web/app/portal/page.tsx
@@ -22,10 +22,16 @@ export default async function PortalPage() {
 
   return (
     <main className="mx-auto max-w-5xl px-6 py-12">
-      <header className="mb-8 flex items-center justify-between">
+      <header className="mb-8 flex items-start justify-between gap-4">
         <h1 className="text-3xl font-semibold tracking-tight">Portal</h1>
-        <div className="flex items-center gap-4">
-          <span className="text-sm text-slate-500">{user?.email ?? user?.name}</span>
+        <div className="flex items-start gap-4">
+          <div className="text-right text-sm leading-tight">
+            <div className="font-medium">{user?.name ?? "—"}</div>
+            <div className="text-slate-500">{user?.email ?? "—"}</div>
+            <div className="text-xs text-slate-400">
+              {user?.groups?.length ? user.groups.join(", ") : "no groups"}
+            </div>
+          </div>
           <form
             action={async () => {
               "use server";


### PR DESCRIPTION
The #402 portal redesign dropped the name/groups display, breaking `portal.integration.test.ts`'s session.user → DOM contract (name + email + groups). That test only runs on the release PR, so #402's CI showed `integration skipping` and the release PR #401 went red.

Restores a compact identity block (name, email, groups) in the header. Verified: web unit suite 65 passed, typecheck clean, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)