### PR TITLE
feat(slate): prediction-gated dive-slate populate + fix missing object-store read (part 4)

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_dive_slate_label_studio_project_activity.py
@@ -11,8 +11,10 @@ slate label so the workflow is idempotent.
 
 from typing import List
 
+from botocore.exceptions import BotoCoreError, ClientError
 from fishsense_api_sdk.models.dive_slate_label import DiveSlateLabel
 from fishsense_api_sdk.models.image import Image
+from fishsense_api_sdk.models.slate_prediction import SlatePrediction
 from fishsense_api_sdk.models.species_label import SpeciesLabel
 from temporalio import activity
 
@@ -21,12 +23,87 @@ from fishsense_api_workflow_worker.activities.populate_utils import (
     import_tasks_and_record_labels,
     publish_label_studio_project,
 )
+from fishsense_api_workflow_worker.activities.sync_dive_slate_labels_for_label_studio_project_activity import (  # noqa: E501  pylint: disable=line-too-long
+    compute_pdf_panel_aspect_ratio,
+    compute_pdf_panel_width_in_composite,
+)
 from fishsense_api_workflow_worker.activities.utils import get_fs_client
+from fishsense_api_workflow_worker.object_store import open_object_store_client
 
 # Physical Garage prefix the data-worker writes slate JPEGs to (stage 9).
 # Was the nginx virtual name "dive_slate_jpgs"; now the real key prefix.
 DIVE_SLATE_FOLDER = "preprocess_slate_images_jpeg"
 SLATE_CONTENT_MARKER = "Slate, Laser on slate"
+
+# LS keypoint control names on the dive-slate labeling config (see
+# create_dive_slate_label_studio_project_activity's XML) + the sync parser.
+_KEYPOINT_FROM_NAME = "reference_points"
+_KEYPOINT_TO_NAME = "image"
+_REFERENCE_POINT_LABEL = "Reference Point"
+
+
+def _prediction_annotations(prediction, panel_width: float) -> list:
+    """Build the LS `predictions` list (one keypoint per reference point) from a
+    model `SlatePrediction`, or [] when there's nothing seedable.
+
+    The prediction's `reference_points` are in rectified-photo pixels; the LS
+    canvas is the composite (PDF panel left + photo right), so shift x right by
+    the rendered `panel_width` and express both as percentages of the composite
+    dimensions — the inverse of the panel-offset strip the sync activity applies
+    on write-back.
+    """
+    if prediction is None or not prediction.reference_points:
+        return []
+    if not prediction.width or not prediction.height:
+        return []
+    composite_width = float(panel_width) + float(prediction.width)
+    composite_height = float(prediction.height)
+    result = [
+        {
+            "from_name": _KEYPOINT_FROM_NAME,
+            "to_name": _KEYPOINT_TO_NAME,
+            "type": "keypointlabels",
+            "original_width": int(round(composite_width)),
+            "original_height": int(round(composite_height)),
+            "value": {
+                "x": (float(x) + float(panel_width)) / composite_width * 100.0,
+                "y": float(y) / composite_height * 100.0,
+                "width": 0.5,
+                "keypointlabels": [_REFERENCE_POINT_LABEL],
+            },
+        }
+        for x, y in prediction.reference_points
+    ]
+    return [
+        {
+            "model_version": "slate-detector",
+            "score": float(prediction.confidence),
+            "result": result,
+        }
+    ]
+
+
+async def _slate_panel_aspect(dive_id: int, fs) -> float | None:
+    """Fetch the dive's slate PDF from Garage and return its width/height aspect
+    (points), or None when it can't be resolved. A missing aspect just means no
+    pre-annotation (labeler places from scratch) — never fail populate over it,
+    unlike the sync activity where wrong-space *persistence* is the danger.
+    """
+    dive = await fs.dives.get(dive_id=dive_id)
+    slate_id = getattr(dive, "dive_slate_id", None) if dive is not None else None
+    if slate_id is None:
+        return None
+    try:
+        pdf_bytes = await open_object_store_client().download_slate_pdf(slate_id)
+    except (ClientError, BotoCoreError) as exc:
+        activity.logger.warning(
+            "slate PDF for slate_id=%s unavailable (%s); seeding slate tasks "
+            "without pre-annotations",
+            slate_id,
+            exc,
+        )
+        return None
+    return compute_pdf_panel_aspect_ratio(pdf_bytes)
 
 
 def _select_target_image_ids(
@@ -46,14 +123,15 @@ def _select_target_image_ids(
     ]
 
 
-def _build_task(image: Image) -> dict:
-    """Build an LS task. Emits both `image` and `img` keys to satisfy
-    legacy LS labeling-config XML across prod projects — see
-    `populate_laser_label_studio_project_activity._build_task`."""
+def _build_task(image: Image, prediction=None, panel_width: float = 0.0) -> dict:
+    """Build an LS task. Emits both `image` and `img` keys to satisfy legacy LS
+    labeling-config XML across prod projects. Seeds a keypoint pre-annotation
+    from the model `SlatePrediction` when one exists (assisted review) — a
+    labeler confirms/nudges the board points rather than placing all of them."""
     url = build_image_url(DIVE_SLATE_FOLDER, image.checksum)
     return {
         "data": {"image": url, "img": url},
-        "predictions": [],
+        "predictions": _prediction_annotations(prediction, panel_width),
         "annotations": [],
     }
 
@@ -72,6 +150,15 @@ async def populate_dive_slate_label_studio_project_activity(
 
         target_ids = _select_target_image_ids(species_labels, existing_slate)
 
+        # Model pre-annotations (assisted review). The predict parent (+35 min)
+        # writes SlatePrediction rows before this populate runs (stage-9 +45);
+        # a missing prediction just means no pre-annotation for that frame.
+        predictions: List[SlatePrediction] = (
+            await fs.labels.get_slate_predictions(dive_id) or []
+        )
+        prediction_by_image = {p.image_id: p for p in predictions}
+        aspect = await _slate_panel_aspect(dive_id, fs) if prediction_by_image else None
+
         new_count = 0
         images: List[Image] = []
         for image_id in target_ids:
@@ -81,7 +168,18 @@ async def populate_dive_slate_label_studio_project_activity(
             activity.heartbeat()
 
         if images:
-            tasks = [_build_task(image) for image in images]
+            def _task(image: Image) -> dict:
+                prediction = prediction_by_image.get(image.id)
+                panel_width = (
+                    compute_pdf_panel_width_in_composite(aspect, prediction.height)
+                    if aspect is not None
+                    and prediction is not None
+                    and prediction.height
+                    else 0.0
+                )
+                return _build_task(image, prediction, panel_width)
+
+            tasks = [_task(image) for image in images]
 
             async def _record(image: Image, task_id: int) -> None:
                 label = DiveSlateLabel(

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/object_store.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/object_store.py
@@ -153,6 +153,15 @@ class ObjectStoreClient:
             self._s3.put_object, Bucket=self._bucket, Key=key, Body=data
         )
 
+    async def _get(self, key: str, bucket: str | None = None) -> bytes:
+        target = bucket or self._bucket
+
+        def _do() -> bytes:
+            response = self._s3.get_object(Bucket=target, Key=key)
+            return response["Body"].read()
+
+        return await asyncio.to_thread(_do)
+
     async def _delete(self, key: str) -> None:
         # S3 delete_object is idempotent: deleting an absent key returns
         # success (no ClientError), so retries are naturally safe.
@@ -186,6 +195,15 @@ class ObjectStoreClient:
 
     async def upload_slate_pdf(self, slate_id: int, data: bytes) -> None:
         await self._put(slate_pdf_key(slate_id), data)
+
+    async def download_slate_pdf(self, slate_id: int) -> bytes:
+        """Read a staged slate template PDF back from Garage.
+
+        The dive-slate sync (panel-offset strip) and the slate populate
+        (pre-annotation composite conversion) both need the template's
+        aspect ratio; both read it through here.
+        """
+        return await self._get(slate_pdf_key(slate_id))
 
     # ----- scratch cleanup (Garage only — NEVER the NAS) -----
 

--- a/services/fishsense-api-workflow-worker/tests/test_populate_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_dive_slate_label_studio_project_activity.py
@@ -124,6 +124,7 @@ def _make_fs_client(
     fs.labels.get_species_labels = AsyncMock(return_value=species_labels)
     fs.labels.get_dive_slate_labels = AsyncMock(return_value=existing_slate)
     fs.labels.put_dive_slate_label = AsyncMock()
+    fs.labels.get_slate_predictions = AsyncMock(return_value=[])
     return fs
 
 
@@ -240,3 +241,57 @@ async def test_does_not_publish_empty_project(monkeypatch):
     )
 
     ls.projects.update.assert_not_called()
+
+
+# --------------------- model pre-annotations (part 4) ---------------------
+
+
+def test_prediction_annotations_converts_photo_to_composite_percent():
+    pred = SimpleNamespace(
+        reference_points=[[100.0, 50.0], [3000.0, 2000.0]],
+        width=4014,
+        height=3016,
+        confidence=0.9,
+    )
+    panel_width = 4967.5  # V-Slate
+    anns = sut._prediction_annotations(pred, panel_width)  # pylint: disable=protected-access
+
+    assert len(anns) == 1
+    assert anns[0]["model_version"] == "slate-detector"
+    assert anns[0]["score"] == pytest.approx(0.9)
+    result = anns[0]["result"]
+    assert len(result) == 2
+    composite_width = panel_width + 4014
+    first = result[0]
+    assert first["from_name"] == "reference_points"
+    assert first["type"] == "keypointlabels"
+    assert first["value"]["keypointlabels"] == ["Reference Point"]
+    # photo x shifted right by the panel, then percent of the composite.
+    assert first["value"]["x"] == pytest.approx((100.0 + panel_width) / composite_width * 100.0)
+    assert first["value"]["y"] == pytest.approx(50.0 / 3016 * 100.0)
+    assert first["original_width"] == round(composite_width)
+    assert first["original_height"] == 3016
+
+
+def test_prediction_annotations_empty_paths():
+    # pylint: disable=protected-access
+    assert not sut._prediction_annotations(None, 100.0)
+    assert not sut._prediction_annotations(
+        SimpleNamespace(reference_points=None, width=4014, height=3016, confidence=0.9),
+        100.0,
+    )
+    # a rejected prediction (no dims) yields no pre-annotation.
+    assert not sut._prediction_annotations(
+        SimpleNamespace(reference_points=[[1.0, 2.0]], width=0, height=0, confidence=0.4),
+        100.0,
+    )
+
+
+def test_build_task_seeds_prediction_only_when_present():
+    # pylint: disable=protected-access
+    pred = SimpleNamespace(
+        reference_points=[[100.0, 50.0]], width=4014, height=3016, confidence=0.9
+    )
+    seeded = sut._build_task(_image(11, "c11"), pred, 4967.5)
+    assert seeded["predictions"] and seeded["predictions"][0]["result"]
+    assert not sut._build_task(_image(12, "c12"))["predictions"]


### PR DESCRIPTION
Closes the slate-detector loop: dive-slate populate now seeds **Label Studio pre-annotations** from `SlatePrediction`, so labelers confirm/nudge the board reference points instead of placing all of them (assisted review).

## Populate change
`populate_dive_slate` reads `get_slate_predictions(dive_id)` and, per image with a prediction, emits a keypoint `predictions` entry — converting the prediction's **rectified-photo** points to **composite** Label Studio coordinates (shift x by the rendered panel width, then percent of composite dims): the exact inverse of the sync activity's panel-offset strip (#462).

- **No hard gate** — a frame without a prediction still gets a task (labeler places from scratch), unlike the laser populate. The slate detector *declines* low-confidence frames by design, so gating would strand them.
- Ordering: the predict schedule (+35) runs before the stage-9-dispatched populate (+45), so predictions exist at populate time. A missing slate PDF just means no pre-annotation (never fails populate).

## Fix: missing object-store read (also unbreaks the sync)
The api-worker `ObjectStoreClient` was **staging-only** — no `_get`/`download_slate_pdf`. But **both** this populate *and* the deployed #462 sync call `download_slate_pdf`; the sync's call therefore raised `AttributeError` on any slate label with geometry (the #462 tests passed only because they mock the exchange — so this went unnoticed). This very likely explains why the panel offset was never applied to the original 104 labels. Added `_get` + `download_slate_pdf`, which fixes part 4 **and** the sync's panel-offset strip.

> ⚠️ Worth knowing: until this merges, completing a slate label makes the dive-slate sync error on its PDF fetch. Low impact right now (little active slate labeling), but this is the fix.

Tests: photo→composite percent conversion, empty/rejected paths, build_task seeding. api-worker **333 passed**; pylint 10/10.

Only **part 5** (BoardMasker checkpoint, ~13 pts more coverage) remains after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)