### PR TITLE
fix(slate): fail-hard on uncomputable panel offset; correct multi-skip point drop

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/create_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/create_dive_slate_label_studio_project_activity.py
@@ -11,18 +11,15 @@ DIVE_SLATE_PROJECT_TITLE_SUFFIX = "Dive Slate Labeling"
 
 # Labeling-config XML from the prod dive-slate project. Control names
 # map 1:1 to fields on `DiveSlateLabel`:
-#   * `upside_down` (Choices)        -> `DiveSlateLabel.upside_down`
 #   * `reference_points` (KeyPoints) -> `DiveSlateLabel.reference_points`
 #   * `slate` (RectangleLabels)      -> `DiveSlateLabel.slate_rectangle`
 #   * `skipped_points` (TextArea)    -> `DiveSlateLabel.skipped_points`
-# The stage 12 sync activity (sync_slate_label, not yet ported) will
-# need to read annotations off these `from_name`s.
+# The `upside_down` Choices control was removed 2026-07-31 — it was never
+# read downstream (only ever set true-or-NULL, never false) and the slate
+# geometry made it redundant. The `DiveSlateLabel.upside_down` column is
+# kept for the historical rows that carry a value; nothing new populates it.
 DIVE_SLATE_LABELING_CONFIG_XML = """\
 <View>
-
-  <Choices name="upside_down" toName="image">
-    <Choice value="Slate upside down" />
-  </Choices>
 
   <Image name="image" value="$image" zoom="true"/>
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_dive_slate_labels_for_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/sync_dive_slate_labels_for_label_studio_project_activity.py
@@ -64,21 +64,39 @@ def _shift_x(points: List[Point], dx: float) -> List[Point]:
     return [(x - dx, y) for x, y in points]
 
 
+def _assert_in_frame(
+    points: List[Point], photo_width: float, *, task_id: Any, slate_id: int
+) -> None:
+    """Reject a panel-offset shift that lands any x outside [0, photo_width].
+
+    The photo occupies composite x in [panel_width, original_width], so a
+    correctly de-offset point lands in [0, original_width - panel_width] =
+    [0, photo_width]. A shift computed from the wrong template's panel width
+    (or none at all) leaves points past the right edge (x > photo_width, still
+    composite space) or overshoots past the left edge (x < 0). Either way the
+    geometry is wrong-space and must fail loudly rather than be persisted.
+    Mirrors `contracts.repair_panel_offset`.
+    """
+    for x, _ in points:
+        if not 0 <= x <= float(photo_width):
+            raise ValueError(
+                f"slate label task_id={task_id} slate_id={slate_id}: panel-offset "
+                f"shift put x={x:.1f} outside [0, {photo_width:.1f}] — wrong slate "
+                f"template or missing offset. Refusing to persist wrong-space geometry."
+            )
+
+
 def _parse_results(annotation: Dict[str, Any]) -> Dict[str, Any]:
     """Pull the slate annotation fields out of an LS task result list.
 
     Returns raw composite-frame coordinates (no offset applied) plus
-    `original_height`. The caller applies the panel-width shift once it
-    has fetched the slate PDF.
+    `original_width`/`original_height`. The caller applies the panel-width
+    shift once it has fetched the slate PDF.
+
+    Note: the `upside_down` Choices control was removed from the labeling
+    config on 2026-07-31 (never read downstream), so it is no longer parsed.
     """
     results = annotation.get("result") or []
-
-    upside_down: bool | None = None
-    upside_down_results = [r for r in results if r["from_name"] == "upside_down"]
-    if upside_down_results:
-        choices = upside_down_results[0]["value"].get("choices") or []
-        if choices:
-            upside_down = choices[0] == "Slate upside down"
 
     reference_results = [r for r in results if r["from_name"] == "reference_points"]
     reference_points: List[Point] = [
@@ -111,17 +129,21 @@ def _parse_results(annotation: Dict[str, Any]) -> Dict[str, Any]:
         skipped_points = [int(p) - 1 for p in text]
 
     original_height: float | None = None
+    original_width: float | None = None
     for r in results:
-        if "original_height" in r:
+        if original_height is None and "original_height" in r:
             original_height = float(r["original_height"])
+        if original_width is None and "original_width" in r:
+            original_width = float(r["original_width"])
+        if original_height is not None and original_width is not None:
             break
 
     return {
-        "upside_down": upside_down,
         "reference_points": reference_points,
         "slate_rectangle": slate_rectangle,
         "skipped_points": skipped_points,
         "original_height": original_height,
+        "original_width": original_width,
     }
 
 
@@ -157,12 +179,13 @@ async def _aspect_ratio_for_slate(
         pdf_bytes = await exchange.download_slate_pdf(slate_id)
     except (ClientError, BotoCoreError) as e:
         # Missing/unreadable slate PDF in Garage (botocore ClientError or
-        # transport error). Skip the panel-width offset for this label
-        # rather than failing the whole sync. Anything else (e.g. a
-        # programming error) propagates and fails the activity.
+        # transport error). Return None; the caller treats an uncomputable
+        # offset as fatal for any label that carries geometry (it FAILS the
+        # label rather than persist composite-space coords). Anything else
+        # (e.g. a programming error) propagates and fails the activity.
         activity.logger.warning(
             "Could not fetch slate PDF for slate_id=%d (%s); "
-            "skipping panel-width offset for this label",
+            "panel-width offset is uncomputable for labels using this slate",
             slate_id,
             e,
         )
@@ -204,40 +227,67 @@ async def _update_slate_label(
         annotation = task.annotations[0]
         parsed = _parse_results(annotation)
 
-        if parsed["upside_down"] is not None:
-            slate_label.upside_down = parsed["upside_down"]
-
         if parsed["skipped_points"] is not None:
             slate_label.skipped_points = parsed["skipped_points"]
 
-        panel_width = 0.0
-        original_height = parsed["original_height"]
-        if (
-            (parsed["reference_points"] or parsed["slate_rectangle"])
-            and original_height is not None
-            and slate_label.image_id is not None
-        ):
+        # The LS canvas is a composite (PDF panel left + photo right), so
+        # stored geometry MUST have the panel width subtracted to land in
+        # photo-frame coords. If we can't compute that offset (no image_id,
+        # unresolvable slate, or the slate PDF is missing from the object
+        # store) we FAIL THE LABEL rather than persist composite-space
+        # geometry with a 0-px shift — the previous silent fallback stranded
+        # 104 prod rows in composite space (out of frame; corrupt for
+        # calibration). A raise fails this (per-dive) project's sync without
+        # advancing the cursor, so the hourly re-run recovers once the PDF
+        # is staged.
+        if parsed["reference_points"] or parsed["slate_rectangle"]:
+            original_height = parsed["original_height"]
+            original_width = parsed["original_width"]
+            if original_height is None or original_width is None:
+                raise ValueError(
+                    f"slate label task_id={task.id} has geometry but the LS result "
+                    f"is missing original_width/height; cannot remove the composite "
+                    f"panel offset."
+                )
+            if slate_label.image_id is None:
+                raise ValueError(
+                    f"slate label task_id={task.id} has geometry but no image_id; "
+                    f"cannot resolve its slate template to remove the panel offset."
+                )
             slate_id = await _slate_id_for_image(
                 fs, slate_label.image_id, image_to_slate
             )
-            if slate_id is not None:
-                aspect = await _aspect_ratio_for_slate(
-                    exchange, slate_id, aspect_cache
+            if slate_id is None:
+                raise ValueError(
+                    f"slate label task_id={task.id} image_id={slate_label.image_id}: "
+                    f"no resolvable dive_slate_id; cannot remove the composite panel "
+                    f"offset. Refusing to persist composite-space geometry."
                 )
-                if aspect is not None:
-                    panel_width = compute_pdf_panel_width_in_composite(
-                        aspect, original_height
-                    )
-
-        if parsed["reference_points"]:
-            slate_label.reference_points = _shift_x(
-                parsed["reference_points"], panel_width
+            aspect = await _aspect_ratio_for_slate(exchange, slate_id, aspect_cache)
+            if aspect is None:
+                raise ValueError(
+                    f"slate label task_id={task.id}: slate PDF for slate_id={slate_id} "
+                    f"is unavailable in the object store; cannot remove the composite "
+                    f"panel offset. Refusing to persist composite-space geometry "
+                    f"(fix: stage the slate PDF, then the hourly sync recovers)."
+                )
+            panel_width = compute_pdf_panel_width_in_composite(
+                aspect, original_height
             )
 
-        if parsed["slate_rectangle"] is not None:
-            slate_label.slate_rectangle = _shift_x(
-                parsed["slate_rectangle"], panel_width
-            )
+            if parsed["reference_points"]:
+                shifted = _shift_x(parsed["reference_points"], panel_width)
+                _assert_in_frame(
+                    shifted, original_width, task_id=task.id, slate_id=slate_id
+                )
+                slate_label.reference_points = shifted
+
+            if parsed["slate_rectangle"] is not None:
+                shifted = _shift_x(parsed["slate_rectangle"], panel_width)
+                _assert_in_frame(
+                    shifted, original_width, task_id=task.id, slate_id=slate_id
+                )
+                slate_label.slate_rectangle = shifted
 
     await fs.labels.put_dive_slate_label(slate_label.image_id, slate_label)
 

--- a/services/fishsense-api-workflow-worker/tests/test_sync_dive_slate_labels_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_sync_dive_slate_labels_activity.py
@@ -20,8 +20,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pymupdf
 import pytest
+from botocore.exceptions import ClientError
 from temporalio.testing import ActivityEnvironment
 
+from fishsense_api_sdk.models.dive_slate_label import DiveSlateLabel
 from fishsense_api_workflow_worker.activities import (
     sync_dive_slate_labels_for_label_studio_project_activity as sut,
     utils as sut_utils,
@@ -74,10 +76,6 @@ def test_parse_results_extracts_all_fields():
     annotation = {
         "result": [
             {
-                "from_name": "upside_down",
-                "value": {"choices": ["Slate upside down"]},
-            },
-            {
                 "from_name": "reference_points",
                 "value": {"x": 50.0, "y": 25.0, "keypointlabels": ["Reference Point"]},
                 "original_width": 1000,
@@ -109,30 +107,33 @@ def test_parse_results_extracts_all_fields():
     }
 
     parsed = sut._parse_results(annotation)  # pylint: disable=protected-access
-    assert parsed["upside_down"] is True
+    assert "upside_down" not in parsed  # removed 2026-07-31
     assert parsed["reference_points"] == [(500.0, 125.0), (750.0, 150.0)]
     assert parsed["slate_rectangle"] == [(600.0, 50.0), (800.0, 200.0)]
     assert parsed["skipped_points"] == [0, 2, 4]
     assert parsed["original_height"] == 500.0
+    assert parsed["original_width"] == 1000.0
 
 
 def test_parse_results_handles_minimal_annotation():
     parsed = sut._parse_results({"result": []})  # pylint: disable=protected-access
-    assert parsed["upside_down"] is None
     assert parsed["reference_points"] == []
     assert parsed["slate_rectangle"] is None
     assert parsed["skipped_points"] is None
     assert parsed["original_height"] is None
+    assert parsed["original_width"] is None
 
 
-def test_parse_results_upside_down_false_when_choice_is_other():
+def test_parse_results_ignores_removed_upside_down_control():
+    # A stale project may still emit an `upside_down` result; it must be a no-op.
     annotation = {
         "result": [
-            {"from_name": "upside_down", "value": {"choices": ["Slate right side up"]}}
+            {"from_name": "upside_down", "value": {"choices": ["Slate upside down"]}}
         ]
     }
     parsed = sut._parse_results(annotation)  # pylint: disable=protected-access
-    assert parsed["upside_down"] is False
+    assert "upside_down" not in parsed
+    assert parsed["reference_points"] == []
 
 
 # --------------------------- pdf aspect ratio --------------------------
@@ -193,6 +194,164 @@ async def test_per_task_concurrency_is_bounded_by_semaphore(monkeypatch):
         f"peak concurrency was {peak_in_flight}, "
         f"expected <= {sut.SYNC_CONCURRENCY}"
     )
+
+
+# ------------------- panel-offset fail-hard + bounds (Bug 1) -------------------
+
+
+def _full_slate_label(image_id: int = 10, ls_id: int = 1) -> DiveSlateLabel:
+    return DiveSlateLabel(
+        id=ls_id,
+        label_studio_task_id=ls_id,
+        label_studio_project_id=66,
+        image_url=None,
+        upside_down=None,
+        reference_points=None,
+        slate_rectangle=None,
+        skipped_points=None,
+        updated_at=None,
+        completed=False,
+        superseded=False,
+        label_studio_json=None,
+        image_id=image_id,
+        user_id=None,
+    )
+
+
+def _geometry_annotation(composite_x: float, y: float, ow: float, oh: float) -> dict:
+    """One reference point at composite pixel (composite_x, y) on an ow×oh canvas."""
+    return {
+        "result": [
+            {
+                "from_name": "reference_points",
+                "value": {
+                    "x": composite_x / ow * 100.0,
+                    "y": y / oh * 100.0,
+                    "keypointlabels": ["Reference Point"],
+                },
+                "original_width": ow,
+                "original_height": oh,
+            }
+        ]
+    }
+
+
+def _make_update_fs(slate_label: DiveSlateLabel, *, slate_id: int | None):
+    fs = MagicMock()
+
+    async def _get_label(label_studio_id):
+        return slate_label
+
+    fs.labels = MagicMock()
+    fs.labels.get_dive_slate_label = AsyncMock(side_effect=_get_label)
+    fs.labels.put_dive_slate_label = AsyncMock()
+
+    async def _get_image(image_id):
+        return SimpleNamespace(dive_id=5)
+
+    async def _get_dive(dive_id):
+        return SimpleNamespace(dive_slate_id=slate_id)
+
+    fs.images = MagicMock()
+    fs.images.get = AsyncMock(side_effect=_get_image)
+    fs.dives = MagicMock()
+    fs.dives.get = AsyncMock(side_effect=_get_dive)
+    return fs
+
+
+def _make_exchange(*, pdf_bytes: bytes | None):
+    ex = MagicMock()
+    if pdf_bytes is None:
+        ex.download_slate_pdf = AsyncMock(
+            side_effect=ClientError(
+                {"Error": {"Code": "NoSuchKey", "Message": "missing"}}, "GetObject"
+            )
+        )
+    else:
+        ex.download_slate_pdf = AsyncMock(return_value=pdf_bytes)
+    return ex
+
+
+def test_assert_in_frame_rejects_out_of_bounds():
+    sut._assert_in_frame([(50.0, 1.0)], 100.0, task_id=1, slate_id=2)  # in frame, no raise
+    sut._assert_in_frame([(100.0, 1.0)], 100.0, task_id=1, slate_id=2)  # right edge OK
+    with pytest.raises(ValueError):
+        sut._assert_in_frame([(150.0, 1.0)], 100.0, task_id=1, slate_id=2)
+    with pytest.raises(ValueError):
+        sut._assert_in_frame([(-5.0, 1.0)], 100.0, task_id=1, slate_id=2)
+
+
+@pytest.mark.asyncio
+async def test_update_slate_label_subtracts_panel_offset_and_persists():
+    # 2:1 PDF, composite height 100 -> panel width 200; canvas 300 wide ->
+    # photo width 100. A point at composite x=250 lands at photo x=50.
+    pdf = _make_synthetic_pdf(216.0, 108.0)  # aspect 2.0
+    label = _full_slate_label()
+    fs = _make_update_fs(label, slate_id=7)
+    exchange = _make_exchange(pdf_bytes=pdf)
+    task = _make_task(1, annotations=[_geometry_annotation(250.0, 50.0, 300.0, 100.0)])
+
+    await sut._update_slate_label(
+        fs, task, exchange=exchange, aspect_cache={}, image_to_slate={}
+    )
+
+    fs.labels.put_dive_slate_label.assert_awaited_once()
+    (persisted_image_id, persisted), _ = fs.labels.put_dive_slate_label.call_args
+    assert persisted_image_id == 10
+    assert len(persisted.reference_points) == 1
+    px, py = persisted.reference_points[0]
+    assert px == pytest.approx(50.0)
+    assert py == pytest.approx(50.0)
+
+
+@pytest.mark.asyncio
+async def test_update_slate_label_raises_and_skips_persist_when_pdf_missing():
+    # The old fallback silently persisted composite-space coords with a 0px
+    # shift. It must now fail the label instead — no put, exception propagates.
+    label = _full_slate_label()
+    fs = _make_update_fs(label, slate_id=7)
+    exchange = _make_exchange(pdf_bytes=None)  # NoSuchKey
+    task = _make_task(1, annotations=[_geometry_annotation(250.0, 50.0, 300.0, 100.0)])
+
+    with pytest.raises(ValueError, match="object store"):
+        await sut._update_slate_label(
+            fs, task, exchange=exchange, aspect_cache={}, image_to_slate={}
+        )
+
+    fs.labels.put_dive_slate_label.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_slate_label_raises_when_slate_unresolvable():
+    label = _full_slate_label()
+    fs = _make_update_fs(label, slate_id=None)  # dive has no dive_slate_id
+    exchange = _make_exchange(pdf_bytes=_make_synthetic_pdf(216.0, 108.0))
+    task = _make_task(1, annotations=[_geometry_annotation(250.0, 50.0, 300.0, 100.0)])
+
+    with pytest.raises(ValueError, match="dive_slate_id"):
+        await sut._update_slate_label(
+            fs, task, exchange=exchange, aspect_cache={}, image_to_slate={}
+        )
+
+    fs.labels.put_dive_slate_label.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_slate_label_raises_when_shift_lands_out_of_frame():
+    # Wrong-template panel width: composite x=250 needs a 200px shift, but a
+    # too-large panel (aspect 3.0 -> 300px) overshoots to -50, out of frame.
+    pdf = _make_synthetic_pdf(324.0, 108.0)  # aspect 3.0 -> panel 300
+    label = _full_slate_label()
+    fs = _make_update_fs(label, slate_id=7)
+    exchange = _make_exchange(pdf_bytes=pdf)
+    task = _make_task(1, annotations=[_geometry_annotation(250.0, 50.0, 300.0, 100.0)])
+
+    with pytest.raises(ValueError, match="outside"):
+        await sut._update_slate_label(
+            fs, task, exchange=exchange, aspect_cache={}, image_to_slate={}
+        )
+
+    fs.labels.put_dive_slate_label.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/perform_laser_calibration_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/perform_laser_calibration_activity.py
@@ -33,6 +33,30 @@ MIN_LASER_POINTS = 2
 __all__ = ["perform_laser_calibration_activity"]
 
 
+def _drop_skipped(points: list, skipped) -> list:
+    """Remove `skipped` indices from `points`, resolved against the ORIGINAL list.
+
+    A sequential ``list.pop(idx)`` (the previous implementation, and the
+    stage-13 notebook) is only correct for <=1 skipped point: popping index 2
+    slides every later element down one, so a subsequent ``pop(5)`` removes what
+    was originally index 6 — feeding a wrong 3D<->2D pair into solvePnP. Latent
+    while every production label skips <=1 point, but model-assisted labeling
+    emits per-point visibility (multi-skip), so it activates the moment that
+    ships. Resolve all indices up front, and reject duplicate / out-of-range
+    indices. Mirrors `slate_training.contracts.drop_skipped`.
+    """
+    indices = [int(i) for i in skipped]
+    if len(set(indices)) != len(indices):
+        raise ValueError(f"duplicate skipped index in {indices}")
+    for i in indices:
+        if not 0 <= i < len(points):
+            raise ValueError(
+                f"skipped index {i} out of range for {len(points)} points"
+            )
+    drop = set(indices)
+    return [p for i, p in enumerate(points) if i not in drop]
+
+
 def _laser_point_in_camera_space(
     label: DiveSlateLabel,
     laser_label: LaserLabel,
@@ -44,12 +68,23 @@ def _laser_point_in_camera_space(
     Returns None when the observation can't be used (PnP failure, NaN
     ray). Mirrors the per-label kernel from `scripts/validate_stage13_refactor.py`.
     """
-    source_points = list(slate.reference_points or [])
-    for idx in label.skipped_points or []:
-        source_points.pop(idx)
+    source_points = _drop_skipped(
+        list(slate.reference_points or []), label.skipped_points or []
+    )
+    image_points = list(label.reference_points or [])
+    # solvePnP pairs body<->image points purely by position, so a count that
+    # disagrees with (template - skipped) silently mis-pairs the geometry.
+    # Make that a hard error. Mirrors `contracts.template_correspondences`.
+    if len(image_points) != len(source_points):
+        raise ValueError(
+            f"slate label reference_points={len(image_points)} disagrees with "
+            f"template {slate.id} ({len(slate.reference_points or [])}) minus "
+            f"{len(set(int(i) for i in (label.skipped_points or [])))} skipped "
+            f"= {len(source_points)}; refusing to mis-pair solvePnP correspondences"
+        )
     body_points = np.zeros((len(source_points), 3), dtype=np.float32)
     body_points[:, :2] = (np.array(source_points) / float(slate.dpi)) * INCH_TO_M
-    image_space = np.array(label.reference_points)
+    image_space = np.array(image_points)
 
     ret, rvec, tvec = cv2.solvePnP(
         body_points,

--- a/services/fishsense-data-processing-workflow-worker/tests/test_perform_laser_calibration_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_perform_laser_calibration_activity.py
@@ -274,3 +274,65 @@ async def test_recovers_known_laser_extrinsics_from_synthetic_scene(monkeypatch)
     fitted_pos = np.asarray(written_le.laser_position, dtype=float)
     pos_xy_l2 = float(np.linalg.norm(fitted_pos[:2] - laser_origin[:2]))
     assert pos_xy_l2 < 0.001
+
+
+# --------------------------- skipped-points (Bug 2) ---------------------------
+
+
+def test_drop_skipped_resolves_indices_against_original_list():
+    """skipped=[2,5] on 8 points keeps {0,1,3,4,6,7} — NOT the {0,1,3,4,5,7}
+    a sequential pop() would leave. Regression for the stage-13 mis-pair."""
+    pts = list("abcdefgh")
+    assert sut._drop_skipped(pts, [2, 5]) == ["a", "b", "d", "e", "g", "h"]
+    # single skip (the only case the old pop() got right) still works
+    assert sut._drop_skipped(pts, [5]) == ["a", "b", "c", "d", "e", "g", "h"]
+    # no skip is identity
+    assert sut._drop_skipped(pts, []) == pts
+
+
+def test_drop_skipped_rejects_duplicate_and_out_of_range():
+    with pytest.raises(ValueError):
+        sut._drop_skipped(list("abcdef"), [2, 2])
+    with pytest.raises(ValueError):
+        sut._drop_skipped(list("abcdef"), [6])
+    with pytest.raises(ValueError):
+        sut._drop_skipped(list("abcdef"), [-1])
+
+
+def test_laser_point_raises_when_reference_count_mismatches_template():
+    """A labeled point count that disagrees with (template - skipped) must fail
+    loudly rather than mis-pair solvePnP correspondences."""
+    slate = _slate()  # 6 template points
+    label = DiveSlateLabel(
+        id=1,
+        label_studio_task_id=1,
+        label_studio_project_id=66,
+        image_url=None,
+        upside_down=False,
+        # 6 template - 1 skipped = 5 expected, but only 4 provided
+        reference_points=[(10.0, 10.0), (20.0, 10.0), (10.0, 20.0), (20.0, 20.0)],
+        slate_rectangle=None,
+        skipped_points=[2],
+        updated_at=None,
+        completed=True,
+        superseded=False,
+        label_studio_json=None,
+        image_id=1,
+        user_id=None,
+    )
+    laser = LaserLabel(
+        id=1,
+        label_studio_task_id=1,
+        label_studio_project_id=73,
+        x=100.0,
+        y=100.0,
+        label="laser",
+        updated_at=None,
+        superseded=False,
+        completed=True,
+        label_studio_json=None,
+        image_id=1,
+        user_id=None,
+    )
+    with pytest.raises(ValueError):
+        sut._laser_point_in_camera_space(label, laser, slate, _camera_intrinsics())


### PR DESCRIPTION
Two dive-slate labeling geometry defects surfaced by the 2026-07-31 prod dump, plus a small labeling-config cleanup.

## Bug 1 — composite panel offset silently not removed (api-worker sync)
The LS slate task is a composite canvas: template PDF panel on the left, rectified photo on the right. Labelers click the photo half, so raw LS coords carry a horizontal offset of the rendered panel width. `sync_dive_slate_labels_...` is supposed to subtract it, but on any failure to fetch the slate PDF from the object store it fell back to a **0px shift and persisted composite-space geometry**.

Evidence from the dump: photo 4014×3016, all **104** completed labels had `reference_points` x in [5709, 7522] — **0/104 in-frame**. Subtracting the per-template panel width (4967.5px V-Slate, 3903.1px Tic-Tac-Toe 6) lands 104/104 back on the physical fiducials and improves median solvePnP RMS 1.06→0.64px. Root cause: the slate PDFs weren't staged in Garage, so `download_slate_pdf` raised → the `except (ClientError, BotoCoreError)` fallback → `panel_width=0.0`.

**Fix:** the label now **fails (raise)** rather than persist wrong-space geometry when the offset is uncomputable (no `image_id`, unresolvable `dive_slate_id`, or missing PDF). Added a bounds guard rejecting any shift that lands x outside `[0, photo_width]` (wrong-template panel width). A raise fails only that per-dive project's sync (TaskGroup) without advancing the cursor, so the hourly re-run recovers once the PDF is staged.

## Bug 2 — skipped-points mis-pair at ≥2 skips (data-worker stage-13 calibration)
`_laser_point_in_camera_space` dropped skipped template indices with a sequential `list.pop(idx)`. Correct only for ≤1 skip: popping index 2 slides later elements down, so a subsequent `pop(5)` removes what was originally index 6 — feeding a **mis-paired 3D↔2D correspondence into solvePnP**. Latent today (88 labels skip nothing, 16 skip one, none ≥2) but activates silently the moment model-assisted labeling ships.

**Fix:** set-based `_drop_skipped` (resolves all indices against the original list; rejects duplicate / out-of-range indices) + a hard assert that `len(reference_points) == len(template) - len(skipped)`.

## Cleanup — remove "Slate upside down"
Removed the unused `upside_down` Choices control from the dive-slate labeling config and stopped parsing/writing it in the sync activity (only ever set true-or-NULL, never read downstream). The `DiveSlateLabel.upside_down` column is retained for historical rows.

Both fixes mirror the tested reference contracts (`repair_panel_offset` / `drop_skipped` / `template_correspondences`) in the slate-training repo.

## Tests
- data-worker: `test_perform_laser_calibration_activity.py` — `_drop_skipped` resolves `[2,5]`→keep {0,1,3,4,6,7}, rejects dup/OOR, count-mismatch raises (7 passed).
- api-worker: `test_sync_dive_slate_labels_activity.py` — panel offset subtracted+persisted, raises+skips-persist on missing PDF / unresolvable slate / out-of-frame shift, `_assert_in_frame` bounds, `upside_down` no longer parsed (12 passed).
- Full suites green: api-worker 327 passed, data-worker 111 passed.

## Follow-ups (separate, not in this PR)
- Idempotent backfill of the 104 composite-space rows (per-template-family, reject OOB).
- Decide whether to recompute the 8 existing `LaserExtrinsics` (+ measurement cascade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)