### PR TITLE
fix(data-worker): exclude arch-mislabeled NRP node bak-hpc2

### DIFF
--- a/deploy/k8s/data-worker/deployment.yaml
+++ b/deploy/k8s/data-worker/deployment.yaml
@@ -54,6 +54,21 @@ spec:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
+      # Exclude nodes that advertise `kubernetes.io/arch: amd64` but cannot
+      # actually exec an amd64 binary (arm64/emulated nodes with a wrong arch
+      # label), which defeats the nodeSelector above and lands our amd64-only
+      # image in CrashLoopBackOff with `exec format error`. Observed on
+      # bak-hpc2.csub.edu (2026-07-28) — reported to NRP; remove once the node
+      # is fixed/cordoned. Add other offenders here if they surface.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                      - bak-hpc2.csub.edu
       # We're a guest on a shared cluster — let NRP preempt our pods
       # whenever it needs the capacity. No PodDisruptionBudget on
       # purpose; an evicted activity just times out and re-runs


### PR DESCRIPTION
`bak-hpc2.csub.edu` advertises `kubernetes.io/arch=amd64` but can't exec amd64 binaries (arm64/broken emulation), so it passes our amd64 nodeSelector and then CrashLoopBackOffs our amd64-only image with `exec format error`. Same image runs fine on real amd64 nodes (e.g. k8s-ravi-01). An arch nodeAffinity can't help (reads the same wrong label), so this excludes the node by hostname until NRP fixes it. Reported to NRP separately (report + minimal repro prepared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)