### PR TITLE
feat(species-sync): set dive_slate_id from the labeler's slate choice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1187,6 +1187,23 @@ so Create-on-fresh-deploy stands up a usable project immediately.
 There is no discovery query or fan-out — each dive owns one project
 per stage.
 
+**Species sync is the only writer of `Dive.dive_slate_id`** (2026-07-23).
+The species Taxonomy's slate sub-choices (`H-Slate` / `Tic-Tac-Toe 1..6`
+/ `V-Slate 1..4`) are, by name, exactly the 11 `DiveSlate` template rows.
+`sync_species_labels_for_label_studio_project_activity` extracts the
+slate-type leaf from each *completed* task's taxonomy (a separate path
+from `content_of_image`'s `taxonomy[0]`, which stays the `"Slate, Laser
+on slate"` marker that stage 14 parses), maps the name → `DiveSlate.id`,
+resolves the image's dive, and sets `dive_slate_id` (most-recent-completed
+wins) via `PUT /api/v1/dives/{id}/dive-slate/{slate_id}`
+(SDK `dives.set_dive_slate`). Nothing else in the pipeline writes
+`dive_slate_id` — stages 9/12/13 only read it — so before this, it was
+hand-set (only 17/479 prod dives ever had it, the historically-measured
+ones where the slate frame lived *inside* the fish dive). A dedicated
+slate-only dive (e.g. the FishModels `*_Slate_*` dives) still has to pass
+through species labeling for a labeler to pick its slate type before
+this fires.
+
 The populate workflows are dispatched automatically by the
 preprocess parents (see "Cross-worker orchestration pattern"); manual
 `temporal workflow start` is only needed for backfill of dives the

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
@@ -183,3 +183,24 @@ class DiveClient(ClientBase):
             f"/api/v1/dives/{dive_id}/calibration-source/"
         )
         response.raise_for_status()
+
+    async def set_dive_slate(self, dive_id: int, dive_slate_id: int) -> int:
+        """Set which DiveSlate template a dive was shot with.
+
+        Identifies the physical slate (H-Slate / V-Slate N / Tic-Tac-Toe N),
+        which the slate preprocess / sync / calibration stages need before a
+        dive can be calibrated.
+
+        Args:
+            dive_id (int): The dive to set.
+            dive_slate_id (int): The DiveSlate template id.
+
+        Returns:
+            int: The dive id.
+        """
+        response = await self._put(
+            f"/api/v1/dives/{dive_id}/dive-slate/{dive_slate_id}"
+        )
+        response.raise_for_status()
+
+        return response.json()

--- a/libs/fishsense-api-sdk/tests/clients/test_dive_client.py
+++ b/libs/fishsense-api-sdk/tests/clients/test_dive_client.py
@@ -268,6 +268,24 @@ class TestDiveClient:
                     "/api/v1/dives/2/calibration-source/1"
                 )
 
+    async def test_set_dive_slate_puts_to_the_dive_slate_endpoint(self):
+        """Sets which DiveSlate template a dive used via the path-param PUT."""
+        client = _make_client()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = 5
+        mock_response.raise_for_status = Mock()
+
+        with patch.object(client, "_put", new_callable=AsyncMock) as mock_put:
+            mock_put.return_value = mock_response
+
+            async with client:
+                returned = await client.set_dive_slate(5, 9)
+                assert returned == 5
+                mock_put.assert_awaited_once_with(
+                    "/api/v1/dives/5/dive-slate/9"
+                )
+
     async def test_clear_calibration_source_deletes_the_link(self):
         """Unlinks a dive via DELETE on the calibration-source endpoint."""
         client = _make_client()

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_species_labels_for_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_species_labels_for_label_studio_project_activity.py
@@ -17,7 +17,9 @@ notebook resolved annotators by parsing the email out of
 ride the existing user-sync upstream of every sync run.
 """
 
+import asyncio
 import json
+from datetime import datetime
 from typing import Any, Dict
 
 from fishsense_api_sdk.client import Client
@@ -26,6 +28,8 @@ from temporalio import activity
 
 from fishsense_api_workflow_worker.activities.utils import (
     SYNC_CONCURRENCY,
+    _coerce_updated_at,
+    get_fs_client,
     resolve_annotator_user,
     sync_label_studio_project,
 )
@@ -116,10 +120,51 @@ def _apply_parsed(species_label: SpeciesLabel, parsed: Dict[str, Any]) -> None:
         species_label.fish_curved_category = parsed["fish_curved_category"]
 
 
-async def _update_species_label(fs: Client, task: Any) -> None:
+def _slate_type_choice(
+    results: list[dict], valid_slate_names: set[str]
+) -> str | None:
+    """The DiveSlate-template name a labeler picked, or None.
+
+    The species Taxonomy carries the slate type (H-Slate / V-Slate N /
+    Tic-Tac-Toe N) as its own leaf under `Slate`, alongside `Laser on
+    slate`. `content_of_image` only keeps `taxonomy[0]` (the laser
+    marker, which stage 14 parses), so the slate-type path is dropped
+    there. Here we scan *all* taxonomy paths and return the leaf that
+    matches a real DiveSlate template name — that's the "which slate"
+    answer we map to `dive_slate_id`.
+    """
+    for r in results:
+        if r.get("from_name") == "species":
+            for path in r.get("value", {}).get("taxonomy") or []:
+                if path and path[-1] in valid_slate_names:
+                    return path[-1]
+    return None
+
+
+def _reduce_slate_winners(
+    votes: list[tuple[int, datetime | None, int]],
+) -> dict[int, int]:
+    """Collapse per-image slate votes to one `dive_slate_id` per dive.
+
+    `votes` is `(dive_id, updated_at, dive_slate_id)`. Most-recent
+    completed annotation wins (a re-label with a newer timestamp
+    overrides an older one); a vote with no timestamp never displaces
+    one that has a timestamp.
+    """
+    best: dict[int, tuple[datetime | None, int]] = {}
+    for dive_id, ts, slate_id in votes:
+        current = best.get(dive_id)
+        if current is None or (
+            ts is not None and (current[0] is None or ts > current[0])
+        ):
+            best[dive_id] = (ts, slate_id)
+    return {dive_id: slate_id for dive_id, (_, slate_id) in best.items()}
+
+
+async def _update_species_label(fs: Client, task: Any) -> int | None:
     species_label = await fs.labels.get_species_label(label_studio_id=task.id)
     if species_label is None:
-        return
+        return None
 
     # Attribution is best-effort: hosted LS returns `annotators` as
     # dicts rather than ints, and mis-handling that used to 422 and
@@ -137,11 +182,76 @@ async def _update_species_label(fs: Client, task: Any) -> None:
         _apply_parsed(species_label, parsed)
 
     await fs.labels.put_species_label(species_label.image_id, species_label)
+    return species_label.image_id
+
+
+async def _resolve_dive_slates(
+    completed: list[tuple[int, datetime | None, list[dict]]],
+) -> None:
+    """Set `dive_slate_id` from the slate type labelers picked.
+
+    `completed` is `(image_id, updated_at, annotation_results)` for every
+    completed task this sync processed. Maps each slate-type choice to a
+    DiveSlate id, resolves the image's dive, and writes the most-recent
+    winner per dive. No-op when nothing was completed or no slate type was
+    chosen — so it never touches a dive whose labelers didn't identify a
+    slate this run.
+    """
+    if not completed:
+        return
+
+    async with get_fs_client() as fs:
+        slates = await fs.dive_slates.get() or []
+        name_to_id = {slate.name: slate.id for slate in slates}
+        valid_names = set(name_to_id)
+
+        votes: list[tuple[int, datetime | None, int]] = []
+        dive_by_image: dict[int, int | None] = {}
+        for image_id, ts, results in completed:
+            slate_name = _slate_type_choice(results, valid_names)
+            if slate_name is None:
+                continue
+            if image_id not in dive_by_image:
+                image = await fs.images.get(image_id=image_id)
+                dive_by_image[image_id] = image.dive_id if image else None
+            dive_id = dive_by_image[image_id]
+            if dive_id is not None:
+                votes.append((dive_id, ts, name_to_id[slate_name]))
+
+        for dive_id, slate_id in _reduce_slate_winners(votes).items():
+            await fs.dives.set_dive_slate(dive_id, slate_id)
+            activity.logger.info(
+                "species sync set dive_slate dive_id=%d dive_slate_id=%d",
+                dive_id,
+                slate_id,
+            )
 
 
 @activity.defn
 async def sync_species_labels_for_label_studio_project_activity(project_id: int):
-    """Activity to sync species labels for a Label Studio project."""
-    await sync_label_studio_project(
-        project_id, _update_species_label, kind="species"
-    )
+    """Activity to sync species labels for a Label Studio project.
+
+    Besides writing each SpeciesLabel, this collects the slate-type
+    choice from every *completed* task and, after the sync, sets each
+    dive's `dive_slate_id` (most-recent-completed wins). That's the only
+    thing in the pipeline that populates `dive_slate_id` from labeler
+    input — stages 9/12/13 read it but nothing else writes it.
+    """
+    completed: list[tuple[int, datetime | None, list[dict]]] = []
+    lock = asyncio.Lock()
+
+    async def _update(fs: Client, task: Any) -> None:
+        image_id = await _update_species_label(fs, task)
+        if image_id is None or not getattr(task, "is_labeled", False):
+            return
+        annotations = task.annotations or []
+        if not annotations:
+            return
+        results = annotations[0].get("result") or []
+        ts = _coerce_updated_at(getattr(task, "updated_at", None))
+        async with lock:
+            completed.append((image_id, ts, results))
+
+    await sync_label_studio_project(project_id, _update, kind="species")
+
+    await _resolve_dive_slates(completed)

--- a/services/fishsense-api-workflow-worker/tests/test_sync_species_labels_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_sync_species_labels_activity.py
@@ -18,6 +18,7 @@ Three things this file pins down:
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any, List
 from unittest.mock import AsyncMock, MagicMock
@@ -48,7 +49,7 @@ def _make_task(
     )
 
 
-def _make_fs_client(label_lookup, *, cursor=None):
+def _make_fs_client(label_lookup, *, cursor=None, dive_slates=None, image_to_dive=None):
     fs = MagicMock()
     fs.__aenter__ = AsyncMock(return_value=fs)
     fs.__aexit__ = AsyncMock(return_value=None)
@@ -67,6 +68,27 @@ def _make_fs_client(label_lookup, *, cursor=None):
     # Default: the annotator isn't user-synced yet -> None.
     fs.users = MagicMock()
     fs.users.get_by_label_studio_id = AsyncMock(return_value=None)
+
+    # DiveSlate templates for the slate-identification pass. Names must
+    # match the species Taxonomy slate leaves.
+    slates = dive_slates if dive_slates is not None else [
+        SimpleNamespace(id=1, name="H-Slate"),
+        SimpleNamespace(id=9, name="V-Slate 2"),
+    ]
+    fs.dive_slates = MagicMock()
+    fs.dive_slates.get = AsyncMock(return_value=slates)
+
+    img_map = image_to_dive or {}
+
+    async def _get_image(dive_id=None, image_id=None, checksum=None):
+        did = img_map.get(image_id)
+        return SimpleNamespace(dive_id=did) if did is not None else None
+
+    fs.images = MagicMock()
+    fs.images.get = AsyncMock(side_effect=_get_image)
+
+    fs.dives = MagicMock()
+    fs.dives.set_dive_slate = AsyncMock()
     return fs
 
 
@@ -352,3 +374,172 @@ async def test_writes_parsed_fields_when_annotation_present(monkeypatch):
     written = fs.labels.put_species_label.await_args.args[1]
     assert written.grouping == "Part of previous group"
     assert written.content_of_image == "Reef fish, Yellowtail Snapper"
+
+
+# ----------------------- slate identification -------------------------
+
+
+def test_slate_type_choice_finds_the_slate_template():
+    results = [
+        {
+            "from_name": "species",
+            "value": {"taxonomy": [["Slate", "Laser on slate"], ["Slate", "V-Slate 2"]]},
+        }
+    ]
+    assert (
+        sut._slate_type_choice(results, {"H-Slate", "V-Slate 2"})  # pylint: disable=protected-access
+        == "V-Slate 2"
+    )
+
+
+def test_slate_type_choice_none_when_only_laser_marker():
+    results = [
+        {"from_name": "species", "value": {"taxonomy": [["Slate", "Laser on slate"]]}}
+    ]
+    assert (
+        sut._slate_type_choice(results, {"H-Slate", "V-Slate 2"})  # pylint: disable=protected-access
+        is None
+    )
+
+
+def test_slate_type_choice_none_for_fish():
+    results = [
+        {"from_name": "species", "value": {"taxonomy": [["Fish", "Hogfish"]]}}
+    ]
+    assert sut._slate_type_choice(results, {"H-Slate"}) is None  # pylint: disable=protected-access
+
+
+def test_slate_type_choice_empty_results():
+    assert sut._slate_type_choice([], {"H-Slate"}) is None  # pylint: disable=protected-access
+
+
+def test_reduce_slate_winners_most_recent_per_dive():
+    votes = [
+        (7, datetime(2026, 5, 1, tzinfo=timezone.utc), 9),
+        (7, datetime(2026, 5, 3, tzinfo=timezone.utc), 1),  # newer -> wins for dive 7
+        (8, datetime(2026, 5, 2, tzinfo=timezone.utc), 5),
+    ]
+    assert sut._reduce_slate_winners(votes) == {7: 1, 8: 5}  # pylint: disable=protected-access
+
+
+def test_reduce_slate_winners_timestamp_beats_none_either_order():
+    ts = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    assert sut._reduce_slate_winners([(7, None, 9), (7, ts, 1)]) == {7: 1}  # pylint: disable=protected-access
+    assert sut._reduce_slate_winners([(7, ts, 1), (7, None, 9)]) == {7: 1}  # pylint: disable=protected-access
+
+
+@pytest.mark.asyncio
+async def test_sync_sets_dive_slate_from_slate_choice(monkeypatch):
+    annotation = {
+        "result": [
+            {
+                "from_name": "species",
+                "value": {
+                    "taxonomy": [["Slate", "Laser on slate"], ["Slate", "V-Slate 2"]]
+                },
+            }
+        ]
+    }
+    task = _make_task(101, annotations=[annotation])
+    task.is_labeled = True
+    task.updated_at = "2026-05-02T10:00:00Z"
+    label = _empty_species_label(image_id=42)
+    fs = _make_fs_client(label_lookup={101: label}, image_to_dive={42: 7})
+    ls = _make_ls_client([task])
+
+    monkeypatch.setattr(sut_utils, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "get_ls_client", lambda: ls)
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    await ActivityEnvironment().run(
+        sut.sync_species_labels_for_label_studio_project_activity, 1
+    )
+
+    # V-Slate 2 -> DiveSlate id 9, image 42 -> dive 7.
+    fs.dives.set_dive_slate.assert_awaited_once_with(7, 9)
+
+
+@pytest.mark.asyncio
+async def test_sync_does_not_touch_dive_slate_without_a_slate_choice(monkeypatch):
+    annotation = {
+        "result": [
+            {"from_name": "species", "value": {"taxonomy": [["Fish", "Hogfish"]]}}
+        ]
+    }
+    task = _make_task(101, annotations=[annotation])
+    task.is_labeled = True
+    label = _empty_species_label(image_id=42)
+    fs = _make_fs_client(label_lookup={101: label}, image_to_dive={42: 7})
+    ls = _make_ls_client([task])
+
+    monkeypatch.setattr(sut_utils, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "get_ls_client", lambda: ls)
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    await ActivityEnvironment().run(
+        sut.sync_species_labels_for_label_studio_project_activity, 1
+    )
+
+    fs.dives.set_dive_slate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sync_ignores_incomplete_slate_choice(monkeypatch):
+    """A slate type on a not-yet-completed task must not set dive_slate_id."""
+    annotation = {
+        "result": [
+            {"from_name": "species", "value": {"taxonomy": [["Slate", "V-Slate 2"]]}}
+        ]
+    }
+    task = _make_task(101, annotations=[annotation])
+    task.is_labeled = False  # incomplete
+    label = _empty_species_label(image_id=42)
+    fs = _make_fs_client(label_lookup={101: label}, image_to_dive={42: 7})
+    ls = _make_ls_client([task])
+
+    monkeypatch.setattr(sut_utils, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "get_ls_client", lambda: ls)
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    await ActivityEnvironment().run(
+        sut.sync_species_labels_for_label_studio_project_activity, 1
+    )
+
+    fs.dives.set_dive_slate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sync_most_recent_completed_slate_choice_wins(monkeypatch):
+    a_old = {
+        "result": [
+            {"from_name": "species", "value": {"taxonomy": [["Slate", "V-Slate 2"]]}}
+        ]
+    }
+    a_new = {
+        "result": [
+            {"from_name": "species", "value": {"taxonomy": [["Slate", "H-Slate"]]}}
+        ]
+    }
+    t_old = _make_task(101, annotations=[a_old])
+    t_old.is_labeled = True
+    t_old.updated_at = "2026-05-01T00:00:00Z"
+    t_new = _make_task(102, annotations=[a_new])
+    t_new.is_labeled = True
+    t_new.updated_at = "2026-05-03T00:00:00Z"
+
+    fs = _make_fs_client(
+        label_lookup={101: _empty_species_label(41), 102: _empty_species_label(42)},
+        image_to_dive={41: 7, 42: 7},  # same dive
+    )
+    ls = _make_ls_client([t_old, t_new])
+
+    monkeypatch.setattr(sut_utils, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "get_ls_client", lambda: ls)
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    await ActivityEnvironment().run(
+        sut.sync_species_labels_for_label_studio_project_activity, 1
+    )
+
+    # H-Slate (id 1) is the most-recent completed choice for dive 7.
+    fs.dives.set_dive_slate.assert_awaited_once_with(7, 1)

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -17,6 +17,7 @@ from fishsense_api.models.dive_frame_cluster import (
     DiveFrameCluster,
     DiveFrameClusterImageMapping,
 )
+from fishsense_api.models.dive_slate import DiveSlate
 from fishsense_api.models.dive_slate_label import DiveSlateLabel
 from fishsense_api.models.head_tail_label import HeadTailLabel
 from fishsense_api.models.image import Image
@@ -717,3 +718,37 @@ async def clear_dive_calibration_source(
     dive.calibration_dive_id = None
     session.add(dive)
     await session.flush()
+
+
+@app.put("/api/v1/dives/{dive_id}/dive-slate/{dive_slate_id}")
+async def set_dive_slate(
+    dive_id: int,
+    dive_slate_id: int,
+    session: AsyncSession = Depends(get_async_session),
+) -> int:
+    """Set which `DiveSlate` template a dive was shot with.
+
+    Identifies the physical slate (H-Slate / V-Slate N / Tic-Tac-Toe N),
+    which stages 9/12/13 need before a dive can be slate-labeled and
+    calibrated. Populated by the species-label sync from the labeler's
+    slate-type choice; also settable by an operator.
+
+    Returns the dive id. 404 if the dive or the DiveSlate template is
+    missing.
+    """
+    logger.debug(
+        "Setting dive id=%d dive_slate_id=%d", dive_id, dive_slate_id
+    )
+    dive = await session.get(Dive, dive_id)
+    if dive is None:
+        raise HTTPException(status_code=404, detail="Dive not found")
+
+    slate = await session.get(DiveSlate, dive_slate_id)
+    if slate is None:
+        raise HTTPException(status_code=404, detail="DiveSlate template not found")
+
+    dive.dive_slate_id = dive_slate_id
+    session.add(dive)
+    await session.flush()
+
+    return dive_id

--- a/services/fishsense-api/tests/test_set_dive_slate_endpoint.py
+++ b/services/fishsense-api/tests/test_set_dive_slate_endpoint.py
@@ -1,0 +1,108 @@
+"""Tests for `set_dive_slate` — the only write path for `Dive.dive_slate_id`.
+
+Populated by the species-label sync from the labeler's slate-type choice
+(and usable by an operator). FK-less in-memory sqlite, same as the
+calibration-source endpoint tests — we exercise the controller directly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+def _dive(dive_id: int, *, dive_slate_id=None):
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+
+    return Dive(
+        id=dive_id,
+        path=f"/dev/null/{dive_id}",
+        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        priority=Priority.HIGH,
+        dive_slate_id=dive_slate_id,
+    )
+
+
+def _dive_slate(slate_id: int):
+    from fishsense_api.models.dive_slate import DiveSlate  # pylint: disable=import-outside-toplevel
+
+    return DiveSlate(
+        id=slate_id,
+        name=f"V-Slate {slate_id}",
+        dpi=300,
+        path=f"/dev/null/slate-{slate_id}.pdf",
+    )
+
+
+async def test_set_dive_slate_sets_the_fk(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        set_dive_slate,
+    )
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    session.add(_dive_slate(9))
+    await session.flush()
+
+    returned = await set_dive_slate(1, 9, session=session)
+    assert returned == 1
+    assert (await session.get(Dive, 1)).dive_slate_id == 9
+
+
+async def test_set_dive_slate_overwrites_existing(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        set_dive_slate,
+    )
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1, dive_slate_id=8))
+    session.add_all([_dive_slate(8), _dive_slate(9)])
+    await session.flush()
+
+    await set_dive_slate(1, 9, session=session)
+    assert (await session.get(Dive, 1)).dive_slate_id == 9
+
+
+async def test_set_dive_slate_404_when_dive_missing(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        set_dive_slate,
+    )
+
+    session.add(_dive_slate(9))
+    await session.flush()
+
+    with pytest.raises(HTTPException) as exc:
+        await set_dive_slate(999, 9, session=session)
+    assert exc.value.status_code == 404
+
+
+async def test_set_dive_slate_404_when_template_missing(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        set_dive_slate,
+    )
+
+    session.add(_dive(1))
+    await session.flush()
+
+    with pytest.raises(HTTPException) as exc:
+        await set_dive_slate(1, 999, session=session)
+    assert exc.value.status_code == 404


### PR DESCRIPTION
## Why

Getting the FishModels dives calibrated surfaced that **nothing in the pipeline writes `Dive.dive_slate_id`** — stages 9/12/13 only read it, and only **17 of 479** prod dives ever had it (hand-set, on dives where the slate frame lived *inside* the fish dive). That's the prerequisite for the whole slate → calibration → measurement chain.

The species project **already asks** which slate a dive used: its Taxonomy slate sub-choices (`H-Slate`, `Tic-Tac-Toe 1–6`, `V-Slate 1–4`) are, by name, exactly the 11 `DiveSlate` templates. But the sync only kept `taxonomy[0]` (the `"Slate, Laser on slate"` marker stage 14 parses) and **threw the slate-type path away**.

## What

Wire the species sync to turn that answer into `dive_slate_id`:

- **Species sync** extracts the slate-type leaf from every *completed* task's taxonomy (a path distinct from `content_of_image`, so stage 14's parsing is untouched), maps the name → `DiveSlate.id`, resolves the image's dive, and sets `dive_slate_id`. **Most-recent-completed wins** (a re-label with a newer timestamp overrides). No-op when no slate type was chosen this run.
- **New write path** (the only one): `PUT /api/v1/dives/{dive_id}/dive-slate/{dive_slate_id}` (validates the dive and the `DiveSlate` template exist) + SDK `dives.set_dive_slate`.

Per the design decision: **reuse the existing slate leaves** (no LS config change) and **most-recent-completed wins**.

## Tests (TDD)

- Pure: `_slate_type_choice` (finds the template leaf, ignores the laser-only marker / fish / empty) and `_reduce_slate_winners` (most-recent per dive, timestamp beats none in either order).
- Endpoint: sets / overwrites / 404 on missing dive / 404 on missing template.
- SDK: `set_dive_slate` hits the path-param PUT.
- Activity: sets `dive_slate_id` from a slate choice; ignores fish / no-choice / incomplete tasks; most-recent completed wins across two images of one dive.

api **203** · worker **303** · sdk **113** · pylint **10.00**.

## Caveat

A **dedicated slate-only dive** (e.g. the FishModels `*_Slate_*` dives) still has to pass through species labeling for a labeler to pick its slate type before this fires — this automates the capture, it doesn't route those dives into labeling. Documented in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)