### PR TITLE
feat(laser-predict): orchestration — parent + selector + schedule (phase 4)

### DIFF
--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
@@ -105,6 +105,10 @@ class DiveClient(ClientBase):
         """Stage 9 cohort selector. See `select_next_for_laser_preprocessing`."""
         return await self._select_next("slate-preprocessing")
 
+    async def select_next_for_laser_prediction(self) -> int | None:
+        """Laser-detector cohort selector. See `select_next_for_laser_preprocessing`."""
+        return await self._select_next("laser-prediction")
+
     async def select_next_for_laser_calibration(self) -> int | None:
         """Stage 13 cohort selector. See `select_next_for_laser_preprocessing`."""
         return await self._select_next("laser-calibration")

--- a/libs/fishsense-api-sdk/tests/clients/test_dive_client.py
+++ b/libs/fishsense-api-sdk/tests/clients/test_dive_client.py
@@ -302,6 +302,23 @@ class TestDiveClient:
                     "/api/v1/dives/2/calibration-source/"
                 )
 
+    async def test_select_next_for_laser_prediction_hits_the_cohort_endpoint(self):
+        client = _make_client()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = 42
+        mock_response.raise_for_status = Mock()
+
+        with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            async with client:
+                result = await client.select_next_for_laser_prediction()
+                assert result == 42
+                mock_get.assert_awaited_once_with(
+                    "/api/v1/dives/select-next/laser-prediction/"
+                )
+
     async def test_get_dives_needing_species_population_returns_list(self):
         """Returns the full list of dive ids from the population endpoint."""
         client = _make_client()

--- a/libs/fishsense-shared/src/fishsense_shared/__init__.py
+++ b/libs/fishsense-shared/src/fishsense_shared/__init__.py
@@ -12,6 +12,7 @@ from fishsense_shared.logging import configure_log_handler, configure_logging
 from fishsense_shared.preprocess_contracts import (
     ClusterDiveFrameImage,
     ClusterDiveFramesInput,
+    LaserPredictionResult,
     PredictLaserImage,
     PredictLaserImagesInput,
     PreprocessHeadtailImagesInput,
@@ -30,6 +31,7 @@ __all__ = [
     "ClusterDiveFrameImage",
     "ClusterDiveFramesInput",
     "ExceptionGroupErrorLogging",
+    "LaserPredictionResult",
     "PredictLaserImage",
     "PredictLaserImagesInput",
     "PreprocessHeadtailImagesInput",

--- a/libs/fishsense-shared/src/fishsense_shared/preprocess_contracts.py
+++ b/libs/fishsense-shared/src/fishsense_shared/preprocess_contracts.py
@@ -122,6 +122,22 @@ class PredictLaserImagesInput(BaseModel):
     wavelength: str | None = None
 
 
+class LaserPredictionResult(BaseModel):
+    """One image's predicted laser dot, returned by the data-worker
+    `PredictLaserImagesWorkflow` and persisted by the api-worker parent.
+
+    In rectified-image pixels (the space labelers place `LaserLabel.x/y`).
+    `x`/`y` are None when the detector found no laser; `confidence` is always
+    reported. Cross-worker, so it lives here rather than in the data-worker
+    workflow module.
+    """
+
+    image_id: int
+    x: float | None
+    y: float | None
+    confidence: float
+
+
 class PreprocessSlateImagesInput(BaseModel):
     """Stage 9 (slate preprocess) workflow-level input.
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/persist_laser_predictions_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/persist_laser_predictions_activity.py
@@ -1,0 +1,41 @@
+"""Activity to persist the laser-detector's per-image predictions.
+
+The data-worker `PredictLaserImagesWorkflow` returns one
+`LaserPredictionResult` per image; the api-worker parent hands them here to
+upsert via the SDK (`put_laser_prediction`, natural-key on image_id). Runs on
+the api side so the SDK call stays on the orchestrator's docker network.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+from fishsense_api_sdk.models.laser_prediction import LaserPrediction
+from fishsense_shared import LaserPredictionResult
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.utils import get_fs_client
+
+
+@activity.defn
+async def persist_laser_predictions_activity(results: List[Any]) -> int:
+    """Upsert each prediction; returns the count written."""
+    parsed: List[LaserPredictionResult] = [
+        r if isinstance(r, LaserPredictionResult)
+        else LaserPredictionResult.model_validate(r)
+        for r in results
+    ]
+    activity.logger.info("persisting %d laser predictions", len(parsed))
+
+    async with get_fs_client() as fs:
+        for result in parsed:
+            await fs.labels.put_laser_prediction(
+                result.image_id,
+                LaserPrediction(
+                    image_id=result.image_id,
+                    x=result.x,
+                    y=result.y,
+                    confidence=result.confidence,
+                ),
+            )
+    return len(parsed)

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_predict_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_predict_inputs_activity.py
@@ -1,0 +1,81 @@
+"""Activity to resolve the per-image inputs the laser-detector stage needs.
+
+Returns a fully-populated `PredictLaserImagesInput` for the data-worker's
+`PredictLaserImagesWorkflow`. Image filter mirrors the API selector: an image
+needs a prediction only if it has no `LaserPrediction` and no non-sentinel
+`LaserLabel` — so re-runs return only still-unpredicted images and the model
+never re-predicts a labeled image.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from fishsense_api_sdk.models.image import Image
+from fishsense_api_sdk.models.laser_label import LaserLabel
+from fishsense_api_sdk.models.laser_prediction import LaserPrediction
+from fishsense_shared import PredictLaserImage, PredictLaserImagesInput
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.utils import get_fs_client
+
+
+def _select_images_needing_prediction(
+    images: List[Image],
+    predictions: List[LaserPrediction],
+    labels: List[LaserLabel],
+) -> List[Image]:
+    """Images with no prediction and no non-sentinel laser label."""
+    predicted_ids = {p.image_id for p in predictions}
+    labeled_ids = {
+        label.image_id
+        for label in labels
+        if label.label_studio_project_id is not None
+    }
+    return [
+        image
+        for image in images
+        if image.id not in predicted_ids and image.id not in labeled_ids
+    ]
+
+
+@activity.defn
+async def resolve_laser_predict_inputs_activity(
+    dive_id: int,
+) -> PredictLaserImagesInput:
+    activity.logger.info("resolving laser predict inputs dive_id=%d", dive_id)
+    async with get_fs_client() as fs:
+        dive = await fs.dives.get(dive_id=dive_id)
+        if dive is None:
+            raise ValueError(f"dive_id={dive_id} not found")
+        if dive.camera_id is None:
+            raise ValueError(f"dive_id={dive_id} has no camera_id")
+
+        intrinsics = await fs.cameras.get_intrinsics(dive.camera_id)
+        if intrinsics is None:
+            raise ValueError(f"camera_id={dive.camera_id} has no intrinsics")
+
+        images = await fs.images.get(dive_id=dive_id) or []
+        predictions = await fs.labels.get_laser_predictions(dive_id) or []
+        labels = await fs.labels.get_laser_labels(dive_id) or []
+        needing = _select_images_needing_prediction(images, predictions, labels)
+
+        activity.logger.info(
+            "resolved laser predict inputs dive_id=%d images=%d needing=%d",
+            dive_id,
+            len(images),
+            len(needing),
+        )
+        return PredictLaserImagesInput(
+            dive_id=dive_id,
+            images=[
+                PredictLaserImage(image_id=image.id, checksum=image.checksum)
+                for image in needing
+            ],
+            camera_matrix=intrinsics.camera_matrix.tolist(),
+            distortion_coefficients=intrinsics.distortion_coefficients.tolist(),
+            # Laser color isn't tracked per-dive yet; the model uses its
+            # "unknown wavelength" channel. Wire a real value here if/when a
+            # per-dive laser color lands.
+            wavelength=None,
+        )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_laser_prediction_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_laser_prediction_activity.py
@@ -1,0 +1,35 @@
+"""Activity to pick the next HIGH-priority dive needing laser predictions.
+
+Cohort: HIGH-priority + at least one image with no `LaserPrediction` and no
+non-sentinel `LaserLabel` (see `select_next_for_laser_prediction` in the api's
+dive_controller). The GPU laser-detector stage seeds a prediction per such
+image; the laser populate step then serves it as a Label Studio pre-annotation
+(assisted review).
+
+Single SDK call — the cohort answer is one query on the api side.
+"""
+
+from __future__ import annotations
+
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.utils import get_fs_client
+
+
+@activity.defn
+async def select_next_high_priority_dive_for_laser_prediction_activity() -> (
+    int | None
+):
+    async with get_fs_client() as fs:
+        dive_id = await fs.dives.select_next_for_laser_prediction()
+
+    if dive_id is None:
+        activity.logger.info(
+            "no HIGH-priority dives needing laser predictions; nothing to predict"
+        )
+    else:
+        activity.logger.info(
+            "next HIGH-priority dive needing laser predictions: dive_id=%d",
+            dive_id,
+        )
+    return dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -90,6 +90,12 @@ from fishsense_api_workflow_worker.activities.resolve_headtail_preprocess_inputs
 from fishsense_api_workflow_worker.activities.resolve_laser_preprocess_inputs_activity import (  # pylint: disable=line-too-long
     resolve_laser_preprocess_inputs_activity,
 )
+from fishsense_api_workflow_worker.activities.resolve_laser_predict_inputs_activity import (  # noqa: E501  pylint: disable=line-too-long
+    resolve_laser_predict_inputs_activity,
+)
+from fishsense_api_workflow_worker.activities.persist_laser_predictions_activity import (  # noqa: E501  pylint: disable=line-too-long
+    persist_laser_predictions_activity,
+)
 from fishsense_api_workflow_worker.activities.resolve_slate_preprocess_inputs_activity import (  # pylint: disable=line-too-long
     resolve_slate_preprocess_inputs_activity,
 )
@@ -110,6 +116,9 @@ from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for
 )
 from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for_laser_preprocessing_activity import (  # pylint: disable=line-too-long
     select_next_high_priority_dive_for_laser_preprocessing_activity,
+)
+from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for_laser_prediction_activity import (  # noqa: E501  pylint: disable=line-too-long
+    select_next_high_priority_dive_for_laser_prediction_activity,
 )
 from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for_measure_fish_activity import (  # pylint: disable=line-too-long
     select_next_high_priority_dive_for_measure_fish_activity,
@@ -186,6 +195,9 @@ from fishsense_api_workflow_worker.workflows.preprocess_species_images_parent_wo
 )
 from fishsense_api_workflow_worker.workflows.preprocess_headtail_images_parent_workflow import (  # pylint: disable=line-too-long
     PreprocessHeadtailImagesParentWorkflow,
+)
+from fishsense_api_workflow_worker.workflows.predict_laser_images_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PredictLaserImagesParentWorkflow,
 )
 from fishsense_api_workflow_worker.workflows.preprocess_laser_images_parent_workflow import (  # pylint: disable=line-too-long
     PreprocessLaserImagesParentWorkflow,
@@ -337,6 +349,22 @@ async def schedule_workflows(client: Client):
                     PreprocessLaserImagesParentWorkflow,
                     timedelta(hours=1),
                     run_timeout=timedelta(hours=1),
+                    overlap=ScheduleOverlapPolicy.SKIP,
+                )
+            )
+            # Laser-detector (model-assisted labeling) parent: hourly at
+            # +10 min (free slot between cluster +5 and species +15). Scales
+            # the GPU data-worker up, predicts a laser dot per unlabeled
+            # image, and persists them for the laser populate step to serve
+            # as LS pre-annotations. SKIP overlap; drains one dive per firing.
+            tg.create_task(
+                schedule_workflow(
+                    client,
+                    "predict-laser-images-workflow-schedule",
+                    PredictLaserImagesParentWorkflow,
+                    timedelta(hours=1),
+                    offset=timedelta(minutes=10),
+                    run_timeout=timedelta(hours=2),
                     overlap=ScheduleOverlapPolicy.SKIP,
                 )
             )
@@ -513,6 +541,7 @@ async def main():
                 PopulateDiveSlateLabelStudioProjectWorkflow,
                 UpdateDiveImageGroupsWorkflow,
                 ClusterDiveFramesParentWorkflow,
+                PredictLaserImagesParentWorkflow,
                 PreprocessLaserImagesParentWorkflow,
                 PreprocessSpeciesImagesParentWorkflow,
                 PreprocessHeadtailImagesParentWorkflow,
@@ -545,12 +574,15 @@ async def main():
                 update_dive_image_groups_activity,
                 resolve_dive_frame_clustering_inputs_activity,
                 resolve_laser_preprocess_inputs_activity,
+                resolve_laser_predict_inputs_activity,
+                persist_laser_predictions_activity,
                 resolve_species_preprocess_inputs_activity,
                 resolve_headtail_preprocess_inputs_activity,
                 resolve_slate_preprocess_inputs_activity,
                 persist_dive_frame_clusters_activity,
                 select_next_high_priority_dive_for_clustering_activity,
                 select_next_high_priority_dive_for_laser_preprocessing_activity,
+                select_next_high_priority_dive_for_laser_prediction_activity,
                 select_next_high_priority_dive_for_species_preprocessing_activity,
                 select_dives_needing_species_population_activity,
                 select_next_high_priority_dive_for_headtail_preprocessing_activity,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/predict_laser_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/predict_laser_images_parent_workflow.py
@@ -1,0 +1,134 @@
+"""Laser-detector parent workflow (api-worker side).
+
+Model-assisted laser labeling. Picks the next HIGH-priority dive needing
+laser predictions, resolves its unpredicted-image set + camera intrinsics via
+SDK, stages the raw `.ORF` bytes, and dispatches the data-worker's GPU
+`PredictLaserImagesWorkflow`. The child returns one prediction per image; the
+parent persists them (`put_laser_prediction`) so the laser populate step can
+serve them as Label Studio pre-annotations (assisted review).
+
+Cohort: HIGH-priority + at least one image with no `LaserPrediction` and no
+non-sentinel `LaserLabel` (see `select_next_for_laser_prediction`). One-shot
+per image — a dive drops out once every image is predicted.
+
+Same cluster-correctness invariants as the preprocess parents: the schedule
+fires with `overlap=SKIP`; the child id is deterministic
+(`predict-laser-{dive_id}`) with `ALLOW_DUPLICATE` so a dive can re-predict
+images that became eligible later; per-image predict activities are read-only
+against Garage + the SDK upsert is idempotent.
+"""
+
+from datetime import timedelta
+from typing import List
+
+from fishsense_shared import LaserPredictionResult, PredictLaserImagesInput
+from temporalio import workflow
+from temporalio.common import WorkflowIDReusePolicy
+from temporalio.exceptions import WorkflowAlreadyStartedError
+
+with workflow.unsafe.imports_passed_through():
+    from fishsense_api_workflow_worker.workflows._retry_policies import (
+        SCALING_RETRY_POLICY,
+        SDK_FAIL_FAST_RETRY_POLICY,
+        STAGE_RAW_RETRY_POLICY,
+    )
+
+DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
+
+
+@workflow.defn
+class PredictLaserImagesParentWorkflow:
+    # pylint: disable=too-few-public-methods
+    """Auto-pick the next HIGH-priority dive needing laser predictions and
+    dispatch the GPU detector to the data-worker. Returns the dive_id
+    processed (or None when the backlog is empty) — each invocation drains
+    exactly one dive.
+    """
+
+    @workflow.run
+    async def run(self) -> int | None:
+        dive_id = await workflow.execute_activity(
+            "select_next_high_priority_dive_for_laser_prediction_activity",
+            args=(),
+            schedule_to_close_timeout=timedelta(minutes=5),
+            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+        )
+        if dive_id is None:
+            return None
+
+        inputs = await workflow.execute_activity(
+            "resolve_laser_predict_inputs_activity",
+            args=(dive_id,),
+            schedule_to_close_timeout=timedelta(minutes=5),
+            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+            result_type=PredictLaserImagesInput,
+        )
+
+        workflow.logger.info(
+            "dispatching laser predict to data-worker dive_id=%d images=%d",
+            inputs.dive_id,
+            len(inputs.images),
+        )
+
+        if not inputs.images:
+            return inputs.dive_id
+
+        # Wake the NRP GPU data-worker before its child lands on the queue
+        # (scales to zero when idle). Idempotent; no-op when k8s scaling
+        # isn't configured.
+        await workflow.execute_activity(
+            "ensure_data_worker_running_activity",
+            args=(),
+            schedule_to_close_timeout=timedelta(minutes=5),
+            retry_policy=SCALING_RETRY_POLICY,
+        )
+
+        await workflow.execute_activity(
+            "stage_raw_bytes_for_dive_activity",
+            args=(dive_id,),
+            schedule_to_close_timeout=timedelta(hours=1),
+            heartbeat_timeout=timedelta(minutes=5),
+            retry_policy=STAGE_RAW_RETRY_POLICY,
+        )
+
+        results: List[LaserPredictionResult] = []
+        try:
+            results = await workflow.execute_child_workflow(
+                "PredictLaserImagesWorkflow",
+                inputs,
+                id=f"predict-laser-{dive_id}",
+                task_queue=DATA_PROCESSING_TASK_QUEUE,
+                execution_timeout=timedelta(hours=2),
+                # ALLOW_DUPLICATE so a dive can re-predict images that became
+                # eligible after a prior run; the resolver returns only
+                # still-unpredicted images and put_laser_prediction upserts.
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+                result_type=List[LaserPredictionResult],
+            )
+        except WorkflowAlreadyStartedError:
+            # A prior child with this id is still running (manual run
+            # overlapping the schedule). It's doing the work; skip persist
+            # this firing and let cleanup run.
+            workflow.logger.info(
+                "predict-laser-%d already running; skipping duplicate dispatch",
+                dive_id,
+            )
+
+        if results:
+            await workflow.execute_activity(
+                "persist_laser_predictions_activity",
+                args=(results,),
+                schedule_to_close_timeout=timedelta(minutes=15),
+                retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+            )
+
+        # Drop the staged raw `.ORF` scratch from Garage; the NAS source is
+        # never touched.
+        await workflow.execute_activity(
+            "cleanup_raw_bytes_for_dive_activity",
+            args=(dive_id,),
+            schedule_to_close_timeout=timedelta(minutes=15),
+            heartbeat_timeout=timedelta(minutes=5),
+        )
+
+        return inputs.dive_id

--- a/services/fishsense-api-workflow-worker/tests/test_persist_laser_predictions_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_persist_laser_predictions_activity.py
@@ -1,0 +1,71 @@
+# pylint: disable=protected-access
+"""Unit tests for persist_laser_predictions_activity."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from temporalio.testing import ActivityEnvironment
+
+from fishsense_shared import LaserPredictionResult
+from fishsense_api_workflow_worker.activities import (
+    persist_laser_predictions_activity as sut,
+)
+
+
+def _make_fs():
+    fs = MagicMock()
+    fs.__aenter__ = AsyncMock(return_value=fs)
+    fs.__aexit__ = AsyncMock(return_value=None)
+    fs.labels = MagicMock()
+    fs.labels.put_laser_prediction = AsyncMock(return_value=1)
+    return fs
+
+
+@pytest.mark.asyncio
+async def test_persists_each_prediction(monkeypatch):
+    fs = _make_fs()
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    results = [
+        LaserPredictionResult(image_id=11, x=1.0, y=2.0, confidence=0.9),
+        LaserPredictionResult(image_id=12, x=None, y=None, confidence=0.1),
+    ]
+    count = await ActivityEnvironment().run(
+        sut.persist_laser_predictions_activity, results
+    )
+
+    assert count == 2
+    assert fs.labels.put_laser_prediction.await_count == 2
+    first = fs.labels.put_laser_prediction.await_args_list[0]
+    assert first.args[0] == 11
+    assert (first.args[1].x, first.args[1].y, first.args[1].confidence) == (1.0, 2.0, 0.9)
+
+
+@pytest.mark.asyncio
+async def test_accepts_dict_payloads(monkeypatch):
+    """Across the Temporal boundary results may arrive as plain dicts."""
+    fs = _make_fs()
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    count = await ActivityEnvironment().run(
+        sut.persist_laser_predictions_activity,
+        [{"image_id": 11, "x": 1.0, "y": 2.0, "confidence": 0.9}],
+    )
+
+    assert count == 1
+    assert fs.labels.put_laser_prediction.await_args.args[0] == 11
+
+
+@pytest.mark.asyncio
+async def test_empty_results_writes_nothing(monkeypatch):
+    fs = _make_fs()
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    count = await ActivityEnvironment().run(
+        sut.persist_laser_predictions_activity, []
+    )
+
+    assert count == 0
+    fs.labels.put_laser_prediction.assert_not_called()

--- a/services/fishsense-api-workflow-worker/tests/test_predict_laser_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_predict_laser_images_parent_workflow.py
@@ -29,6 +29,7 @@ from fishsense_shared import (
     PredictLaserImagesInput,
 )
 from fishsense_api_workflow_worker.workflows.predict_laser_images_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    DATA_PROCESSING_TASK_QUEUE,
     PredictLaserImagesParentWorkflow,
 )
 
@@ -54,7 +55,7 @@ class _StubChild:
         ]
 
 
-def _stubs(dive_id, images, child_ids, persisted, task_queues):
+def _stubs(dive_id, images, child_ids, persisted):
     @activity.defn(name="select_next_high_priority_dive_for_laser_prediction_activity")
     async def selector() -> int | None:
         return dive_id
@@ -93,12 +94,22 @@ def _stubs(dive_id, images, child_ids, persisted, task_queues):
     return [selector, resolver, ensure, stage, cleanup, persist, record]
 
 
-async def _run(env, dive_id, images, child_ids, persisted, task_queues):
+async def _run(env, dive_id, images, child_ids, persisted):
+    activities = _stubs(dive_id, images, child_ids, persisted)
+    # Two workers: the parent (+ its activities) on the parent queue, and the
+    # stub child on the data-processing queue the parent dispatches to — the
+    # activities are registered on both so the child's _record_child_dispatch
+    # and the parent's persist both resolve.
     async with Worker(
         env.client,
         task_queue="test-predict-parent",
-        workflows=[PredictLaserImagesParentWorkflow, _StubChild],
-        activities=_stubs(dive_id, images, child_ids, persisted, task_queues),
+        workflows=[PredictLaserImagesParentWorkflow],
+        activities=activities,
+    ), Worker(
+        env.client,
+        task_queue=DATA_PROCESSING_TASK_QUEUE,
+        workflows=[_StubChild],
+        activities=activities,
     ):
         return await env.client.execute_workflow(
             PredictLaserImagesParentWorkflow.run,
@@ -112,7 +123,7 @@ async def test_selector_none_returns_none():
     child_ids: List[str] = []
     persisted: List = []
     async with await WorkflowEnvironment.start_time_skipping() as env:
-        result = await _run(env, None, [], child_ids, persisted, [])
+        result = await _run(env, None, [], child_ids, persisted)
     assert result is None
     assert not child_ids
     assert not persisted
@@ -124,7 +135,7 @@ async def test_full_path_dispatches_child_and_persists():
     persisted: List = []
     async with await WorkflowEnvironment.start_time_skipping() as env:
         result = await _run(
-            env, 440, [(1, "a"), (2, "b")], child_ids, persisted, []
+            env, 440, [(1, "a"), (2, "b")], child_ids, persisted
         )
     assert result == 440
     assert child_ids == ["predict-laser-440"]  # deterministic id
@@ -139,7 +150,7 @@ async def test_no_images_skips_child_and_persist():
     child_ids: List[str] = []
     persisted: List = []
     async with await WorkflowEnvironment.start_time_skipping() as env:
-        result = await _run(env, 440, [], child_ids, persisted, [])
+        result = await _run(env, 440, [], child_ids, persisted)
     assert result == 440
     assert not child_ids
     assert not persisted

--- a/services/fishsense-api-workflow-worker/tests/test_predict_laser_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_predict_laser_images_parent_workflow.py
@@ -1,0 +1,145 @@
+# pylint: disable=unused-argument
+"""Workflow contract test for PredictLaserImagesParentWorkflow.
+
+Pins down:
+  1. Selector None -> parent returns None, no resolver/child.
+  2. Full path: dispatches the child on the data-worker queue with the
+     deterministic id `predict-laser-{dive_id}`, then persists the child's
+     results and returns the dive_id.
+  3. Resolver returning 0 images skips the child + persist.
+
+The child stub returns predictions; the persist stub records what the parent
+handed it (via an activity, so it survives the workflow sandbox boundary).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from typing import List
+
+import pytest
+from temporalio import activity, workflow
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from fishsense_shared import (
+    LaserPredictionResult,
+    PredictLaserImage,
+    PredictLaserImagesInput,
+)
+from fishsense_api_workflow_worker.workflows.predict_laser_images_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PredictLaserImagesParentWorkflow,
+)
+
+_K = [[1000.0, 0.0, 960.0], [0.0, 1000.0, 540.0], [0.0, 0.0, 1.0]]
+_D = [-0.1, 0.05, 0.0, 0.0, 0.0]
+
+
+@workflow.defn(name="PredictLaserImagesWorkflow")
+class _StubChild:
+    # pylint: disable=too-few-public-methods
+    @workflow.run
+    async def run(self, payload: PredictLaserImagesInput) -> List[LaserPredictionResult]:
+        await workflow.execute_activity(
+            "_record_child_dispatch",
+            args=(workflow.info().workflow_id, payload.dive_id),
+            schedule_to_close_timeout=timedelta(seconds=5),
+        )
+        return [
+            LaserPredictionResult(
+                image_id=img.image_id, x=1.0, y=2.0, confidence=0.9
+            )
+            for img in payload.images
+        ]
+
+
+def _stubs(dive_id, images, child_ids, persisted, task_queues):
+    @activity.defn(name="select_next_high_priority_dive_for_laser_prediction_activity")
+    async def selector() -> int | None:
+        return dive_id
+
+    @activity.defn(name="resolve_laser_predict_inputs_activity")
+    async def resolver(d: int) -> PredictLaserImagesInput:
+        return PredictLaserImagesInput(
+            dive_id=d,
+            images=[PredictLaserImage(image_id=i, checksum=c) for i, c in images],
+            camera_matrix=_K,
+            distortion_coefficients=_D,
+            wavelength=None,
+        )
+
+    @activity.defn(name="ensure_data_worker_running_activity")
+    async def ensure() -> None:
+        return None
+
+    @activity.defn(name="stage_raw_bytes_for_dive_activity")
+    async def stage(d: int) -> None:
+        return None
+
+    @activity.defn(name="cleanup_raw_bytes_for_dive_activity")
+    async def cleanup(d: int) -> None:
+        return None
+
+    @activity.defn(name="persist_laser_predictions_activity")
+    async def persist(results: list) -> int:
+        persisted.extend(results)
+        return len(results)
+
+    @activity.defn(name="_record_child_dispatch")
+    async def record(workflow_id: str, d: int) -> None:
+        child_ids.append(workflow_id)
+
+    return [selector, resolver, ensure, stage, cleanup, persist, record]
+
+
+async def _run(env, dive_id, images, child_ids, persisted, task_queues):
+    async with Worker(
+        env.client,
+        task_queue="test-predict-parent",
+        workflows=[PredictLaserImagesParentWorkflow, _StubChild],
+        activities=_stubs(dive_id, images, child_ids, persisted, task_queues),
+    ):
+        return await env.client.execute_workflow(
+            PredictLaserImagesParentWorkflow.run,
+            id=f"predict-parent-{uuid.uuid4()}",
+            task_queue="test-predict-parent",
+        )
+
+
+@pytest.mark.asyncio
+async def test_selector_none_returns_none():
+    child_ids: List[str] = []
+    persisted: List = []
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        result = await _run(env, None, [], child_ids, persisted, [])
+    assert result is None
+    assert not child_ids
+    assert not persisted
+
+
+@pytest.mark.asyncio
+async def test_full_path_dispatches_child_and_persists():
+    child_ids: List[str] = []
+    persisted: List = []
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        result = await _run(
+            env, 440, [(1, "a"), (2, "b")], child_ids, persisted, []
+        )
+    assert result == 440
+    assert child_ids == ["predict-laser-440"]  # deterministic id
+    assert {p["image_id"] if isinstance(p, dict) else p.image_id for p in persisted} == {
+        1,
+        2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_no_images_skips_child_and_persist():
+    child_ids: List[str] = []
+    persisted: List = []
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        result = await _run(env, 440, [], child_ids, persisted, [])
+    assert result == 440
+    assert not child_ids
+    assert not persisted

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_laser_predict_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_laser_predict_inputs_activity.py
@@ -1,0 +1,83 @@
+# pylint: disable=protected-access
+"""Unit tests for resolve_laser_predict_inputs_activity."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
+from temporalio.testing import ActivityEnvironment
+
+from fishsense_api_workflow_worker.activities import (
+    resolve_laser_predict_inputs_activity as sut,
+)
+
+
+def _image(image_id, checksum):
+    return SimpleNamespace(id=image_id, checksum=checksum)
+
+
+def _make_fs(*, camera_id=1, images=None, predictions=None, labels=None, intrinsics=True):
+    fs = MagicMock()
+    fs.__aenter__ = AsyncMock(return_value=fs)
+    fs.__aexit__ = AsyncMock(return_value=None)
+    fs.dives = MagicMock()
+    fs.dives.get = AsyncMock(return_value=SimpleNamespace(id=1, camera_id=camera_id))
+    fs.cameras = MagicMock()
+    intr = SimpleNamespace(
+        camera_matrix=np.eye(3), distortion_coefficients=np.zeros(5)
+    ) if intrinsics else None
+    fs.cameras.get_intrinsics = AsyncMock(return_value=intr)
+    fs.images = MagicMock()
+    fs.images.get = AsyncMock(return_value=images or [])
+    fs.labels = MagicMock()
+    fs.labels.get_laser_predictions = AsyncMock(return_value=predictions or [])
+    fs.labels.get_laser_labels = AsyncMock(return_value=labels or [])
+    return fs
+
+
+def test_select_filters_predicted_and_labeled():
+    images = [_image(1, "a"), _image(2, "b"), _image(3, "c")]
+    predictions = [SimpleNamespace(image_id=1)]
+    labels = [SimpleNamespace(image_id=2, label_studio_project_id=73)]
+    needing = sut._select_images_needing_prediction(images, predictions, labels)
+    assert [i.id for i in needing] == [3]
+
+
+def test_sentinel_label_does_not_exclude():
+    images = [_image(1, "a")]
+    labels = [SimpleNamespace(image_id=1, label_studio_project_id=None)]
+    needing = sut._select_images_needing_prediction(images, [], labels)
+    assert [i.id for i in needing] == [1]
+
+
+@pytest.mark.asyncio
+async def test_activity_builds_input_dto(monkeypatch):
+    fs = _make_fs(
+        images=[_image(1, "a"), _image(2, "b")],
+        predictions=[SimpleNamespace(image_id=1)],
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.resolve_laser_predict_inputs_activity, 1
+    )
+
+    assert result.dive_id == 1
+    assert [img.image_id for img in result.images] == [2]
+    assert [img.checksum for img in result.images] == ["b"]
+    assert len(result.camera_matrix) == 3
+    assert result.wavelength is None
+
+
+@pytest.mark.asyncio
+async def test_activity_raises_without_intrinsics(monkeypatch):
+    fs = _make_fs(images=[_image(1, "a")], intrinsics=False)
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    with pytest.raises(ValueError, match="intrinsics"):
+        await ActivityEnvironment().run(
+            sut.resolve_laser_predict_inputs_activity, 1
+        )

--- a/services/fishsense-api-workflow-worker/tests/test_schedule_registration.py
+++ b/services/fishsense-api-workflow-worker/tests/test_schedule_registration.py
@@ -27,6 +27,7 @@ from fishsense_api_workflow_worker import worker as sut
 # excluded deliberately (they select no dives and share offset 0).
 _DIVE_SELECTING_PARENT_SCHEDULE_IDS = (
     "preprocess-laser-images-workflow-schedule",
+    "predict-laser-images-workflow-schedule",
     "cluster-dive-frames-workflow-schedule",
     "preprocess-species-images-workflow-schedule",
     "populate-species-labels-workflow-schedule",
@@ -65,6 +66,12 @@ async def test_measure_fish_is_scheduled_hourly_at_40(registered):
 
     assert _every(schedule) == timedelta(hours=1)
     assert _offset(schedule) == timedelta(minutes=40)
+
+
+async def test_laser_predict_is_scheduled_hourly_at_10(registered):
+    schedule = registered["predict-laser-images-workflow-schedule"]
+    assert _interval(schedule) == timedelta(hours=1)
+    assert _offset(schedule) == timedelta(minutes=10)
 
 
 async def test_species_populate_is_scheduled_hourly_at_20(registered):

--- a/services/fishsense-api-workflow-worker/tests/test_schedule_registration.py
+++ b/services/fishsense-api-workflow-worker/tests/test_schedule_registration.py
@@ -70,7 +70,7 @@ async def test_measure_fish_is_scheduled_hourly_at_40(registered):
 
 async def test_laser_predict_is_scheduled_hourly_at_10(registered):
     schedule = registered["predict-laser-images-workflow-schedule"]
-    assert _interval(schedule) == timedelta(hours=1)
+    assert _every(schedule) == timedelta(hours=1)
     assert _offset(schedule) == timedelta(minutes=10)
 
 

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -23,6 +23,7 @@ from fishsense_api.models.head_tail_label import HeadTailLabel
 from fishsense_api.models.image import Image
 from fishsense_api.models.laser_extrinsics import LaserExtrinsics
 from fishsense_api.models.laser_label import LaserLabel
+from fishsense_api.models.laser_prediction import LaserPrediction
 from fishsense_api.models.measurement import Measurement
 from fishsense_api.models.priority import Priority
 from fishsense_api.models.species_label import SpeciesLabel
@@ -179,6 +180,45 @@ async def select_next_for_laser_preprocessing(
         select(Dive.id)
         .where(Dive.priority == Priority.HIGH)
         .where(has_image_without_real_laser_label)
+        .order_by(Dive.id)
+        .limit(1)
+    )
+    return (await session.exec(query)).first()
+
+
+@app.get("/api/v1/dives/select-next/laser-prediction/")
+async def select_next_for_laser_prediction(
+    session: AsyncSession = Depends(get_async_session),
+) -> int | None:
+    """Model-assisted laser labeling: HIGH-priority + at least one image
+    with no `LaserPrediction` row and no non-sentinel `LaserLabel` row.
+
+    An image needs a prediction only if it has neither been predicted nor
+    labeled yet — so a dive drops out of the cohort once every image is
+    predicted (one-shot per image; re-prediction is a manual affair), and
+    images a human already labeled are never predicted over. Mirrors the
+    stage-0.1 "non-sentinel label" convention (`project_id IS NOT NULL`).
+    """
+    has_image_needing_prediction = (
+        select(Image.id)
+        .where(Image.dive_id == Dive.id)
+        .where(
+            ~select(LaserPrediction.id)
+            .where(LaserPrediction.image_id == Image.id)
+            .exists()
+        )
+        .where(
+            ~select(LaserLabel.id)
+            .where(LaserLabel.image_id == Image.id)
+            .where(LaserLabel.label_studio_project_id != None)
+            .exists()
+        )
+        .exists()
+    )
+    query = (
+        select(Dive.id)
+        .where(Dive.priority == Priority.HIGH)
+        .where(has_image_needing_prediction)
         .order_by(Dive.id)
         .limit(1)
     )

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -1883,3 +1883,68 @@ async def test_species_preprocessing_picks_dive_with_a_clustered_qualifying_imag
     await session.flush()
 
     assert await select_next_for_species_preprocessing(session=session) == 1
+
+
+# ---------- laser-prediction (model-assisted labeling) ----------
+#
+# Cohort: HIGH + at least one image with no LaserPrediction AND no
+# non-sentinel LaserLabel. One-shot per image — a prediction (or a real
+# label) drops the image out.
+
+
+def _laser_label(image_id: int, *, project_id=73):
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    return LaserLabel(image_id=image_id, label_studio_project_id=project_id)
+
+
+def _laser_prediction(image_id: int):
+    from fishsense_api.models.laser_prediction import LaserPrediction  # pylint: disable=import-outside-toplevel
+
+    return LaserPrediction(image_id=image_id, x=1.0, y=2.0, confidence=0.9)
+
+
+async def test_laser_prediction_selects_dive_with_unpredicted_unlabeled_image(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_prediction,
+    )
+
+    # dive 1: image already predicted -> excluded.
+    # dive 2: image already labeled (real project) -> excluded.
+    # dive 3: image with neither -> selected.
+    session.add_all([_dive(1), _dive(2), _dive(3)])
+    session.add_all([_image(11, 1), _image(21, 2), _image(31, 3)])
+    await session.flush()
+    session.add(_laser_prediction(11))
+    session.add(_laser_label(21))
+    await session.flush()
+
+    assert await select_next_for_laser_prediction(session=session) == 3
+
+
+async def test_laser_prediction_none_when_all_predicted_or_labeled(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_prediction,
+    )
+
+    session.add_all([_dive(1), _image(11, 1), _image(12, 1)])
+    await session.flush()
+    session.add_all([_laser_prediction(11), _laser_label(12)])
+    await session.flush()
+
+    assert await select_next_for_laser_prediction(session=session) is None
+
+
+async def test_laser_prediction_sentinel_label_does_not_exclude(session):
+    """A NULL-project sentinel LaserLabel doesn't count as labeled — the
+    image still needs a prediction."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_prediction,
+    )
+
+    session.add_all([_dive(1), _image(11, 1)])
+    await session.flush()
+    session.add(_laser_label(11, project_id=None))  # sentinel
+    await session.flush()
+
+    assert await select_next_for_laser_prediction(session=session) == 1

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/predict_laser_images_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/predict_laser_images_workflow.py
@@ -18,9 +18,15 @@ import asyncio
 from datetime import timedelta
 from typing import List
 
-from fishsense_shared import PredictLaserImagesInput
+from fishsense_shared import LaserPredictionResult, PredictLaserImagesInput
 from pydantic import BaseModel
 from temporalio import workflow
+
+__all__ = [
+    "LaserPredictionResult",
+    "PredictLaserImageInput",
+    "PredictLaserImagesWorkflow",
+]
 
 
 class PredictLaserImageInput(BaseModel):
@@ -33,17 +39,6 @@ class PredictLaserImageInput(BaseModel):
     # Laser wavelength ("red" / "green"), or None when unknown — the model
     # takes an "unknown" wavelength channel in that case.
     wavelength: str | None = None
-
-
-class LaserPredictionResult(BaseModel):
-    """One image's predicted laser dot, in rectified-image pixels (the same
-    space labelers place `LaserLabel.x/y`). `x`/`y` are None when the model
-    detected no laser; `confidence` is always reported."""
-
-    image_id: int
-    x: float | None
-    y: float | None
-    confidence: float
 
 
 @workflow.defn


### PR DESCRIPTION
Phase 4 of model-assisted laser labeling — wires the GPU predict stage (phases 1–3, all merged) into an hourly api-worker parent that drains one dive per firing, exactly like the preprocess parents.

## What
- **API**: `GET /api/v1/dives/select-next/laser-prediction/` + SDK `select_next_for_laser_prediction`. Cohort: **HIGH + ≥1 image with no `LaserPrediction` and no non-sentinel `LaserLabel`** (one-shot per image; a prediction or a real label drops it out).
- **api-worker activities**: selector; `resolve_laser_predict_inputs` (builds `PredictLaserImagesInput`, filtering already-predicted/labeled images + camera intrinsics); `persist_laser_predictions` (upserts the child's results via `put_laser_prediction`).
- **`PredictLaserImagesParentWorkflow`**: selector → resolver → scale the **GPU** data-worker up → stage raw `.ORF` → dispatch `PredictLaserImagesWorkflow` child (deterministic id `predict-laser-{dive_id}`, `ALLOW_DUPLICATE`) → persist results → cleanup raw scratch. Registered + **scheduled hourly at +10 min** (free slot between cluster +5 and species +15), SKIP overlap.
- `LaserPredictionResult` moved to `fishsense_shared` (cross-worker contract); the data-worker workflow re-exports it (no behavior change to phase 1).

## Tests (TDD)
- API selector cohort: predicted / labeled / sentinel-label cases.
- Resolver: filter (predicted+labeled excluded, sentinel kept) + DTO shape + missing-intrinsics.
- Persist: model payloads, dict payloads (Temporal boundary), empty.
- Parent contract: selector-None short-circuit / full-path dispatches child + persists results / no-images skips.
- Schedule: +10 slot + stagger guard.
- **api 212 · sdk 117 · pylint 10.**

⚠️ The two Temporal `WorkflowEnvironment` tests (parent + schedule) collect cleanly locally but need the test-server binary, which won't download in my sandbox — **they run in CI** (same as every other parent-workflow test in this repo).

## Deploy note
Once merged + deployed, the hourly `predict-laser-images-workflow-schedule` starts scaling the GPU data-worker up at :10 and computing predictions for HIGH-priority laser-unlabeled dives. **Not user-visible until phase 5** wires the laser populate to serve predictions as LS pre-annotations — until then predictions just accumulate in the `laserprediction` table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)