### PR TITLE
fix(api): make laserprediction migrations idempotent vs create_all bootstrap

### DIFF
--- a/services/fishsense-api/src/fishsense_api/alembic/versions/a7d21e4f0c93_add_laser_prediction_table.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/a7d21e4f0c93_add_laser_prediction_table.py
@@ -25,7 +25,19 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    """Upgrade schema."""
+    """Upgrade schema.
+
+    Idempotent against `SQLModel.metadata.create_all`: the FastAPI
+    lifespan runs `create_all` before alembic upgrade, and
+    `laserprediction` is in the ORM model registry, so on an existing
+    DB the table already exists by the time this migration runs. Skip
+    the DDL when the table is present rather than crash startup with
+    `DuplicateTableError`.
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("laserprediction"):
+        return
     op.create_table(
         "laserprediction",
         sa.Column("id", sa.Integer(), nullable=False),

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/b8e3f1a09d24_add_dims_to_laser_prediction.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/b8e3f1a09d24_add_dims_to_laser_prediction.py
@@ -24,9 +24,25 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    """Upgrade schema."""
-    op.add_column("laserprediction", sa.Column("width", sa.Integer(), nullable=True))
-    op.add_column("laserprediction", sa.Column("height", sa.Integer(), nullable=True))
+    """Upgrade schema.
+
+    Idempotent against `SQLModel.metadata.create_all`: on an existing DB
+    the lifespan's `create_all` may have already materialized
+    `laserprediction` with width/height from the current ORM model
+    before alembic runs. Add each column only when it's missing so
+    `upgrade head` can't crash with `DuplicateColumnError`.
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = {c["name"] for c in inspector.get_columns("laserprediction")}
+    if "width" not in existing:
+        op.add_column(
+            "laserprediction", sa.Column("width", sa.Integer(), nullable=True)
+        )
+    if "height" not in existing:
+        op.add_column(
+            "laserprediction", sa.Column("height", sa.Integer(), nullable=True)
+        )
 
 
 def downgrade() -> None:

--- a/services/fishsense-api/tests/test_laser_prediction_migration.py
+++ b/services/fishsense-api/tests/test_laser_prediction_migration.py
@@ -1,0 +1,136 @@
+"""Regression tests for the laserprediction migrations' idempotency.
+
+The FastAPI lifespan runs `SQLModel.metadata.create_all` *before*
+`run_alembic_upgrade`. `laserprediction` is a brand-new table, so on an
+existing DB the deploy that ships the model creates the table via
+`create_all` and *then* alembic's `upgrade head` reaches the
+`create_table` / `add_column` ops for it. Without a guard those ops hit
+`DuplicateTableError` / `DuplicateColumnError` and crash startup — which
+is exactly the outage that took down fishsense-api. Both migrations must
+skip their DDL when the table / columns already exist.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_VERSIONS = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "fishsense_api"
+    / "alembic"
+    / "versions"
+)
+
+
+def _load(filename: str, mod_name: str):
+    """Migration filenames start with a digit, so importlib.util is needed."""
+    spec = importlib.util.spec_from_file_location(mod_name, _VERSIONS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def create_migration():
+    return _load("a7d21e4f0c93_add_laser_prediction_table.py", "lp_create_migration")
+
+
+@pytest.fixture
+def dims_migration():
+    return _load("b8e3f1a09d24_add_dims_to_laser_prediction.py", "lp_dims_migration")
+
+
+# ---------------- a7d21e4f0c93: create laserprediction ----------------
+
+
+def test_create_upgrade_skips_when_table_exists(create_migration, monkeypatch):
+    """create_all already made the table — upgrade must be a no-op."""
+    fake_inspector = MagicMock()
+    fake_inspector.has_table.return_value = True
+    fake_op = MagicMock()
+    fake_op.get_bind.return_value = "bind"
+
+    monkeypatch.setattr(create_migration, "op", fake_op)
+    monkeypatch.setattr(create_migration.sa, "inspect", lambda _b: fake_inspector)
+
+    create_migration.upgrade()
+
+    fake_inspector.has_table.assert_called_once_with("laserprediction")
+    fake_op.create_table.assert_not_called()
+
+
+def test_create_upgrade_creates_when_table_absent(create_migration, monkeypatch):
+    """If the table somehow doesn't exist, the migration must still build it."""
+    fake_inspector = MagicMock()
+    fake_inspector.has_table.return_value = False
+    fake_op = MagicMock()
+    fake_op.get_bind.return_value = "bind"
+
+    monkeypatch.setattr(create_migration, "op", fake_op)
+    monkeypatch.setattr(create_migration.sa, "inspect", lambda _b: fake_inspector)
+
+    create_migration.upgrade()
+
+    fake_op.create_table.assert_called_once()
+
+
+# ---------------- b8e3f1a09d24: add width/height ----------------
+
+
+def _dims_setup(dims_migration, monkeypatch, existing_columns):
+    fake_inspector = MagicMock()
+    fake_inspector.get_columns.return_value = [
+        {"name": name} for name in existing_columns
+    ]
+    fake_op = MagicMock()
+    fake_op.get_bind.return_value = "bind"
+
+    monkeypatch.setattr(dims_migration, "op", fake_op)
+    monkeypatch.setattr(dims_migration.sa, "inspect", lambda _b: fake_inspector)
+    return fake_op
+
+
+def test_dims_upgrade_skips_when_both_columns_exist(dims_migration, monkeypatch):
+    """create_all made the table with width+height already — no-op."""
+    fake_op = _dims_setup(
+        dims_migration,
+        monkeypatch,
+        ["id", "x", "y", "confidence", "width", "height", "created_at", "image_id"],
+    )
+
+    dims_migration.upgrade()
+
+    fake_op.add_column.assert_not_called()
+
+
+def test_dims_upgrade_adds_when_columns_absent(dims_migration, monkeypatch):
+    """Table came from the create_table migration (no dims) — add both."""
+    fake_op = _dims_setup(
+        dims_migration,
+        monkeypatch,
+        ["id", "x", "y", "confidence", "created_at", "image_id"],
+    )
+
+    dims_migration.upgrade()
+
+    added = {c.args[1].name for c in fake_op.add_column.call_args_list}
+    assert added == {"width", "height"}
+
+
+def test_dims_upgrade_adds_only_missing_column(dims_migration, monkeypatch):
+    """Partial state (only width present) — add just the missing height."""
+    fake_op = _dims_setup(
+        dims_migration,
+        monkeypatch,
+        ["id", "x", "y", "confidence", "width", "created_at", "image_id"],
+    )
+
+    dims_migration.upgrade()
+
+    added = {c.args[1].name for c in fake_op.add_column.call_args_list}
+    assert added == {"height"}


### PR DESCRIPTION
## What
Make the two `laserprediction` alembic migrations idempotent so they can't collide with the lifespan's `create_all`:
- `a7d21e4f0c93` — skip `op.create_table` when `inspector.has_table("laserprediction")`.
- `b8e3f1a09d24` — add `width`/`height` only when each column is absent.

Mirrors the existing guard in `299428e39cb9_add_label_studio_sync_cursor.py`.

## Why (prod outage 2026-07-28)
`fishsense_api.server.lifespan` runs `SQLModel.metadata.create_all` **before** `run_alembic_upgrade`. `laserprediction` is a brand-new table in the ORM model registry (`database.py`), so on the existing prod DB:

1. `create_all` created the whole `laserprediction` table (final shape, width/height included).
2. `alembic upgrade head` then reached `a7d21e4f0c93`'s `op.create_table("laserprediction")` → `DuplicateTableError` → **startup crash-loop**, which broke the web app's SSR fetch.

This was the first `fishsense-api` restart since the laser-detector work shipped (the api-worker converge force-recreates the whole compose stack), so it's the first time the collision could fire.

Column-add migrations to *existing* tables don't hit this (create_all skips existing tables entirely, never adds columns), and fresh DBs are already safe (`run_alembic_upgrade` stamps head when `alembic_version` is absent). The gap was specifically the **existing-DB-behind-a-new-table** path — which every future new-table migration would also hit.

Prod was unblocked live via an `alembic stamp head` equivalent (`UPDATE alembic_version SET version_num='b8e3f1a09d24'`); this PR prevents recurrence.

## Tests
New `test_laser_prediction_migration.py` (mirrors `test_label_studio_sync_cursor_migration.py`): each migration's upgrade is a no-op when the table/columns already exist, still creates/adds when absent, and `b8e3f1a09d24` adds only the missing column in a partial state. `test_alembic_upgrade.py` + `test_laser_prediction_endpoint.py` still green; pylint 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)