### PR TITLE
fix(api-worker): predict resolver keys off completed, not project_id

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_predict_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_predict_inputs_activity.py
@@ -25,13 +25,18 @@ def _select_images_needing_prediction(
     predictions: List[LaserPrediction],
     labels: List[LaserLabel],
 ) -> List[Image]:
-    """Images with no prediction and no non-sentinel laser label."""
+    """Images with no prediction and no *completed* laser label.
+
+    Keys off `completed`, NOT `label_studio_project_id`: the laser populate
+    step seeds placeholder rows (`completed=False`) that carry a project_id,
+    so a project-id check would exclude every populate-seeded-but-unlabeled
+    image and the detector would never predict it (the dive-84 / project-274728
+    case). `labels` is already superseded-filtered by `get_laser_labels`, so a
+    completed row here is a live human label. Mirrors the API selector
+    (`select_next_for_laser_prediction`) and populate's own definition.
+    """
     predicted_ids = {p.image_id for p in predictions}
-    labeled_ids = {
-        label.image_id
-        for label in labels
-        if label.label_studio_project_id is not None
-    }
+    labeled_ids = {label.image_id for label in labels if label.completed}
     return [
         image
         for image in images

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_laser_predict_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_laser_predict_inputs_activity.py
@@ -38,17 +38,31 @@ def _make_fs(*, camera_id=1, images=None, predictions=None, labels=None, intrins
     return fs
 
 
-def test_select_filters_predicted_and_labeled():
+def test_select_filters_predicted_and_completed():
     images = [_image(1, "a"), _image(2, "b"), _image(3, "c")]
     predictions = [SimpleNamespace(image_id=1)]
-    labels = [SimpleNamespace(image_id=2, label_studio_project_id=73)]
+    # image 2 has a completed (live) laser label -> excluded.
+    labels = [SimpleNamespace(image_id=2, label_studio_project_id=73, completed=True)]
     needing = sut._select_images_needing_prediction(images, predictions, labels)
     assert [i.id for i in needing] == [3]
 
 
+def test_seeded_placeholder_does_not_exclude():
+    """A populate-seeded placeholder (project_id set but completed=False) is
+    NOT a human label — the image still needs a prediction. Regression for
+    dive 84 / project 274728, whose 53 unlabeled images carried placeholder
+    rows and got 0 predictions."""
+    images = [_image(1, "a")]
+    labels = [SimpleNamespace(image_id=1, label_studio_project_id=274728, completed=False)]
+    needing = sut._select_images_needing_prediction(images, [], labels)
+    assert [i.id for i in needing] == [1]
+
+
 def test_sentinel_label_does_not_exclude():
     images = [_image(1, "a")]
-    labels = [SimpleNamespace(image_id=1, label_studio_project_id=None)]
+    labels = [
+        SimpleNamespace(image_id=1, label_studio_project_id=None, completed=False)
+    ]
     needing = sut._select_images_needing_prediction(images, [], labels)
     assert [i.id for i in needing] == [1]
 


### PR DESCRIPTION
## What
The predict **resolver** (`_select_images_needing_prediction`) now excludes images with a *completed* laser label instead of any project-id-bearing label — completing the fix started in #447 (which only fixed the *selector*).

## Why
Populate seeds placeholder rows (`completed=False`) that carry a `project_id`. The resolver's `project_id IS NOT NULL` check therefore excluded every populate-seeded-but-unlabeled image. Result: for a dive whose unlabeled images were already seeded (e.g. **dive 84 / project 274728**, populated 2026-07-22 before the detector shipped), the parent *selected* the dive (selector fixed in #447) but the resolver returned **0 images** → 0 predictions, every hour.

`labels` comes from `get_laser_labels` (superseded-filtered), so a `completed` row here is a live human label — matching the selector and populate's `_select_unlabeled_images`. Selector and resolver now agree.

## Tests
- `test_seeded_placeholder_does_not_exclude` — placeholder (project_id set, completed=False) still needs prediction.
- `test_select_filters_predicted_and_completed` — completed label excludes.
- sentinel test updated. 5 pass; pylint 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)