### PR TITLE
feat(api): expose dive_name in dive_pipeline_status view

### DIFF
--- a/services/fishsense-api/src/fishsense_api/alembic/versions/f4a9c2b17e60_add_dive_name_to_pipeline_status_view.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/f4a9c2b17e60_add_dive_name_to_pipeline_status_view.py
@@ -1,0 +1,43 @@
+"""add dive_name to dive_pipeline_status view
+
+Superset's pipeline-status dashboard reads this view keyed by `dive_id`,
+which is opaque to a human scanning the board. Expose `d.name AS dive_name`
+so the dashboard can show the readable dive name (e.g.
+`083023_FishModels_FSL05`) alongside the stage flags.
+
+Drop + recreate rather than CREATE OR REPLACE — postgres is restrictive
+about column-shape changes and the view has no dependents.
+
+Revision ID: f4a9c2b17e60
+Revises: b8e3f1a09d24
+Create Date: 2026-07-28 00:00:00.000000
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from fishsense_api.views import (
+    DIVE_PIPELINE_STATUS_VIEW_SQL,
+    DROP_DIVE_PIPELINE_STATUS_VIEW_SQL,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "f4a9c2b17e60"
+down_revision: Union[str, Sequence[str], None] = "b8e3f1a09d24"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)
+
+
+def downgrade() -> None:
+    """Drop the new view; to restore the prior shape, re-run the previous
+    view-defining migration's `op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)`
+    against a checkout that predates the `dive_name` column."""
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -77,6 +77,7 @@ DIVE_PIPELINE_STATUS_VIEW_SQL = f"""
 CREATE VIEW {DIVE_PIPELINE_STATUS_VIEW_NAME} AS
 SELECT
     d.id AS dive_id,
+    d.name AS dive_name,
     d.priority,
     d.dive_slate_id,
 

--- a/services/fishsense-api/tests/test_dive_pipeline_status_view.py
+++ b/services/fishsense-api/tests/test_dive_pipeline_status_view.py
@@ -50,7 +50,12 @@ async def session():
 
 
 def _dive(
-    dive_id: int, *, priority: str = "HIGH", dive_slate_id=None, calibration_dive_id=None
+    dive_id: int,
+    *,
+    priority: str = "HIGH",
+    dive_slate_id=None,
+    calibration_dive_id=None,
+    name=None,
 ):
     from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
     from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
@@ -62,6 +67,7 @@ def _dive(
         priority=Priority[priority],
         dive_slate_id=dive_slate_id,
         calibration_dive_id=calibration_dive_id,
+        name=name,
     )
 
 
@@ -139,14 +145,28 @@ async def test_empty_dive_emits_a_row_with_every_flag_false(session):
 
 
 async def test_identity_columns_pass_through(session):
-    session.add(_dive(7, priority="LOW", dive_slate_id=42))
+    session.add(
+        _dive(7, priority="LOW", dive_slate_id=42, name="083023_FishModels_FSL05")
+    )
     await session.flush()
 
     row = await _row(session, 7)
     assert row["dive_id"] == 7
+    # Superset dashboards key on dive_id but display the readable name.
+    assert row["dive_name"] == "083023_FishModels_FSL05"
     # priority enum stored as enum-name string by sqlmodel.
     assert row["priority"] == "LOW"
     assert row["dive_slate_id"] == 42
+
+
+async def test_dive_name_null_passes_through_as_none(session):
+    """A dive with no name (NULL) still emits a row; dive_name is None."""
+    session.add(_dive(8, name=None))
+    await session.flush()
+
+    row = await _row(session, 8)
+    assert row["dive_id"] == 8
+    assert row["dive_name"] is None
 
 
 # ---------- laser_preprocessed (stage 0.1) ----------


### PR DESCRIPTION
## What
Adds `d.name AS dive_name` to the `dive_pipeline_status` view so Superset's pipeline-status dashboard can display the readable dive name (e.g. `083023_FishModels_FSL05`) next to the stage flags, instead of only the opaque `dive_id`.

## How
- `views.py` — the canonical view SQL gains `dive_name` (single source of truth for both the migration and the test fixtures).
- New migration `f4a9c2b17e60` (off head `b8e3f1a09d24`) drops + recreates the view (postgres is restrictive about column-shape changes; the view has no dependents).
- `test_dive_pipeline_status_view.py` — `_dive` helper gains a `name` kwarg; `test_identity_columns_pass_through` asserts `dive_name`, plus a NULL-name case.

44 view tests green; pylint 10/10.

## Follow-up (Superset side, not code)
After this deploys and the view has the column, the Superset **dataset** needs its columns re-synced and `dive_name` added to the dashboard's chart(s). That's a Superset UI/metadata step — I'll do it (or hand off) once the migration is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)