### PR TITLE
feat(slate): select_next_for_slate_prediction cohort (pipeline part 3a)

### DIFF
--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
@@ -11,7 +11,7 @@ from fishsense_api_sdk.models.laser_extrinsics import LaserExtrinsics, _LaserExt
 
 
 class DiveClient(ClientBase):
-    # pylint: disable=too-few-public-methods
+    # pylint: disable=too-few-public-methods,too-many-public-methods
     """Client for interacting with dive-related endpoints of the Fishsense API."""
 
     async def get(self, dive_id: int | None = None) -> Dive | List[Dive] | None:
@@ -111,6 +111,10 @@ class DiveClient(ClientBase):
     async def select_next_for_laser_prediction(self) -> int | None:
         """Laser-detector cohort selector. See `select_next_for_laser_preprocessing`."""
         return await self._select_next("laser-prediction")
+
+    async def select_next_for_slate_prediction(self) -> int | None:
+        """Slate-detector cohort selector. See `select_next_for_laser_preprocessing`."""
+        return await self._select_next("slate-prediction")
 
     async def select_next_for_laser_calibration(self) -> int | None:
         """Stage 13 cohort selector. See `select_next_for_laser_preprocessing`."""

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_slate_prediction_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_slate_prediction_activity.py
@@ -1,0 +1,36 @@
+"""Activity to pick the next HIGH-priority dive needing slate predictions.
+
+Cohort: HIGH-priority + `dive_slate_id` set + at least one slate frame
+(`SpeciesLabel.content_of_image='Slate, Laser on slate'`) with no
+`SlatePrediction` and no *completed* `DiveSlateLabel` (see
+`select_next_for_slate_prediction` in the api's dive_controller). The CPU
+slate-detector stage seeds a prediction per such frame; the dive-slate populate
+step then serves it as a Label Studio pre-annotation (assisted review).
+
+Single SDK call — the cohort answer is one query on the api side.
+"""
+
+from __future__ import annotations
+
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.utils import get_fs_client
+
+
+@activity.defn
+async def select_next_high_priority_dive_for_slate_prediction_activity() -> (
+    int | None
+):
+    async with get_fs_client() as fs:
+        dive_id = await fs.dives.select_next_for_slate_prediction()
+
+    if dive_id is None:
+        activity.logger.info(
+            "no HIGH-priority dives needing slate predictions; nothing to predict"
+        )
+    else:
+        activity.logger.info(
+            "next HIGH-priority dive needing slate predictions: dive_id=%d",
+            dive_id,
+        )
+    return dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -126,6 +126,9 @@ from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for
 from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for_measure_fish_activity import (  # pylint: disable=line-too-long
     select_next_high_priority_dive_for_measure_fish_activity,
 )
+from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for_slate_prediction_activity import (  # pylint: disable=line-too-long
+    select_next_high_priority_dive_for_slate_prediction_activity,
+)
 from fishsense_api_workflow_worker.activities.select_next_high_priority_dive_for_slate_preprocessing_activity import (  # pylint: disable=line-too-long
     select_next_high_priority_dive_for_slate_preprocessing_activity,
 )
@@ -608,6 +611,7 @@ async def main():
                 select_next_high_priority_dive_for_clustering_activity,
                 select_next_high_priority_dive_for_laser_preprocessing_activity,
                 select_next_high_priority_dive_for_laser_prediction_activity,
+                select_next_high_priority_dive_for_slate_prediction_activity,
                 select_next_high_priority_dive_for_species_preprocessing_activity,
                 select_dives_needing_laser_population_activity,
                 select_dives_needing_species_population_activity,

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -28,6 +28,7 @@ from fishsense_api.models.laser_label import LaserLabel
 from fishsense_api.models.laser_prediction import LaserPrediction
 from fishsense_api.models.measurement import Measurement
 from fishsense_api.models.priority import Priority
+from fishsense_api.models.slate_prediction import SlatePrediction
 from fishsense_api.models.species_label import SpeciesLabel
 from fishsense_api.server import app
 
@@ -235,6 +236,54 @@ async def select_next_for_laser_prediction(
         select(Dive.id)
         .where(Dive.priority == Priority.HIGH)
         .where(has_image_needing_prediction)
+        .order_by(Dive.id)
+        .limit(1)
+    )
+    return (await session.exec(query)).first()
+
+
+@app.get("/api/v1/dives/select-next/slate-prediction/")
+async def select_next_for_slate_prediction(
+    session: AsyncSession = Depends(get_async_session),
+) -> int | None:
+    """Model-assisted slate labeling: HIGH-priority + `dive_slate_id` set + at
+    least one slate frame with no `SlatePrediction` and no *completed*
+    `DiveSlateLabel`.
+
+    A slate frame is an image with a `SpeciesLabel.content_of_image =
+    'Slate, Laser on slate'` (the same frames stage 9 preprocesses). Such a
+    frame needs a prediction only if it has neither been predicted nor
+    labeled by a human yet — so a dive drops out once every slate frame is
+    predicted (one-shot per image), and human-labeled frames are never
+    predicted over. "Labeled" = `completed IS TRUE AND superseded IS FALSE`,
+    matching the laser-prediction cohort's rationale (populate seeds
+    placeholder rows that carry a project_id, so a project-id check would
+    starve the detector).
+    """
+    has_slate_frame_needing_prediction = (
+        select(SpeciesLabel.id)
+        .join(Image, Image.id == SpeciesLabel.image_id)
+        .where(Image.dive_id == Dive.id)
+        .where(SpeciesLabel.content_of_image == SLATE_CONTENT_MARKER)
+        .where(
+            ~select(SlatePrediction.id)
+            .where(SlatePrediction.image_id == Image.id)
+            .exists()
+        )
+        .where(
+            ~select(DiveSlateLabel.id)
+            .where(DiveSlateLabel.image_id == Image.id)
+            .where(DiveSlateLabel.completed == True)
+            .where(DiveSlateLabel.superseded == False)
+            .exists()
+        )
+        .exists()
+    )
+    query = (
+        select(Dive.id)
+        .where(Dive.priority == Priority.HIGH)
+        .where(Dive.dive_slate_id != None)
+        .where(has_slate_frame_needing_prediction)
         .order_by(Dive.id)
         .limit(1)
     )

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -1317,6 +1317,101 @@ async def test_slate_preprocessing_excludes_dive_when_sentinel_coexists_with_rea
     assert await select_next_for_slate_preprocessing(session=session) is None
 
 
+# --------------------------- slate prediction ---------------------------
+
+
+async def test_slate_prediction_requires_marker_and_no_prediction_or_label(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        SLATE_CONTENT_MARKER,
+        select_next_for_slate_prediction,
+    )
+    from fishsense_api.models.slate_prediction import (  # pylint: disable=import-outside-toplevel
+        SlatePrediction,
+    )
+    from fishsense_api.models.species_label import (  # pylint: disable=import-outside-toplevel
+        SpeciesLabel,
+    )
+
+    # dive 1: no dive_slate_id -> excluded.
+    # dive 2: slate frame already has a SlatePrediction -> excluded.
+    # dive 3: slate frame, no prediction, no completed label -> picked.
+    session.add_all(
+        [_dive(1, dive_slate_id=None), _dive(2, dive_slate_id=99), _dive(3, dive_slate_id=99)]
+    )
+    await session.flush()
+    session.add_all([_image(11, 1), _image(21, 2), _image(31, 3)])
+    await session.flush()
+    session.add_all(
+        [
+            SpeciesLabel(image_id=11, content_of_image=SLATE_CONTENT_MARKER),
+            SpeciesLabel(image_id=21, content_of_image=SLATE_CONTENT_MARKER),
+            SpeciesLabel(image_id=31, content_of_image=SLATE_CONTENT_MARKER),
+            SlatePrediction(image_id=21, confidence=0.9),
+        ]
+    )
+    await session.flush()
+
+    assert await select_next_for_slate_prediction(session=session) == 3
+
+
+async def test_slate_prediction_placeholder_label_still_needs_prediction(session):
+    """Unlike the preprocess cohort, an incomplete (populate-seeded) slate
+    label must NOT exclude the frame — it still needs a prediction. The
+    prediction cohort keys on `completed`, not on project_id."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        SLATE_CONTENT_MARKER,
+        select_next_for_slate_prediction,
+    )
+    from fishsense_api.models.dive_slate_label import (  # pylint: disable=import-outside-toplevel
+        DiveSlateLabel,
+    )
+    from fishsense_api.models.species_label import (  # pylint: disable=import-outside-toplevel
+        SpeciesLabel,
+    )
+
+    session.add(_dive(1, dive_slate_id=99))
+    await session.flush()
+    session.add(_image(11, 1))
+    session.add(SpeciesLabel(image_id=11, content_of_image=SLATE_CONTENT_MARKER))
+    session.add(
+        DiveSlateLabel(image_id=11, completed=False, label_studio_project_id=66)
+    )
+    await session.flush()
+
+    assert await select_next_for_slate_prediction(session=session) == 1
+
+
+async def test_slate_prediction_excludes_completed_but_reenters_when_superseded(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        SLATE_CONTENT_MARKER,
+        select_next_for_slate_prediction,
+    )
+    from fishsense_api.models.dive_slate_label import (  # pylint: disable=import-outside-toplevel
+        DiveSlateLabel,
+    )
+    from fishsense_api.models.species_label import (  # pylint: disable=import-outside-toplevel
+        SpeciesLabel,
+    )
+
+    session.add(_dive(1, dive_slate_id=99))
+    await session.flush()
+    session.add(_image(11, 1))
+    session.add(SpeciesLabel(image_id=11, content_of_image=SLATE_CONTENT_MARKER))
+    label = DiveSlateLabel(
+        image_id=11, completed=True, superseded=False, label_studio_project_id=66
+    )
+    session.add(label)
+    await session.flush()
+    # completed + not superseded -> the only frame is done -> excluded.
+    assert await select_next_for_slate_prediction(session=session) is None
+
+    # supersede it -> invalidated -> the frame re-enters the cohort.
+    label.superseded = True
+    session.add(label)
+    await session.flush()
+    assert await select_next_for_slate_prediction(session=session) == 1
+
+
 async def test_slate_preprocessing_ignores_null_project_sentinels(session):
     """NULL-`project_id` DiveSlateLabel rows are legacy sentinels — see
     the dive-image cohort docstring. They must NOT drop a dive from


### PR DESCRIPTION
The cohort selector for the slate-prediction stage, mirroring the laser one. Part 3a of the pipeline (the parent workflow builds on this in 3b).

- **API** `GET /api/v1/dives/select-next/slate-prediction/`: HIGH-priority + `dive_slate_id` set + ≥1 slate frame (`SpeciesLabel.content_of_image='Slate, Laser on slate'`) with **no `SlatePrediction`** and **no *completed* (non-superseded) `DiveSlateLabel`**.
  - Keys on `completed`, **not** project_id — unlike the *preprocess* cohort. An incomplete populate-seeded label must NOT exclude a frame (it still needs a prediction), and a superseded-completed label re-enters the cohort. (Same rationale as the laser-prediction cohort.)
- **SDK** `dives.select_next_for_slate_prediction`.
- **api-worker** `select_next_high_priority_dive_for_slate_prediction_activity` (thin SDK wrapper), registered on the worker.

Tests pin marker/prediction/label gates + the two behaviours that differ from preprocess (placeholder-still-needs-prediction; supersede-reenters). fishsense-api **244 passed**, SDK **118**.

**Part 3b** (next): `PredictSlateImagesParentWorkflow` + `resolve_slate_predict_inputs_activity` + `persist_slate_predictions_activity` + the `fishsense_shared` input/result DTOs + raw/PDF staging + hourly schedule slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)