### PR TITLE
fix(api-worker): JPEG-gate laser populate to avoid seeding tasks for missing JPEGs

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_laser_label_studio_project_activity.py
@@ -19,6 +19,7 @@ from fishsense_api_workflow_worker.activities.populate_utils import (
     publish_label_studio_project,
 )
 from fishsense_api_workflow_worker.activities.utils import get_fs_client
+from fishsense_api_workflow_worker.object_store import open_object_store_client
 
 PREPROCESS_FOLDER = "preprocess_jpeg"
 
@@ -102,6 +103,36 @@ def _select_unlabeled_images(
     ]
 
 
+async def _gate_on_jpeg_presence(images: List[Image]) -> List[Image]:
+    """Keep only images whose stage-0.1 laser JPEG is already in Garage.
+
+    Populate runs decoupled from preprocess (its own schedule) and is
+    prediction-gated — but the predictor works off the raw `.ORF`, so it can
+    predict an image whose `preprocess_jpeg` JPEG was never written (e.g. a
+    dive labeled before the Garage migration, whose originals live on the old
+    file-exchange). Seeding a task for such an image points its LS `data.image`
+    at a missing key and the labeler gets a Garage `NoSuchKey`. Gate on JPEG
+    existence so those images defer to a later run (once preprocess has written
+    them); a no-op when the JPEG is already present. Mirrors species populate's
+    `_gate_on_jpeg_presence`.
+    """
+    if not images:
+        return images
+    store = open_object_store_client()
+    present: List[Image] = []
+    for image in images:
+        if await store.has_processed_jpeg(PREPROCESS_FOLDER, image.checksum):
+            present.append(image)
+        else:
+            activity.logger.info(
+                "laser JPEG not yet in Garage for image %d (checksum=%s); "
+                "deferring to a later populate run",
+                image.id,
+                image.checksum,
+            )
+    return present
+
+
 def _build_task(image: Image, prediction=None) -> dict:
     """Build an LS task referencing the preprocessed JPEG.
 
@@ -142,6 +173,9 @@ async def populate_laser_label_studio_project_activity(
         unlabeled = _select_unlabeled_images(
             images, existing_labels, set(predictions_by_image)
         )
+        # Never seed a task for an image whose laser JPEG isn't in Garage —
+        # its LS task would 404 (NoSuchKey). Deferred images retry next run.
+        unlabeled = await _gate_on_jpeg_presence(unlabeled)
         if not unlabeled:
             activity.logger.info(
                 "Dive %d has a completed laser label for every image; "

--- a/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
@@ -29,6 +29,17 @@ from fishsense_api_workflow_worker.activities import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _default_store_all_present(monkeypatch):
+    """Default: every image's laser JPEG is in Garage, so the JPEG-gate is a
+    no-op and the existing tests decide populate purely on the label/prediction
+    state. Tests that exercise the gate override open_object_store_client."""
+    store = MagicMock()
+    store.has_processed_jpeg = AsyncMock(return_value=True)
+    monkeypatch.setattr(sut, "open_object_store_client", lambda: store)
+    return store
+
+
 def _prediction(image_id: int, *, x=100.0, y=200.0, width=4000, height=3000):
     return LaserPrediction(
         id=image_id,
@@ -271,6 +282,39 @@ async def test_imports_tasks_and_writes_one_label_per_incomplete_image(
     assert {label.label_studio_task_id for label in written_labels} == {1001, 1002}
     assert all(label.label_studio_project_id == 73 for label in written_labels)
     assert all(label.completed is False for label in written_labels)
+
+
+@pytest.mark.asyncio
+async def test_defers_image_whose_laser_jpeg_is_not_in_garage(monkeypatch):
+    """An image with a prediction + no completed label but NO laser JPEG in
+    Garage must NOT be populated — its LS task would 404 (NoSuchKey).
+    Regression for the project-276057 broken tasks on dive 60's pre-Garage
+    stragglers."""
+    images = [_image(1, "has-jpeg"), _image(2, "missing-jpeg")]
+    fs = _make_fs_client(images, existing_labels=[])  # both predicted, none done
+    ls = _make_ls_client(returned_task_ids=[2001])
+
+    store = MagicMock()
+
+    async def _has(_folder, checksum):
+        return checksum != "missing-jpeg"
+
+    store.has_processed_jpeg = AsyncMock(side_effect=_has)
+    monkeypatch.setattr(sut, "open_object_store_client", lambda: store)
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+
+    n = await ActivityEnvironment().run(
+        sut.populate_laser_label_studio_project_activity, 42, 73
+    )
+
+    assert n == 1  # only the image whose JPEG exists got a task
+    _args, kwargs = ls.projects.import_tasks.call_args
+    imported = [t["data"].get("image", "") for t in kwargs["request"]]
+    assert len(imported) == 1
+    assert any("missing-jpeg" not in u for u in imported)
+    assert not any("missing-jpeg" in u for u in imported)
+    assert fs.labels.put_laser_label.await_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What
Adds a per-image JPEG-existence gate to the laser populate activity, mirroring species populate's `_gate_on_jpeg_presence`.

## Why (found in prod)
Laser populate was **prediction-gated but not JPEG-gated**. The laser predictor runs off the raw `.ORF`, so it can produce a `LaserPrediction` for an image whose stage-0.1 `preprocess_jpeg` JPEG was never written to Garage — e.g. dive 60, labeled before the Garage migration (its originals live on the old file-exchange; only 70 laser JPEGs exist in Garage). Populate then seeded an LS task whose `data.image` points at a non-existent key, and the labeler hit:

```
<Error><Code>NoSuchKey</Code><Resource>/labels-fishsense-lite/fishsense-lite/preprocess_jpeg/6c340df4…JPG</Resource></Error>
```

This surfaced when the predict→populate flow reached now-predicted dive 60 and created project 276057 with 2 broken tasks.

## Fix
`_gate_on_jpeg_presence(images)` keeps only images whose `preprocess_jpeg/<checksum>.JPG` is in Garage (`ObjectStoreClient.has_processed_jpeg`), applied right after `_select_unlabeled_images`. Images without a JPEG **defer** to a later populate run (once preprocess writes them) instead of producing a 404 task. No-op when populate is chained right after preprocess. Identical pattern to species populate (which was already JPEG-gated).

## Tests
- New `test_defers_image_whose_laser_jpeg_is_not_in_garage` — an image with a prediction + no completed label but no Garage JPEG is not populated.
- Autouse fixture defaults "all JPEGs present" so existing tests are unchanged.
- 13 tests pass; pylint 10/10.

## Related
The predict schedule stays on; the **laser-populate schedule is paused** in prod until this deploys (to stop broken-task accumulation). I'll un-pause after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)