### PR TITLE
fix(deps): require synology-filestation>=0.2.0 in NAS consumers (ship the 502 fix)

### DIFF
--- a/services/fishsense-api-workflow-worker/pyproject.toml
+++ b/services/fishsense-api-workflow-worker/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "platformdirs>=4.3.8",
     "pyaml>=25.7.0",
     "pymupdf>=1.24.0",
-    "synology-filestation",
+    "synology-filestation>=0.2.0",  # >=0.2.0: SMB-preferred + throttled NAS transfers (fixes FileStation download 502s)
     "temporalio>=1.15.0",
     "validators>=0.35.0",
 ]

--- a/services/fishsense-backup-worker/pyproject.toml
+++ b/services/fishsense-backup-worker/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "fishsense-shared",
     "platformdirs>=4.3.8",
     "pydantic>=2.11.9",
-    "synology-filestation",
+    "synology-filestation>=0.2.0",  # >=0.2.0: SMB-preferred + throttled NAS transfers (fixes FileStation download 502s)
     "temporalio>=1.17.0",
     "validators>=0.35.0",
 ]


### PR DESCRIPTION
## What
Declares `synology-filestation>=0.2.0` in the two consumers (`fishsense-api-workflow-worker`, `fishsense-backup-worker`).

## Why
#456 bumped the workspace pin to 0.2.0 (SMB-preferred + throttled NAS transfers — fixes the FileStation download **HTTP 502s** that were failing raw `.ORF` staging) but only touched the **root** `pyproject`/`uv.lock`. release-please attributes commits per package path, so a root-only change cuts **no release** — the deployed api-worker still runs **0.1.19** (old HTTP client, verified in prod).

This per-path floor makes release-please release both consumers so the 0.2.0 wheel actually ships. The floor is satisfied by the URL-pinned wheel; it also documents why the version matters (SMB fallback + throttle so we stop tripping the NAS backend).

## Context
The NAS was rebooted as a stopgap (cleared the current 502 state), but until 0.2.0 deploys the old HTTP client will resume the same bulk-download pattern and can re-trigger the 502s under load (7 slate dives + the predict wave staging at `:45`/`:00`/`:10`/`:15`). This ships the durable fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)