### PR TITLE
feat(calibration): persist per-dive laser-line fingerprint

### DIFF
--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
@@ -4,6 +4,7 @@ from typing import List
 
 from fishsense_api_sdk.clients.client_base import ClientBase
 from fishsense_api_sdk.models.dive import Dive
+from fishsense_api_sdk.models.dive_laser_line import DiveLaserLine
 from fishsense_api_sdk.models.laser_extrinsics import LaserExtrinsics, _LaserExtrinsics
 
 
@@ -157,6 +158,46 @@ class DiveClient(ClientBase):
             json=laser_extrinsics._to_internal().model_dump(  # pylint: disable=protected-access
                 exclude_unset=True, mode="json"
             ),
+        )
+        response.raise_for_status()
+
+        return response.json()
+
+    async def get_dive_laser_line(self, dive_id: int) -> DiveLaserLine | None:
+        """Get the fitted laser-line fingerprint for a dive.
+
+        Args:
+            dive_id (int): The ID of the dive.
+
+        Returns:
+            DiveLaserLine | None: The dive's laser-line fingerprint, or None if
+            it has not been fitted yet.
+        """
+        response = await self._get(f"/api/v1/dives/{dive_id}/laser-line/")
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+
+        json = response.json()
+        if json is None:
+            return None
+        return DiveLaserLine.model_validate(json)
+
+    async def put_dive_laser_line(
+        self, dive_id: int, laser_line: DiveLaserLine
+    ) -> int:
+        """Upsert the laser-line fingerprint for a dive.
+
+        Args:
+            dive_id (int): The ID of the dive.
+            laser_line (DiveLaserLine): The fitted line + metrics to persist.
+
+        Returns:
+            int: The persisted row ID.
+        """
+        response = await self._put(
+            f"/api/v1/dives/{dive_id}/laser-line/",
+            json=laser_line.model_dump(exclude_unset=True, mode="json"),
         )
         response.raise_for_status()
 

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
@@ -54,6 +54,30 @@ class DiveFrameClusterJson(BaseModel):
     fish_id: int | None = Field(..., title='Fish Id')
 
 
+class DiveLaserLine(BaseModel):
+    """
+    A dive's fitted 2D laser line `a*x + b*y + c = 0` plus fit-quality metrics.
+
+    One row per dive (`uq_diveslaserline_dive_id`); `put_dive_laser_line`
+    upserts on `dive_id`. `camera_id` / `dive_datetime` are NOT duplicated here
+    — consumers join `Dive`. Same NULL-safe `server_default` pattern as
+    LaserExtrinsics so a row can never be inserted with a NULL timestamp.
+    """
+
+    id: int | None = Field(None, title='Id')
+    dive_id: int | None = Field(None, title='Dive Id')
+    a: float = Field(..., title='A')
+    b: float = Field(..., title='B')
+    c: float = Field(..., title='C')
+    n_points: int = Field(..., title='N Points')
+    inlier_count: int = Field(..., title='Inlier Count')
+    inlier_fraction: float = Field(..., title='Inlier Fraction')
+    residual_std: float = Field(..., title='Residual Std')
+    label_noise_mad: float = Field(..., title='Label Noise Mad')
+    line_confidence: float = Field(..., title='Line Confidence')
+    fitted_at: AwareDatetime | None = Field(None, title='Fitted At')
+
+
 class DiveSlate(BaseModel):
     """
     Model representing a dive slate.

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/dive_laser_line.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/dive_laser_line.py
@@ -1,0 +1,30 @@
+"""Module defining the per-dive laser-line fingerprint model for the SDK.
+
+Wire mirror of `fishsense_api.models.dive_laser_line.DiveLaserLine`: the fitted
+2D laser line `a*x + b*y + c = 0` (Hesse normal form) plus fit-quality metrics.
+See the API model for what the fingerprint is used for.
+"""
+
+from datetime import datetime
+
+from fishsense_api_sdk.models.model_base import ModelBase
+
+
+class DiveLaserLine(ModelBase):
+    """A dive's fitted 2D laser line plus fit-quality metrics."""
+
+    id: int | None = None
+    dive_id: int | None = None
+
+    a: float
+    b: float
+    c: float
+
+    n_points: int
+    inlier_count: int
+    inlier_fraction: float
+    residual_std: float
+    label_noise_mad: float
+    line_confidence: float
+
+    fitted_at: datetime | None = None

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/5a7782ca68dc_add_diveslaserline_table.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/5a7782ca68dc_add_diveslaserline_table.py
@@ -1,0 +1,62 @@
+"""add diveslaserline table
+
+Revision ID: 5a7782ca68dc
+Revises: fab962df0484
+Create Date: 2026-08-01 15:14:02.480958
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '5a7782ca68dc'
+down_revision: Union[str, Sequence[str], None] = 'fab962df0484'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Idempotent against `SQLModel.metadata.create_all`: the FastAPI lifespan
+    runs `create_all` before alembic upgrade, and `divelaserline` is in the ORM
+    model registry, so on an existing DB the table already exists by the time
+    this migration runs. Skip the DDL when the table is present.
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("divelaserline"):
+        return
+    op.create_table(
+        "divelaserline",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("dive_id", sa.Integer(), nullable=True),
+        sa.Column("a", sa.Float(), nullable=False),
+        sa.Column("b", sa.Float(), nullable=False),
+        sa.Column("c", sa.Float(), nullable=False),
+        sa.Column("n_points", sa.Integer(), nullable=False),
+        sa.Column("inlier_count", sa.Integer(), nullable=False),
+        sa.Column("inlier_fraction", sa.Float(), nullable=False),
+        sa.Column("residual_std", sa.Float(), nullable=False),
+        sa.Column("label_noise_mad", sa.Float(), nullable=False),
+        sa.Column("line_confidence", sa.Float(), nullable=False),
+        sa.Column(
+            "fitted_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(["dive_id"], ["dive.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("dive_id", name="uq_divelaserline_dive_id"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table("divelaserline")

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -18,6 +18,7 @@ from fishsense_api.models.dive_frame_cluster import (
     DiveFrameCluster,
     DiveFrameClusterImageMapping,
 )
+from fishsense_api.models.dive_laser_line import DiveLaserLine
 from fishsense_api.models.dive_slate import DiveSlate
 from fishsense_api.models.dive_slate_label import DiveSlateLabel
 from fishsense_api.models.head_tail_label import HeadTailLabel
@@ -769,6 +770,50 @@ async def put_laser_extrinsics_for_dive(
     extrinsics_id = extrinsics.id
 
     return extrinsics_id
+
+
+@app.put("/api/v1/dives/{dive_id}/laser-line/", status_code=201)
+async def put_dive_laser_line(
+    dive_id: int,
+    line: DiveLaserLine,
+    session: AsyncSession = Depends(get_async_session),
+) -> int:
+    """Upsert the per-dive laser-line fingerprint (keyed on `dive_id`).
+
+    The laser-label validation refits this line each run; upserting keeps one
+    row per dive so the fingerprint stays current (and tightens as outliers are
+    superseded across runs). `fitted_at` is always stamped — same NULL-safe
+    contract as `put_laser_extrinsics_for_dive`.
+    """
+    logger.debug("Upserting laser-line fingerprint for dive id=%d", dive_id)
+    line = DiveLaserLine.model_validate(jsonable_encoder(line))
+    line.dive_id = dive_id
+
+    existing = (
+        await session.exec(
+            select(DiveLaserLine).where(DiveLaserLine.dive_id == dive_id)
+        )
+    ).first()
+    if existing is not None:
+        line.id = existing.id  # resolve natural key -> merge updates in place
+    line.fitted_at = datetime.now(timezone.utc)
+
+    line = await session.merge(line)
+    await session.flush()
+
+    return line.id
+
+
+@app.get("/api/v1/dives/{dive_id}/laser-line/")
+async def get_dive_laser_line(
+    dive_id: int, session: AsyncSession = Depends(get_async_session)
+) -> DiveLaserLine | None:
+    """Return the dive's laser-line fingerprint, or None if not yet fitted."""
+    return (
+        await session.exec(
+            select(DiveLaserLine).where(DiveLaserLine.dive_id == dive_id)
+        )
+    ).first()
 
 
 @app.put("/api/v1/dives/{dive_id}/calibration-source/{source_dive_id}")

--- a/services/fishsense-api/src/fishsense_api/database.py
+++ b/services/fishsense-api/src/fishsense_api/database.py
@@ -24,6 +24,7 @@ from fishsense_api.models.dive_frame_cluster import (
     DiveFrameCluster,
     DiveFrameClusterImageMapping,
 )
+from fishsense_api.models.dive_laser_line import DiveLaserLine
 from fishsense_api.models.dive_slate import DiveSlate
 from fishsense_api.models.dive_slate_label import DiveSlateLabel
 from fishsense_api.models.fish import Fish

--- a/services/fishsense-api/src/fishsense_api/models/dive_laser_line.py
+++ b/services/fishsense-api/src/fishsense_api/models/dive_laser_line.py
@@ -1,0 +1,62 @@
+"""Per-dive laser-line fingerprint model for the FishSense API.
+
+The laser dots across a dive's frames are collinear in image space (the
+projection of the fixed laser ray), so a RANSAC/TLS fit yields a single 2D
+line `a*x + b*y + c = 0` (Hesse normal form, unit normal). That line is the
+*fingerprint of the mount state*: on a given camera it changes only when the
+cold-shoe mount rotates, drifts (PLA thermal/creep), or is swapped. Persisting
+it — a byproduct the laser-label validation already computes — turns four
+questions into queries over `(camera_id, line)`:
+
+  * borrow: two dives on one camera with the same confident line share a 3D
+    laser geometry, so one's `LaserExtrinsics` transfers to the other;
+  * drift: the line's wander over time per camera;
+  * mount swaps: step discontinuities in that per-camera series;
+  * pooled calibration: dives with a matching line can co-fit one calibration.
+
+`line_confidence` / `residual_std` double as a stability signal — a mount that
+deformed mid-dive smears the dots off a clean line and shows up as a poor fit.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import UniqueConstraint, func
+from sqlmodel import DateTime, Field
+
+from fishsense_api.models.model_base import ModelBase
+
+
+class DiveLaserLine(ModelBase, table=True):
+    """A dive's fitted 2D laser line `a*x + b*y + c = 0` plus fit-quality metrics.
+
+    One row per dive (`uq_diveslaserline_dive_id`); `put_dive_laser_line`
+    upserts on `dive_id`. `camera_id` / `dive_datetime` are NOT duplicated here
+    — consumers join `Dive`. Same NULL-safe `server_default` pattern as
+    LaserExtrinsics so a row can never be inserted with a NULL timestamp.
+    """
+
+    __table_args__ = (UniqueConstraint("dive_id", name="uq_divelaserline_dive_id"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    dive_id: int | None = Field(default=None, foreign_key="dive.id")
+
+    # Line in Hesse normal form: a*x + b*y + c = 0 with a^2 + b^2 = 1.
+    a: float
+    b: float
+    c: float
+
+    # Fit-quality metrics (mirror line_fit.LineFit); double as a stability signal.
+    n_points: int
+    inlier_count: int
+    inlier_fraction: float
+    residual_std: float
+    label_noise_mad: float
+    line_confidence: float
+
+    fitted_at: datetime | None = Field(
+        sa_type=DateTime(timezone=True),
+        default=None,
+        # func.now() is dialect-aware (CURRENT_TIMESTAMP on sqlite, now() on
+        # Postgres); pylint's not-callable on func.* is a known false positive.
+        sa_column_kwargs={"server_default": func.now()},  # pylint: disable=not-callable
+    )

--- a/services/fishsense-api/tests/test_dive_laser_line_endpoint.py
+++ b/services/fishsense-api/tests/test_dive_laser_line_endpoint.py
@@ -1,0 +1,94 @@
+"""Tests for the per-dive laser-line fingerprint endpoints.
+
+`DiveLaserLine` persists the RANSAC/TLS laser line the validation already
+fits, so `(camera_id, line)` becomes queryable (borrow candidates, drift,
+mount-swap epochs, pooled calibration). Same upsert + non-NULL timestamp
+guarantees as LaserExtrinsics, so a re-fit overwrites in place and the row
+never carries a NULL `fitted_at`. FK-less in-memory sqlite harness.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+def _line(dive_id: int, *, a, b, c, confidence=10.0):
+    from fishsense_api.models.dive_laser_line import (  # pylint: disable=import-outside-toplevel
+        DiveLaserLine,
+    )
+
+    return DiveLaserLine(
+        dive_id=dive_id,
+        a=a,
+        b=b,
+        c=c,
+        n_points=20,
+        inlier_count=19,
+        inlier_fraction=0.95,
+        residual_std=0.5,
+        label_noise_mad=0.4,
+        line_confidence=confidence,
+    )
+
+
+async def _count(session: AsyncSession, dive_id: int) -> int:
+    from fishsense_api.models.dive_laser_line import (  # pylint: disable=import-outside-toplevel
+        DiveLaserLine,
+    )
+
+    rows = (
+        await session.exec(select(DiveLaserLine).where(DiveLaserLine.dive_id == dive_id))
+    ).all()
+    return len(rows)
+
+
+async def test_put_upserts_on_dive_id(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        get_dive_laser_line,
+        put_dive_laser_line,
+    )
+
+    id1 = await put_dive_laser_line(1, _line(1, a=1.0, b=0.0, c=-5.0), session=session)
+    id2 = await put_dive_laser_line(1, _line(1, a=0.0, b=1.0, c=-9.0), session=session)
+    await session.flush()
+
+    assert await _count(session, 1) == 1  # upsert, not append
+    assert id1 == id2
+    got = await get_dive_laser_line(1, session=session)
+    assert (got.a, got.b, got.c) == (0.0, 1.0, -9.0)  # latest wins
+
+
+async def test_put_stamps_non_null_fitted_at(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        get_dive_laser_line,
+        put_dive_laser_line,
+    )
+
+    await put_dive_laser_line(1, _line(1, a=1.0, b=0.0, c=-5.0), session=session)
+    await session.flush()
+    got = await get_dive_laser_line(1, session=session)
+    assert got.fitted_at is not None
+
+
+async def test_get_returns_none_when_absent(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        get_dive_laser_line,
+    )
+
+    assert await get_dive_laser_line(999, session=session) is None

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/validate_laser_labels_for_dive_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/validate_laser_labels_for_dive_activity.py
@@ -33,6 +33,7 @@ import contextlib
 from typing import AsyncIterator, List
 
 import numpy as np
+from fishsense_api_sdk.models.dive_laser_line import DiveLaserLine
 from fishsense_api_sdk.models.laser_label import LaserLabel
 from temporalio import activity
 
@@ -195,6 +196,28 @@ async def validate_laser_labels_for_dive_activity(dive_id: int) -> int:
             fit.line_confidence,
             fit.is_confident,
         )
+
+        # Persist the line fingerprint (byproduct we already computed) so
+        # (camera_id, line) becomes queryable: borrow candidates, drift,
+        # mount-swap epochs, pooled calibration. Written every run — even a
+        # clean dive with no outliers — and tightens as outliers are
+        # superseded across runs. Upsert keyed on dive_id.
+        await fs.dives.put_dive_laser_line(
+            dive_id,
+            DiveLaserLine(
+                dive_id=dive_id,
+                a=fit.a,
+                b=fit.b,
+                c=fit.c,
+                n_points=fit.n_points,
+                inlier_count=fit.inlier_count,
+                inlier_fraction=fit.inlier_fraction,
+                residual_std=fit.residual_std,
+                label_noise_mad=fit.label_noise_mad,
+                line_confidence=fit.line_confidence,
+            ),
+        )
+        activity.heartbeat()
 
         outlier_mask = flag_outliers(xy, fit)
         n_outliers = int(outlier_mask.sum())

--- a/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_activity.py
@@ -58,6 +58,8 @@ def _make_fs(labels: List[LaserLabel]):
     fs.labels.put_laser_label = AsyncMock(
         side_effect=lambda image_id, label: label.id or 0
     )
+    fs.dives = MagicMock()
+    fs.dives.put_dive_laser_line = AsyncMock(return_value=1)
     return fs
 
 
@@ -105,9 +107,33 @@ async def test_clean_dive_flags_no_outliers_and_does_not_write(monkeypatch):
     env = ActivityEnvironment()
     result = await env.run(sut.validate_laser_labels_for_dive_activity, 99)
     assert result == 0
-    # No outliers → no writes. Pins that the activity doesn't ever
+    # No outliers → no label writes. Pins that the activity doesn't ever
     # supersede a clean dive's labels.
     fs.labels.put_laser_label.assert_not_called()
+    # ...but the line fingerprint is still persisted on a clean dive.
+    fs.dives.put_dive_laser_line.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_persists_line_fingerprint_matching_the_fit(monkeypatch):
+    fs = _make_fs(labels=_colinear_labels(40))  # y = 0.4*x + 100
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    env = ActivityEnvironment()
+    await env.run(sut.validate_laser_labels_for_dive_activity, 77)
+
+    fs.dives.put_dive_laser_line.assert_called_once()
+    (dive_id, line), _ = fs.dives.put_dive_laser_line.call_args
+    assert dive_id == 77
+    assert line.dive_id == 77
+    # The persisted Hesse-form line must vanish on points of y = 0.4x + 100.
+    for x in (200.0, 1200.0):
+        y = 0.4 * x + 100.0
+        assert abs(line.a * x + line.b * y + line.c) < 1.0  # within ~1px
+    assert abs((line.a * line.a + line.b * line.b) - 1.0) < 1e-6  # unit normal
+    assert line.n_points == 40
+    assert line.inlier_fraction > 0.9
+    assert line.line_confidence > 0  # clearly a line, not a blob
 
 
 @pytest.mark.asyncio
@@ -218,6 +244,8 @@ async def test_rerun_after_supersede_is_a_noop(monkeypatch):
     fs.labels = MagicMock()
     fs.labels.get_laser_labels = AsyncMock(side_effect=fake_get_laser_labels)
     fs.labels.put_laser_label = AsyncMock(side_effect=fake_put_laser_label)
+    fs.dives = MagicMock()
+    fs.dives.put_dive_laser_line = AsyncMock(return_value=1)
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
 
     env = ActivityEnvironment()
@@ -275,6 +303,8 @@ async def test_inlier_fraction_strictly_improves_after_supersede(
     fs.labels = MagicMock()
     fs.labels.get_laser_labels = AsyncMock(side_effect=fake_get_laser_labels)
     fs.labels.put_laser_label = AsyncMock(side_effect=fake_put_laser_label)
+    fs.dives = MagicMock()
+    fs.dives.put_dive_laser_line = AsyncMock(return_value=1)
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
 
     def _parse_inlier_fraction(records) -> float:
@@ -402,6 +432,8 @@ async def test_supersede_writes_run_concurrently(monkeypatch):
     fs.labels = MagicMock()
     fs.labels.get_laser_labels = AsyncMock(return_value=labels)
     fs.labels.put_laser_label = AsyncMock(side_effect=gated_put)
+    fs.dives = MagicMock()
+    fs.dives.put_dive_laser_line = AsyncMock(return_value=1)
     monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
 
     env = ActivityEnvironment()


### PR DESCRIPTION
Persists the RANSAC/TLS laser line the laser-label validation **already fits** (Hesse normal form `a*x + b*y + c = 0` + fit-quality metrics) as a new `DiveLaserLine`, upserted per dive. This makes `(camera_id, line)` queryable and is the foundation for a family of calibration features.

## Why the line is the right primitive
On a fixed camera the laser dots are collinear in image space, and that 2D line changes only when the cold-shoe mount **rotates**, drifts (PLA thermal/creep), or is **swapped**. Because every mount is the same shape seated in the same cold shoe, a matching 2D line *forces* the same 3D laser geometry — so the line is a faithful fingerprint of the mount state. Dates can't identify mounts (multiple undated PLA swaps); the line can. Fit tightness (`residual_std` / `line_confidence`) doubles as a within-dive stability signal — a mount deforming mid-dive smears the dots off a clean line.

Crucially, the fingerprint comes from **laser labels, not slate labels**, so *every* dive with confident laser labeling gets one — the whole corpus, not just the handful of slate-calibrated dives.

## What this unlocks (follow-on PRs)
- **Borrow candidates** — same camera + matching line ⇒ safe to borrow `LaserExtrinsics` (the 466 problem, done right).
- **Drift** — line wander over time per camera, translatable to mm of length error.
- **Mount-swap epochs** — step discontinuities in the per-camera series recover the undated swap history.
- **Pooled calibration** — dives sharing a line can co-fit one calibration (rescues thin dives like 347 where a camera has enough total observations).

## Changes
- **API:** `DiveLaserLine` model (one row per dive, `uq_divelaserline_dive_id`, NULL-safe `server_default` `fitted_at` — same contract as the #466 extrinsics fix); PUT/GET `/api/v1/dives/{id}/laser-line/` (upsert keyed on `dive_id`); registered in the model registry; alembic `5a7782ca68dc` (idempotent `create_table`, validated against the prod schema in a rolled-back txn).
- **SDK:** `DiveLaserLine` wire model + `dives.get/put_dive_laser_line`; regenerated `_generated.py`.
- **data-worker:** `validate_laser_labels_for_dive_activity` persists the fit each run (even on a clean dive with no outliers), so the fingerprint stays current and tightens as outliers are superseded across runs.

## Tests
- API: upsert on `dive_id` (no dupes, latest wins), non-NULL `fitted_at`, GET-None-when-absent. Drift + freshness green. Full `fishsense-api` suite 229 passed.
- data-worker: persisted line vanishes on points of the known synthetic line (Hesse form, unit normal), metrics match the fit, persisted even on a clean dive. Validation suite 12 passed.

Built on top of the merged #466 (`created_at`/upsert fix), which it mirrors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)