### PR TITLE
feat(data-worker): predict_slate_image activity (slate-prediction pipeline, part 1)

### DIFF
--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_slate_image.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_slate_image.py
@@ -1,0 +1,211 @@
+"""Model-assisted slate labeling (data-worker, CPU).
+
+Runs the fishsense-core dive-slate estimator (`fishsense_core.slate`, v2.4.0+)
+on one rectified frame and returns the board's reference points in
+rectified-photo pixels — the same space the sync activity stores
+`DiveSlateLabel.reference_points` (after stripping the composite panel offset) —
+so the prediction can seed the dive-slate Label Studio task as a pre-annotation.
+
+The estimator is CPU-only (~200 ms/frame). This first cut uses the classical
+path (`board_mask=None`), a supported estimate_plane mode that costs ~13 points
+of coverage vs the learned `BoardMasker` mask; the mask (behind the `[slate]`
+extra, a HuggingFace checkpoint) is a follow-on.
+
+Gating mirrors `slate_training.predict.predict_slate`: only V-Slate / Tic-Tac-Toe
+families, ECC >= the confidence floor, and every projected point on the photo.
+A bad pre-annotation is worse than none (a labeler may accept it into the
+corpus), so every rejection returns a *reason* and the default is to decline.
+"""
+
+import asyncio
+import logging
+from typing import Any, Sequence
+
+from temporalio import activity
+
+from fishsense_data_processing_workflow_worker.object_store import (
+    open_object_store_client,
+)
+
+_log = logging.getLogger(__name__)
+
+# ECC >= 0.80 keeps ~58% of frames at median ~6 px (measured on the corpus in
+# slate_training/docs/design.md). Coverage matters more than the last few px for
+# assisted labeling. Only meaningful within the current estimator config.
+DEFAULT_MIN_CONFIDENCE = 0.80
+
+# V-Slate and Tic-Tac-Toe are measured-good; H-Slate is excluded on zero
+# evidence (no labeled frames), not bad evidence — enable it when one exists.
+SUPPORTED_FAMILIES = frozenset({"v-slate", "tic-tac-toe"})
+
+
+def slate_family(slate_name: str) -> str:
+    """Coarse family key for a `DiveSlate.name` ('V-Slate 3' -> 'v-slate')."""
+    name = (slate_name or "").strip().lower()
+    if name.startswith("v-slate"):
+        return "v-slate"
+    if name.startswith("tic-tac-toe"):
+        return "tic-tac-toe"
+    if name.startswith("h-slate"):
+        return "h-slate"
+    return name
+
+
+def gate_estimate(
+    estimate: Any,
+    slate_name: str,
+    width: int,
+    height: int,
+    min_confidence: float = DEFAULT_MIN_CONFIDENCE,
+) -> tuple[list[list[float]] | None, float, str | None]:
+    """Decide whether an estimate is seedable. Pure — no OpenCV/model work.
+
+    Returns `(reference_points | None, confidence, rejected_reason)`. Points are
+    the estimate's projected image points, in rectified-photo pixels, only when
+    all gates pass; otherwise None + a reason. Mirrors `predict_slate`'s posture:
+    decline unless every gate passes.
+    """
+    if slate_family(slate_name) not in SUPPORTED_FAMILIES:
+        return None, 0.0, "unsupported_slate_family"
+    if estimate is None:
+        return None, 0.0, "no_board"
+
+    confidence = float(estimate.ecc_score)
+    if confidence < min_confidence:
+        return None, confidence, "low_confidence"
+
+    points = [[float(x), float(y)] for x, y in estimate.image_points]
+    # A partial set breaks stage-13's positional pairing — reject if any point
+    # falls off the photo (the photo-space analog of predict_slate's
+    # points_off_canvas gate; the composite check happens in populate).
+    if any(not (0.0 <= x <= width and 0.0 <= y <= height) for x, y in points):
+        return None, confidence, "points_off_canvas"
+
+    return points, confidence, None
+
+
+def _render_template_gray(pdf_bytes: bytes, dpi: int):
+    """Render page 0 of the slate template PDF to a grayscale array at `dpi`
+    (the DiveSlate.dpi the reference points are expressed in, so template pixels
+    and template_points share a scale)."""
+    import numpy as np  # pylint: disable=import-outside-toplevel
+    import pymupdf  # pylint: disable=import-outside-toplevel
+
+    with pymupdf.open(stream=pdf_bytes, filetype="pdf") as document:
+        page = document.load_page(0)
+        pixmap = page.get_pixmap(dpi=dpi, colorspace=pymupdf.csGRAY)
+    return np.frombuffer(pixmap.samples, dtype=np.uint8).reshape(
+        pixmap.height, pixmap.width
+    )
+
+
+def _predict_from_bytes(  # pylint: disable=too-many-locals
+    raw_bytes: bytes,
+    pdf_bytes: bytes,
+    camera_matrix: list[list[float]],
+    distortion_coefficients: list[float],
+    dpi: float,
+    template_points: Sequence[Sequence[float]],
+    slate_name: str,
+    min_confidence: float,
+) -> tuple[list[list[float]] | None, float, str | None, int, int]:
+    """Off-loop CPU work: rectify the raw frame, render the template, run the
+    fishsense-core board-plane estimator, and gate the result.
+
+    Returns `(reference_points | None, confidence, reason, width, height)`.
+    """
+    import numpy as np  # pylint: disable=import-outside-toplevel
+    from fishsense_api_sdk.models.camera_intrinsics import (  # pylint: disable=import-outside-toplevel
+        CameraIntrinsics,
+    )
+    from fishsense_core.image.raw_image import (  # pylint: disable=import-outside-toplevel,no-name-in-module
+        RawImage,
+    )
+    from fishsense_core.image.rectified_image import (  # pylint: disable=import-outside-toplevel,no-name-in-module
+        RectifiedImage,
+    )
+    from fishsense_core.slate import (  # pylint: disable=import-outside-toplevel,no-name-in-module
+        estimate_plane,
+    )
+
+    cam = np.array(camera_matrix, dtype=float)
+    intrinsics = CameraIntrinsics(
+        camera_matrix=cam,
+        distortion_coefficients=np.array(distortion_coefficients, dtype=float),
+        camera_id=None,
+    )
+    bgr = RectifiedImage(RawImage(raw_bytes), intrinsics).data
+    height, width = bgr.shape[:2]
+
+    template_gray = _render_template_gray(pdf_bytes, dpi=int(dpi))
+    estimate = estimate_plane(
+        bgr,
+        template_gray,
+        [[float(x), float(y)] for x, y in template_points],
+        float(dpi),
+        cam,
+        board_mask=None,
+    )
+    points, confidence, reason = gate_estimate(
+        estimate, slate_name, int(width), int(height), min_confidence
+    )
+    return points, confidence, reason, int(width), int(height)
+
+
+def _models():
+    # pylint: disable=import-outside-toplevel
+    from fishsense_data_processing_workflow_worker.workflows.predict_slate_images_workflow import (
+        PredictSlateImageInput,
+        SlatePredictionResult,
+    )
+
+    return PredictSlateImageInput, SlatePredictionResult
+
+
+@activity.defn
+async def predict_slate_image(payload):  # type: ignore[no-untyped-def]
+    """Download one raw slate frame + its template PDF from Garage, run the
+    board-plane estimator, and return the gated reference-point prediction."""
+    payload_cls, result_cls = _models()
+    if not isinstance(payload, payload_cls):
+        payload = payload_cls.model_validate(payload)
+
+    activity.logger.info(
+        "predicting slate image checksum=%s image_id=%d slate_id=%d",
+        payload.checksum,
+        payload.image_id,
+        payload.slate_id,
+    )
+
+    client = open_object_store_client()
+    raw_bytes = await client.download_raw(payload.checksum)
+    pdf_bytes = await client.download_slate_pdf(payload.slate_id)
+
+    points, confidence, reason, width, height = await asyncio.to_thread(
+        _predict_from_bytes,
+        raw_bytes,
+        pdf_bytes,
+        payload.camera_matrix,
+        payload.distortion_coefficients,
+        payload.dpi,
+        payload.template_points,
+        payload.slate_name,
+        DEFAULT_MIN_CONFIDENCE,
+    )
+
+    activity.logger.info(
+        "predicted slate image_id=%d confidence=%.3f reason=%s dims=%dx%d",
+        payload.image_id,
+        confidence,
+        reason,
+        width,
+        height,
+    )
+    return result_cls(
+        image_id=payload.image_id,
+        reference_points=points,
+        confidence=confidence,
+        rejected_reason=reason,
+        width=width,
+        height=height,
+    )

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
@@ -33,6 +33,9 @@ from fishsense_data_processing_workflow_worker.activities.preprocess_headtail_im
 from fishsense_data_processing_workflow_worker.activities.predict_laser_image import (
     predict_laser_image,
 )
+from fishsense_data_processing_workflow_worker.activities.predict_slate_image import (
+    predict_slate_image,
+)
 from fishsense_data_processing_workflow_worker.activities.preprocess_laser_image import (
     preprocess_laser_image,
 )
@@ -60,6 +63,9 @@ from fishsense_data_processing_workflow_worker.workflows.preprocess_headtail_ima
 )
 from fishsense_data_processing_workflow_worker.workflows.predict_laser_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
     PredictLaserImagesWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.predict_slate_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PredictSlateImagesWorkflow,
 )
 from fishsense_data_processing_workflow_worker.workflows.preprocess_laser_images_workflow import (
     PreprocessLaserImagesWorkflow,
@@ -129,6 +135,7 @@ def build_worker(
             PreprocessSpeciesImagesWorkflow,
             PreprocessHeadtailImagesWorkflow,
             PredictLaserImagesWorkflow,
+            PredictSlateImagesWorkflow,
             PreprocessLaserImagesWorkflow,
             PreprocessSlateImagesWorkflow,
             ValidateLaserLabelsForDiveWorkflow,
@@ -139,6 +146,7 @@ def build_worker(
             measure_fish_activity,
             perform_laser_calibration_activity,
             predict_laser_image,
+            predict_slate_image,
             preprocess_species_image,
             preprocess_headtail_image,
             preprocess_laser_image,

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/predict_slate_images_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/predict_slate_images_workflow.py
@@ -1,0 +1,120 @@
+"""Model-assisted slate labeling: fan out `predict_slate_image` across a dive's
+slate frames and return one gated prediction per image.
+
+Runs the fishsense-core dive-slate estimator (`fishsense_core.slate`, v2.4.0+)
+on the CPU data-worker. Predictions seed the dive-slate Label Studio tasks as
+pre-annotations (assisted review) — a labeler confirms or nudges the board
+reference points rather than placing all of them from scratch.
+
+Same split as the preprocess/laser-predict stages: an api-worker parent does
+dive selection + SDK fetches + raw-byte staging and starts this as a child on
+`fishsense_data_processing_queue`. The per-image `PredictSlateImageInput` and
+`SlatePredictionResult` live here because they're only constructed inside the
+fan-out; the parent-facing `PredictSlateImagesInput` will move to
+`fishsense_shared` when the parent lands (kept local until then).
+"""
+
+import asyncio
+from datetime import timedelta
+from typing import List
+
+from pydantic import BaseModel
+from temporalio import workflow
+
+__all__ = [
+    "SlateImageRef",
+    "PredictSlateImageInput",
+    "SlatePredictionResult",
+    "PredictSlateImagesInput",
+    "PredictSlateImagesWorkflow",
+]
+
+
+class SlateImageRef(BaseModel):
+    """One slate frame to predict: its raw checksum + image id."""
+
+    checksum: str
+    image_id: int
+
+
+class PredictSlateImageInput(BaseModel):
+    """Per-image payload passed to the predict_slate_image activity."""
+
+    checksum: str
+    image_id: int
+    slate_id: int
+    slate_name: str
+    dpi: float
+    # DiveSlate.reference_points — the template's metric reference points.
+    template_points: List[List[float]]
+    camera_matrix: List[List[float]]
+    distortion_coefficients: List[float]
+
+
+class SlatePredictionResult(BaseModel):
+    """One frame's gated prediction, or the reason there isn't one.
+
+    `reference_points` are in rectified-photo pixels (the same space the sync
+    activity stores `DiveSlateLabel.reference_points` after stripping the
+    composite panel offset); the slate populate step converts them to composite
+    Label Studio coordinates. `None` when the estimate was rejected — see
+    `rejected_reason` (`unsupported_slate_family` / `no_board` /
+    `low_confidence` / `points_off_canvas`).
+    """
+
+    image_id: int
+    reference_points: List[List[float]] | None = None
+    confidence: float = 0.0
+    rejected_reason: str | None = None
+    width: int = 0
+    height: int = 0
+
+
+class PredictSlateImagesInput(BaseModel):
+    """Parent-built workflow input: the dive's slate template + frames."""
+
+    dive_id: int
+    slate_id: int
+    slate_name: str
+    dpi: float
+    template_points: List[List[float]]
+    camera_matrix: List[List[float]]
+    distortion_coefficients: List[float]
+    images: List[SlateImageRef]
+
+
+@workflow.defn
+class PredictSlateImagesWorkflow:
+    # pylint: disable=too-few-public-methods
+    @workflow.run
+    async def run(
+        self, payload: PredictSlateImagesInput
+    ) -> List[SlatePredictionResult]:
+        workflow.logger.info(
+            "predicting slate images dive_id=%d slate_id=%d images=%d",
+            payload.dive_id,
+            payload.slate_id,
+            len(payload.images),
+        )
+
+        results = await asyncio.gather(
+            *[
+                workflow.execute_activity(
+                    "predict_slate_image",
+                    PredictSlateImageInput(
+                        checksum=image.checksum,
+                        image_id=image.image_id,
+                        slate_id=payload.slate_id,
+                        slate_name=payload.slate_name,
+                        dpi=payload.dpi,
+                        template_points=payload.template_points,
+                        camera_matrix=payload.camera_matrix,
+                        distortion_coefficients=payload.distortion_coefficients,
+                    ),
+                    start_to_close_timeout=timedelta(minutes=10),
+                    result_type=SlatePredictionResult,
+                )
+                for image in payload.images
+            ]
+        )
+        return list(results)

--- a/services/fishsense-data-processing-workflow-worker/tests/test_predict_slate_image.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_predict_slate_image.py
@@ -1,0 +1,73 @@
+"""Unit tests for the slate-prediction gating (pure logic, no OpenCV/model).
+
+The estimate -> seed/decline decision is where the safety lives (a bad
+pre-annotation can be accepted into the corpus as ground truth), so it is a
+pure function tested exhaustively here. The rectify + template-render +
+estimate_plane path needs a real .ORF + PDF fixture and is an integration test
+(follow-on), like the other data-worker stage ports.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from fishsense_data_processing_workflow_worker.activities import (
+    predict_slate_image as sut,
+)
+
+
+def _estimate(ecc: float, points):
+    return SimpleNamespace(ecc_score=ecc, image_points=points)
+
+
+@pytest.mark.parametrize(
+    "name,family",
+    [
+        ("V-Slate 3", "v-slate"),
+        ("v-slate 1", "v-slate"),
+        ("Tic-Tac-Toe 6", "tic-tac-toe"),
+        ("H-Slate", "h-slate"),
+        ("Something Else", "something else"),
+    ],
+)
+def test_slate_family(name, family):
+    assert sut.slate_family(name) == family
+
+
+def test_gate_rejects_unsupported_family():
+    est = _estimate(0.99, [[1.0, 1.0]])
+    pts, conf, reason = sut.gate_estimate(est, "H-Slate", 4000, 3000)
+    assert pts is None and conf == 0.0 and reason == "unsupported_slate_family"
+
+
+def test_gate_rejects_no_board():
+    pts, conf, reason = sut.gate_estimate(None, "V-Slate 1", 4000, 3000)
+    assert pts is None and conf == 0.0 and reason == "no_board"
+
+
+def test_gate_rejects_low_confidence():
+    est = _estimate(0.5, [[10.0, 10.0]])
+    pts, conf, reason = sut.gate_estimate(est, "V-Slate 1", 4000, 3000)
+    assert pts is None and conf == pytest.approx(0.5) and reason == "low_confidence"
+
+
+def test_gate_rejects_points_off_canvas():
+    est = _estimate(0.95, [[10.0, 10.0], [4200.0, 10.0]])  # 2nd x > width
+    pts, _conf, reason = sut.gate_estimate(est, "Tic-Tac-Toe 6", 4000, 3000)
+    assert pts is None and reason == "points_off_canvas"
+
+
+def test_gate_accepts_and_returns_points():
+    est = _estimate(0.9, [[10.0, 20.0], [3000.0, 2000.0]])
+    pts, conf, reason = sut.gate_estimate(est, "V-Slate 4", 4014, 3016)
+    assert reason is None
+    assert conf == pytest.approx(0.9)
+    assert pts == [[10.0, 20.0], [3000.0, 2000.0]]
+
+
+def test_gate_confidence_boundary_is_inclusive():
+    est = _estimate(sut.DEFAULT_MIN_CONFIDENCE, [[1.0, 1.0]])
+    pts, _conf, reason = sut.gate_estimate(est, "V-Slate 1", 4000, 3000)
+    assert reason is None and pts == [[1.0, 1.0]]


### PR DESCRIPTION
First piece of the model-assisted **slate-labeling pipeline**, mirroring the laser detector. Now that fishsense-core 2.4.1 `[slate]` is deployed (#475), this wires the estimator into a data-worker activity.

## What it does
`predict_slate_image` downloads a raw slate frame + its template PDF from Garage, rectifies the frame, renders the template, runs `fishsense_core.slate.estimate_plane`, and returns the board's **reference points in rectified-photo pixels** — the same space the sync activity stores `DiveSlateLabel.reference_points` (after stripping the composite panel offset). Points come out in photo space; the slate *populate* step (a follow-on) converts them to composite Label Studio coordinates, reusing the #462 panel-offset logic.

## The safety is in the gate
`gate_estimate` is pure logic, tested exhaustively (11 tests): only **V-Slate / Tic-Tac-Toe** families (H-Slate excluded on zero evidence), **ECC ≥ 0.80**, and **every projected point on the photo**. It mirrors `slate_training.predict.predict_slate`'s posture — a bad pre-annotation is worse than none (a labeler may accept it into the corpus), so it declines unless every gate passes and always returns a reason (`unsupported_slate_family` / `no_board` / `low_confidence` / `points_off_canvas`).

## Scope
- Classical path (`board_mask=None`) — a supported estimate_plane mode; the learned `BoardMasker` mask (behind `[slate]`, a HuggingFace checkpoint) is a follow-on worth ~13 pts of coverage.
- `PredictSlateImageInput` / `SlatePredictionResult` / `PredictSlateImagesWorkflow` fan-out; registered on the data-worker.
- Full data-worker suite: **123 passed**; pylint 10/10.

## Follow-ons (the rest of the pipeline)
`SlatePrediction` model + controller + SDK + migration; api-worker parent + `select_next_for_slate_prediction` cohort + schedule; **prediction-gated dive-slate populate**; the `BoardMasker` checkpoint delivery. Integration/parity tests need a real `.ORF` + slate PDF fixture (like the other stage ports).

Context: `docs/laser-calibration-fingerprint-roadmap.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)