### PR TITLE
fix(calibration): tighten borrow-candidate default tolerance to measurement grade

### DIFF
--- a/services/fishsense-api/src/fishsense_api/controllers/calibration_candidate_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/calibration_candidate_controller.py
@@ -24,13 +24,18 @@ from fishsense_api.server import app
 
 logger = logging.getLogger(__name__)
 
-# Default line-match tolerance. Starting values pending the labeling validation
-# experiment (pos/neg controls) that will lock them from data; overridable per
-# request. min_confidence mirrors the data-worker's LINE_CONFIDENCE_THRESHOLD
-# (kept as a literal to avoid importing the worker).
-_DEFAULT_MAX_ANGLE_DEG = 1.0
-_DEFAULT_MAX_OFFSET_PX = 30.0
-_DEFAULT_MIN_CONFIDENCE = 5.0
+# Default line-match tolerance — measurement-grade, still provisional pending the
+# cam-5 validation experiment that will lock them from data; overridable per
+# request. Empirically length is ~14%/deg sensitive to the laser axis, and a
+# 1.1deg line difference (dives 383/471) already gave 44-305% length error, so
+# the original 1deg default was 10-25x too loose. At the measured line->length
+# coupling (~38%/deg of line), 0.1deg line ~= 4% length, so 0.1deg is the
+# measurement-grade default. Offset tightened in step. min_confidence raised off
+# the bare "is it a line at all" floor (5.0) to drop the low-confidence outlier
+# fits (clear bad fits clustered <~1700; the good cluster was >2500).
+_DEFAULT_MAX_ANGLE_DEG = 0.1
+_DEFAULT_MAX_OFFSET_PX = 15.0
+_DEFAULT_MIN_CONFIDENCE = 1000.0
 
 
 class CalibrationCandidate(BaseModel):

--- a/services/fishsense-api/tests/test_calibration_candidates_endpoint.py
+++ b/services/fishsense-api/tests/test_calibration_candidates_endpoint.py
@@ -48,7 +48,7 @@ def _dive(dive_id: int, camera_id: int | None, *, days: int = 0):
     )
 
 
-def _line(dive_id: int, angle_deg: float, c: float, *, confidence: float = 100.0):
+def _line(dive_id: int, angle_deg: float, c: float, *, confidence: float = 5000.0):
     """A unit-normal Hesse line rotated `angle_deg` from the x-axis normal."""
     from fishsense_api.models.dive_laser_line import (  # pylint: disable=import-outside-toplevel
         DiveLaserLine,
@@ -142,8 +142,23 @@ async def test_ranks_closer_line_first(session):
     )
     await session.flush()
 
-    result = await _candidates(session, 1)
+    # widen tolerance so the 0.5deg candidate is admitted (it's outside the
+    # tightened default) — this test is about ordering, not the gate.
+    result = await _candidates(session, 1, max_angle_deg=1.0, max_offset_px=30.0)
     assert [c.dive_id for c in result] == [3, 2]
+
+
+async def test_default_tolerance_excludes_a_half_degree_match(session):
+    # The tightened default (0.1deg) must reject a 0.5deg line match that the
+    # old 1deg default would have (wrongly) admitted — measurement-grade gate.
+    session.add_all([_dive(1, 5), _dive(2, 5)])
+    await session.flush()
+    session.add_all([_line(1, 0.0, -100.0), _line(2, 0.5, -100.0), _extrinsics(2, 5)])
+    await session.flush()
+
+    assert await _candidates(session, 1) == []  # excluded at default 0.1deg
+    # ...but admitted when tolerance is explicitly widened.
+    assert [c.dive_id for c in await _candidates(session, 1, max_angle_deg=1.0)] == [2]
 
 
 async def test_low_confidence_candidate_excluded(session):
@@ -179,7 +194,7 @@ async def test_sign_flipped_line_still_matches(session):
         DiveLaserLine(  # same line, sign-flipped
             dive_id=2, a=-1.0, b=0.0, c=100.0,
             n_points=30, inlier_count=29, inlier_fraction=0.96,
-            residual_std=0.5, label_noise_mad=0.4, line_confidence=100.0,
+            residual_std=0.5, label_noise_mad=0.4, line_confidence=5000.0,
         )
     )
     session.add(_extrinsics(2, 5))


### PR DESCRIPTION
The borrow-candidate finder (#473) shipped with a **1° line tolerance**, which the empirical investigation showed is **10–25× too loose**:

- Fish length is **~14%/deg** sensitive to the laser axis (position is forgiving, ~0.25%/mm).
- The one same-camera calibrated pair whose lines were 1.1° apart (383/471) disagreed **44–305%** on measured length.
- At the measured line→length coupling (~38%/deg of *line*), **0.1° line ≈ 4% length**.

So the defaults move to measurement grade:

| param | old | new |
|---|---|---|
| `max_angle_deg` | 1.0 | **0.1** |
| `max_offset_px` | 30 | 15 |
| `min_confidence` | 5.0 | 1000 |

`min_confidence` was the bare "is it a line at all" floor; the outlier analysis showed low-confidence fits (<~1700) are the bad-fit outliers while the good cluster is >2500, so raising it drops the junk. All three stay **overridable per request** and remain **provisional** — the cam-5 validation experiment (roadmap) will lock them from data.

Tests decoupled from the defaults (explicit tolerances where a case is about ordering/logic) + a new test locking that the 0.1° default rejects a 0.5° match the old default would have admitted. Finder suite 7 passed; pylint 10/10.

Context in `docs/laser-calibration-fingerprint-roadmap.md` (the reframe section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)