### PR TITLE
feat(laser-populate): assisted-review LS pre-annotations, decoupled populate (phase 5)

### DIFF
--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
@@ -117,6 +117,15 @@ class DiveClient(ClientBase):
         """Stage 14 cohort selector. See `select_next_for_laser_preprocessing`."""
         return await self._select_next("measure-fish")
 
+    async def get_dives_needing_laser_population(self) -> list[int]:
+        """Every dive needing model-assisted laser LS tasks (re)populated —
+        prediction-gated. Returns all matches so the scheduled populate parent
+        fans out one populate child per dive. See the
+        `needing-laser-population` endpoint docstring."""
+        response = await self._get("/api/v1/dives/needing-laser-population/")
+        response.raise_for_status()
+        return response.json() or []
+
     async def get_dives_needing_species_population(self) -> list[int]:
         """Every dive needing species LS tasks (re)populated onto a live
         project — superseded-aware, returns *all* matches (not one), so

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
@@ -185,6 +185,8 @@ class LaserPrediction(BaseModel):
     x: float | None = Field(None, title='X')
     y: float | None = Field(None, title='Y')
     confidence: float | None = Field(0.0, title='Confidence')
+    width: int | None = Field(None, title='Width')
+    height: int | None = Field(None, title='Height')
     created_at: AwareDatetime | None = Field(None, title='Created At')
     image_id: int | None = Field(None, title='Image Id')
 

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/laser_prediction.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/laser_prediction.py
@@ -18,5 +18,9 @@ class LaserPrediction(ModelBase):
     x: float | None = None
     y: float | None = None
     confidence: float
+    # Rectified frame dimensions the x/y are relative to (for the pixel ->
+    # Label Studio keypoint-percentage conversion in laser populate).
+    width: int | None = None
+    height: int | None = None
     created_at: datetime | None = None
     image_id: int | None = None

--- a/libs/fishsense-api-sdk/tests/clients/test_dive_client.py
+++ b/libs/fishsense-api-sdk/tests/clients/test_dive_client.py
@@ -319,6 +319,23 @@ class TestDiveClient:
                     "/api/v1/dives/select-next/laser-prediction/"
                 )
 
+    async def test_get_dives_needing_laser_population_returns_list(self):
+        client = _make_client()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [5, 9]
+        mock_response.raise_for_status = Mock()
+
+        with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            async with client:
+                result = await client.get_dives_needing_laser_population()
+                assert result == [5, 9]
+                mock_get.assert_awaited_once_with(
+                    "/api/v1/dives/needing-laser-population/"
+                )
+
     async def test_get_dives_needing_species_population_returns_list(self):
         """Returns the full list of dive ids from the population endpoint."""
         client = _make_client()

--- a/libs/fishsense-shared/src/fishsense_shared/preprocess_contracts.py
+++ b/libs/fishsense-shared/src/fishsense_shared/preprocess_contracts.py
@@ -128,14 +128,18 @@ class LaserPredictionResult(BaseModel):
 
     In rectified-image pixels (the space labelers place `LaserLabel.x/y`).
     `x`/`y` are None when the detector found no laser; `confidence` is always
-    reported. Cross-worker, so it lives here rather than in the data-worker
-    workflow module.
+    reported. `width`/`height` are the rectified frame dimensions the x/y are
+    relative to — the laser populate step needs them to convert pixels to the
+    percentages Label Studio keypoints use. Cross-worker, so it lives here
+    rather than in the data-worker workflow module.
     """
 
     image_id: int
     x: float | None
     y: float | None
     confidence: float
+    width: int | None = None
+    height: int | None = None
 
 
 class PreprocessSlateImagesInput(BaseModel):

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/persist_laser_predictions_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/persist_laser_predictions_activity.py
@@ -36,6 +36,8 @@ async def persist_laser_predictions_activity(results: List[Any]) -> int:
                     x=result.x,
                     y=result.y,
                     confidence=result.confidence,
+                    width=result.width,
+                    height=result.height,
                 ),
             )
     return len(parsed)

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_laser_label_studio_project_activity.py
@@ -22,27 +22,87 @@ from fishsense_api_workflow_worker.activities.utils import get_fs_client
 
 PREPROCESS_FOLDER = "preprocess_jpeg"
 
+# Laser LS labeling config (see create_laser_label_studio_project_activity):
+# <KeyPointLabels name="laser" toName="img"> with Red/Green Laser labels.
+_KEYPOINT_FROM_NAME = "laser"
+_KEYPOINT_TO_NAME = "img"
+# The model doesn't know the laser color (wavelength unknown), so pre-fill the
+# more common one; the labeler flips it to Green when needed. A keypointlabels
+# result must name a label to be valid.
+_DEFAULT_LASER_LABEL = "Red Laser"
+
+
+def _prediction_annotations(prediction) -> list:
+    """Build the LS `predictions` list (one keypoint pre-annotation) from a
+    model `LaserPrediction`, or [] when there's nothing placeable.
+
+    Label Studio keypoints are in percentages, so convert the prediction's
+    rectified pixels using its own recorded frame dims. Skips a prediction
+    with no detection (x/y None) or missing dims.
+    """
+    if prediction is None:
+        return []
+    x, y, width, height = (
+        prediction.x,
+        prediction.y,
+        prediction.width,
+        prediction.height,
+    )
+    if x is None or y is None or not width or not height:
+        return []
+    return [
+        {
+            "model_version": "laser-detector",
+            "result": [
+                {
+                    "from_name": _KEYPOINT_FROM_NAME,
+                    "to_name": _KEYPOINT_TO_NAME,
+                    "type": "keypointlabels",
+                    "original_width": width,
+                    "original_height": height,
+                    "image_rotation": 0,
+                    "value": {
+                        "x": x / width * 100,
+                        "y": y / height * 100,
+                        "width": 0.5,
+                        "keypointlabels": [_DEFAULT_LASER_LABEL],
+                    },
+                }
+            ],
+        }
+    ]
+
 
 def _select_unlabeled_images(
-    images: List[Image], existing_labels: List[LaserLabel]
+    images: List[Image],
+    existing_labels: List[LaserLabel],
+    predicted_image_ids: set,
 ) -> List[Image]:
-    """Return only images that need a fresh LS task — no completed
-    LaserLabel exists for them in any project.
+    """Return images that need a fresh laser LS task: no completed
+    LaserLabel in any project, AND a model prediction already exists.
 
-    Multi-row-aware: an image carrying both a completed row in
-    project 43 and an incomplete sentinel row in project NULL is
-    treated as labeled. The previous shape collapsed labels into a
-    `{image_id: label}` dict and let SDK iteration order pick which
-    row won, which silently leaked already-labeled images into the
-    task-import set when the incomplete row happened to land last.
+    **Prediction-gated** (like species populate is JPEG-gated): seeding a
+    LaserLabel for an un-predicted image would exclude it from the predict
+    cohort (which requires "no LaserLabel") before the detector ever ran,
+    permanently starving it of a prediction. So an image is only populated
+    once its `LaserPrediction` is in place — un-predicted images defer to a
+    later run.
+
+    Multi-row-aware: an image carrying a completed row in one project and an
+    incomplete sentinel elsewhere is treated as labeled.
     """
     completed_image_ids = {
         label.image_id for label in existing_labels if label.completed
     }
-    return [image for image in images if image.id not in completed_image_ids]
+    return [
+        image
+        for image in images
+        if image.id not in completed_image_ids
+        and image.id in predicted_image_ids
+    ]
 
 
-def _build_task(image: Image) -> dict:
+def _build_task(image: Image, prediction=None) -> dict:
     """Build an LS task referencing the preprocessed JPEG.
 
     Emits BOTH `image` and `img` keys in `data` because legacy prod
@@ -58,6 +118,10 @@ def _build_task(image: Image) -> dict:
     return {
         "data": {"image": url, "img": url},
         "annotations": [],
+        # Model-assisted labeling: seed the laser-detector's predicted dot as
+        # a pre-annotation the labeler confirms/nudges. Empty when there's no
+        # prediction for this image yet.
+        "predictions": _prediction_annotations(prediction),
     }
 
 
@@ -72,8 +136,12 @@ async def populate_laser_label_studio_project_activity(
     async with get_fs_client() as fs:
         images = await fs.images.get(dive_id=dive_id) or []
         existing_labels = await fs.labels.get_laser_labels(dive_id) or []
+        predictions = await fs.labels.get_laser_predictions(dive_id) or []
+        predictions_by_image = {p.image_id: p for p in predictions}
 
-        unlabeled = _select_unlabeled_images(images, existing_labels)
+        unlabeled = _select_unlabeled_images(
+            images, existing_labels, set(predictions_by_image)
+        )
         if not unlabeled:
             activity.logger.info(
                 "Dive %d has a completed laser label for every image; "
@@ -91,7 +159,10 @@ async def populate_laser_label_studio_project_activity(
                 await publish_label_studio_project(project_id)
             return 0
 
-        tasks = [_build_task(image) for image in unlabeled]
+        tasks = [
+            _build_task(image, predictions_by_image.get(image.id))
+            for image in unlabeled
+        ]
 
         async def _record(image: Image, task_id: int) -> None:
             label = LaserLabel(

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_dives_needing_laser_population_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_dives_needing_laser_population_activity.py
@@ -1,0 +1,26 @@
+"""Activity: list every dive that needs model-assisted laser LS population.
+
+Prediction-gated cohort (see the api's `needing-laser-population` endpoint):
+HIGH-priority dives with an image that has a `LaserPrediction` and no
+completed `LaserLabel`. Returns *all* matches so the scheduled populate
+parent fans out one populate child per dive.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.utils import get_fs_client
+
+
+@activity.defn
+async def select_dives_needing_laser_population_activity() -> List[int]:
+    async with get_fs_client() as fs:
+        dive_ids = await fs.dives.get_dives_needing_laser_population()
+
+    activity.logger.info(
+        "%d dive(s) need laser population: %s", len(dive_ids), dive_ids
+    )
+    return dive_ids

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -105,6 +105,9 @@ from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for
 from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for_species_preprocessing_activity import (  # pylint: disable=line-too-long
     select_next_high_priority_dive_for_species_preprocessing_activity,
 )
+from fishsense_api_workflow_worker.activities.select_dives_needing_laser_population_activity import (  # noqa: E501  pylint: disable=line-too-long
+    select_dives_needing_laser_population_activity,
+)
 from fishsense_api_workflow_worker.activities.select_dives_needing_species_population_activity import (  # pylint: disable=line-too-long
     select_dives_needing_species_population_activity,
 )
@@ -174,6 +177,9 @@ from fishsense_api_workflow_worker.workflows.populate_headtail_label_studio_proj
 )
 from fishsense_api_workflow_worker.workflows.populate_laser_label_studio_project_workflow import (  # pylint: disable=line-too-long
     PopulateLaserLabelStudioProjectWorkflow,
+)
+from fishsense_api_workflow_worker.workflows.populate_laser_label_studio_project_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PopulateLaserLabelStudioProjectParentWorkflow,
 )
 from fishsense_api_workflow_worker.workflows.populate_species_label_studio_project_workflow import (  # pylint: disable=line-too-long
     PopulateSpeciesLabelStudioProjectWorkflow,
@@ -368,6 +374,24 @@ async def schedule_workflows(client: Client):
                     overlap=ScheduleOverlapPolicy.SKIP,
                 )
             )
+            # Laser populate parent: hourly at +12 min, just after the +10
+            # laser-detector predict parent has written LaserPrediction rows.
+            # Decoupled from the stage-0.1 preprocess parent (which no longer
+            # chains into populate) because populate seeds LaserLabel rows and
+            # the predict cohort excludes any labeled image — populating before
+            # predict would starve the detector. Prediction-gated + idempotent,
+            # so SKIP-overlap hourly firings converge.
+            tg.create_task(
+                schedule_workflow(
+                    client,
+                    "populate-laser-labels-workflow-schedule",
+                    PopulateLaserLabelStudioProjectParentWorkflow,
+                    timedelta(hours=1),
+                    offset=timedelta(minutes=12),
+                    run_timeout=timedelta(hours=1),
+                    overlap=ScheduleOverlapPolicy.SKIP,
+                )
+            )
             tg.create_task(
                 schedule_workflow(
                     client,
@@ -534,6 +558,7 @@ async def main():
                 CreateHeadTailLabelStudioProjectWorkflow,
                 CreateDiveSlateLabelStudioProjectWorkflow,
                 PopulateLaserLabelStudioProjectWorkflow,
+                PopulateLaserLabelStudioProjectParentWorkflow,
                 PopulateSpeciesLabelStudioProjectWorkflow,
                 PopulateSpeciesLabelStudioProjectParentWorkflow,
                 PopulateHeadTailLabelStudioProjectWorkflow,
@@ -584,6 +609,7 @@ async def main():
                 select_next_high_priority_dive_for_laser_preprocessing_activity,
                 select_next_high_priority_dive_for_laser_prediction_activity,
                 select_next_high_priority_dive_for_species_preprocessing_activity,
+                select_dives_needing_laser_population_activity,
                 select_dives_needing_species_population_activity,
                 select_next_high_priority_dive_for_headtail_preprocessing_activity,
                 select_next_high_priority_dive_for_slate_preprocessing_activity,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/populate_laser_label_studio_project_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/populate_laser_label_studio_project_parent_workflow.py
@@ -1,0 +1,81 @@
+"""Scheduled parent: (re)populate laser LS tasks for every dive needing it.
+
+Decoupled from the stage-0.1 preprocess parent (2026-07-28, model-assisted
+labeling). Selects the prediction-gated "needs laser population" cohort (see
+the api's `needing-laser-population` endpoint) and fans out one
+`PopulateLaserLabelStudioProjectWorkflow` child per dive.
+
+Runs at +12 min, after the laser-detector predict parent (+10) has written
+`LaserPrediction` rows — the populate activity only seeds a task (and its
+non-sentinel `LaserLabel` row) for an image that already has a prediction, so
+it never starves the predict cohort. Idempotent + prediction-gated, so
+SKIP-overlap hourly firings converge and one dive's failure doesn't abort the
+fan-out.
+"""
+
+import asyncio
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.common import WorkflowIDReusePolicy
+from temporalio.exceptions import WorkflowAlreadyStartedError
+
+from fishsense_shared import ExceptionGroupErrorLogging
+
+with workflow.unsafe.imports_passed_through():
+    from fishsense_api_workflow_worker.workflows._retry_policies import (
+        SDK_FAIL_FAST_RETRY_POLICY,
+    )
+
+# Bound on concurrent per-dive populate children — a handful of LS API calls
+# each; keep modest so a backlog doesn't hammer hosted Label Studio.
+POPULATE_CONCURRENCY = 4
+
+
+@workflow.defn
+class PopulateLaserLabelStudioProjectParentWorkflow:
+    # pylint: disable=too-few-public-methods
+    """Fan out laser populate across every dive needing it. Returns the list
+    of dive_ids dispatched (empty when the cohort is empty)."""
+
+    @workflow.run
+    async def run(self) -> list[int]:
+        dive_ids = await workflow.execute_activity(
+            "select_dives_needing_laser_population_activity",
+            args=(),
+            schedule_to_close_timeout=timedelta(minutes=5),
+            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+        )
+        if not dive_ids:
+            return []
+
+        sem = asyncio.Semaphore(POPULATE_CONCURRENCY)
+
+        async def __populate(dive_id: int) -> None:
+            async with sem:
+                try:
+                    await workflow.execute_child_workflow(
+                        "PopulateLaserLabelStudioProjectWorkflow",
+                        dive_id,
+                        id=f"populate-laser-{dive_id}",
+                        execution_timeout=timedelta(minutes=30),
+                        # ALLOW_DUPLICATE (not FAILED_ONLY): a scheduled re-run
+                        # can populate newly-predicted images after the prior
+                        # run closed; the child is idempotent (LS import dedupes,
+                        # SDK upserts), so a no-op re-run is cheap.
+                        id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+                    )
+                except WorkflowAlreadyStartedError:
+                    workflow.logger.info(
+                        "populate-laser-%d already running; skipping duplicate "
+                        "dispatch",
+                        dive_id,
+                    )
+
+        # suppress=True: one dive's failure must not abort the fan-out.
+        async with ExceptionGroupErrorLogging(workflow.logger, suppress=True):
+            async with asyncio.TaskGroup() as tg:
+                for dive_id in dive_ids:
+                    tg.create_task(__populate(dive_id))
+
+        return dive_ids

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_laser_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_laser_images_parent_workflow.py
@@ -162,19 +162,12 @@ class PreprocessLaserImagesParentWorkflow:
             heartbeat_timeout=timedelta(minutes=5),
         )
 
-        try:
-            await workflow.execute_child_workflow(
-                "PopulateLaserLabelStudioProjectWorkflow",
-                dive_id,
-                id=f"populate-laser-{dive_id}",
-                execution_timeout=timedelta(minutes=30),
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
-            )
-        except WorkflowAlreadyStartedError:
-            workflow.logger.info(
-                "populate-laser-%d already ran in a prior hourly firing; "
-                "skipping LS task import",
-                dive_id,
-            )
-
+        # Laser populate is DECOUPLED from preprocess (2026-07-28, model-
+        # assisted labeling). It now runs as its own scheduled parent
+        # (PopulateLaserLabelStudioProjectParentWorkflow, +12 min) AFTER the
+        # laser-detector predict stage (+10), because populate seeds
+        # non-sentinel LaserLabel rows and the predict cohort excludes any
+        # image that already has a LaserLabel — populating here (at +0) would
+        # starve the predictor before it ever ran. See that parent + the
+        # `needing-laser-population` cohort.
         return inputs.dive_id

--- a/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
@@ -22,10 +22,23 @@ from temporalio.testing import ActivityEnvironment
 
 from fishsense_api_sdk.models.image import Image
 from fishsense_api_sdk.models.laser_label import LaserLabel
+from fishsense_api_sdk.models.laser_prediction import LaserPrediction
 from fishsense_api_workflow_worker.activities import (
     populate_laser_label_studio_project_activity as sut,
     populate_utils as sut_utils,
 )
+
+
+def _prediction(image_id: int, *, x=100.0, y=200.0, width=4000, height=3000):
+    return LaserPrediction(
+        id=image_id,
+        image_id=image_id,
+        x=x,
+        y=y,
+        confidence=0.9,
+        width=width,
+        height=height,
+    )
 
 
 def _image(image_id: int, checksum: str) -> Image:
@@ -63,7 +76,7 @@ def test_select_unlabeled_excludes_images_with_any_completed_label():
     images = [_image(1, "a"), _image(2, "b"), _image(3, "c")]
     existing = [_label(1, completed=True), _label(2, completed=False)]
 
-    result = sut._select_unlabeled_images(images, existing)  # pylint: disable=protected-access
+    result = sut._select_unlabeled_images(images, existing, {i.id for i in images})  # pylint: disable=protected-access
 
     # Image 1 has a completed label -> excluded.
     # Image 2's only label is incomplete -> included.
@@ -91,7 +104,7 @@ def test_select_unlabeled_treats_null_project_sentinel_as_unlabeled():
         _label(2, completed=True, project_id=43),
     ]
 
-    result = sut._select_unlabeled_images(images, existing)  # pylint: disable=protected-access
+    result = sut._select_unlabeled_images(images, existing, {i.id for i in images})  # pylint: disable=protected-access
 
     # Image 1 still needs a task; image 2 doesn't.
     assert [img.id for img in result] == [1]
@@ -112,7 +125,7 @@ def test_select_unlabeled_handles_multi_row_state():
         _label(2, completed=False, project_id=43),
     ]
 
-    result = sut._select_unlabeled_images(images, existing)  # pylint: disable=protected-access
+    result = sut._select_unlabeled_images(images, existing, {i.id for i in images})  # pylint: disable=protected-access
 
     assert [img.id for img in result] == [2]
 
@@ -139,10 +152,46 @@ def test_build_task_uses_configured_url_base_and_dual_keys(monkeypatch):
     assert task == {
         "data": {"image": expected_url, "img": expected_url},
         "annotations": [],
+        "predictions": [],
     }
 
 
-def _make_fs_client(images: List[Image], existing_labels: List[LaserLabel]):
+def test_select_unlabeled_gates_on_prediction_present():
+    """An image with no LaserPrediction is deferred — populating it would
+    stamp a LaserLabel and starve the predict cohort before the detector ran."""
+    images = [_image(1, "a"), _image(2, "b")]
+    # Only image 1 has been predicted.
+    result = sut._select_unlabeled_images(images, [], {1})  # pylint: disable=protected-access
+    assert [img.id for img in result] == [1]
+
+
+def test_prediction_annotations_converts_pixels_to_percent():
+    pred = _prediction(1, x=2000.0, y=1500.0, width=4000, height=3000)
+    result = sut._prediction_annotations(pred)  # pylint: disable=protected-access
+    assert len(result) == 1
+    kp = result[0]["result"][0]
+    assert kp["from_name"] == "laser" and kp["to_name"] == "img"
+    assert kp["type"] == "keypointlabels"
+    assert kp["original_width"] == 4000 and kp["original_height"] == 3000
+    assert kp["value"]["x"] == 50.0  # 2000/4000*100
+    assert kp["value"]["y"] == 50.0  # 1500/3000*100
+    assert kp["value"]["keypointlabels"] == ["Red Laser"]
+
+
+def test_prediction_annotations_empty_for_none_or_missing_dims():
+    # pylint: disable=protected-access
+    assert not sut._prediction_annotations(None)
+    assert not sut._prediction_annotations(_prediction(1, x=None, y=None))
+    assert not sut._prediction_annotations(
+        LaserPrediction(image_id=1, x=1.0, y=2.0, confidence=0.9, width=None, height=None)
+    )
+
+
+def _make_fs_client(
+    images: List[Image],
+    existing_labels: List[LaserLabel],
+    predictions: List[LaserPrediction] | None = None,
+):
     fs = MagicMock()
     fs.__aenter__ = AsyncMock(return_value=fs)
     fs.__aexit__ = AsyncMock(return_value=None)
@@ -153,6 +202,12 @@ def _make_fs_client(images: List[Image], existing_labels: List[LaserLabel]):
     fs.labels = MagicMock()
     fs.labels.get_laser_labels = AsyncMock(return_value=existing_labels)
     fs.labels.put_laser_label = AsyncMock()
+    # Default: every image has a prediction, so the prediction-gate is a no-op
+    # and the completed-label filter alone decides what gets populated. Tests
+    # that exercise the gate pass an explicit subset.
+    if predictions is None:
+        predictions = [_prediction(image.id) for image in images]
+    fs.labels.get_laser_predictions = AsyncMock(return_value=predictions)
     return fs
 
 

--- a/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_parent_workflow.py
@@ -1,0 +1,108 @@
+# pylint: disable=unused-argument
+"""Workflow contract test for PopulateLaserLabelStudioProjectParentWorkflow."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from typing import List
+
+import pytest
+from temporalio import activity, workflow
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from fishsense_api_workflow_worker.workflows.populate_laser_label_studio_project_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PopulateLaserLabelStudioProjectParentWorkflow,
+)
+
+
+@workflow.defn(name="PopulateLaserLabelStudioProjectWorkflow")
+class _StubPopulateWorkflow:
+    # pylint: disable=too-few-public-methods
+    @workflow.run
+    async def run(self, dive_id: int) -> int:
+        await workflow.execute_activity(
+            "_record_populate",
+            args=(workflow.info().workflow_id, dive_id),
+            schedule_to_close_timeout=timedelta(seconds=5),
+        )
+        return 0
+
+
+def _make_selector(dive_ids: List[int], calls: List[int]):
+    @activity.defn(name="select_dives_needing_laser_population_activity")
+    async def select() -> List[int]:
+        calls.append(1)
+        return dive_ids
+
+    return select
+
+
+def _make_recorder(captures: List[tuple]):
+    @activity.defn(name="_record_populate")
+    async def record(workflow_id: str, dive_id: int) -> None:
+        captures.append((workflow_id, dive_id))
+
+    return record
+
+
+@pytest.mark.asyncio
+async def test_fans_out_populate_child_per_dive():
+    dispatched: List[tuple] = []
+    selector_calls: List[int] = []
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-queue",
+            workflows=[
+                PopulateLaserLabelStudioProjectParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[
+                _make_selector([10, 20, 30], selector_calls),
+                _make_recorder(dispatched),
+            ],
+        ):
+            result = await env.client.execute_workflow(
+                PopulateLaserLabelStudioProjectParentWorkflow.run,
+                id=f"parent-{uuid.uuid4()}",
+                task_queue="test-queue",
+            )
+
+    assert result == [10, 20, 30]
+    assert len(selector_calls) == 1
+    assert {d for _, d in dispatched} == {10, 20, 30}
+    assert {wid for wid, _ in dispatched} == {
+        "populate-laser-10",
+        "populate-laser-20",
+        "populate-laser-30",
+    }
+
+
+@pytest.mark.asyncio
+async def test_no_dispatch_when_cohort_empty():
+    dispatched: List[tuple] = []
+    selector_calls: List[int] = []
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-queue",
+            workflows=[
+                PopulateLaserLabelStudioProjectParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[
+                _make_selector([], selector_calls),
+                _make_recorder(dispatched),
+            ],
+        ):
+            result = await env.client.execute_workflow(
+                PopulateLaserLabelStudioProjectParentWorkflow.run,
+                id=f"parent-{uuid.uuid4()}",
+                task_queue="test-queue",
+            )
+
+    assert result == []
+    assert len(selector_calls) == 1
+    assert not dispatched

--- a/services/fishsense-api-workflow-worker/tests/test_preprocess_laser_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preprocess_laser_images_parent_workflow.py
@@ -189,7 +189,10 @@ async def test_dispatches_child_with_deterministic_id_and_correct_payload():
     assert child_id == "preprocess-laser-440"
     assert child_dive_id == 440
     assert child_checksums == ["a", "b", "c"]
-    assert populate_runs == [("populate-laser-440", 440)]
+    # Populate is DECOUPLED (2026-07-28): the preprocess parent no longer
+    # chains into it — the scheduled PopulateLaserLabelStudioProjectParentWorkflow
+    # (+12, after the +10 predict parent) owns laser task import now.
+    assert not populate_runs
 
 
 @pytest.mark.asyncio
@@ -274,64 +277,3 @@ async def test_skips_child_dispatch_when_no_incomplete_images():
     assert not stage_calls
     assert not child_runs
     assert not populate_runs
-
-
-@pytest.mark.asyncio
-async def test_repeat_invocation_swallows_workflow_already_started():
-    """Stage-0.1's cohort keeps a dive selectable until stage-13 writes
-    LaserExtrinsics, so the parent re-runs hourly on the same dive_id.
-    The deterministic populate child id makes the second+ firing's
-    populate dispatch hit WorkflowAlreadyStarted, which the parent
-    catches so the run still completes successfully.
-    """
-    inputs = PreprocessLaserImagesInput(
-        dive_id=441,
-        image_checksums=["x"],
-        camera_matrix=_K,
-        distortion_coefficients=_D,
-        bbox=_BBOX,
-    )
-    activities, _, _, _ = _make_stub_activities(
-        selector_result=441, resolver_result=inputs
-    )
-    child_runs: List[tuple] = []
-    record = _make_recording_activity(child_runs)
-    populate_runs: List[tuple] = []
-    record_populate = _make_populate_recording_activity(populate_runs)
-
-    async with await WorkflowEnvironment.start_time_skipping() as env:
-        # Pre-seed: start a populate child with the same id that the
-        # parent will try to use, then let it complete.
-        existing = await env.client.start_workflow(
-            _StubPopulateWorkflow.run,
-            441,
-            id="populate-laser-441",
-            task_queue="test-stage01-parent-rerun",
-        )
-        async with Worker(
-            env.client,
-            task_queue="test-stage01-parent-rerun",
-            workflows=[
-                PreprocessLaserImagesParentWorkflow,
-                _StubPopulateWorkflow,
-            ],
-            activities=[*activities, record_populate],
-        ), Worker(
-            env.client,
-            task_queue=DATA_PROCESSING_TASK_QUEUE,
-            workflows=[_StubChildWorkflow],
-            activities=[record],
-        ):
-            await existing.result()
-            result = await env.client.execute_workflow(
-                PreprocessLaserImagesParentWorkflow.run,
-                id=f"test-stage01-parent-rerun-{uuid.uuid4()}",
-                task_queue="test-stage01-parent-rerun",
-            )
-
-    assert result == 441
-    assert len(child_runs) == 1
-    # Pre-seeded populate ran once; the parent's attempt was rejected
-    # with WorkflowAlreadyStarted and caught, so no second populate
-    # invocation happened.
-    assert populate_runs == [("populate-laser-441", 441)]

--- a/services/fishsense-api-workflow-worker/tests/test_schedule_registration.py
+++ b/services/fishsense-api-workflow-worker/tests/test_schedule_registration.py
@@ -28,6 +28,7 @@ from fishsense_api_workflow_worker import worker as sut
 _DIVE_SELECTING_PARENT_SCHEDULE_IDS = (
     "preprocess-laser-images-workflow-schedule",
     "predict-laser-images-workflow-schedule",
+    "populate-laser-labels-workflow-schedule",
     "cluster-dive-frames-workflow-schedule",
     "preprocess-species-images-workflow-schedule",
     "populate-species-labels-workflow-schedule",
@@ -72,6 +73,13 @@ async def test_laser_predict_is_scheduled_hourly_at_10(registered):
     schedule = registered["predict-laser-images-workflow-schedule"]
     assert _every(schedule) == timedelta(hours=1)
     assert _offset(schedule) == timedelta(minutes=10)
+
+
+async def test_laser_populate_is_scheduled_hourly_at_12(registered):
+    """Runs after the +10 predict parent (predictions must exist first)."""
+    schedule = registered["populate-laser-labels-workflow-schedule"]
+    assert _every(schedule) == timedelta(hours=1)
+    assert _offset(schedule) == timedelta(minutes=12)
 
 
 async def test_species_populate_is_scheduled_hourly_at_20(registered):

--- a/services/fishsense-api-workflow-worker/tests/test_select_dives_needing_laser_population_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_select_dives_needing_laser_population_activity.py
@@ -1,0 +1,28 @@
+# pylint: disable=protected-access
+"""Unit test for select_dives_needing_laser_population_activity."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from temporalio.testing import ActivityEnvironment
+
+from fishsense_api_workflow_worker.activities import (
+    select_dives_needing_laser_population_activity as sut,
+)
+
+
+@pytest.mark.asyncio
+async def test_returns_cohort_from_sdk(monkeypatch):
+    fs = MagicMock()
+    fs.__aenter__ = AsyncMock(return_value=fs)
+    fs.__aexit__ = AsyncMock(return_value=None)
+    fs.dives = MagicMock()
+    fs.dives.get_dives_needing_laser_population = AsyncMock(return_value=[5, 9])
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.select_dives_needing_laser_population_activity
+    )
+    assert result == [5, 9]

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/b8e3f1a09d24_add_dims_to_laser_prediction.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/b8e3f1a09d24_add_dims_to_laser_prediction.py
@@ -1,0 +1,35 @@
+"""add width/height to laserprediction
+
+The laser populate step converts a prediction's pixel x/y into the percentages
+Label Studio keypoints use, which needs the rectified frame dimensions the
+prediction was made against. The GPU predict stage now records them.
+
+Revision ID: b8e3f1a09d24
+Revises: a7d21e4f0c93
+Create Date: 2026-07-28 00:00:00.000000
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b8e3f1a09d24"
+down_revision: Union[str, Sequence[str], None] = "a7d21e4f0c93"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("laserprediction", sa.Column("width", sa.Integer(), nullable=True))
+    op.add_column("laserprediction", sa.Column("height", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("laserprediction", "height")
+    op.drop_column("laserprediction", "width")

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -407,6 +407,50 @@ async def select_dives_needing_species_population(
     return list((await session.exec(query)).all())
 
 
+@app.get("/api/v1/dives/needing-laser-population/")
+async def select_dives_needing_laser_population(
+    session: AsyncSession = Depends(get_async_session),
+) -> List[int]:
+    """Dives that need model-assisted laser LS tasks (re)populated.
+
+    Cohort: HIGH priority + at least one image that has a `LaserPrediction`
+    (the detector has run for it) and no *completed* `LaserLabel`. The
+    prediction gate is what makes this the decoupled populate cohort rather
+    than the preprocess one: laser populate seeds non-sentinel `LaserLabel`
+    rows, and the predict cohort excludes any image with a `LaserLabel`, so
+    populating an un-predicted image would starve it of a prediction forever.
+    Gating on "prediction exists" guarantees the detector ran first.
+
+    "No completed label" (not "no row") keeps a dive in the cohort until its
+    labelers finish, so the idempotent populate self-heals hourly. Returns
+    every match; the scheduled populate parent fans out one
+    `PopulateLaserLabelStudioProjectWorkflow` child per dive.
+    """
+    has_predicted_incomplete_image = (
+        select(Image.id)
+        .where(Image.dive_id == Dive.id)
+        .where(
+            select(LaserPrediction.id)
+            .where(LaserPrediction.image_id == Image.id)
+            .exists()
+        )
+        .where(
+            ~select(LaserLabel.id)
+            .where(LaserLabel.image_id == Image.id)
+            .where(LaserLabel.completed == True)
+            .exists()
+        )
+        .exists()
+    )
+    query = (
+        select(Dive.id)
+        .where(Dive.priority == Priority.HIGH)
+        .where(has_predicted_incomplete_image)
+        .order_by(Dive.id)
+    )
+    return list((await session.exec(query)).all())
+
+
 @app.get("/api/v1/dives/select-next/headtail-preprocessing/")
 async def select_next_for_headtail_preprocessing(
     session: AsyncSession = Depends(get_async_session),

--- a/services/fishsense-api/src/fishsense_api/models/laser_prediction.py
+++ b/services/fishsense-api/src/fishsense_api/models/laser_prediction.py
@@ -31,6 +31,10 @@ class LaserPrediction(ModelBase, table=True):
     x: float | None = Field(default=None)
     y: float | None = Field(default=None)
     confidence: float = Field(default=0.0)
+    # Rectified frame dimensions the x/y are relative to — the laser populate
+    # step needs them to convert pixels to Label Studio keypoint percentages.
+    width: int | None = Field(default=None)
+    height: int | None = Field(default=None)
     created_at: datetime | None = Field(sa_type=DateTime(timezone=True), default=None)
 
     image_id: int | None = Field(default=None, foreign_key="image.id")

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -1948,3 +1948,47 @@ async def test_laser_prediction_sentinel_label_does_not_exclude(session):
     await session.flush()
 
     assert await select_next_for_laser_prediction(session=session) == 1
+
+
+# ---------- needing-laser-population (decoupled model-assisted populate) ----------
+#
+# Cohort: HIGH + >=1 image with a LaserPrediction and no completed LaserLabel.
+# Prediction-gated so populate never seeds a LaserLabel before the detector ran.
+
+
+async def test_needing_laser_population_lists_predicted_incomplete_dives(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_dives_needing_laser_population,
+    )
+
+    # dive 1: predicted image, no completed label -> included.
+    # dive 2: predicted image but completed label -> excluded.
+    # dive 3: unpredicted image -> excluded (gate).
+    session.add_all([_dive(1), _dive(2), _dive(3)])
+    session.add_all([_image(11, 1), _image(21, 2), _image(31, 3)])
+    await session.flush()
+    session.add_all([_laser_prediction(11), _laser_prediction(21)])
+    session.add(_laser_label(21, project_id=73))  # completed below
+    await session.flush()
+    # mark dive 2's label completed
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from sqlmodel import select as _select  # pylint: disable=import-outside-toplevel
+
+    lbl = (await session.exec(_select(LaserLabel).where(LaserLabel.image_id == 21))).first()
+    lbl.completed = True
+    session.add(lbl)
+    await session.flush()
+
+    result = await select_dives_needing_laser_population(session=session)
+    assert result == [1]
+
+
+async def test_needing_laser_population_empty_when_nothing_predicted(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_dives_needing_laser_population,
+    )
+
+    session.add_all([_dive(1), _image(11, 1)])
+    await session.flush()
+
+    assert await select_dives_needing_laser_population(session=session) == []

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_laser_image.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_laser_image.py
@@ -68,7 +68,11 @@ def _predict_from_raw(
     (linear + Bayer-excess, which the 6-channel model needs) and run the
     detector with rectified output so the point lands in labeling space.
 
-    Returns the fishsense-core `LaserPrediction` (`.x`, `.y`, `.confidence`).
+    Returns `(prediction, width, height)` — the fishsense-core
+    `LaserPrediction` (`.x`, `.y`, `.confidence`) plus the rectified frame
+    dimensions the x/y are relative to (needed to convert to Label Studio
+    keypoint percentages downstream). `cv2.undistort` preserves the image
+    size, so the rectified dims equal the decoded raw dims.
     """
     import numpy as np  # pylint: disable=import-outside-toplevel
     # no-name-in-module: linear_raw_image ships in fishsense-core >= 2.2.0
@@ -78,14 +82,16 @@ def _predict_from_raw(
     )
 
     image = LinearRawImage(raw_bytes)
+    height, width = image.data.shape[:2]
     detector = _get_detector(checkpoint_path)
-    return detector.predict(
+    prediction = detector.predict(
         image,
         wavelength=wavelength,
         rectify_output=True,
         camera_matrix=np.array(camera_matrix, dtype=float),
         distortion=np.array(distortion_coefficients, dtype=float),
     )
+    return prediction, int(width), int(height)
 
 
 def _models():
@@ -115,7 +121,7 @@ async def predict_laser_image(payload):  # type: ignore[no-untyped-def]
     client = open_object_store_client()
     raw_bytes = await client.download_raw(payload.checksum)
 
-    prediction = await asyncio.to_thread(
+    prediction, width, height = await asyncio.to_thread(
         _predict_from_raw,
         raw_bytes,
         payload.camera_matrix,
@@ -125,15 +131,19 @@ async def predict_laser_image(payload):  # type: ignore[no-untyped-def]
     )
 
     activity.logger.info(
-        "predicted laser image_id=%d x=%s y=%s confidence=%.3f",
+        "predicted laser image_id=%d x=%s y=%s confidence=%.3f dims=%dx%d",
         payload.image_id,
         prediction.x,
         prediction.y,
         prediction.confidence,
+        width,
+        height,
     )
     return result_cls(
         image_id=payload.image_id,
         x=prediction.x,
         y=prediction.y,
         confidence=prediction.confidence,
+        width=width,
+        height=height,
     )

--- a/services/fishsense-data-processing-workflow-worker/tests/test_predict_laser_image.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_predict_laser_image.py
@@ -49,6 +49,8 @@ def _install_fake_linear_raw_image(monkeypatch, captured):
         def __init__(self, source, *, bayer_upsample="repeat"):
             captured["source"] = source
             captured["bayer_upsample"] = bayer_upsample
+            # (H, W, C) — the activity reads dims from image.data.shape.
+            self.data = SimpleNamespace(shape=(3000, 4000, 3))
 
     mod.LinearRawImage = _LinearRawImage
     monkeypatch.setitem(
@@ -73,7 +75,7 @@ def test_predict_from_raw_calls_detector_with_rectified_output(monkeypatch):
 
     monkeypatch.setattr(sut, "_get_detector", lambda checkpoint_path: _FakeDetector())
 
-    pred = sut._predict_from_raw(
+    pred, width, height = sut._predict_from_raw(
         b"rawbytes",
         camera_matrix=[[1000.0, 0.0, 960.0], [0.0, 1000.0, 540.0], [0.0, 0.0, 1.0]],
         distortion_coefficients=[0.1, -0.2, 0.0, 0.0, 0.0],
@@ -82,6 +84,7 @@ def test_predict_from_raw_calls_detector_with_rectified_output(monkeypatch):
     )
 
     assert (pred.x, pred.y, pred.confidence) == (12.5, 34.0, 0.9)
+    assert (width, height) == (4000, 3000)  # from image.data.shape (H, W)
     # Built a LinearRawImage straight from the raw bytes.
     assert captured["source"] == b"rawbytes"
     # Rectified output in labeling space, with the dive's intrinsics + wavelength.
@@ -139,7 +142,7 @@ async def test_activity_returns_mapped_prediction(monkeypatch):
 
     def _fake_predict(raw_bytes, *_args):
         assert raw_bytes == b"ORFBYTES"
-        return SimpleNamespace(x=100.0, y=200.0, confidence=0.77)
+        return SimpleNamespace(x=100.0, y=200.0, confidence=0.77), 4000, 3000
 
     monkeypatch.setattr(sut, "_predict_from_raw", _fake_predict)
 
@@ -150,6 +153,7 @@ async def test_activity_returns_mapped_prediction(monkeypatch):
     assert isinstance(result, LaserPredictionResult)
     assert result.image_id == 7
     assert (result.x, result.y, result.confidence) == (100.0, 200.0, 0.77)
+    assert (result.width, result.height) == (4000, 3000)
     client.download_raw.assert_awaited_once_with("abc123")
 
 
@@ -159,7 +163,7 @@ async def test_activity_handles_non_detection(monkeypatch):
     monkeypatch.setattr(
         sut,
         "_predict_from_raw",
-        lambda *a, **k: SimpleNamespace(x=None, y=None, confidence=0.05),
+        lambda *a, **k: (SimpleNamespace(x=None, y=None, confidence=0.05), 4000, 3000),
     )
 
     result = await ActivityEnvironment().run(
@@ -178,7 +182,7 @@ async def test_activity_validates_dict_payload(monkeypatch):
     monkeypatch.setattr(
         sut,
         "_predict_from_raw",
-        lambda *a, **k: SimpleNamespace(x=1.0, y=2.0, confidence=0.5),
+        lambda *a, **k: (SimpleNamespace(x=1.0, y=2.0, confidence=0.5), 4000, 3000),
     )
 
     result = await ActivityEnvironment().run(


### PR DESCRIPTION
The **user-visible** half of model-assisted laser labeling (phases 1–4 merged): the detector's predictions now seed each Label Studio task as a **keypoint pre-annotation** the labeler confirms/nudges instead of placing from scratch.

## Predictions carry their frame dims
LS keypoints are percentages, so the conversion needs the rectified frame size. `LaserPredictionResult` (shared) + `LaserPrediction` (model/SDK/`_generated`) gain **width/height**; the predict activity reads them from `image.data.shape`; persist passes them through. Migration `b8e3f1a09d24` adds the columns.

## Populate emits the pre-annotation
`populate_laser` reads the dive's `LaserPrediction`s, converts pixel x/y → percent (per prediction's own dims), and emits `predictions: [{keypoint "laser"…}]` on the task (default label "Red Laser" since color is unknown; empty when no detection/dims). `import_tasks` forwards it intact.

## Decoupled populate — fixes a cohort/ordering deadlock
Laser populate seeds **non-sentinel `LaserLabel` rows**, and the predict cohort **excludes any labeled image** — so populating at preprocess time (:00) would stamp labels and starve the detector before it ran (predictions would never be made). So:
- **Removed** the populate child from the preprocess-laser parent.
- **Added** `PopulateLaserLabelStudioProjectParentWorkflow` on its own hourly schedule at **+12** (after predict +10), with a **prediction-gated cohort** (`needing-laser-population` endpoint + SDK) — mirrors the species-populate decoupling.
- The populate **activity** now only seeds a task for an image that already has a prediction (like species populate is JPEG-gated), so it never starves the predictor.

Flow per dive/hour: preprocess `:00` (JPEGs) → predict `:10` (predictions) → populate `:12` (tasks **with** pre-annotations + LaserLabel rows).

## Tests (TDD)
Dims round-trip; px→percent conversion + task shape + prediction-gate; `needing-laser-population` cohort + SDK; populate-parent contract; +12 schedule; preprocess-parent test updated (no populate) + obsolete populate-dedup test removed.
**api 214 · sdk 118 · shared 21 · api-worker 320 · pylint 10.** (Data-worker predict-activity edits — tuple return + dims — are simple; torch isn't installable in my sandbox so CI validates those.)

## This completes the feature
With 1–4 + this, model-assisted laser labeling is end-to-end: hourly GPU predict → stored predictions → LS pre-annotations for labelers. Deploying releases api + api-worker (+ SDK cascade); the `predict-laser-images` (:10) and `populate-laser-labels` (:12) schedules register on api-worker startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)