### PR TITLE
test(api-worker): stub laser JPEG-gate in LS integration tests

### DIFF
--- a/services/fishsense-api-workflow-worker/tests/test_label_studio_integration.py
+++ b/services/fishsense-api-workflow-worker/tests/test_label_studio_integration.py
@@ -163,6 +163,20 @@ async def test_create_activity_raises_when_xml_constant_empty(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _stub_laser_jpeg_gate(monkeypatch):
+    """Laser populate is JPEG-gated (`_gate_on_jpeg_presence` →
+    `has_processed_jpeg`). These tests exercise the real LS-import path, not
+    the gate, and don't stage `preprocess_jpeg` JPEGs in the integration
+    Garage — so stub the gate to "present" (a no-op), mirroring how the
+    prediction gate is no-op'd via injected predictions in `_make_fs_client`.
+    Only laser populate is exercised in this file, so this is inert elsewhere.
+    """
+    store = MagicMock()
+    store.has_processed_jpeg = AsyncMock(return_value=True)
+    monkeypatch.setattr(populate_sut, "open_object_store_client", lambda: store)
+
+
 def _make_fs_client(images: List[Image], existing_labels: List[LaserLabel]):
     fs = MagicMock()
     fs.__aenter__ = AsyncMock(return_value=fs)


### PR DESCRIPTION
## What
Fixes 3 laser-populate integration tests broken by #443's JPEG-gate.

## Why
#443 made laser populate JPEG-gated (`_gate_on_jpeg_presence` → `has_processed_jpeg`). The real-LS integration tests inject predictions (no-op'ing the prediction gate) but never stage `preprocess_jpeg` JPEGs in the integration Garage, so the new gate filtered every image → populate imported 0 tasks (`assert 0 == N`). Feature-branch CI skips integration, so it only surfaced on the release PR (#448):

```
FAILED test_populate_imports_tasks_to_real_ls_in_input_order - assert 0 == 10
FAILED test_populate_skips_completed_against_real_ls - assert 0 == 5
FAILED test_populate_workflow_creates_then_imports_tasks_against_real_ls - assert 0 == 4
```

## Fix
Autouse fixture stubs `populate_sut.open_object_store_client` so `has_processed_jpeg` returns True (no-op gate) — mirroring how the prediction gate is no-op'd via injected predictions. Only laser populate is exercised in this file, so it's inert elsewhere.

Labeled `integration-tests` so CI runs the integration suite on this PR to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)