### PR TITLE
fix(data-worker): require GPU compute capability >= 7.5

### DIFF
--- a/deploy/k8s/data-worker/deployment.yaml
+++ b/deploy/k8s/data-worker/deployment.yaml
@@ -54,6 +54,30 @@ spec:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
+      # GPU compute-capability floor. The laser-detector's torch build
+      # (cu13x / cuDNN 9.2) dropped support for GPUs with SM < 7.5, so a
+      # conv2d on an older card dies at runtime with "cuDNN version 92000 is
+      # not compatible with devices with SM < 7.5" — observed live when NRP
+      # scheduled us onto a GTX 1080 Ti (SM 6.1). Require SM >= 7.5: Turing
+      # (major 7, minor 5) OR Ampere/Ada/Hopper/Blackwell+ (major >= 8).
+      # Excludes Pascal (6.x) and Volta (7.0). Labels come from NVIDIA GPU
+      # Feature Discovery (runs on NRP's GPU nodes). The two nodeSelectorTerms
+      # are OR'd; this AND's with the amd64 nodeSelector above.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: nvidia.com/gpu.compute.major
+                    operator: In
+                    values: ["8", "9", "10", "11", "12"]
+              - matchExpressions:
+                  - key: nvidia.com/gpu.compute.major
+                    operator: In
+                    values: ["7"]
+                  - key: nvidia.com/gpu.compute.minor
+                    operator: In
+                    values: ["5"]
       # We're a guest on a shared cluster — let NRP preempt our pods
       # whenever it needs the capacity. No PodDisruptionBudget on
       # purpose; an evicted activity just times out and re-runs


### PR DESCRIPTION
## What
Adds a `nodeAffinity` to the data-worker Deployment requiring GPU **compute capability ≥ 7.5**.

## Why (confirmed live)
The first real predict run failed. The laser-detector's torch build (**cu13x / cuDNN 9.2**) dropped support for GPUs with **SM < 7.5**, and NRP scheduled the pod onto a **GTX 1080 Ti (SM 6.1)**, so every `conv2d` died:

```
RuntimeError: cuDNN version 92000 is not compatible with devices with SM < 7.5
```

The predict activity retry-looped (workflow stuck ~18 min, 0 `LaserPrediction` rows) while burning 2 GPUs. Our Deployment had no GPU-model constraint, so it could land on any of NRP's old cards.

## Fix
Require SM ≥ 7.5 via two OR'd nodeSelectorTerms:
- `nvidia.com/gpu.compute.major In [8,9,10,11,12]` (Ampere/Ada/Hopper/Blackwell+), OR
- `nvidia.com/gpu.compute.major In [7]` AND `nvidia.com/gpu.compute.minor In [5]` (Turing 7.5)

Excludes Pascal (6.x) and Volta (7.0). AND's with the existing `amd64` nodeSelector.

## Validation
- `kubectl kustomize deploy/k8s/data-worker` renders the affinity correctly.
- Ran a throwaway probe pod with this exact affinity — it **scheduled and completed on an SM≥7.5 node**, confirming NRP's GPU Feature Discovery publishes `nvidia.com/gpu.compute.major/minor` and that compatible capacity exists.

## Rollout note
This is a manifest-only change (no image bump), so it won't trigger the auto-deploy path. After merge it needs `kubectl apply -k deploy/k8s/data-worker` (deploy.yml `workflow_dispatch` target `data-worker`, or direct apply). The predict schedule is **paused** right now; I'll un-pause after this is applied and confirm predictions land.

## Alternative considered
Downgrading torch to a Pascal-compatible cu12x build (runs on any GPU incl. NRP's abundant Pascal cards) — deferred; this scheduling constraint is the faster fix and keeps the modern torch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)