### PR TITLE
feat(slate): wire the learned BoardMasker into slate prediction (part 5)

### DIFF
--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_slate_image.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_slate_image.py
@@ -19,6 +19,7 @@ corpus), so every rejection returns a *reason* and the default is to decline.
 
 import asyncio
 import logging
+import os
 from typing import Any, Sequence
 
 from temporalio import activity
@@ -28,6 +29,48 @@ from fishsense_data_processing_workflow_worker.object_store import (
 )
 
 _log = logging.getLogger(__name__)
+
+# Optional learned board mask (BoardMasker, behind fishsense_core[slate]). A
+# local checkpoint path overrides the HuggingFace download. The classical path
+# (board_mask=None) is a supported fallback (~13 pts less coverage), so any
+# load/inference failure degrades gracefully instead of failing the frame.
+DEFAULT_SLATE_CHECKPOINT_PATH = os.environ.get("E4EFS_SLATE_DETECTOR__CHECKPOINT", "")
+_MASKER: Any = None
+_MASKER_LOADED = False
+
+
+def _get_masker() -> Any:
+    """Return the process-wide BoardMasker, or None if it can't be loaded.
+
+    Caches the outcome (including failure) so a missing mask doesn't retry the
+    load on every frame. Loads from a local checkpoint when
+    `E4EFS_SLATE_DETECTOR__CHECKPOINT` points at one, else from HuggingFace.
+    """
+    global _MASKER, _MASKER_LOADED  # pylint: disable=global-statement
+    if _MASKER_LOADED:
+        return _MASKER
+    _MASKER_LOADED = True
+    try:
+        # no-name-in-module: BoardMasker ships in fishsense-core[slate] >= 2.4.0
+        from fishsense_core.slate import (  # pylint: disable=import-outside-toplevel,import-error,no-name-in-module
+            BoardMasker,
+        )
+
+        if DEFAULT_SLATE_CHECKPOINT_PATH and os.path.exists(
+            DEFAULT_SLATE_CHECKPOINT_PATH
+        ):
+            _MASKER = BoardMasker.from_checkpoint(DEFAULT_SLATE_CHECKPOINT_PATH)
+        else:
+            _MASKER = BoardMasker.from_pretrained()
+        _log.info("loaded BoardMasker (learned board mask)")
+    except Exception as exc:  # pylint: disable=broad-except
+        # torch/hf missing, no network, or bad checkpoint — fall back to the
+        # classical estimator. The mask only adds coverage; it's never required.
+        _log.warning(
+            "BoardMasker unavailable (%s); using classical slate path", exc
+        )
+        _MASKER = None
+    return _MASKER
 
 # ECC >= 0.80 keeps ~58% of frames at median ~6 px (measured on the corpus in
 # slate_training/docs/design.md). Coverage matters more than the last few px for
@@ -138,13 +181,26 @@ def _predict_from_bytes(  # pylint: disable=too-many-locals
     height, width = bgr.shape[:2]
 
     template_gray = _render_template_gray(pdf_bytes, dpi=int(dpi))
+
+    # Learned board mask improves localization when available; None is the
+    # supported classical fallback.
+    board_mask = None
+    masker = _get_masker()
+    if masker is not None:
+        try:
+            board_mask = masker.predict(bgr)
+        except Exception as exc:  # pylint: disable=broad-except
+            _log.warning(
+                "board mask inference failed (%s); classical slate path", exc
+            )
+
     estimate = estimate_plane(
         bgr,
         template_gray,
         [[float(x), float(y)] for x, y in template_points],
         float(dpi),
         cam,
-        board_mask=None,
+        board_mask=board_mask,
     )
     points, confidence, reason = gate_estimate(
         estimate, slate_name, int(width), int(height), min_confidence

--- a/services/fishsense-data-processing-workflow-worker/tests/test_predict_slate_image.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_predict_slate_image.py
@@ -71,3 +71,25 @@ def test_gate_confidence_boundary_is_inclusive():
     est = _estimate(sut.DEFAULT_MIN_CONFIDENCE, [[1.0, 1.0]])
     pts, _conf, reason = sut.gate_estimate(est, "V-Slate 1", 4000, 3000)
     assert reason is None and pts == [[1.0, 1.0]]
+
+
+def test_get_masker_falls_back_to_none_and_caches(monkeypatch):
+    # pylint: disable=protected-access
+    """A BoardMasker that can't load (no net / no checkpoint) must degrade to
+    the classical path (None), and the failure is cached (no per-frame retry)."""
+    import fishsense_core.slate as slate_mod  # pylint: disable=import-outside-toplevel
+
+    calls = {"n": 0}
+
+    def _boom(*_a, **_k):
+        calls["n"] += 1
+        raise RuntimeError("no network")
+
+    monkeypatch.setattr(slate_mod.BoardMasker, "from_pretrained", _boom)
+    monkeypatch.setattr(sut, "DEFAULT_SLATE_CHECKPOINT_PATH", "")
+    monkeypatch.setattr(sut, "_MASKER", None)
+    monkeypatch.setattr(sut, "_MASKER_LOADED", False)
+
+    assert sut._get_masker() is None
+    assert sut._get_masker() is None  # cached
+    assert calls["n"] == 1  # loaded once, failure cached


### PR DESCRIPTION
The final piece of the slate-prediction pipeline: use the learned board-mask (`fishsense_core.slate.BoardMasker`, behind the `[slate]` extra) to improve localization — **~13 pts more coverage** than classical (67% → 80% seeded on the corpus).

- **Lazy, process-cached masker**: `BoardMasker.from_checkpoint` when `E4EFS_SLATE_DETECTOR__CHECKPOINT` points at a local file, else `from_pretrained()` (HuggingFace download — mirrors `LaserDetector.from_pretrained`; the `[slate]` extra provides `huggingface-hub`). CPU-only, ~200 ms/frame.
- `predict_slate_image` computes the mask and passes `board_mask=mask` to `estimate_plane`.
- **Graceful degradation**: any load/inference failure (no network, missing extra, bad checkpoint) falls back to `board_mask=None` (the supported classical path) and is **cached** so it doesn't retry per frame — the mask only *adds* coverage, it's never required.

**Checkpoint delivery**: via HF at first use (cached in the pod). No image bake needed; the env var allows pointing at a baked/local checkpoint later if desired.

Test: masker-load failure → None, cached (single attempt). data-worker **124 passed**; pylint 10/10.

## Pipeline complete (parts 1–5)
| part | what | PR |
|---|---|---|
| 1 | `predict_slate_image` activity + gating | #480 ✅ |
| 2 | `SlatePrediction` persistence | #482 ✅ |
| 3a | cohort selector | #483 ✅ |
| 3b | parent + resolver + persist + schedule | #484 ✅ |
| 4 | prediction-gated populate + object-store fix | #485 ✅ |
| 5 | learned BoardMasker | this |

The slate detector now runs hourly end-to-end: predict → persist → seed LS pre-annotations (assisted review), with the learned mask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)