### PR TITLE
fix(api): predict cohort keys off completed, not project_id

### DIFF
--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -191,13 +191,20 @@ async def select_next_for_laser_prediction(
     session: AsyncSession = Depends(get_async_session),
 ) -> int | None:
     """Model-assisted laser labeling: HIGH-priority + at least one image
-    with no `LaserPrediction` row and no non-sentinel `LaserLabel` row.
+    with no `LaserPrediction` row and no *completed* `LaserLabel` row.
 
     An image needs a prediction only if it has neither been predicted nor
-    labeled yet — so a dive drops out of the cohort once every image is
-    predicted (one-shot per image; re-prediction is a manual affair), and
-    images a human already labeled are never predicted over. Mirrors the
-    stage-0.1 "non-sentinel label" convention (`project_id IS NOT NULL`).
+    *labeled by a human* yet — so a dive drops out of the cohort once every
+    image is predicted (one-shot per image; re-prediction is a manual
+    affair), and images a human already labeled are never predicted over.
+
+    "Labeled" here means `completed IS TRUE`, NOT merely
+    `project_id IS NOT NULL`: the laser populate step seeds placeholder
+    rows (`completed=False`, x/y NULL) that *carry* a `project_id`, so a
+    project-id check would exclude every populate-seeded-but-unlabeled
+    image — starving the detector on exactly the dives it should assist
+    (e.g. a dive populated before the detector shipped). Matches populate's
+    own `completed`-based definition of "labeled" (`_select_unlabeled_images`).
     """
     has_image_needing_prediction = (
         select(Image.id)
@@ -210,7 +217,7 @@ async def select_next_for_laser_prediction(
         .where(
             ~select(LaserLabel.id)
             .where(LaserLabel.image_id == Image.id)
-            .where(LaserLabel.label_studio_project_id != None)
+            .where(LaserLabel.completed == True)
             .exists()
         )
         .exists()

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -1888,14 +1888,19 @@ async def test_species_preprocessing_picks_dive_with_a_clustered_qualifying_imag
 # ---------- laser-prediction (model-assisted labeling) ----------
 #
 # Cohort: HIGH + at least one image with no LaserPrediction AND no
-# non-sentinel LaserLabel. One-shot per image — a prediction (or a real
-# label) drops the image out.
+# *completed* LaserLabel. One-shot per image — a prediction (or a completed
+# human label) drops the image out. A populate-seeded placeholder
+# (completed=False, carries a project_id) does NOT drop it out.
 
 
-def _laser_label(image_id: int, *, project_id=73):
+def _laser_label(image_id: int, *, project_id=73, completed=False):
     from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
 
-    return LaserLabel(image_id=image_id, label_studio_project_id=project_id)
+    return LaserLabel(
+        image_id=image_id,
+        label_studio_project_id=project_id,
+        completed=completed,
+    )
 
 
 def _laser_prediction(image_id: int):
@@ -1910,13 +1915,13 @@ async def test_laser_prediction_selects_dive_with_unpredicted_unlabeled_image(se
     )
 
     # dive 1: image already predicted -> excluded.
-    # dive 2: image already labeled (real project) -> excluded.
+    # dive 2: image with a completed human label -> excluded.
     # dive 3: image with neither -> selected.
     session.add_all([_dive(1), _dive(2), _dive(3)])
     session.add_all([_image(11, 1), _image(21, 2), _image(31, 3)])
     await session.flush()
     session.add(_laser_prediction(11))
-    session.add(_laser_label(21))
+    session.add(_laser_label(21, completed=True))
     await session.flush()
 
     assert await select_next_for_laser_prediction(session=session) == 3
@@ -1929,7 +1934,7 @@ async def test_laser_prediction_none_when_all_predicted_or_labeled(session):
 
     session.add_all([_dive(1), _image(11, 1), _image(12, 1)])
     await session.flush()
-    session.add_all([_laser_prediction(11), _laser_label(12)])
+    session.add_all([_laser_prediction(11), _laser_label(12, completed=True)])
     await session.flush()
 
     assert await select_next_for_laser_prediction(session=session) is None
@@ -1945,6 +1950,25 @@ async def test_laser_prediction_sentinel_label_does_not_exclude(session):
     session.add_all([_dive(1), _image(11, 1)])
     await session.flush()
     session.add(_laser_label(11, project_id=None))  # sentinel
+    await session.flush()
+
+    assert await select_next_for_laser_prediction(session=session) == 1
+
+
+async def test_laser_prediction_seeded_placeholder_does_not_exclude(session):
+    """A populate-seeded placeholder (carries a project_id but
+    completed=False, x/y NULL) is NOT a human label — the image still
+    needs a prediction. This is the dive-84 case: a dive populated before
+    the detector shipped has project-id-bearing incomplete rows that must
+    not starve the predict cohort."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_prediction,
+    )
+
+    session.add_all([_dive(1), _image(11, 1)])
+    await session.flush()
+    # project-bearing but incomplete — exactly what populate seeds.
+    session.add(_laser_label(11, project_id=274728, completed=False))
     await session.flush()
 
     assert await select_next_for_laser_prediction(session=session) == 1


### PR DESCRIPTION
## What
`select_next_for_laser_prediction` now excludes an image only when it has a **completed** `LaserLabel` (a real human label), instead of any `LaserLabel` with `label_studio_project_id IS NOT NULL`.

## Why
The laser populate step seeds placeholder rows (`completed=False`, x/y NULL) that **carry a project_id**. The old project-id predicate therefore treated those seeded-but-unlabeled images as "labeled" and excluded them from prediction. Any dive populated before the detector shipped was permanently starved.

Concrete case found in prod: **dive 84 (`083023_FishModels_FSL05`, LS project 274728)** — its images were labeled long ago under legacy LS project 43 and later re-associated to hosted project 274728, leaving 50 project-id-bearing incomplete rows. Even after promoting the dive to HIGH it could never enter the predict cohort under the old predicate.

## Fix
Exclude on `completed IS TRUE`, aligning the predict cohort with:
- populate's own `completed`-based definition of "labeled" (`_select_unlabeled_images`), and
- the `needing-laser-population` cohort ("no completed LaserLabel").

Seeded placeholders and NULL-project sentinels no longer starve the detector; a completed human label or an existing `LaserPrediction` still drops the image out (one-shot per image).

**Ballooning-safe:** `import_tasks_and_record_labels` dedupes LS tasks by image URL before importing, so re-running populate on a newly-eligible dive upserts label rows without creating duplicate tasks.

## Tests (TDD)
`test_select_next_dive_endpoints.py`:
- new `test_laser_prediction_seeded_placeholder_does_not_exclude` — the dive-84 case (project-id-bearing, `completed=False`) still needs a prediction.
- updated the two existing tests that conflated "has a project-id label" with "labeled" to use `completed=True`.
- `_laser_label` helper gained a `completed` kwarg.

Full selector suite (57) green; pylint 10/10.

## Note
For dives whose LS tasks were already imported (like dive 84), predictions will now land in the DB, but the *already-existing* LS tasks won't display the predicted dot (populate's task-dedup skips re-import). Surfacing predictions on pre-existing tasks would need a separate populate enhancement (update task predictions) — flagged for a follow-up decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)