### PR TITLE
feat(laser-detector): predict activity + fan-out workflow (phase 1)

### DIFF
--- a/libs/fishsense-shared/src/fishsense_shared/__init__.py
+++ b/libs/fishsense-shared/src/fishsense_shared/__init__.py
@@ -12,6 +12,8 @@ from fishsense_shared.logging import configure_log_handler, configure_logging
 from fishsense_shared.preprocess_contracts import (
     ClusterDiveFrameImage,
     ClusterDiveFramesInput,
+    PredictLaserImage,
+    PredictLaserImagesInput,
     PreprocessHeadtailImagesInput,
     PreprocessLaserImagesInput,
     PreprocessSlateImagesInput,
@@ -28,6 +30,8 @@ __all__ = [
     "ClusterDiveFrameImage",
     "ClusterDiveFramesInput",
     "ExceptionGroupErrorLogging",
+    "PredictLaserImage",
+    "PredictLaserImagesInput",
     "PreprocessHeadtailImagesInput",
     "PreprocessLaserImagesInput",
     "PreprocessSlateImagesInput",

--- a/libs/fishsense-shared/src/fishsense_shared/preprocess_contracts.py
+++ b/libs/fishsense-shared/src/fishsense_shared/preprocess_contracts.py
@@ -91,6 +91,37 @@ class PreprocessHeadtailImagesInput(BaseModel):
     distortion_coefficients: List[float]
 
 
+class PredictLaserImage(BaseModel):
+    """Per-image (checksum, image_id) pair for laser prediction.
+
+    Both are needed: the checksum fetches the raw bytes from Garage, and
+    the image_id is what the prediction result is keyed back to so the
+    api-worker can persist it against the right image.
+    """
+
+    image_id: int
+    checksum: str
+
+
+class PredictLaserImagesInput(BaseModel):
+    """Laser-detector (model-assisted labeling) workflow-level input.
+
+    Constructed by the api-worker parent (selector + resolver), passed to
+    the GPU data-worker `PredictLaserImagesWorkflow` child. The fishsense-core
+    `LaserDetector` rectifies its output into camera-corrected pixels using
+    the dive's intrinsics, so predictions land in the same space labelers
+    place `LaserLabel.x/y`.
+    """
+
+    dive_id: int
+    images: List[PredictLaserImage]
+    camera_matrix: List[List[float]]
+    distortion_coefficients: List[float]
+    # Laser wavelength ("red" / "green"); None when the dive's laser color
+    # isn't known — the model uses an "unknown" wavelength channel then.
+    wavelength: str | None = None
+
+
 class PreprocessSlateImagesInput(BaseModel):
     """Stage 9 (slate preprocess) workflow-level input.
 

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_laser_image.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_laser_image.py
@@ -1,0 +1,139 @@
+"""Model-assisted laser labeling (data-worker, GPU).
+
+Runs the fishsense-core `LaserDetector` (v2.2.0+) on one image and returns
+the predicted laser dot in rectified-image pixels — the same space labelers
+place `LaserLabel.x/y` — so the prediction can seed the laser Label Studio
+task as a pre-annotation.
+
+`torch` (via `fishsense_core[laser-detector]`) and the detector checkpoint are
+only needed at run time, so both `fishsense_core.laser` and
+`fishsense_core.image.linear_raw_image` are imported lazily inside the CPU/GPU
+helper. That keeps this module importable without the extra installed and lets
+the unit tests mock the detector.
+"""
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+from temporalio import activity
+
+from fishsense_data_processing_workflow_worker.object_store import (
+    open_object_store_client,
+)
+
+_log = logging.getLogger(__name__)
+
+# Checkpoint baked into the image (see the Dockerfile). Overridable via env for
+# local runs / a future checkpoint swap.
+DEFAULT_CHECKPOINT_PATH = os.environ.get(
+    "E4EFS_LASER_DETECTOR__CHECKPOINT", "/e4efs/models/run3_epoch_021.pt"
+)
+
+# Module-level cache: the detector loads its weights once per worker process
+# (loading is expensive and every per-image activity in the fan-out reuses it).
+_DETECTOR: Any = None
+
+
+def _load_detector(checkpoint_path: str) -> Any:
+    """Build a LaserDetector from a local checkpoint. Imported lazily so the
+    torch/segmentation-models extra is only required at run time."""
+    # no-name-in-module: LaserDetector ships in fishsense-core >= 2.2.0; the
+    # pinned wheel is bumped to 2.3.0 in the deps/GPU phase of this feature.
+    from fishsense_core.laser import (  # pylint: disable=import-outside-toplevel,import-error,no-name-in-module
+        LaserDetector,
+    )
+
+    return LaserDetector.from_checkpoint(checkpoint_path)
+
+
+def _get_detector(checkpoint_path: str = DEFAULT_CHECKPOINT_PATH) -> Any:
+    """Return the process-wide detector, loading it on first use."""
+    global _DETECTOR  # pylint: disable=global-statement
+    if _DETECTOR is None:
+        _log.info("loading LaserDetector checkpoint=%s", checkpoint_path)
+        _DETECTOR = _load_detector(checkpoint_path)
+    return _DETECTOR
+
+
+def _predict_from_raw(
+    raw_bytes: bytes,
+    camera_matrix: list[list[float]],
+    distortion_coefficients: list[float],
+    wavelength: str | None,
+    checkpoint_path: str,
+) -> Any:
+    """Off-loop CPU/GPU work: decode the raw bytes to a `LinearRawImage`
+    (linear + Bayer-excess, which the 6-channel model needs) and run the
+    detector with rectified output so the point lands in labeling space.
+
+    Returns the fishsense-core `LaserPrediction` (`.x`, `.y`, `.confidence`).
+    """
+    import numpy as np  # pylint: disable=import-outside-toplevel
+    # no-name-in-module: linear_raw_image ships in fishsense-core >= 2.2.0
+    # (bumped to 2.3.0 in the deps/GPU phase).
+    from fishsense_core.image.linear_raw_image import (  # pylint: disable=import-outside-toplevel,import-error,no-name-in-module
+        LinearRawImage,
+    )
+
+    image = LinearRawImage(raw_bytes)
+    detector = _get_detector(checkpoint_path)
+    return detector.predict(
+        image,
+        wavelength=wavelength,
+        rectify_output=True,
+        camera_matrix=np.array(camera_matrix, dtype=float),
+        distortion=np.array(distortion_coefficients, dtype=float),
+    )
+
+
+def _models():
+    # pylint: disable=import-outside-toplevel
+    from fishsense_data_processing_workflow_worker.workflows.predict_laser_images_workflow import (
+        LaserPredictionResult,
+        PredictLaserImageInput,
+    )
+
+    return PredictLaserImageInput, LaserPredictionResult
+
+
+@activity.defn
+async def predict_laser_image(payload):  # type: ignore[no-untyped-def]
+    """Download one raw image from Garage, run the laser detector, and return
+    its predicted laser dot keyed to `image_id`."""
+    payload_cls, result_cls = _models()
+    if not isinstance(payload, payload_cls):
+        payload = payload_cls.model_validate(payload)
+
+    activity.logger.info(
+        "predicting laser image checksum=%s image_id=%d",
+        payload.checksum,
+        payload.image_id,
+    )
+
+    client = open_object_store_client()
+    raw_bytes = await client.download_raw(payload.checksum)
+
+    prediction = await asyncio.to_thread(
+        _predict_from_raw,
+        raw_bytes,
+        payload.camera_matrix,
+        payload.distortion_coefficients,
+        payload.wavelength,
+        DEFAULT_CHECKPOINT_PATH,
+    )
+
+    activity.logger.info(
+        "predicted laser image_id=%d x=%s y=%s confidence=%.3f",
+        payload.image_id,
+        prediction.x,
+        prediction.y,
+        prediction.confidence,
+    )
+    return result_cls(
+        image_id=payload.image_id,
+        x=prediction.x,
+        y=prediction.y,
+        confidence=prediction.confidence,
+    )

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
@@ -30,6 +30,9 @@ from fishsense_data_processing_workflow_worker.activities.preprocess_species_ima
 from fishsense_data_processing_workflow_worker.activities.preprocess_headtail_image import (
     preprocess_headtail_image,
 )
+from fishsense_data_processing_workflow_worker.activities.predict_laser_image import (
+    predict_laser_image,
+)
 from fishsense_data_processing_workflow_worker.activities.preprocess_laser_image import (
     preprocess_laser_image,
 )
@@ -54,6 +57,9 @@ from fishsense_data_processing_workflow_worker.workflows.preprocess_species_imag
 )
 from fishsense_data_processing_workflow_worker.workflows.preprocess_headtail_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
     PreprocessHeadtailImagesWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.predict_laser_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PredictLaserImagesWorkflow,
 )
 from fishsense_data_processing_workflow_worker.workflows.preprocess_laser_images_workflow import (
     PreprocessLaserImagesWorkflow,
@@ -122,6 +128,7 @@ def build_worker(
             PerformLaserCalibrationWorkflow,
             PreprocessSpeciesImagesWorkflow,
             PreprocessHeadtailImagesWorkflow,
+            PredictLaserImagesWorkflow,
             PreprocessLaserImagesWorkflow,
             PreprocessSlateImagesWorkflow,
             ValidateLaserLabelsForDiveWorkflow,
@@ -131,6 +138,7 @@ def build_worker(
             cluster_dive_frames,
             measure_fish_activity,
             perform_laser_calibration_activity,
+            predict_laser_image,
             preprocess_species_image,
             preprocess_headtail_image,
             preprocess_laser_image,

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/predict_laser_images_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/predict_laser_images_workflow.py
@@ -1,0 +1,79 @@
+"""Model-assisted laser labeling: fan out `predict_laser_image` across a
+dive's laser-unlabeled images and return one prediction per image.
+
+The fishsense-core `LaserDetector` (v2.2.0+) runs on the GPU data-worker.
+Predictions seed the laser Label Studio tasks as pre-annotations
+(assisted review) — a labeler confirms or nudges each point rather than
+placing it from scratch.
+
+Same split as the preprocess stages: the api-worker parent does dive
+selection + SDK fetches + raw-byte staging and starts this as a child on
+`fishsense_data_processing_queue`. The workflow-level input DTO lives in
+`fishsense_shared` (the api-worker / data-worker contract); the per-image
+`PredictLaserImageInput` and `LaserPredictionResult` stay here because
+they're only constructed inside the fan-out.
+"""
+
+import asyncio
+from datetime import timedelta
+from typing import List
+
+from fishsense_shared import PredictLaserImagesInput
+from pydantic import BaseModel
+from temporalio import workflow
+
+
+class PredictLaserImageInput(BaseModel):
+    """Per-image payload passed to the predict_laser_image activity."""
+
+    checksum: str
+    image_id: int
+    camera_matrix: List[List[float]]
+    distortion_coefficients: List[float]
+    # Laser wavelength ("red" / "green"), or None when unknown — the model
+    # takes an "unknown" wavelength channel in that case.
+    wavelength: str | None = None
+
+
+class LaserPredictionResult(BaseModel):
+    """One image's predicted laser dot, in rectified-image pixels (the same
+    space labelers place `LaserLabel.x/y`). `x`/`y` are None when the model
+    detected no laser; `confidence` is always reported."""
+
+    image_id: int
+    x: float | None
+    y: float | None
+    confidence: float
+
+
+@workflow.defn
+class PredictLaserImagesWorkflow:
+    # pylint: disable=too-few-public-methods
+    @workflow.run
+    async def run(
+        self, payload: PredictLaserImagesInput
+    ) -> List[LaserPredictionResult]:
+        workflow.logger.info(
+            "predicting laser images dive_id=%d images=%d",
+            payload.dive_id,
+            len(payload.images),
+        )
+
+        results = await asyncio.gather(
+            *[
+                workflow.execute_activity(
+                    "predict_laser_image",
+                    PredictLaserImageInput(
+                        checksum=image.checksum,
+                        image_id=image.image_id,
+                        camera_matrix=payload.camera_matrix,
+                        distortion_coefficients=payload.distortion_coefficients,
+                        wavelength=payload.wavelength,
+                    ),
+                    start_to_close_timeout=timedelta(minutes=10),
+                    result_type=LaserPredictionResult,
+                )
+                for image in payload.images
+            ]
+        )
+        return list(results)

--- a/services/fishsense-data-processing-workflow-worker/tests/test_predict_laser_image.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_predict_laser_image.py
@@ -115,13 +115,13 @@ def test_get_detector_loads_once_and_caches(monkeypatch):
 
 
 def _make_payload(**overrides) -> PredictLaserImageInput:
-    base = dict(
-        checksum="abc123",
-        image_id=42,
-        camera_matrix=[[1000.0, 0.0, 960.0], [0.0, 1000.0, 540.0], [0.0, 0.0, 1.0]],
-        distortion_coefficients=[0.0, 0.0, 0.0, 0.0, 0.0],
-        wavelength=None,
-    )
+    base = {
+        "checksum": "abc123",
+        "image_id": 42,
+        "camera_matrix": [[1000.0, 0.0, 960.0], [0.0, 1000.0, 540.0], [0.0, 0.0, 1.0]],
+        "distortion_coefficients": [0.0, 0.0, 0.0, 0.0, 0.0],
+        "wavelength": None,
+    }
     base.update(overrides)
     return PredictLaserImageInput(**base)
 
@@ -137,7 +137,7 @@ def _mock_object_store(monkeypatch, raw=b"raw"):
 async def test_activity_returns_mapped_prediction(monkeypatch):
     client = _mock_object_store(monkeypatch, raw=b"ORFBYTES")
 
-    def _fake_predict(raw_bytes, camera_matrix, distortion, wavelength, checkpoint):
+    def _fake_predict(raw_bytes, *_args):
         assert raw_bytes == b"ORFBYTES"
         return SimpleNamespace(x=100.0, y=200.0, confidence=0.77)
 

--- a/services/fishsense-data-processing-workflow-worker/tests/test_predict_laser_image.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_predict_laser_image.py
@@ -1,0 +1,189 @@
+# pylint: disable=protected-access
+"""Unit tests for the model-assisted laser predict activity.
+
+The fishsense-core `LaserDetector` (torch, GPU) and `LinearRawImage` are
+imported lazily inside the activity, so these tests mock them at the seams
+and never need the `[laser-detector]` extra installed:
+
+  1. `_predict_from_raw` builds a LinearRawImage and calls the detector with
+     rectified output + the dive's intrinsics, and returns its prediction.
+  2. `_get_detector` loads the checkpoint once and caches it per process.
+  3. The activity downloads the raw bytes, runs the prediction off-loop, and
+     maps the result to a `LaserPredictionResult` keyed by image_id
+     (including the no-detection x/y=None case).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from temporalio.testing import ActivityEnvironment
+
+from fishsense_data_processing_workflow_worker.activities import (
+    predict_laser_image as sut,
+)
+from fishsense_data_processing_workflow_worker.workflows.predict_laser_images_workflow import (
+    LaserPredictionResult,
+    PredictLaserImageInput,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_detector_cache():
+    """Each test starts with a cold module-level detector cache."""
+    sut._DETECTOR = None
+    yield
+    sut._DETECTOR = None
+
+
+def _install_fake_linear_raw_image(monkeypatch, captured):
+    """Inject a fake `fishsense_core.image.linear_raw_image.LinearRawImage`
+    so `_predict_from_raw`'s lazy import resolves without fishsense-core 2.3."""
+    mod = types.ModuleType("fishsense_core.image.linear_raw_image")
+
+    class _LinearRawImage:  # pylint: disable=too-few-public-methods
+        def __init__(self, source, *, bayer_upsample="repeat"):
+            captured["source"] = source
+            captured["bayer_upsample"] = bayer_upsample
+
+    mod.LinearRawImage = _LinearRawImage
+    monkeypatch.setitem(
+        sys.modules, "fishsense_core.image.linear_raw_image", mod
+    )
+
+
+# ----------------------------- _predict_from_raw -----------------------------
+
+
+def test_predict_from_raw_calls_detector_with_rectified_output(monkeypatch):
+    captured: dict = {}
+    _install_fake_linear_raw_image(monkeypatch, captured)
+
+    predict_calls: dict = {}
+
+    class _FakeDetector:  # pylint: disable=too-few-public-methods
+        def predict(self, image, **kwargs):
+            predict_calls["image"] = image
+            predict_calls["kwargs"] = kwargs
+            return SimpleNamespace(x=12.5, y=34.0, confidence=0.9)
+
+    monkeypatch.setattr(sut, "_get_detector", lambda checkpoint_path: _FakeDetector())
+
+    pred = sut._predict_from_raw(
+        b"rawbytes",
+        camera_matrix=[[1000.0, 0.0, 960.0], [0.0, 1000.0, 540.0], [0.0, 0.0, 1.0]],
+        distortion_coefficients=[0.1, -0.2, 0.0, 0.0, 0.0],
+        wavelength="red",
+        checkpoint_path="/models/run3.pt",
+    )
+
+    assert (pred.x, pred.y, pred.confidence) == (12.5, 34.0, 0.9)
+    # Built a LinearRawImage straight from the raw bytes.
+    assert captured["source"] == b"rawbytes"
+    # Rectified output in labeling space, with the dive's intrinsics + wavelength.
+    kw = predict_calls["kwargs"]
+    assert kw["rectify_output"] is True
+    assert kw["wavelength"] == "red"
+    assert kw["camera_matrix"].shape == (3, 3)
+    assert kw["distortion"].shape == (5,)
+
+
+# ------------------------------- _get_detector -------------------------------
+
+
+def test_get_detector_loads_once_and_caches(monkeypatch):
+    loads: list[str] = []
+
+    def _fake_load(checkpoint_path):
+        loads.append(checkpoint_path)
+        return SimpleNamespace(name="detector")
+
+    monkeypatch.setattr(sut, "_load_detector", _fake_load)
+
+    first = sut._get_detector("/models/run3.pt")
+    second = sut._get_detector("/models/run3.pt")
+
+    assert first is second
+    assert loads == ["/models/run3.pt"]  # loaded exactly once
+
+
+# --------------------------------- activity ----------------------------------
+
+
+def _make_payload(**overrides) -> PredictLaserImageInput:
+    base = dict(
+        checksum="abc123",
+        image_id=42,
+        camera_matrix=[[1000.0, 0.0, 960.0], [0.0, 1000.0, 540.0], [0.0, 0.0, 1.0]],
+        distortion_coefficients=[0.0, 0.0, 0.0, 0.0, 0.0],
+        wavelength=None,
+    )
+    base.update(overrides)
+    return PredictLaserImageInput(**base)
+
+
+def _mock_object_store(monkeypatch, raw=b"raw"):
+    client = MagicMock()
+    client.download_raw = AsyncMock(return_value=raw)
+    monkeypatch.setattr(sut, "open_object_store_client", lambda: client)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_activity_returns_mapped_prediction(monkeypatch):
+    client = _mock_object_store(monkeypatch, raw=b"ORFBYTES")
+
+    def _fake_predict(raw_bytes, camera_matrix, distortion, wavelength, checkpoint):
+        assert raw_bytes == b"ORFBYTES"
+        return SimpleNamespace(x=100.0, y=200.0, confidence=0.77)
+
+    monkeypatch.setattr(sut, "_predict_from_raw", _fake_predict)
+
+    result = await ActivityEnvironment().run(
+        sut.predict_laser_image, _make_payload(image_id=7)
+    )
+
+    assert isinstance(result, LaserPredictionResult)
+    assert result.image_id == 7
+    assert (result.x, result.y, result.confidence) == (100.0, 200.0, 0.77)
+    client.download_raw.assert_awaited_once_with("abc123")
+
+
+@pytest.mark.asyncio
+async def test_activity_handles_non_detection(monkeypatch):
+    _mock_object_store(monkeypatch)
+    monkeypatch.setattr(
+        sut,
+        "_predict_from_raw",
+        lambda *a, **k: SimpleNamespace(x=None, y=None, confidence=0.05),
+    )
+
+    result = await ActivityEnvironment().run(
+        sut.predict_laser_image, _make_payload(image_id=9)
+    )
+
+    assert result.image_id == 9
+    assert result.x is None and result.y is None
+    assert result.confidence == 0.05
+
+
+@pytest.mark.asyncio
+async def test_activity_validates_dict_payload(monkeypatch):
+    """Temporal hands the activity a plain dict across the boundary."""
+    _mock_object_store(monkeypatch)
+    monkeypatch.setattr(
+        sut,
+        "_predict_from_raw",
+        lambda *a, **k: SimpleNamespace(x=1.0, y=2.0, confidence=0.5),
+    )
+
+    result = await ActivityEnvironment().run(
+        sut.predict_laser_image, _make_payload(image_id=11).model_dump()
+    )
+
+    assert result.image_id == 11
+    assert (result.x, result.y) == (1.0, 2.0)

--- a/services/fishsense-data-processing-workflow-worker/tests/test_predict_laser_images_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_predict_laser_images_workflow.py
@@ -1,0 +1,114 @@
+"""Workflow contract test for PredictLaserImagesWorkflow.
+
+Runs the workflow against an in-process Temporal test server with a stubbed
+activity. Asserts the fan-out shape, per-image arg propagation, and that the
+workflow returns one prediction per image keyed by image_id.
+"""
+
+import uuid
+from typing import List
+
+import pytest
+from temporalio import activity
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from fishsense_shared import PredictLaserImage, PredictLaserImagesInput
+from fishsense_data_processing_workflow_worker.workflows.predict_laser_images_workflow import (
+    LaserPredictionResult,
+    PredictLaserImageInput,
+    PredictLaserImagesWorkflow,
+)
+
+_K = [[1000.0, 0.0, 960.0], [0.0, 1000.0, 540.0], [0.0, 0.0, 1.0]]
+_D = [-0.1, 0.05, 0.0, 0.0, 0.0]
+
+
+@pytest.mark.asyncio
+async def test_workflow_fans_out_and_returns_one_prediction_per_image():
+    calls: List[PredictLaserImageInput] = []
+
+    @activity.defn(name="predict_laser_image")
+    async def stub_predict_laser_image(
+        payload: PredictLaserImageInput,
+    ) -> LaserPredictionResult:
+        calls.append(payload)
+        # Echo image_id into the coords so we can prove the mapping.
+        return LaserPredictionResult(
+            image_id=payload.image_id,
+            x=float(payload.image_id),
+            y=float(payload.image_id) * 2,
+            confidence=0.9,
+        )
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-predict",
+            workflows=[PredictLaserImagesWorkflow],
+            activities=[stub_predict_laser_image],
+        ):
+            results = await env.client.execute_workflow(
+                PredictLaserImagesWorkflow.run,
+                PredictLaserImagesInput(
+                    dive_id=440,
+                    images=[
+                        PredictLaserImage(image_id=1, checksum="a"),
+                        PredictLaserImage(image_id=2, checksum="b"),
+                        PredictLaserImage(image_id=3, checksum="c"),
+                    ],
+                    camera_matrix=_K,
+                    distortion_coefficients=_D,
+                    wavelength="red",
+                ),
+                id=f"test-predict-{uuid.uuid4()}",
+                task_queue="test-predict",
+            )
+
+    assert len(calls) == 3
+    by_checksum = {c.checksum: c for c in calls}
+    assert set(by_checksum) == {"a", "b", "c"}
+    for c in calls:
+        assert c.camera_matrix == _K
+        assert c.distortion_coefficients == _D
+        assert c.wavelength == "red"
+
+    # Result carries one prediction per image, keyed by image_id.
+    by_id = {r["image_id"] if isinstance(r, dict) else r.image_id: r for r in results}
+    assert set(by_id) == {1, 2, 3}
+
+
+@pytest.mark.asyncio
+async def test_workflow_with_no_images_returns_empty_and_calls_nothing():
+    calls: List[PredictLaserImageInput] = []
+
+    @activity.defn(name="predict_laser_image")
+    async def stub_predict_laser_image(
+        payload: PredictLaserImageInput,
+    ) -> LaserPredictionResult:
+        calls.append(payload)
+        return LaserPredictionResult(
+            image_id=payload.image_id, x=None, y=None, confidence=0.0
+        )
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-predict-empty",
+            workflows=[PredictLaserImagesWorkflow],
+            activities=[stub_predict_laser_image],
+        ):
+            results = await env.client.execute_workflow(
+                PredictLaserImagesWorkflow.run,
+                PredictLaserImagesInput(
+                    dive_id=440,
+                    images=[],
+                    camera_matrix=_K,
+                    distortion_coefficients=_D,
+                ),
+                id=f"test-predict-empty-{uuid.uuid4()}",
+                task_queue="test-predict-empty",
+            )
+
+    assert not calls
+    assert not results


### PR DESCRIPTION
Phase 1 of **model-assisted laser labeling**. fishsense-core **v2.2.0+** now ships a `LaserDetector` inference stack — a port of your `UCSD-E4E/2026-05-02_laser_detector` production recipe (val `hit_n3 = 0.9081`). This wires a GPU data-worker stage around it so predictions can seed the laser Label Studio tasks (assisted review), unblocking laser labeling without from-scratch human placement.

## This PR (locally testable, decision-independent)
- **`predict_laser_image` activity** — download raw from Garage → `LinearRawImage` → `LaserDetector.predict(rectify_output=True, camera_matrix, distortion)` so the point lands in the **same rectified space** labelers place `LaserLabel.x/y`. Returns `LaserPredictionResult(image_id, x, y, confidence)`. torch / `LinearRawImage` imported **lazily** (module loads without the `[laser-detector]` extra; detector loads **once per worker** via a module-level cache).
- **`PredictLaserImagesWorkflow`** — thin per-image fan-out returning one prediction per image; `PredictLaserImagesInput` / `PredictLaserImage` added to `fishsense_shared` as the api↔data contract.
- Registered in the worker.

## Tests (TDD, mocked detector — no torch needed)
- Activity: detector-call contract (rectified output + intrinsics + wavelength), once-per-process caching, result mapping incl. non-detection (`x/y=None`) and dict-payload validation.
- Workflow: fan-out + per-image mapping + empty case.
- data-worker **103 passed**; pylint **10.00**.

## What's intentionally deferred (later phases, own PRs)
1. **Deps + GPU** — fishsense-core 2.0.0 → 2.3.0 + `[laser-detector]`, `uv.lock` regen, bake `run3_epoch_021.pt` into the image, k8s `nvidia.com/gpu:1`. *(The `no-name-in-module` suppressions on the lazy imports drop here — `LaserDetector`/`LinearRawImage` don't exist in the pinned 2.0.0 wheel yet.)*
2. **Schema** — `LaserPrediction` store + endpoints + SDK.
3. **Orchestration** — api-worker parent + cohort selector + scale-GPU-worker + schedule.
4. **Assisted review** — laser populate reads predictions → LS pre-annotations.

⚠️ **Nothing runs end-to-end until phase 1 (deps/GPU) lands** — this PR is safe to merge (dead code path behind an unregistered cohort), but the detector can't actually load until fishsense-core 2.3.0 + the checkpoint are in the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)