### PR TITLE
feat(api): SlatePrediction persistence (slate-prediction pipeline, part 2)

### DIFF
--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/label_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/label_client.py
@@ -8,6 +8,7 @@ from fishsense_api_sdk.models.headtail_label import HeadTailLabel
 from fishsense_api_sdk.models.label_studio_sync_cursor import LabelStudioSyncCursor
 from fishsense_api_sdk.models.laser_label import LaserLabel
 from fishsense_api_sdk.models.laser_prediction import LaserPrediction
+from fishsense_api_sdk.models.slate_prediction import SlatePrediction
 from fishsense_api_sdk.models.species_label import SpeciesLabel
 
 
@@ -385,6 +386,39 @@ class LabelClient(ClientBase):
         response.raise_for_status()
         json = response.json()
         return [LaserPrediction.model_validate(row) for row in (json or [])]
+
+    async def put_slate_prediction(
+        self, image_id: int, prediction: SlatePrediction
+    ) -> int:
+        """Upsert the model's slate prediction for an image.
+
+        Args:
+            image_id (int): The image the prediction is for.
+            prediction (SlatePrediction): The predicted board reference points.
+
+        Returns:
+            int: The id of the upserted prediction row.
+        """
+        response = await self._put(
+            f"/api/v1/images/{image_id}/slate-prediction/",
+            json=prediction.model_dump(exclude_unset=True, mode="json"),
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def get_slate_predictions(self, dive_id: int) -> List[SlatePrediction]:
+        """Get every model slate prediction for a dive's images.
+
+        Args:
+            dive_id (int): The dive to retrieve predictions for.
+
+        Returns:
+            List[SlatePrediction]: Predictions (empty when the dive has none).
+        """
+        response = await self._get(f"/api/v1/dives/{dive_id}/slate-predictions/")
+        response.raise_for_status()
+        json = response.json()
+        return [SlatePrediction.model_validate(row) for row in (json or [])]
 
     async def put_laser_label(self, image_id: int, laser_label: LaserLabel) -> int:
         """Put a laser label to an image .

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
@@ -260,6 +260,28 @@ class Priority(Enum):
     HIGH = 'HIGH'
 
 
+class SlatePrediction(BaseModel):
+    """
+    A model-predicted slate board for one image. One row per image —
+    re-prediction upserts on the natural key.
+
+    `reference_points` are in rectified-photo pixels (the space labelers place
+    `DiveSlateLabel.reference_points` after the composite panel offset is
+    stripped), or None when the estimate was rejected. `rejected_reason` records
+    why nothing was seeded (`unsupported_slate_family` / `no_board` /
+    `low_confidence` / `points_off_canvas`) for seed-rate monitoring.
+    """
+
+    id: int | None = Field(None, title='Id')
+    reference_points: list[list[float]] | None = Field(None, title='Reference Points')
+    confidence: float | None = Field(0.0, title='Confidence')
+    rejected_reason: str | None = Field(None, title='Rejected Reason')
+    width: int | None = Field(None, title='Width')
+    height: int | None = Field(None, title='Height')
+    created_at: AwareDatetime | None = Field(None, title='Created At')
+    image_id: int | None = Field(None, title='Image Id')
+
+
 class Species(BaseModel):
     """
     Species model representing a fish species in the database.

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/slate_prediction.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/slate_prediction.py
@@ -1,0 +1,27 @@
+"""Module defining slate prediction model for Fishsense API SDK.
+
+Mirrors fishsense-api's `SlatePrediction` SQLModel — a model-predicted dive-slate
+board for an image (fishsense-core slate-detector stage). `reference_points` are
+in rectified-photo pixels, or None when the estimate was rejected (see
+`rejected_reason`); `confidence` is always set.
+"""
+
+from datetime import datetime
+from typing import List
+
+from fishsense_api_sdk.models.model_base import ModelBase
+
+
+class SlatePrediction(ModelBase):
+    """Model representing a model-predicted dive-slate board."""
+
+    id: int | None = None
+    reference_points: List[List[float]] | None = None
+    confidence: float
+    rejected_reason: str | None = None
+    # Rectified frame dimensions the points are relative to (for the pixel ->
+    # Label Studio keypoint-percentage conversion in slate populate).
+    width: int | None = None
+    height: int | None = None
+    created_at: datetime | None = None
+    image_id: int | None = None

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/a3d0440cda27_add_slateprediction_table.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/a3d0440cda27_add_slateprediction_table.py
@@ -1,0 +1,53 @@
+"""add slateprediction table
+
+Revision ID: a3d0440cda27
+Revises: 5a7782ca68dc
+Create Date: 2026-08-02 09:46:49.230547
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a3d0440cda27'
+down_revision: Union[str, Sequence[str], None] = '5a7782ca68dc'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Idempotent against `SQLModel.metadata.create_all`: the FastAPI lifespan runs
+    `create_all` before alembic upgrade, and `slateprediction` is in the ORM
+    model registry, so on an existing DB the table already exists by the time
+    this migration runs. Skip the DDL when the table is present.
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("slateprediction"):
+        return
+    op.create_table(
+        "slateprediction",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("reference_points", sa.JSON(), nullable=True),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column("rejected_reason", sa.String(), nullable=True),
+        sa.Column("width", sa.Integer(), nullable=True),
+        sa.Column("height", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("image_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["image_id"], ["image.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("image_id", name="uq_slate_prediction_image"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table("slateprediction")

--- a/services/fishsense-api/src/fishsense_api/controllers/__init__.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/__init__.py
@@ -8,4 +8,5 @@ import fishsense_api.controllers.fish_controller
 import fishsense_api.controllers.image_controller
 import fishsense_api.controllers.label_controller
 import fishsense_api.controllers.laser_prediction_controller
+import fishsense_api.controllers.slate_prediction_controller
 import fishsense_api.controllers.user_controller

--- a/services/fishsense-api/src/fishsense_api/controllers/slate_prediction_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/slate_prediction_controller.py
@@ -1,0 +1,73 @@
+# pylint: disable=C0121
+"""Slate-prediction endpoints.
+
+Model-predicted dive-slate boards from the fishsense-core slate-detector stage.
+The predict stage upserts one per image; the dive-slate populate step reads a
+dive's predictions to seed Label Studio pre-annotations (assisted review).
+"""
+
+import logging
+from typing import List
+
+from fastapi import Depends
+from fastapi.encoders import jsonable_encoder
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from fishsense_api.database import get_async_session
+from fishsense_api.models.dive import Dive
+from fishsense_api.models.image import Image
+from fishsense_api.models.slate_prediction import SlatePrediction
+from fishsense_api.server import app
+
+logger = logging.getLogger(__name__)
+
+
+@app.put("/api/v1/images/{image_id}/slate-prediction/", status_code=201)
+async def put_slate_prediction(
+    image_id: int,
+    prediction: SlatePrediction,
+    session: AsyncSession = Depends(get_async_session),
+) -> int:
+    """Create or update the model's slate prediction for an image.
+
+    Upserts on `image_id` (the natural key) so a re-run of the predict stage
+    overwrites rather than duplicating — merge on `id=None` would always
+    INSERT and violate `uq_slate_prediction_image`.
+    """
+    logger.debug("Upserting slate prediction for image with id=%d", image_id)
+    prediction = SlatePrediction.model_validate(jsonable_encoder(prediction))
+    prediction.image_id = image_id
+
+    if prediction.id is None:
+        existing = (
+            await session.exec(
+                select(SlatePrediction).where(SlatePrediction.image_id == image_id)
+            )
+        ).first()
+        if existing is not None:
+            prediction.id = existing.id
+
+    prediction = await session.merge(prediction)
+    await session.flush()
+
+    return prediction.id
+
+
+@app.get("/api/v1/dives/{dive_id}/slate-predictions/")
+async def get_slate_predictions_for_dive(
+    dive_id: int, session: AsyncSession = Depends(get_async_session)
+) -> List[SlatePrediction]:
+    """Every model slate prediction for a dive's images.
+
+    Empty list (not 404) when the dive has none — the dive-slate populate step
+    treats "no prediction" as "no pre-annotation," not an error.
+    """
+    logger.debug("Retrieving slate predictions for dive with id=%d", dive_id)
+    query = (
+        select(SlatePrediction)
+        .join_from(SlatePrediction, Image, SlatePrediction.image_id == Image.id)
+        .join_from(Image, Dive, Image.dive_id == Dive.id)
+        .where(Dive.id == dive_id)
+    )
+    return (await session.exec(query)).all()

--- a/services/fishsense-api/src/fishsense_api/database.py
+++ b/services/fishsense-api/src/fishsense_api/database.py
@@ -35,6 +35,7 @@ from fishsense_api.models.laser_extrinsics import LaserExtrinsics
 from fishsense_api.models.laser_label import LaserLabel
 from fishsense_api.models.laser_prediction import LaserPrediction
 from fishsense_api.models.measurement import Measurement
+from fishsense_api.models.slate_prediction import SlatePrediction
 from fishsense_api.models.species import Species
 from fishsense_api.models.species_label import SpeciesLabel
 from fishsense_api.models.user import User

--- a/services/fishsense-api/src/fishsense_api/models/slate_prediction.py
+++ b/services/fishsense-api/src/fishsense_api/models/slate_prediction.py
@@ -1,0 +1,49 @@
+"""Model representing a model-predicted dive-slate board for an image.
+
+Written by the CPU slate-detector stage (fishsense-core `slate.estimate_plane`)
+and read by the dive-slate populate step, which emits it as a Label Studio
+pre-annotation so a labeler confirms/nudges the board reference points rather
+than placing them from scratch (assisted review). Kept in its own table —
+separate from `DiveSlateLabel` — so a prediction never counts toward the
+pipeline's slate gates; a labeler's confirmation still lands as a normal
+`DiveSlateLabel` via the usual sync.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from sqlmodel import JSON, Column, DateTime, Field, UniqueConstraint
+
+from fishsense_api.models.model_base import ModelBase
+
+
+class SlatePrediction(ModelBase, table=True):
+    """A model-predicted slate board for one image. One row per image —
+    re-prediction upserts on the natural key.
+
+    `reference_points` are in rectified-photo pixels (the space labelers place
+    `DiveSlateLabel.reference_points` after the composite panel offset is
+    stripped), or None when the estimate was rejected. `rejected_reason` records
+    why nothing was seeded (`unsupported_slate_family` / `no_board` /
+    `low_confidence` / `points_off_canvas`) for seed-rate monitoring.
+    """
+
+    __table_args__ = (
+        UniqueConstraint("image_id", name="uq_slate_prediction_image"),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    reference_points: List[List[float]] | None = Field(
+        default=None, sa_column=Column(JSON)
+    )
+    confidence: float = Field(default=0.0)
+    rejected_reason: str | None = Field(default=None)
+    # Rectified frame dimensions the points are relative to — the slate populate
+    # step needs them to convert pixels to Label Studio keypoint percentages.
+    width: int | None = Field(default=None)
+    height: int | None = Field(default=None)
+    created_at: datetime | None = Field(sa_type=DateTime(timezone=True), default=None)
+
+    image_id: int | None = Field(default=None, foreign_key="image.id")

--- a/services/fishsense-api/tests/test_sdk_drift.py
+++ b/services/fishsense-api/tests/test_sdk_drift.py
@@ -61,6 +61,7 @@ MODEL_PAIRS: list[Pair] = [
     Pair("laser_label", "LaserLabel", "laser_label", "LaserLabel"),
     Pair("laser_prediction", "LaserPrediction", "laser_prediction", "LaserPrediction"),
     Pair("measurement", "Measurement", "measurement", "Measurement"),
+    Pair("slate_prediction", "SlatePrediction", "slate_prediction", "SlatePrediction"),
     Pair("species", "Species", "species", "Species"),
     Pair("species_label", "SpeciesLabel", "species_label", "SpeciesLabel"),
     Pair("user", "User", "user", "User"),

--- a/services/fishsense-api/tests/test_slate_prediction_endpoint.py
+++ b/services/fishsense-api/tests/test_slate_prediction_endpoint.py
@@ -1,0 +1,135 @@
+"""Tests for the slate-prediction endpoints (model-assisted labeling store).
+
+FK-less in-memory sqlite, same as the other controller tests — we exercise the
+controller functions directly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+def _dive(dive_id: int):
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import (  # pylint: disable=import-outside-toplevel
+        Priority,
+    )
+
+    return Dive(
+        id=dive_id,
+        path=f"/dev/null/{dive_id}",
+        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        priority=Priority.HIGH,
+    )
+
+
+def _image(image_id: int, dive_id: int):
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    return Image(
+        id=image_id,
+        path=f"/dev/null/img-{image_id}",
+        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        checksum=f"img-{image_id:032d}"[:32],
+        dive_id=dive_id,
+    )
+
+
+def _prediction(*, reference_points=None, confidence=0.9, rejected_reason=None):
+    from fishsense_api.models.slate_prediction import (  # pylint: disable=import-outside-toplevel
+        SlatePrediction,
+    )
+
+    return SlatePrediction(
+        reference_points=reference_points,
+        confidence=confidence,
+        rejected_reason=rejected_reason,
+        width=4014,
+        height=3016,
+    )
+
+
+async def _count(session, image_id):
+    from fishsense_api.models.slate_prediction import (  # pylint: disable=import-outside-toplevel
+        SlatePrediction,
+    )
+
+    rows = (
+        await session.exec(
+            select(SlatePrediction).where(SlatePrediction.image_id == image_id)
+        )
+    ).all()
+    return len(rows)
+
+
+async def test_put_upserts_on_image_id(session):
+    from fishsense_api.controllers.slate_prediction_controller import (  # pylint: disable=import-outside-toplevel
+        get_slate_predictions_for_dive,
+        put_slate_prediction,
+    )
+
+    session.add_all([_dive(1), _image(10, 1)])
+    await session.flush()
+
+    id1 = await put_slate_prediction(
+        10, _prediction(reference_points=[[1.0, 2.0]], confidence=0.9), session=session
+    )
+    id2 = await put_slate_prediction(
+        10, _prediction(reference_points=[[3.0, 4.0]], confidence=0.95), session=session
+    )
+    await session.flush()
+
+    assert await _count(session, 10) == 1  # upsert, not append
+    assert id1 == id2
+    preds = await get_slate_predictions_for_dive(1, session=session)
+    assert len(preds) == 1
+    assert preds[0].reference_points == [[3.0, 4.0]]  # latest wins
+    assert preds[0].confidence == pytest.approx(0.95)
+
+
+async def test_put_stores_rejection_with_null_points(session):
+    from fishsense_api.controllers.slate_prediction_controller import (  # pylint: disable=import-outside-toplevel
+        get_slate_predictions_for_dive,
+        put_slate_prediction,
+    )
+
+    session.add_all([_dive(1), _image(10, 1)])
+    await session.flush()
+    await put_slate_prediction(
+        10,
+        _prediction(reference_points=None, confidence=0.4, rejected_reason="low_confidence"),
+        session=session,
+    )
+    await session.flush()
+
+    preds = await get_slate_predictions_for_dive(1, session=session)
+    assert preds[0].reference_points is None
+    assert preds[0].rejected_reason == "low_confidence"
+
+
+async def test_get_empty_when_dive_has_no_predictions(session):
+    from fishsense_api.controllers.slate_prediction_controller import (  # pylint: disable=import-outside-toplevel
+        get_slate_predictions_for_dive,
+    )
+
+    session.add(_dive(1))
+    await session.flush()
+    assert await get_slate_predictions_for_dive(1, session=session) == []


### PR DESCRIPTION
Part 2 of the slate-prediction pipeline: the store the predict stage (#480) writes and the dive-slate populate step will read. Mirrors `LaserPrediction` end-to-end.

- **`SlatePrediction` SQLModel** — one row per image (`uq_slate_prediction_image`): `reference_points` (rectified-photo px, JSON) or null + `rejected_reason`, `confidence`, `width`/`height`, `image_id`. In the model registry.
- **Controller** — `PUT /api/v1/images/{id}/slate-prediction/` (upsert on the natural key; merge-on-`id=None` would violate the unique constraint) + `GET /api/v1/dives/{id}/slate-predictions/` (empty list, not 404, when a dive has none). In the route registry.
- **SDK** — `SlatePrediction` wire model + label-client `put_slate_prediction` / `get_slate_predictions`; drift `MODEL_PAIRS` entry added; committed `_generated.py` refreshed.
- **Migration `a3d0440cda27`** — idempotent `create_table` (has_table-guarded, like the laserprediction migration). Validated against the **prod** schema in a rolled-back txn.

Tests: `test_slate_prediction_endpoint.py` (upsert-on-image_id, rejection-with-null-points, empty-for-dive); fishsense-api suite **241 passed**, SDK **118 passed**.

Next: api-worker parent + `select_next_for_slate_prediction` cohort + schedule, then the prediction-gated dive-slate populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)