### PR TITLE
feat(laser-prediction): LaserPrediction model + endpoints + SDK (phase 3)

### DIFF
--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/label_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/label_client.py
@@ -7,10 +7,12 @@ from fishsense_api_sdk.models.dive_slate_label import DiveSlateLabel
 from fishsense_api_sdk.models.headtail_label import HeadTailLabel
 from fishsense_api_sdk.models.label_studio_sync_cursor import LabelStudioSyncCursor
 from fishsense_api_sdk.models.laser_label import LaserLabel
+from fishsense_api_sdk.models.laser_prediction import LaserPrediction
 from fishsense_api_sdk.models.species_label import SpeciesLabel
 
 
 class LabelClient(ClientBase):
+    # pylint: disable=too-many-public-methods
     """Client for interacting with label-related endpoints of the Fishsense API."""
 
     async def get_dive_slate_label(
@@ -350,6 +352,39 @@ class LabelClient(ClientBase):
         )
         response.raise_for_status()
         return list(response.json() or [])
+
+    async def put_laser_prediction(
+        self, image_id: int, prediction: LaserPrediction
+    ) -> int:
+        """Upsert the model's laser prediction for an image.
+
+        Args:
+            image_id (int): The image the prediction is for.
+            prediction (LaserPrediction): The predicted laser dot.
+
+        Returns:
+            int: The id of the upserted prediction row.
+        """
+        response = await self._put(
+            f"/api/v1/images/{image_id}/laser-prediction/",
+            json=prediction.model_dump(exclude_unset=True, mode="json"),
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def get_laser_predictions(self, dive_id: int) -> List[LaserPrediction]:
+        """Get every model laser prediction for a dive's images.
+
+        Args:
+            dive_id (int): The dive to retrieve predictions for.
+
+        Returns:
+            List[LaserPrediction]: Predictions (empty when the dive has none).
+        """
+        response = await self._get(f"/api/v1/dives/{dive_id}/laser-predictions/")
+        response.raise_for_status()
+        json = response.json()
+        return [LaserPrediction.model_validate(row) for row in (json or [])]
 
     async def put_laser_label(self, image_id: int, laser_label: LaserLabel) -> int:
         """Put a laser label to an image .

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
@@ -174,6 +174,21 @@ class LaserLabel(BaseModel):
     user_id: int | None = Field(None, title='User Id')
 
 
+class LaserPrediction(BaseModel):
+    """
+    A model-predicted laser dot, in rectified-image pixels (the space
+    labelers place `LaserLabel.x/y`). One row per image — re-prediction
+    upserts on the natural key.
+    """
+
+    id: int | None = Field(None, title='Id')
+    x: float | None = Field(None, title='X')
+    y: float | None = Field(None, title='Y')
+    confidence: float | None = Field(0.0, title='Confidence')
+    created_at: AwareDatetime | None = Field(None, title='Created At')
+    image_id: int | None = Field(None, title='Image Id')
+
+
 class Measurement(BaseModel):
     """
     Measurement model representing fish measurements in the database.

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/laser_prediction.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/laser_prediction.py
@@ -1,0 +1,22 @@
+"""Module defining laser prediction model for Fishsense API SDK.
+
+Mirrors fishsense-api's `LaserPrediction` SQLModel — a model-predicted laser
+dot for an image (fishsense-core LaserDetector stage), in rectified-image
+pixels. `x`/`y` are None when no laser was detected; `confidence` is always
+set.
+"""
+
+from datetime import datetime
+
+from fishsense_api_sdk.models.model_base import ModelBase
+
+
+class LaserPrediction(ModelBase):
+    """Model representing a model-predicted laser dot."""
+
+    id: int | None = None
+    x: float | None = None
+    y: float | None = None
+    confidence: float
+    created_at: datetime | None = None
+    image_id: int | None = None

--- a/libs/fishsense-api-sdk/tests/clients/test_label_client.py
+++ b/libs/fishsense-api-sdk/tests/clients/test_label_client.py
@@ -70,6 +70,53 @@ class TestLabelClient:  # pylint: disable=too-many-public-methods
             async with client:
                 assert await client.get_laser_label(label_studio_id=999) is None
 
+    async def test_put_laser_prediction_puts_to_image_endpoint(self):
+        from fishsense_api_sdk.models.laser_prediction import (  # pylint: disable=import-outside-toplevel
+            LaserPrediction,
+        )
+
+        client = _make_client()
+        resp = Mock()
+        resp.status_code = 201
+        resp.json.return_value = 7
+        resp.raise_for_status = Mock()
+        with patch.object(client, "_put", new_callable=AsyncMock) as mock_put:
+            mock_put.return_value = resp
+            async with client:
+                pid = await client.put_laser_prediction(
+                    11, LaserPrediction(x=1.0, y=2.0, confidence=0.9)
+                )
+        assert pid == 7
+        endpoint, *_ = mock_put.call_args.args
+        assert endpoint == "/api/v1/images/11/laser-prediction/"
+
+    async def test_get_laser_predictions_returns_list(self):
+        client = _make_client()
+        resp = Mock()
+        resp.status_code = 200
+        resp.json.return_value = [
+            {"id": 1, "x": 1.0, "y": 2.0, "confidence": 0.9, "image_id": 11},
+            {"id": 2, "x": None, "y": None, "confidence": 0.1, "image_id": 12},
+        ]
+        resp.raise_for_status = Mock()
+        with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = resp
+            async with client:
+                preds = await client.get_laser_predictions(1)
+        assert [p.image_id for p in preds] == [11, 12]
+        mock_get.assert_awaited_once_with("/api/v1/dives/1/laser-predictions/")
+
+    async def test_get_laser_predictions_empty_on_null_body(self):
+        client = _make_client()
+        resp = Mock()
+        resp.status_code = 200
+        resp.json.return_value = None
+        resp.raise_for_status = Mock()
+        with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = resp
+            async with client:
+                assert await client.get_laser_predictions(1) == []
+
     async def test_get_species_label_returns_none_on_404(self):
         client = _make_client()
         with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/a7d21e4f0c93_add_laser_prediction_table.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/a7d21e4f0c93_add_laser_prediction_table.py
@@ -1,0 +1,45 @@
+"""add laserprediction table
+
+Model-predicted laser dots from the fishsense-core LaserDetector stage. One
+row per image (unique image_id — re-prediction upserts). Read by laser
+populate to seed Label Studio pre-annotations (assisted review); kept separate
+from LaserLabel so predictions never count toward the human "valid laser" gate.
+
+Revision ID: a7d21e4f0c93
+Revises: f2b5d0c8e3a1
+Create Date: 2026-07-28 00:00:00.000000
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a7d21e4f0c93"
+down_revision: Union[str, Sequence[str], None] = "f2b5d0c8e3a1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "laserprediction",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("x", sa.Float(), nullable=True),
+        sa.Column("y", sa.Float(), nullable=True),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("image_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["image_id"], ["image.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("image_id", name="uq_laser_prediction_image"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table("laserprediction")

--- a/services/fishsense-api/src/fishsense_api/controllers/__init__.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/__init__.py
@@ -6,4 +6,5 @@ import fishsense_api.controllers.dive_slate_controller
 import fishsense_api.controllers.fish_controller
 import fishsense_api.controllers.image_controller
 import fishsense_api.controllers.label_controller
+import fishsense_api.controllers.laser_prediction_controller
 import fishsense_api.controllers.user_controller

--- a/services/fishsense-api/src/fishsense_api/controllers/laser_prediction_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/laser_prediction_controller.py
@@ -1,0 +1,73 @@
+# pylint: disable=C0121
+"""Laser-prediction endpoints.
+
+Model-predicted laser dots from the fishsense-core LaserDetector stage. The
+GPU predict stage upserts one per image; the laser populate step reads a
+dive's predictions to seed Label Studio pre-annotations (assisted review).
+"""
+
+import logging
+from typing import List
+
+from fastapi import Depends
+from fastapi.encoders import jsonable_encoder
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from fishsense_api.database import get_async_session
+from fishsense_api.models.dive import Dive
+from fishsense_api.models.image import Image
+from fishsense_api.models.laser_prediction import LaserPrediction
+from fishsense_api.server import app
+
+logger = logging.getLogger(__name__)
+
+
+@app.put("/api/v1/images/{image_id}/laser-prediction/", status_code=201)
+async def put_laser_prediction(
+    image_id: int,
+    prediction: LaserPrediction,
+    session: AsyncSession = Depends(get_async_session),
+) -> int:
+    """Create or update the model's laser prediction for an image.
+
+    Upserts on `image_id` (the natural key) so a re-run of the predict stage
+    overwrites rather than duplicating — merge on `id=None` would always
+    INSERT and violate `uq_laser_prediction_image`.
+    """
+    logger.debug("Upserting laser prediction for image with id=%d", image_id)
+    prediction = LaserPrediction.model_validate(jsonable_encoder(prediction))
+    prediction.image_id = image_id
+
+    if prediction.id is None:
+        existing = (
+            await session.exec(
+                select(LaserPrediction).where(LaserPrediction.image_id == image_id)
+            )
+        ).first()
+        if existing is not None:
+            prediction.id = existing.id
+
+    prediction = await session.merge(prediction)
+    await session.flush()
+
+    return prediction.id
+
+
+@app.get("/api/v1/dives/{dive_id}/laser-predictions/")
+async def get_laser_predictions_for_dive(
+    dive_id: int, session: AsyncSession = Depends(get_async_session)
+) -> List[LaserPrediction]:
+    """Every model laser prediction for a dive's images.
+
+    Empty list (not 404) when the dive has none — the laser populate step
+    treats "no prediction" as "no pre-annotation," not an error.
+    """
+    logger.debug("Retrieving laser predictions for dive with id=%d", dive_id)
+    query = (
+        select(LaserPrediction)
+        .join_from(LaserPrediction, Image, LaserPrediction.image_id == Image.id)
+        .join_from(Image, Dive, Image.dive_id == Dive.id)
+        .where(Dive.id == dive_id)
+    )
+    return (await session.exec(query)).all()

--- a/services/fishsense-api/src/fishsense_api/database.py
+++ b/services/fishsense-api/src/fishsense_api/database.py
@@ -32,6 +32,7 @@ from fishsense_api.models.image import Image
 from fishsense_api.models.label_studio_sync_cursor import LabelStudioSyncCursor
 from fishsense_api.models.laser_extrinsics import LaserExtrinsics
 from fishsense_api.models.laser_label import LaserLabel
+from fishsense_api.models.laser_prediction import LaserPrediction
 from fishsense_api.models.measurement import Measurement
 from fishsense_api.models.species import Species
 from fishsense_api.models.species_label import SpeciesLabel

--- a/services/fishsense-api/src/fishsense_api/models/laser_prediction.py
+++ b/services/fishsense-api/src/fishsense_api/models/laser_prediction.py
@@ -1,0 +1,36 @@
+"""Model representing a model-predicted laser dot for an image.
+
+Written by the GPU laser-detector stage (fishsense-core `LaserDetector`) and
+read by the laser populate step, which emits it as a Label Studio
+pre-annotation so a labeler confirms/nudges rather than placing from scratch
+(assisted review). Kept in its own table — separate from `LaserLabel` — so a
+prediction never counts toward the human "valid laser" gates; a labeler's
+confirmation still lands as a normal `LaserLabel` via the usual sync.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlmodel import DateTime, Field, UniqueConstraint
+
+from fishsense_api.models.model_base import ModelBase
+
+
+class LaserPrediction(ModelBase, table=True):
+    """A model-predicted laser dot, in rectified-image pixels (the space
+    labelers place `LaserLabel.x/y`). One row per image — re-prediction
+    upserts on the natural key."""
+
+    __table_args__ = (
+        UniqueConstraint("image_id", name="uq_laser_prediction_image"),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    # x/y are None when the detector found no laser; confidence is always set.
+    x: float | None = Field(default=None)
+    y: float | None = Field(default=None)
+    confidence: float = Field(default=0.0)
+    created_at: datetime | None = Field(sa_type=DateTime(timezone=True), default=None)
+
+    image_id: int | None = Field(default=None, foreign_key="image.id")

--- a/services/fishsense-api/tests/test_laser_prediction_endpoint.py
+++ b/services/fishsense-api/tests/test_laser_prediction_endpoint.py
@@ -1,0 +1,123 @@
+"""Tests for the laser-prediction endpoints (model-assisted labeling store).
+
+FK-less in-memory sqlite, same as the other controller tests — we exercise
+the controller functions directly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+def _dive(dive_id: int):
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+
+    return Dive(
+        id=dive_id,
+        path=f"/dev/null/{dive_id}",
+        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        priority=Priority.HIGH,
+    )
+
+
+def _image(image_id: int, dive_id: int):
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    return Image(
+        id=image_id,
+        path=f"/dev/null/img-{image_id}",
+        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        checksum=f"img-{image_id:032d}"[:32],
+        dive_id=dive_id,
+    )
+
+
+def _prediction(*, x=1.0, y=2.0, confidence=0.9):
+    from fishsense_api.models.laser_prediction import LaserPrediction  # pylint: disable=import-outside-toplevel
+
+    return LaserPrediction(x=x, y=y, confidence=confidence)
+
+
+async def test_put_creates_a_prediction(session):
+    from fishsense_api.controllers.laser_prediction_controller import (  # pylint: disable=import-outside-toplevel
+        put_laser_prediction,
+    )
+    from fishsense_api.models.laser_prediction import LaserPrediction  # pylint: disable=import-outside-toplevel
+
+    session.add_all([_dive(1), _image(11, 1)])
+    await session.flush()
+
+    pid = await put_laser_prediction(11, _prediction(x=100.0, y=200.0), session=session)
+    row = await session.get(LaserPrediction, pid)
+    assert row.image_id == 11
+    assert (row.x, row.y, row.confidence) == (100.0, 200.0, 0.9)
+
+
+async def test_put_upserts_on_image_id(session):
+    from fishsense_api.controllers.laser_prediction_controller import (  # pylint: disable=import-outside-toplevel
+        put_laser_prediction,
+    )
+    from fishsense_api.models.laser_prediction import LaserPrediction  # pylint: disable=import-outside-toplevel
+
+    session.add_all([_dive(1), _image(11, 1)])
+    await session.flush()
+
+    first = await put_laser_prediction(11, _prediction(x=1.0, y=1.0), session=session)
+    second = await put_laser_prediction(
+        11, _prediction(x=9.0, y=9.0, confidence=0.5), session=session
+    )
+
+    assert first == second  # same row reused, not a duplicate
+    rows = (
+        await session.exec(
+            select(LaserPrediction).where(LaserPrediction.image_id == 11)
+        )
+    ).all()
+    assert len(rows) == 1
+    assert (rows[0].x, rows[0].y, rows[0].confidence) == (9.0, 9.0, 0.5)
+
+
+async def test_get_returns_predictions_for_the_dive(session):
+    from fishsense_api.controllers.laser_prediction_controller import (  # pylint: disable=import-outside-toplevel
+        get_laser_predictions_for_dive,
+        put_laser_prediction,
+    )
+
+    session.add_all([_dive(1), _dive(2), _image(11, 1), _image(12, 1), _image(21, 2)])
+    await session.flush()
+    await put_laser_prediction(11, _prediction(), session=session)
+    await put_laser_prediction(12, _prediction(), session=session)
+    await put_laser_prediction(21, _prediction(), session=session)  # other dive
+
+    results = await get_laser_predictions_for_dive(1, session=session)
+    assert {r.image_id for r in results} == {11, 12}
+
+
+async def test_get_returns_empty_list_when_none(session):
+    from fishsense_api.controllers.laser_prediction_controller import (  # pylint: disable=import-outside-toplevel
+        get_laser_predictions_for_dive,
+    )
+
+    session.add(_dive(1))
+    await session.flush()
+
+    assert await get_laser_predictions_for_dive(1, session=session) == []

--- a/services/fishsense-api/tests/test_sdk_drift.py
+++ b/services/fishsense-api/tests/test_sdk_drift.py
@@ -59,6 +59,7 @@ MODEL_PAIRS: list[Pair] = [
     ),
     Pair("laser_extrinsics", "_LaserExtrinsics", "laser_extrinsics", "LaserExtrinsics"),
     Pair("laser_label", "LaserLabel", "laser_label", "LaserLabel"),
+    Pair("laser_prediction", "LaserPrediction", "laser_prediction", "LaserPrediction"),
     Pair("measurement", "Measurement", "measurement", "Measurement"),
     Pair("species", "Species", "species", "Species"),
     Pair("species_label", "SpeciesLabel", "species_label", "SpeciesLabel"),

--- a/uv.lock
+++ b/uv.lock
@@ -765,7 +765,7 @@ wheels = [
 
 [[package]]
 name = "fishsense-api"
-version = "1.31.0"
+version = "1.33.0"
 source = { editable = "services/fishsense-api" }
 dependencies = [
     { name = "alembic" },
@@ -818,7 +818,7 @@ dev = [
 
 [[package]]
 name = "fishsense-api-sdk"
-version = "1.37.0"
+version = "1.39.0"
 source = { editable = "libs/fishsense-api-sdk" }
 dependencies = [
     { name = "httpx" },
@@ -847,7 +847,7 @@ dev = [
 
 [[package]]
 name = "fishsense-api-workflow-worker"
-version = "1.44.1"
+version = "1.45.1"
 source = { editable = "services/fishsense-api-workflow-worker" }
 dependencies = [
     { name = "boto3" },
@@ -1009,7 +1009,7 @@ requires-dist = [
 
 [[package]]
 name = "fishsense-data-processing-workflow-worker"
-version = "2.8.0"
+version = "2.8.2"
 source = { editable = "services/fishsense-data-processing-workflow-worker" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Phase 3 of model-assisted laser labeling — the persistence layer the GPU predict stage (phase 1/#418) writes to and the laser populate step (phase 5) reads for assisted-review pre-annotations. Independent of the deps/GPU work (#420); pure API-side.

Kept **separate from `LaserLabel`** so a prediction never counts toward the human "valid laser" gate — a labeler's confirmation still lands as a normal `LaserLabel` via the usual sync.

- **`LaserPrediction` SQLModel** (`id, x, y, confidence, created_at, image_id`; unique `image_id`) + registered in `database.py` + create-table migration `a7d21e4f0c93` (down_revision `f2b5d0c8e3a1`).
- **Endpoints**: `PUT /api/v1/images/{image_id}/laser-prediction/` (natural-key upsert on `image_id` — a re-predict overwrites, no dup) and `GET /api/v1/dives/{dive_id}/laser-predictions/` (empty list, not 404, when none). Registered in `controllers/__init__`.
- **SDK**: `LaserPrediction` mirror + `LabelClient.put_laser_prediction` / `get_laser_predictions`; regenerated `_generated.py`; drift pair added.

## Tests (TDD)
- Endpoint: create / upsert-on-image_id / get-by-dive / empty-list.
- SDK client: put hits the image endpoint, get returns a list, null-body → `[]`.
- Drift guard + generated-freshness guard both updated/passing.
- api **209** · sdk **116** · pylint **10.00**.

Not wired end-to-end yet (parent/selector/schedule = phase 4; LS pre-annotations = phase 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)