### PR TITLE
fix(deps): bump synology-filestation 0.1.19 -> 0.2.0 (fix NAS 502s)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,12 @@ fishsense-shared = { workspace = true }
 # python:3.13-slim-trixie via the stable ABI. Bump the URL when picking
 # up a new release; v0.1.18 raised the project's requires-python to
 # >=3.10, so the platform tag flipped from cp39-abi3 to cp310-abi3.
-synology-filestation = { url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.1.19/synology_filestation-0.1.19-cp310-abi3-manylinux_2_34_x86_64.whl" }
+#
+# v0.2.0 (2026-07-29): auto-prefers SMB with transparent HTTP fallback and
+# throttles bulk transfers to protect the NAS — fixes the FileStation
+# download-API HTTP 502s that were failing raw `.ORF` staging (stage 0.1/1/2/
+# 5.1/9 preprocess parents) under load. No API change; drop-in URL bump.
+synology-filestation = { url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.2.0/synology_filestation-0.2.0-cp310-abi3-manylinux_2_34_x86_64.whl" }
 
 # Workspace-wide pylint configuration. Lives at the repo root so every
 # package picks up the same rules; pylint walks up the directory tree

--- a/uv.lock
+++ b/uv.lock
@@ -783,7 +783,7 @@ requires-dist = [
     { name = "platformdirs", specifier = ">=4.3.8" },
     { name = "pyaml", specifier = ">=25.7.0" },
     { name = "pymupdf", specifier = ">=1.24.0" },
-    { name = "synology-filestation", url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.1.19/synology_filestation-0.1.19-cp310-abi3-manylinux_2_34_x86_64.whl" },
+    { name = "synology-filestation", url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.2.0/synology_filestation-0.2.0-cp310-abi3-manylinux_2_34_x86_64.whl" },
     { name = "temporalio", specifier = ">=1.15.0" },
     { name = "validators", specifier = ">=0.35.0" },
 ]
@@ -827,7 +827,7 @@ requires-dist = [
     { name = "fishsense-shared", editable = "libs/fishsense-shared" },
     { name = "platformdirs", specifier = ">=4.3.8" },
     { name = "pydantic", specifier = ">=2.11.9" },
-    { name = "synology-filestation", url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.1.19/synology_filestation-0.1.19-cp310-abi3-manylinux_2_34_x86_64.whl" },
+    { name = "synology-filestation", url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.2.0/synology_filestation-0.2.0-cp310-abi3-manylinux_2_34_x86_64.whl" },
     { name = "temporalio", specifier = ">=1.17.0" },
     { name = "validators", specifier = ">=0.35.0" },
 ]
@@ -3039,14 +3039,14 @@ wheels = [
 
 [[package]]
 name = "synology-filestation"
-version = "0.1.19"
-source = { url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.1.19/synology_filestation-0.1.19-cp310-abi3-manylinux_2_34_x86_64.whl" }
+version = "0.2.0"
+source = { url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.2.0/synology_filestation-0.2.0-cp310-abi3-manylinux_2_34_x86_64.whl" }
 wheels = [
-    { url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.1.19/synology_filestation-0.1.19-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f951fc7bbbdf4b692b4c2c164fdaee975a1bda524c48ba6944798095268bf104" },
+    { url = "https://github.com/UCSD-E4E/synology-filestation/releases/download/synology_filestation-v0.2.0/synology_filestation-0.2.0-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:667eee98d93851d249b47482162e255d0dbb022b3b5804120b9c8a0f4edc28e1" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "fsspec", marker = "extra == 'fsspec'", specifier = ">=2026.4.0" }]
+requires-dist = [{ name = "fsspec", marker = "extra == 'fsspec'", specifier = ">=2026.7.0" }]
 provides-extras = ["fsspec"]
 
 [[package]]


### PR DESCRIPTION
## What
Bumps the `synology-filestation` wheel pin (workspace-wide `[tool.uv.sources]`) from **v0.1.19 → v0.2.0**.

## Why
Raw `.ORF` staging (`stage_raw_bytes_for_dive_activity`) has been failing with **`HTTP 502 Bad Gateway`** from FileStation's download API. FileStation's shared download backend 502s intermittently under load, and a full dive's staging (dozens of sequential downloads) reliably trips it → the preprocess/predict parents fail. Observed live: the **stage-9 slate dives** (needed to calibrate the FishModels dives) — every hourly `PreprocessSlateImagesParentWorkflow` run FAILED on this 502, so those dives never got slate-labeled/calibrated. Files themselves are fine (manual single-file downloads succeed), confirming it's saturation/intermittent, not missing data.

## The fix (v0.2.0)
- **Auto-prefers SMB transfers** with transparent HTTP fallback — bypasses the flaky FileStation HTTP download endpoint that 502s.
- **Throttles bulk transfers** to protect the NAS from saturation.
- Streaming reads/writes for large files.

**No API change** (per release notes) and same platform tag (`cp310-abi3-manylinux_2_34_x86_64`), so it's a drop-in: `NasClient`'s `login`/`download_to`/`upload`/`exists`/`create_folder` calls are unchanged (verified all present in 0.2.0).

## Tests
`test_nas_client.py` + `test_stage_raw_bytes_for_dive_activity.py` — 19 pass against 0.2.0.

## Note
SMB preference needs the NAS reachable on SMB (445) from the slot; if it isn't, it falls back to HTTP but *with* the new throttling, which still reduces the saturation 502s. Once deployed, the stalled slate dives should stage and flow through slate-labeling → calibration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)