### PR TITLE
feat(calibration): borrow-candidate finder endpoint

### DIFF
--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
@@ -1,8 +1,10 @@
 """Client for interacting with dive-related endpoints of the Fishsense API."""
 
 from typing import List
+from urllib.parse import urlencode
 
 from fishsense_api_sdk.clients.client_base import ClientBase
+from fishsense_api_sdk.models.calibration_candidate import CalibrationCandidate
 from fishsense_api_sdk.models.dive import Dive
 from fishsense_api_sdk.models.dive_laser_line import DiveLaserLine
 from fishsense_api_sdk.models.laser_extrinsics import LaserExtrinsics, _LaserExtrinsics
@@ -202,6 +204,44 @@ class DiveClient(ClientBase):
         response.raise_for_status()
 
         return response.json()
+
+    async def get_calibration_candidates(
+        self,
+        dive_id: int,
+        *,
+        max_angle_deg: float | None = None,
+        max_offset_px: float | None = None,
+        min_confidence: float | None = None,
+    ) -> List[CalibrationCandidate]:
+        """Get ranked calibration-borrow candidates for a dive.
+
+        Dives whose laser-line fingerprint matches this dive's (same camera,
+        own extrinsics, confident fits, line within tolerance), ranked by line
+        closeness. Suggest-only — pick one and call `set_calibration_source`.
+
+        Args:
+            dive_id (int): The dive to find borrow candidates for.
+            max_angle_deg / max_offset_px / min_confidence: optional tolerance
+            overrides; the server applies its defaults when omitted.
+
+        Returns:
+            List[CalibrationCandidate]: ranked candidates (may be empty).
+        """
+        query = {
+            k: v
+            for k, v in (
+                ("max_angle_deg", max_angle_deg),
+                ("max_offset_px", max_offset_px),
+                ("min_confidence", min_confidence),
+            )
+            if v is not None
+        }
+        endpoint = f"/api/v1/dives/{dive_id}/calibration-candidates/"
+        if query:
+            endpoint = f"{endpoint}?{urlencode(query)}"
+        response = await self._get(endpoint)
+        response.raise_for_status()
+        return [CalibrationCandidate.model_validate(x) for x in response.json()]
 
     async def set_calibration_source(
         self, dive_id: int, source_dive_id: int

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
@@ -9,6 +9,24 @@ from typing import Any
 from pydantic import AwareDatetime, BaseModel, Field, constr
 
 
+class CalibrationCandidate(BaseModel):
+    """
+    A dive whose laser-line fingerprint matches the target's, so its
+    `LaserExtrinsics` is a borrow candidate. Read-only response DTO.
+    """
+
+    dive_id: int = Field(..., title='Dive Id')
+    name: str | None = Field(..., title='Name')
+    camera_id: int | None = Field(..., title='Camera Id')
+    dive_datetime: AwareDatetime = Field(..., title='Dive Datetime')
+    laser_extrinsics_id: int = Field(..., title='Laser Extrinsics Id')
+    line_angle_deg: float = Field(..., title='Line Angle Deg')
+    line_offset_px: float = Field(..., title='Line Offset Px')
+    line_confidence: float = Field(..., title='Line Confidence')
+    residual_std: float = Field(..., title='Residual Std')
+    days_apart: float = Field(..., title='Days Apart')
+
+
 class Camera(BaseModel):
     """
     Model representing a camera.

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/calibration_candidate.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/calibration_candidate.py
@@ -1,0 +1,25 @@
+"""Calibration-borrow candidate (read-only response DTO).
+
+Wire mirror of `fishsense_api.controllers.dive_controller.CalibrationCandidate`:
+a dive whose laser-line fingerprint matches the target's, so its
+`LaserExtrinsics` can be borrowed. Not a persisted model — no drift-test pair.
+"""
+
+from datetime import datetime
+
+from fishsense_api_sdk.models.model_base import ModelBase
+
+
+class CalibrationCandidate(ModelBase):
+    """A ranked calibration-borrow candidate for a dive."""
+
+    dive_id: int
+    name: str | None
+    camera_id: int | None
+    dive_datetime: datetime
+    laser_extrinsics_id: int
+    line_angle_deg: float
+    line_offset_px: float
+    line_confidence: float
+    residual_std: float
+    days_apart: float

--- a/services/fishsense-api/src/fishsense_api/controllers/__init__.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/__init__.py
@@ -1,5 +1,6 @@
 """Controllers package for FishSense API."""
 
+import fishsense_api.controllers.calibration_candidate_controller
 import fishsense_api.controllers.camera_controller
 import fishsense_api.controllers.dive_controller
 import fishsense_api.controllers.dive_slate_controller

--- a/services/fishsense-api/src/fishsense_api/controllers/calibration_candidate_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/calibration_candidate_controller.py
@@ -1,0 +1,136 @@
+"""Calibration-borrow candidate finder.
+
+Given a dive, returns other dives whose laser-line fingerprint matches it, so
+their `LaserExtrinsics` can be borrowed. Same camera + matching confident line
+⇒ same laser geometry (the mount fingerprint), so the calibration transfers.
+Suggest-only — the caller picks and calls `set_calibration_source`.
+"""
+
+import logging
+import math
+from datetime import datetime
+from typing import List
+
+from fastapi import Depends, HTTPException
+from pydantic import BaseModel
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from fishsense_api.database import get_async_session
+from fishsense_api.models.dive import Dive
+from fishsense_api.models.dive_laser_line import DiveLaserLine
+from fishsense_api.models.laser_extrinsics import LaserExtrinsics
+from fishsense_api.server import app
+
+logger = logging.getLogger(__name__)
+
+# Default line-match tolerance. Starting values pending the labeling validation
+# experiment (pos/neg controls) that will lock them from data; overridable per
+# request. min_confidence mirrors the data-worker's LINE_CONFIDENCE_THRESHOLD
+# (kept as a literal to avoid importing the worker).
+_DEFAULT_MAX_ANGLE_DEG = 1.0
+_DEFAULT_MAX_OFFSET_PX = 30.0
+_DEFAULT_MIN_CONFIDENCE = 5.0
+
+
+class CalibrationCandidate(BaseModel):
+    """A dive whose laser-line fingerprint matches the target's, so its
+    `LaserExtrinsics` is a borrow candidate. Read-only response DTO."""
+
+    dive_id: int
+    name: str | None
+    camera_id: int | None
+    dive_datetime: datetime
+    laser_extrinsics_id: int
+    line_angle_deg: float
+    line_offset_px: float
+    line_confidence: float
+    residual_std: float
+    days_apart: float
+
+
+def _canonical_line(a: float, b: float, c: float) -> tuple[float, float, float]:
+    """Sign-normalize a Hesse line so `(a,b,c)` and `(-a,-b,-c)` compare equal
+    (make the normal point into a fixed half-plane)."""
+    if a < 0 or (a == 0.0 and b < 0):
+        return -a, -b, -c
+    return a, b, c
+
+
+def _line_distance(line_a: DiveLaserLine, line_b: DiveLaserLine) -> tuple[float, float]:
+    """(normal angle in degrees, aligned offset |Δc| in px) between two lines."""
+    a1, b1, c1 = _canonical_line(line_a.a, line_a.b, line_a.c)
+    a2, b2, c2 = _canonical_line(line_b.a, line_b.b, line_b.c)
+    dot = max(-1.0, min(1.0, a1 * a2 + b1 * b2))
+    return math.degrees(math.acos(dot)), abs(c1 - c2)
+
+
+@app.get("/api/v1/dives/{dive_id}/calibration-candidates/")
+async def get_calibration_candidates(
+    dive_id: int,
+    max_angle_deg: float = _DEFAULT_MAX_ANGLE_DEG,
+    max_offset_px: float = _DEFAULT_MAX_OFFSET_PX,
+    min_confidence: float = _DEFAULT_MIN_CONFIDENCE,
+    session: AsyncSession = Depends(get_async_session),
+) -> List[CalibrationCandidate]:
+    """Dives whose laser-line fingerprint matches this dive's, ranked as
+    calibration-borrow candidates. Suggest-only.
+
+    Hard gate: same `camera_id`, the candidate has its own `LaserExtrinsics`,
+    both dives have a confident line fit, and the lines agree within
+    (`max_angle_deg`, `max_offset_px`). Ranked by line closeness, then fit
+    tightness, then temporal proximity (advisory only — a rotating/swappable
+    mount makes time an unreliable gate; the line is the real signal). Returns
+    [] when the dive has no confident fingerprint of its own to match against.
+    """
+    target = await session.get(Dive, dive_id)
+    if target is None:
+        raise HTTPException(status_code=404, detail="Dive not found")
+    if target.camera_id is None:
+        return []
+    target_line = (
+        await session.exec(
+            select(DiveLaserLine).where(DiveLaserLine.dive_id == dive_id)
+        )
+    ).first()
+    if target_line is None or target_line.line_confidence < min_confidence:
+        return []
+
+    rows = (
+        await session.exec(
+            select(Dive, DiveLaserLine, LaserExtrinsics)
+            .join(DiveLaserLine, DiveLaserLine.dive_id == Dive.id)
+            .join(LaserExtrinsics, LaserExtrinsics.dive_id == Dive.id)
+            .where(Dive.camera_id == target.camera_id)
+            .where(Dive.id != dive_id)
+            .where(DiveLaserLine.line_confidence >= min_confidence)
+        )
+    ).all()
+
+    candidates: list[CalibrationCandidate] = []
+    for dive, line, extrinsics in rows:
+        angle_deg, offset_px = _line_distance(target_line, line)
+        if angle_deg > max_angle_deg or offset_px > max_offset_px:
+            continue
+        days_apart = (
+            abs((dive.dive_datetime - target.dive_datetime).total_seconds()) / 86400.0
+        )
+        candidates.append(
+            CalibrationCandidate(
+                dive_id=dive.id,
+                name=dive.name,
+                camera_id=dive.camera_id,
+                dive_datetime=dive.dive_datetime,
+                laser_extrinsics_id=extrinsics.id,
+                line_angle_deg=angle_deg,
+                line_offset_px=offset_px,
+                line_confidence=line.line_confidence,
+                residual_std=line.residual_std,
+                days_apart=days_apart,
+            )
+        )
+
+    candidates.sort(
+        key=lambda c: (c.line_angle_deg, c.line_offset_px, c.residual_std, c.days_apart)
+    )
+    return candidates

--- a/services/fishsense-api/tests/test_calibration_candidates_endpoint.py
+++ b/services/fishsense-api/tests/test_calibration_candidates_endpoint.py
@@ -1,0 +1,191 @@
+"""Tests for the calibration-borrow candidate finder.
+
+`get_calibration_candidates` returns dives whose laser-line fingerprint matches
+the target's, gated on (same camera + candidate has own extrinsics + both fits
+confident + line within tolerance) and ranked by line closeness. Suggest-only.
+FK-less in-memory sqlite harness.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+_T0 = datetime(2024, 6, 1, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+def _dive(dive_id: int, camera_id: int | None, *, days: int = 0):
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import (  # pylint: disable=import-outside-toplevel
+        Priority,
+    )
+
+    return Dive(
+        id=dive_id,
+        name=f"dive-{dive_id}",
+        path=f"/dev/null/{dive_id}",
+        dive_datetime=_T0 + timedelta(days=days),
+        priority=Priority.HIGH,
+        camera_id=camera_id,
+    )
+
+
+def _line(dive_id: int, angle_deg: float, c: float, *, confidence: float = 100.0):
+    """A unit-normal Hesse line rotated `angle_deg` from the x-axis normal."""
+    from fishsense_api.models.dive_laser_line import (  # pylint: disable=import-outside-toplevel
+        DiveLaserLine,
+    )
+
+    rad = math.radians(angle_deg)
+    return DiveLaserLine(
+        dive_id=dive_id,
+        a=math.cos(rad),
+        b=math.sin(rad),
+        c=c,
+        n_points=30,
+        inlier_count=29,
+        inlier_fraction=0.96,
+        residual_std=0.5,
+        label_noise_mad=0.4,
+        line_confidence=confidence,
+    )
+
+
+def _extrinsics(dive_id: int, camera_id: int):
+    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+        LaserExtrinsics,
+    )
+
+    return LaserExtrinsics(
+        dive_id=dive_id,
+        camera_id=camera_id,
+        laser_position=[0.0, 0.0, 0.0],
+        laser_axis=[0.0, 0.0, 1.0],
+        created_at=_T0,
+    )
+
+
+async def _candidates(session, dive_id, **kw):
+    from fishsense_api.controllers.calibration_candidate_controller import (  # pylint: disable=import-outside-toplevel
+        get_calibration_candidates,
+    )
+
+    return await get_calibration_candidates(dive_id, session=session, **kw)
+
+
+async def test_matching_same_camera_dive_with_extrinsics_is_returned(session):
+    session.add_all([_dive(1, 5), _dive(2, 5, days=3)])
+    await session.flush()
+    session.add_all([_line(1, 0.0, -100.0), _line(2, 0.0, -100.0), _extrinsics(2, 5)])
+    await session.flush()
+
+    result = await _candidates(session, 1)
+    assert [c.dive_id for c in result] == [2]
+    assert result[0].line_angle_deg == pytest.approx(0.0, abs=1e-6)
+    assert result[0].line_offset_px == pytest.approx(0.0, abs=1e-6)
+    assert result[0].laser_extrinsics_id is not None
+    assert result[0].days_apart == pytest.approx(3.0)
+
+
+async def test_excludes_different_camera_no_extrinsics_and_out_of_tolerance(session):
+    session.add_all(
+        [_dive(1, 5), _dive(2, 9), _dive(3, 5), _dive(4, 5), _dive(5, 5)]
+    )
+    await session.flush()
+    session.add_all(
+        [
+            _line(1, 0.0, -100.0),  # target
+            _line(2, 0.0, -100.0),  # matching line but DIFFERENT camera (9)
+            _extrinsics(2, 9),
+            _line(3, 0.0, -100.0),  # matching line, same camera, NO extrinsics
+            _line(4, 2.0, -100.0),  # same camera + extrinsics, angle 2deg > 1deg
+            _extrinsics(4, 5),
+            _line(5, 0.0, -200.0),  # same camera + extrinsics, offset 100px > 30
+            _extrinsics(5, 5),
+        ]
+    )
+    await session.flush()
+
+    result = await _candidates(session, 1)
+    assert result == []
+
+
+async def test_ranks_closer_line_first(session):
+    session.add_all([_dive(1, 5), _dive(2, 5), _dive(3, 5)])
+    await session.flush()
+    session.add_all(
+        [
+            _line(1, 0.0, -100.0),  # target
+            _line(2, 0.5, -110.0),  # 0.5deg, offset 10 -> ranked 2nd
+            _extrinsics(2, 5),
+            _line(3, 0.0, -100.0),  # exact match -> ranked 1st
+            _extrinsics(3, 5),
+        ]
+    )
+    await session.flush()
+
+    result = await _candidates(session, 1)
+    assert [c.dive_id for c in result] == [3, 2]
+
+
+async def test_low_confidence_candidate_excluded(session):
+    session.add_all([_dive(1, 5), _dive(2, 5)])
+    await session.flush()
+    session.add_all(
+        [_line(1, 0.0, -100.0), _line(2, 0.0, -100.0, confidence=1.0), _extrinsics(2, 5)]
+    )
+    await session.flush()
+
+    assert await _candidates(session, 1, min_confidence=5.0) == []
+
+
+async def test_returns_empty_when_target_has_no_fingerprint(session):
+    session.add_all([_dive(1, 5), _dive(2, 5)])
+    await session.flush()
+    session.add_all([_line(2, 0.0, -100.0), _extrinsics(2, 5)])  # target (1) has none
+    await session.flush()
+
+    assert await _candidates(session, 1) == []
+
+
+async def test_sign_flipped_line_still_matches(session):
+    # (a,b,c) and (-a,-b,-c) are the same physical line; must compare equal.
+    from fishsense_api.models.dive_laser_line import (  # pylint: disable=import-outside-toplevel
+        DiveLaserLine,
+    )
+
+    session.add_all([_dive(1, 5), _dive(2, 5)])
+    await session.flush()
+    session.add(_line(1, 0.0, -100.0))  # normal (1,0), c=-100
+    session.add(
+        DiveLaserLine(  # same line, sign-flipped
+            dive_id=2, a=-1.0, b=0.0, c=100.0,
+            n_points=30, inlier_count=29, inlier_fraction=0.96,
+            residual_std=0.5, label_noise_mad=0.4, line_confidence=100.0,
+        )
+    )
+    session.add(_extrinsics(2, 5))
+    await session.flush()
+
+    result = await _candidates(session, 1)
+    assert [c.dive_id for c in result] == [2]
+    assert result[0].line_angle_deg == pytest.approx(0.0, abs=1e-6)
+    assert result[0].line_offset_px == pytest.approx(0.0, abs=1e-6)


### PR DESCRIPTION
`GET /api/v1/dives/{id}/calibration-candidates/` returns dives whose laser-line fingerprint (from #467) matches the target's, ranked as calibration-borrow candidates.

## Gate & ranking
**Hard gate:** same `camera_id` + candidate has its own `LaserExtrinsics` + *both* dives have a confident line fit + lines agree within (`max_angle_deg`, `max_offset_px`). Same camera + matching line ⇒ same laser geometry (the mount fingerprint), so the calibration transfers — the physical argument from the roadmap (same-shape mount in the same cold shoe can't put a different 3D ray on the same 2D projection).

**Ranking:** line closeness → fit tightness (`residual_std`) → temporal proximity. Time is **advisory only**: a rotating/swappable, thermally-deforming mount makes time an unreliable gate, so the line does the work and Δdays is surfaced for the human, not gated on.

**Suggest-only:** returns ranked candidates with the metrics that justify each match (angle, Δc, confidence, residual, days-apart, the borrowable extrinsics id); the caller picks and calls the existing `set_calibration_source`.

## Tolerances
`max_angle_deg=1.0`, `max_offset_px=30`, `min_confidence=5.0` — overridable query params, and **starting values** pending the labeling validation experiment (pos/neg controls) that will lock them from data. Sign-normalizes Hesse lines so `(a,b,c)` and `(-a,-b,-c)` compare equal.

## Structure
New `calibration_candidate_controller.py` (keeps `dive_controller` under the 1000-line cap), registered in the route registry. SDK: `dives.get_calibration_candidates(...)`. `CalibrationCandidate` is a read-only response DTO (not a persisted mirror → no drift-test pair).

## Tests
`test_calibration_candidates_endpoint.py` (6): matching same-camera dive with extrinsics returned; excludes different-camera / no-extrinsics / out-of-angle / out-of-offset / low-confidence; ranks closer line first; sign-flipped line still matches; empty when target has no fingerprint. Full api suite 235 passed; SDK drift + freshness green.

Built on the merged #467 (fingerprint persistence). Next: run it over the 219 backfilled fingerprints to surface real candidate groups, then the labeling validation experiment to lock tolerances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)