### PR TITLE
fix(api): predict cohort excludes superseded-completed labels

### DIFF
--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -205,6 +205,12 @@ async def select_next_for_laser_prediction(
     image — starving the detector on exactly the dives it should assist
     (e.g. a dive populated before the detector shipped). Matches populate's
     own `completed`-based definition of "labeled" (`_select_unlabeled_images`).
+
+    "Labeled" also requires `superseded IS FALSE`: a completed label that
+    `ValidateLaserLabelsForDiveWorkflow`'s RANSAC pass dead-lettered is an
+    *invalidated* label — the image has no live human label and should
+    re-enter the cohort. Mirrors the superseded-filter every downstream read
+    (`get_laser_labels`, the preprocess/predict resolvers) already applies.
     """
     has_image_needing_prediction = (
         select(Image.id)
@@ -218,6 +224,7 @@ async def select_next_for_laser_prediction(
             ~select(LaserLabel.id)
             .where(LaserLabel.image_id == Image.id)
             .where(LaserLabel.completed == True)
+            .where(LaserLabel.superseded == False)
             .exists()
         )
         .exists()

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -1893,13 +1893,14 @@ async def test_species_preprocessing_picks_dive_with_a_clustered_qualifying_imag
 # (completed=False, carries a project_id) does NOT drop it out.
 
 
-def _laser_label(image_id: int, *, project_id=73, completed=False):
+def _laser_label(image_id: int, *, project_id=73, completed=False, superseded=False):
     from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
 
     return LaserLabel(
         image_id=image_id,
         label_studio_project_id=project_id,
         completed=completed,
+        superseded=superseded,
     )
 
 
@@ -1972,6 +1973,37 @@ async def test_laser_prediction_seeded_placeholder_does_not_exclude(session):
     await session.flush()
 
     assert await select_next_for_laser_prediction(session=session) == 1
+
+
+async def test_laser_prediction_superseded_completed_label_does_not_exclude(session):
+    """A completed laser label that RANSAC validation superseded is an
+    invalidated label — the image has no live human label and still needs a
+    prediction. Regression for dive 60's straggler 4747, whose only completed
+    row was superseded."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_prediction,
+    )
+
+    session.add_all([_dive(1), _image(11, 1)])
+    await session.flush()
+    session.add(_laser_label(11, completed=True, superseded=True))
+    await session.flush()
+
+    assert await select_next_for_laser_prediction(session=session) == 1
+
+
+async def test_laser_prediction_live_completed_label_excludes(session):
+    """A completed, non-superseded label is a live human label — excluded."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_prediction,
+    )
+
+    session.add_all([_dive(1), _image(11, 1)])
+    await session.flush()
+    session.add(_laser_label(11, completed=True, superseded=False))
+    await session.flush()
+
+    assert await select_next_for_laser_prediction(session=session) is None
 
 
 # ---------- needing-laser-population (decoupled model-assisted populate) ----------


### PR DESCRIPTION
## What
`select_next_for_laser_prediction` now requires `superseded = False` in its "labeled" predicate, so a completed-but-superseded laser label no longer excludes an image from the predict cohort.

## Why
A completed label that `ValidateLaserLabelsForDiveWorkflow`'s RANSAC pass superseded is **invalidated** — the image has no live human label and should be re-predicted. The old predicate (`completed = True` only) counted it as labeled, so such images were silently skipped (under-prediction). Every downstream read (`get_laser_labels`, the preprocess/predict resolvers) already filters `superseded=False`; this brings the selector in step.

Found via dive 60's straggler image 4747, whose only completed laser row (project 10) was superseded back in 2025 — yet the selector treated it as labeled.

## Tests
- `test_laser_prediction_superseded_completed_label_does_not_exclude` — superseded-completed still needs prediction.
- `test_laser_prediction_live_completed_label_excludes` — live completed label still excludes.
- `_laser_label` helper gained a `superseded` kwarg. 6 laser-prediction tests pass; pylint 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)