### PR TITLE
fix(api): upsert LaserExtrinsics on dive_id + non-null created_at

### DIFF
--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
@@ -145,6 +145,13 @@ class LabelStudioSyncCursor(BaseModel):
 class LaserExtrinsics(BaseModel):
     """
     Laser extrinsics model representing laser calibration data in the database.
+
+    One row per dive (`uq_laserextrinsics_dive_id`): calibration is a per-dive
+    property, `put_laser_extrinsics_for_dive` upserts on `dive_id`, and no
+    consumer reads a history of extrinsics — reads take the single row (or borrow
+    a sibling's via `Dive.calibration_dive_id`). `created_at` carries a
+    `server_default=now()` so a row can never be inserted with a NULL timestamp
+    (which broke the latest-wins read: Postgres sorts NULLs first under DESC).
     """
 
     id: int | None = Field(None, title='Id')

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/fab962df0484_laserextrinsics_dedup_created_at_.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/fab962df0484_laserextrinsics_dedup_created_at_.py
@@ -1,0 +1,70 @@
+"""laserextrinsics dedup+created_at default+unique dive_id
+
+Revision ID: fab962df0484
+Revises: f4a9c2b17e60
+Create Date: 2026-08-01 14:33:11.611031
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'fab962df0484'
+down_revision: Union[str, Sequence[str], None] = 'f4a9c2b17e60'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Forward-fix for the #462-recovery bug (see LaserExtrinsics model docstring):
+    the calibration path appended rows and left `created_at` NULL, which broke
+    the latest-wins read. Order matters — de-dup and backfill the data first,
+    then the unique constraint can be added without a violation.
+    """
+    # 1. De-duplicate: keep the newest row per dive (highest id; created_at may
+    #    be NULL on buggy rows so id is the reliable tiebreaker).
+    op.execute(
+        """
+        DELETE FROM laserextrinsics a
+        USING laserextrinsics b
+        WHERE a.dive_id = b.dive_id
+          AND a.dive_id IS NOT NULL
+          AND a.id < b.id
+        """
+    )
+    # 2. Backfill any NULL created_at (the hand-patched #462-recovery rows
+    #    already have timestamps; this covers anything left).
+    op.execute("UPDATE laserextrinsics SET created_at = now() WHERE created_at IS NULL")
+    # 3. Column default so future inserts can never be NULL again.
+    op.alter_column(
+        "laserextrinsics",
+        "created_at",
+        server_default=sa.text("now()"),
+        existing_type=sa.DateTime(timezone=True),
+        existing_nullable=True,
+    )
+    # 4. One calibration per dive.
+    op.create_unique_constraint(
+        "uq_laserextrinsics_dive_id", "laserextrinsics", ["dive_id"]
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint(
+        "uq_laserextrinsics_dive_id", "laserextrinsics", type_="unique"
+    )
+    op.alter_column(
+        "laserextrinsics",
+        "created_at",
+        server_default=None,
+        existing_type=sa.DateTime(timezone=True),
+        existing_nullable=True,
+    )

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -2,6 +2,7 @@
 """Dive Controller for FishSense API."""
 
 import logging
+from datetime import datetime, timezone
 from typing import List
 
 from fastapi import Depends, HTTPException
@@ -741,10 +742,26 @@ async def put_laser_extrinsics_for_dive(
     extrinsics: LaserExtrinsics,
     session: AsyncSession = Depends(get_async_session),
 ) -> int:
-    """Create or update laser extrinsics for a given dive ID."""
+    """Create or update laser extrinsics for a given dive ID.
+
+    Upsert keyed on `dive_id`: a recompute overwrites the dive's existing row
+    in place rather than appending a new one (calibration is per-dive and the
+    table carries `uq_laserextrinsics_dive_id`). `created_at` is always stamped
+    so the latest-wins read never sees a NULL timestamp — a NULL sorts first
+    under `created_at DESC` in Postgres and made the lookup resolve nothing.
+    """
     logger.debug("Creating or updating laser extrinsics for dive with id=%d", dive_id)
     extrinsics = LaserExtrinsics.model_validate(jsonable_encoder(extrinsics))
     extrinsics.dive_id = dive_id
+
+    existing = (
+        await session.exec(
+            select(LaserExtrinsics).where(LaserExtrinsics.dive_id == dive_id)
+        )
+    ).first()
+    if existing is not None:
+        extrinsics.id = existing.id  # resolve natural key -> merge updates in place
+    extrinsics.created_at = datetime.now(timezone.utc)
 
     extrinsics = await session.merge(extrinsics)
     await session.flush()

--- a/services/fishsense-api/src/fishsense_api/models/laser_extrinsics.py
+++ b/services/fishsense-api/src/fishsense_api/models/laser_extrinsics.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import List
 
-from sqlalchemy import UniqueConstraint, text
+from sqlalchemy import UniqueConstraint, func
 from sqlmodel import JSON, Column, DateTime, Field
 
 from fishsense_api.models.model_base import ModelBase
@@ -28,7 +28,10 @@ class LaserExtrinsics(ModelBase, table=True):
     created_at: datetime | None = Field(
         sa_type=DateTime(timezone=True),
         default=None,
-        sa_column_kwargs={"server_default": text("now()")},
+        # func.now() is dialect-aware (CURRENT_TIMESTAMP on sqlite, now() on
+        # Postgres); a literal text("now()") would break the sqlite test DB.
+        # pylint's not-callable on func.* is a known false positive.
+        sa_column_kwargs={"server_default": func.now()},  # pylint: disable=not-callable
     )
 
     dive_id: int | None = Field(default=None, foreign_key="dive.id")

--- a/services/fishsense-api/src/fishsense_api/models/laser_extrinsics.py
+++ b/services/fishsense-api/src/fishsense_api/models/laser_extrinsics.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import List
 
-from sqlalchemy import UniqueConstraint, func
+from sqlalchemy import UniqueConstraint, text
 from sqlmodel import JSON, Column, DateTime, Field
 
 from fishsense_api.models.model_base import ModelBase
@@ -28,7 +28,7 @@ class LaserExtrinsics(ModelBase, table=True):
     created_at: datetime | None = Field(
         sa_type=DateTime(timezone=True),
         default=None,
-        sa_column_kwargs={"server_default": func.now()},
+        sa_column_kwargs={"server_default": text("now()")},
     )
 
     dive_id: int | None = Field(default=None, foreign_key="dive.id")

--- a/services/fishsense-api/src/fishsense_api/models/laser_extrinsics.py
+++ b/services/fishsense-api/src/fishsense_api/models/laser_extrinsics.py
@@ -3,18 +3,33 @@
 from datetime import datetime
 from typing import List
 
+from sqlalchemy import UniqueConstraint, func
 from sqlmodel import JSON, Column, DateTime, Field
 
 from fishsense_api.models.model_base import ModelBase
 
 
 class LaserExtrinsics(ModelBase, table=True):
-    """Laser extrinsics model representing laser calibration data in the database."""
+    """Laser extrinsics model representing laser calibration data in the database.
+
+    One row per dive (`uq_laserextrinsics_dive_id`): calibration is a per-dive
+    property, `put_laser_extrinsics_for_dive` upserts on `dive_id`, and no
+    consumer reads a history of extrinsics — reads take the single row (or borrow
+    a sibling's via `Dive.calibration_dive_id`). `created_at` carries a
+    `server_default=now()` so a row can never be inserted with a NULL timestamp
+    (which broke the latest-wins read: Postgres sorts NULLs first under DESC).
+    """
+
+    __table_args__ = (UniqueConstraint("dive_id", name="uq_laserextrinsics_dive_id"),)
 
     id: int | None = Field(default=None, primary_key=True)
     laser_position: List[float] = Field(default_factory=list, sa_column=Column(JSON))
     laser_axis: List[float] = Field(default_factory=list, sa_column=Column(JSON))
-    created_at: datetime | None = Field(sa_type=DateTime(timezone=True), default=None)
+    created_at: datetime | None = Field(
+        sa_type=DateTime(timezone=True),
+        default=None,
+        sa_column_kwargs={"server_default": func.now()},
+    )
 
     dive_id: int | None = Field(default=None, foreign_key="dive.id")
     camera_id: int = Field(default=None, foreign_key="camera.id")

--- a/services/fishsense-api/tests/test_laser_extrinsics_upsert.py
+++ b/services/fishsense-api/tests/test_laser_extrinsics_upsert.py
@@ -16,7 +16,6 @@ FK-less in-memory sqlite, same harness as test_calibration_source_endpoints.py.
 from __future__ import annotations
 
 import pytest
-from sqlalchemy import func
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -54,13 +53,12 @@ async def _count_for_dive(session: AsyncSession, dive_id: int) -> int:
         LaserExtrinsics,
     )
 
-    return (
+    rows = (
         await session.exec(
-            select(func.count())
-            .select_from(LaserExtrinsics)
-            .where(LaserExtrinsics.dive_id == dive_id)
+            select(LaserExtrinsics).where(LaserExtrinsics.dive_id == dive_id)
         )
-    ).one()
+    ).all()
+    return len(rows)
 
 
 async def test_put_upserts_on_dive_id_no_duplicate(session):

--- a/services/fishsense-api/tests/test_laser_extrinsics_upsert.py
+++ b/services/fishsense-api/tests/test_laser_extrinsics_upsert.py
@@ -1,0 +1,117 @@
+"""Tests for `put_laser_extrinsics_for_dive` upsert + created_at semantics.
+
+Regression for the #462-recovery bug: the calibration path inserted a new
+`LaserExtrinsics` row on every call (merge with id=None) and never set
+`created_at`. The latest-wins read orders by `created_at DESC`, and with
+Postgres sorting NULLs first that resolved nothing -> 404. Two guarantees
+pinned here:
+
+  * put is an upsert keyed on `dive_id` (one row per dive, never a dupe),
+  * put always stamps a non-NULL `created_at`,
+
+so a recalibration overwrites in place and the read always resolves it.
+FK-less in-memory sqlite, same harness as test_calibration_source_endpoints.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+def _extrinsics(dive_id: int, *, position, created_at=None):
+    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+        LaserExtrinsics,
+    )
+
+    return LaserExtrinsics(
+        dive_id=dive_id,
+        camera_id=1,
+        laser_position=position,
+        laser_axis=[0.0, 0.0, 1.0],
+        created_at=created_at,
+    )
+
+
+async def _count_for_dive(session: AsyncSession, dive_id: int) -> int:
+    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+        LaserExtrinsics,
+    )
+
+    return (
+        await session.exec(
+            select(func.count())
+            .select_from(LaserExtrinsics)
+            .where(LaserExtrinsics.dive_id == dive_id)
+        )
+    ).one()
+
+
+async def test_put_upserts_on_dive_id_no_duplicate(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        get_laser_extrinsics_for_dive,
+        put_laser_extrinsics_for_dive,
+    )
+
+    first_id = await put_laser_extrinsics_for_dive(
+        1, _extrinsics(1, position=[1.0, 1.0, 0.0]), session=session
+    )
+    second_id = await put_laser_extrinsics_for_dive(
+        1, _extrinsics(1, position=[2.0, 2.0, 0.0]), session=session
+    )
+    await session.flush()
+
+    assert await _count_for_dive(session, 1) == 1  # upsert, not append
+    assert first_id == second_id  # same row reused
+    result = await get_laser_extrinsics_for_dive(1, session=session)
+    assert result.laser_position == [2.0, 2.0, 0.0]  # latest value wins
+
+
+async def test_put_stamps_non_null_created_at(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        get_laser_extrinsics_for_dive,
+        put_laser_extrinsics_for_dive,
+    )
+
+    # created_at intentionally omitted (None) by the caller, as the
+    # calibration activity does.
+    await put_laser_extrinsics_for_dive(
+        1, _extrinsics(1, position=[1.0, 1.0, 0.0], created_at=None), session=session
+    )
+    await session.flush()
+
+    result = await get_laser_extrinsics_for_dive(1, session=session)
+    assert result.created_at is not None  # read resolves; never 404 on NULL
+
+
+async def test_put_independent_across_dives(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        put_laser_extrinsics_for_dive,
+    )
+
+    await put_laser_extrinsics_for_dive(
+        1, _extrinsics(1, position=[1.0, 1.0, 0.0]), session=session
+    )
+    await put_laser_extrinsics_for_dive(
+        2, _extrinsics(2, position=[2.0, 2.0, 0.0]), session=session
+    )
+    await session.flush()
+
+    assert await _count_for_dive(session, 1) == 1
+    assert await _count_for_dive(session, 2) == 1


### PR DESCRIPTION
Forward-fix for the latent `LaserExtrinsics` bug surfaced during the #462 slate panel-offset recovery. Dormant while recalibration was rare; the slate detector ([2026-07-31_slate_training](https://github.com/UCSD-E4E/2026-07-31_slate_training)) exists to make labeling cheap → recalibration becomes routine → both failure modes below go from theoretical to frequent.

## 1. NULL `created_at` → 404 on the latest-wins read
`LaserExtrinsics.created_at` had no `server_default` and the calibration activity never set it, so every calibration-path insert stored NULL. `get_laser_extrinsics_for_dive` orders by `created_at DESC`; Postgres sorts **NULLs first** under DESC, so the subquery returned NULL and `created_at = NULL` matched nothing → 404 → stage-14 measurement failed.

**Fix:** `server_default=func.now()` on the column + `put_laser_extrinsics_for_dive` stamps `created_at` on every write.

## 2. `put` appended instead of upserting
It merged with `id=None`, so every call inserted a new row rather than updating the dive's existing one — duplicate accumulation on each recalibration.

**Fix:** resolve the existing row by `dive_id` and merge onto its id (natural-key upsert, same pattern as `post_measurement`), backed by a new `uq_laserextrinsics_dive_id` unique constraint. Verified no consumer reads a *history* of extrinsics — every read is existence-or-latest, or borrows via `Dive.calibration_dive_id` — so one row per dive is correct.

## Migration `fab962df0484`
De-dups existing rows (keeps newest per dive), backfills NULL `created_at`, adds the `server_default`, then the unique constraint — **in that order** so the constraint can't trip on pre-existing dupes. Validated against the **prod** schema+data in a rolled-back transaction (DELETE 0 / UPDATE 0 / ALTERs ok / constraint ok — prod was already hand-cleaned during the #462 recovery). This also regularizes those hand-patched rows, which were correct but unreproducible.

## Tests
- `test_laser_extrinsics_upsert.py`: put twice on one dive → single row + latest value (upsert, not append); put with `created_at=None` → read resolves a non-NULL timestamp; independent across dives.
- Regenerated committed SDK wire model (docstring only, no field change); drift + freshness tests green. Full `fishsense-api` suite: 226 passed.

## Context
Part 1 of the two follow-ups from #462. Next: resolve dives 347/466 (stale composite-space calibration — 466 borrows 349 via `calibration-source`, 347 deleted), then wire in the slate predict activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)