### PR TITLE
feat(api-worker): backfill slate predictions onto existing LS tasks

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/backfill_slate_predictions_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/backfill_slate_predictions_activity.py
@@ -1,0 +1,146 @@
+"""Attach persisted `SlatePrediction` rows to EXISTING dive-slate LS tasks.
+
+The dive-slate populate seeds model pre-annotations only at *import* time and
+runs exactly once per dive (stage-9-cohort gated: a slate frame with no
+`DiveSlateLabel` row). So a dive whose LS tasks were imported before the slate
+predictor existed — or before its predictions landed — never receives them; the
+predictions sit in the DB unused, and the dive has already dropped out of every
+cohort that could re-import.
+
+This activity closes that gap by POSTing the predictions to the already-imported
+LS tasks via the LS predictions API (no task re-import, so no duplicate tasks).
+It is idempotent — a task that already carries a `slate-detector` prediction is
+skipped — so it is safe to run repeatedly (the predict parent calls it after
+every persist) and on demand (``BackfillSlatePredictionsWorkflow``) to catch up
+dives predicted before this shipped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, List, Set, Tuple
+
+from fishsense_api_sdk.models.dive_slate_label import DiveSlateLabel
+from fishsense_api_sdk.models.slate_prediction import SlatePrediction
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.populate_dive_slate_label_studio_project_activity import (  # noqa: E501  pylint: disable=line-too-long
+    SLATE_DETECTOR_MODEL_VERSION,
+    _prediction_annotations,
+    _slate_panel_aspect,
+)
+from fishsense_api_workflow_worker.activities.populate_utils import _get_ls_client
+from fishsense_api_workflow_worker.activities.sync_dive_slate_labels_for_label_studio_project_activity import (  # noqa: E501  pylint: disable=line-too-long
+    compute_pdf_panel_width_in_composite,
+)
+from fishsense_api_workflow_worker.activities.utils import get_fs_client
+
+
+def _select_attach_targets(
+    predictions: List[SlatePrediction],
+    slate_labels: List[DiveSlateLabel],
+) -> Dict[int, Tuple[int, int]]:
+    """Map image_id -> (label_studio_task_id, label_studio_project_id).
+
+    Only images that have a *seeded* prediction (non-empty `reference_points`)
+    AND an *incomplete, non-superseded* LS task are eligible. Completed tasks are
+    skipped (a labeler already placed the points; a pre-annotation would be
+    noise); declined predictions seed nothing. First non-superseded task per
+    image wins.
+    """
+    seeded: Set[int] = {
+        p.image_id
+        for p in predictions
+        if p.image_id is not None and p.reference_points
+    }
+    targets: Dict[int, Tuple[int, int]] = {}
+    for label in slate_labels:
+        if label.completed or label.superseded:
+            continue
+        if label.label_studio_task_id is None or label.label_studio_project_id is None:
+            continue
+        if label.image_id not in seeded or label.image_id in targets:
+            continue
+        targets[label.image_id] = (
+            int(label.label_studio_task_id),
+            int(label.label_studio_project_id),
+        )
+    return targets
+
+
+async def _tasks_with_existing_slate_prediction(ls, project_ids: Set[int]) -> Set[int]:
+    """Task ids in `project_ids` that already carry a slate-detector prediction.
+
+    Listed once per project (not per task) so the idempotency check is a handful
+    of calls regardless of task count. LS allows multiple predictions per task,
+    so without this the backfill would stack duplicates on every re-run.
+    """
+    already: Set[int] = set()
+    for project_id in project_ids:
+        existing = await asyncio.to_thread(
+            lambda pid=project_id: ls.predictions.list(project=pid)
+        )
+        for prediction in existing or []:
+            if getattr(prediction, "model_version", None) == SLATE_DETECTOR_MODEL_VERSION:
+                already.add(prediction.task)
+    return already
+
+
+@activity.defn
+async def backfill_slate_predictions_for_dive_activity(dive_id: int) -> int:
+    """Attach seeded `SlatePrediction`s to existing dive-slate LS tasks.
+
+    Returns the number of predictions newly attached (idempotent — already-
+    attached tasks are skipped).
+    """
+    async with get_fs_client() as fs:
+        predictions = await fs.labels.get_slate_predictions(dive_id) or []
+        slate_labels = await fs.labels.get_dive_slate_labels(dive_id) or []
+
+        targets = _select_attach_targets(predictions, slate_labels)
+        if not targets:
+            activity.logger.info(
+                "dive %d: no seeded predictions with attachable LS tasks", dive_id
+            )
+            return 0
+
+        prediction_by_image = {p.image_id: p for p in predictions}
+        # Panel width converts photo-space points to the LS composite canvas
+        # (inverse of the sync's panel-offset strip); None -> no shift.
+        aspect = await _slate_panel_aspect(dive_id, fs)
+
+        ls = _get_ls_client()
+        project_ids = {project_id for _task_id, project_id in targets.values()}
+        already = await _tasks_with_existing_slate_prediction(ls, project_ids)
+
+        attached = 0
+        for image_id, (task_id, _project_id) in targets.items():
+            if task_id in already:
+                continue
+            prediction = prediction_by_image[image_id]
+            panel_width = (
+                compute_pdf_panel_width_in_composite(aspect, prediction.height)
+                if aspect is not None and prediction.height
+                else 0.0
+            )
+            wrapper = _prediction_annotations(prediction, panel_width)
+            if not wrapper:
+                continue
+            body = wrapper[0]
+            await asyncio.to_thread(
+                lambda tid=task_id, payload=body: ls.predictions.create(
+                    task=tid,
+                    model_version=payload["model_version"],
+                    score=payload["score"],
+                    result=payload["result"],
+                )
+            )
+            attached += 1
+            activity.heartbeat()
+
+        activity.logger.info(
+            "dive %d: attached %d slate predictions to existing LS tasks",
+            dive_id,
+            attached,
+        )
+        return attached

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_dive_slate_label_studio_project_activity.py
@@ -41,6 +41,11 @@ _KEYPOINT_FROM_NAME = "reference_points"
 _KEYPOINT_TO_NAME = "image"
 _REFERENCE_POINT_LABEL = "Reference Point"
 
+# LS `model_version` tag stamped on every slate-detector pre-annotation. Shared
+# with the backfill activity so its idempotency check (skip tasks that already
+# carry this version) stays in lockstep with what we write.
+SLATE_DETECTOR_MODEL_VERSION = "slate-detector"
+
 
 def _prediction_annotations(prediction, panel_width: float) -> list:
     """Build the LS `predictions` list (one keypoint per reference point) from a
@@ -76,7 +81,7 @@ def _prediction_annotations(prediction, panel_width: float) -> list:
     ]
     return [
         {
-            "model_version": "slate-detector",
+            "model_version": SLATE_DETECTOR_MODEL_VERSION,
             "score": float(prediction.confidence),
             "result": result,
         }

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -27,6 +27,9 @@ from temporalio.worker import Worker
 from fishsense_api_workflow_worker.activities.reconcile_labeling_configs_activity import (  # pylint: disable=line-too-long
     reconcile_labeling_configs_activity,
 )
+from fishsense_api_workflow_worker.activities.backfill_slate_predictions_activity import (  # pylint: disable=line-too-long
+    backfill_slate_predictions_for_dive_activity,
+)
 from fishsense_api_workflow_worker.activities.cleanup_raw_bytes_for_dive_activity import (  # pylint: disable=line-too-long
     cleanup_raw_bytes_for_dive_activity,
 )
@@ -216,6 +219,9 @@ from fishsense_api_workflow_worker.workflows.predict_laser_images_parent_workflo
 )
 from fishsense_api_workflow_worker.workflows.predict_slate_images_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
     PredictSlateImagesParentWorkflow,
+)
+from fishsense_api_workflow_worker.workflows.backfill_slate_predictions_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    BackfillSlatePredictionsWorkflow,
 )
 from fishsense_api_workflow_worker.workflows.preprocess_laser_images_parent_workflow import (  # pylint: disable=line-too-long
     PreprocessLaserImagesParentWorkflow,
@@ -596,6 +602,7 @@ async def main():
                 ClusterDiveFramesParentWorkflow,
                 PredictLaserImagesParentWorkflow,
                 PredictSlateImagesParentWorkflow,
+                BackfillSlatePredictionsWorkflow,
                 PreprocessLaserImagesParentWorkflow,
                 PreprocessSpeciesImagesParentWorkflow,
                 PreprocessHeadtailImagesParentWorkflow,
@@ -632,6 +639,7 @@ async def main():
                 persist_laser_predictions_activity,
                 resolve_slate_predict_inputs_activity,
                 persist_slate_predictions_activity,
+                backfill_slate_predictions_for_dive_activity,
                 resolve_species_preprocess_inputs_activity,
                 resolve_headtail_preprocess_inputs_activity,
                 resolve_slate_preprocess_inputs_activity,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/backfill_slate_predictions_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/backfill_slate_predictions_workflow.py
@@ -1,0 +1,44 @@
+"""On-demand workflow: backfill slate-detector pre-annotations onto existing
+dive-slate Label Studio tasks for one dive.
+
+The predict parent calls the backfill activity after every persist, so newly-
+predicted dives get their pre-annotations automatically. This standalone
+workflow is for catching up dives predicted *before* the backfill shipped (their
+`SlatePrediction` rows are in the DB but never reached LS, because the populate
+seeds pre-annotations only at import time and won't re-run for an already-
+populated dive). Run it per dive_id:
+
+    temporal workflow start \\
+        --task-queue fishsense_api_queue \\
+        --type BackfillSlatePredictionsWorkflow \\
+        --workflow-id backfill-slate-predictions-<dive_id> \\
+        --input <dive_id>
+"""
+
+from datetime import timedelta
+
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from fishsense_api_workflow_worker.workflows._retry_policies import (
+        SDK_FAIL_FAST_RETRY_POLICY,
+    )
+
+
+@workflow.defn
+class BackfillSlatePredictionsWorkflow:
+    # pylint: disable=too-few-public-methods
+    """Attach a dive's persisted slate predictions to its existing LS tasks.
+
+    Returns the number of predictions newly attached (0 when nothing was
+    eligible or everything was already attached).
+    """
+
+    @workflow.run
+    async def run(self, dive_id: int) -> int:
+        return await workflow.execute_activity(
+            "backfill_slate_predictions_for_dive_activity",
+            args=(dive_id,),
+            schedule_to_close_timeout=timedelta(minutes=15),
+            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+        )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/predict_slate_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/predict_slate_images_parent_workflow.py
@@ -127,6 +127,17 @@ class PredictSlateImagesParentWorkflow:
                 schedule_to_close_timeout=timedelta(minutes=15),
                 retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
             )
+            # Attach the freshly-persisted predictions to any *existing* dive-
+            # slate LS tasks. The populate seeds pre-annotations only at import
+            # time and runs once per dive, so a dive already populated before it
+            # was predicted would otherwise never surface them. Idempotent
+            # (skips tasks that already carry a slate-detector prediction).
+            await workflow.execute_activity(
+                "backfill_slate_predictions_for_dive_activity",
+                args=(dive_id,),
+                schedule_to_close_timeout=timedelta(minutes=15),
+                retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+            )
 
         # Drop the staged raw `.ORF` scratch from Garage; the NAS source is
         # never touched.

--- a/services/fishsense-api-workflow-worker/tests/test_backfill_slate_predictions_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_backfill_slate_predictions_activity.py
@@ -1,0 +1,206 @@
+"""Unit tests for backfill_slate_predictions_for_dive_activity.
+
+The activity attaches persisted `SlatePrediction` rows to *existing* dive-slate
+Label Studio tasks (the populate seeds pre-annotations only at import time and
+runs once per dive, so already-populated dives never receive them). It must:
+  * only target seeded predictions with an incomplete, non-superseded LS task,
+  * be idempotent (skip tasks already carrying a `slate-detector` prediction),
+  * apply the same photo->composite keypoint conversion the populate uses.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from temporalio.testing import ActivityEnvironment
+
+from fishsense_api_sdk.models.dive_slate_label import DiveSlateLabel
+from fishsense_api_sdk.models.slate_prediction import SlatePrediction
+from fishsense_api_workflow_worker.activities import (
+    backfill_slate_predictions_activity as sut,
+)
+
+
+def _pred(image_id: int, *, points, confidence: float = 0.9) -> SlatePrediction:
+    return SlatePrediction(
+        id=image_id * 1000,
+        reference_points=points,
+        confidence=confidence,
+        rejected_reason=None if points else "low_confidence",
+        width=4014,
+        height=3016,
+        created_at=datetime(2026, 8, 2, tzinfo=timezone.utc),
+        image_id=image_id,
+    )
+
+
+def _slate_label(
+    image_id: int,
+    *,
+    task_id: int | None,
+    project_id: int | None = 276394,
+    completed: bool = False,
+    superseded: bool = False,
+) -> DiveSlateLabel:
+    return DiveSlateLabel(
+        id=image_id * 100,
+        label_studio_task_id=task_id,
+        label_studio_project_id=project_id,
+        image_url=None,
+        upside_down=None,
+        reference_points=None,
+        slate_rectangle=None,
+        skipped_points=None,
+        updated_at=None,
+        completed=completed,
+        superseded=superseded,
+        label_studio_json={},
+        image_id=image_id,
+        user_id=None,
+    )
+
+
+# --------------------------- pure target selection ---------------------------
+
+
+def test_select_attach_targets_filters():
+    # pylint: disable=protected-access
+    predictions = [
+        _pred(1, points=[[10.0, 20.0]]),          # seeded + attachable -> yes
+        _pred(2, points=[[10.0, 20.0]]),          # completed task -> no
+        _pred(3, points=[[10.0, 20.0]]),          # superseded task -> no
+        _pred(4, points=None),                    # declined (no points) -> no
+        _pred(5, points=[[10.0, 20.0]]),          # no task_id -> no
+        _pred(6, points=[[10.0, 20.0]]),          # no LS task row at all -> no
+    ]
+    slate_labels = [
+        _slate_label(1, task_id=4001),
+        _slate_label(2, task_id=4002, completed=True),
+        _slate_label(3, task_id=4003, superseded=True),
+        _slate_label(4, task_id=4004),
+        _slate_label(5, task_id=None),
+    ]
+
+    targets = sut._select_attach_targets(predictions, slate_labels)
+
+    assert targets == {1: (4001, 276394)}
+
+
+def test_select_attach_targets_first_non_superseded_wins():
+    # pylint: disable=protected-access
+    predictions = [_pred(1, points=[[1.0, 1.0]])]
+    slate_labels = [
+        _slate_label(1, task_id=9001, superseded=True),
+        _slate_label(1, task_id=9002),
+    ]
+    targets = sut._select_attach_targets(predictions, slate_labels)
+    assert targets == {1: (9002, 276394)}
+
+
+# ------------------------------- activity flow -------------------------------
+
+
+def _make_fs(predictions, slate_labels):
+    fs = MagicMock()
+    fs.__aenter__ = AsyncMock(return_value=fs)
+    fs.__aexit__ = AsyncMock(return_value=None)
+    fs.labels = MagicMock()
+    fs.labels.get_slate_predictions = AsyncMock(return_value=predictions)
+    fs.labels.get_dive_slate_labels = AsyncMock(return_value=slate_labels)
+    return fs
+
+
+def _make_ls(existing_predictions: List | None = None):
+    ls = MagicMock()
+    ls.predictions = MagicMock()
+    ls.predictions.list = MagicMock(return_value=list(existing_predictions or []))
+    ls.predictions.create = MagicMock(return_value=SimpleNamespace(id=1))
+    return ls
+
+
+@pytest.mark.asyncio
+async def test_attaches_predictions_to_existing_tasks(monkeypatch):
+    predictions = [
+        _pred(1, points=[[100.0, 50.0]]),
+        _pred(3, points=[[200.0, 60.0]]),
+    ]
+    slate_labels = [
+        _slate_label(1, task_id=4001),
+        _slate_label(3, task_id=4003),
+    ]
+    fs = _make_fs(predictions, slate_labels)
+    ls = _make_ls()
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut, "_get_ls_client", lambda: ls)
+    # Fixed panel aspect -> deterministic panel width (avoid object store / PDF).
+    monkeypatch.setattr(sut, "_slate_panel_aspect", AsyncMock(return_value=1.5))
+
+    n = await ActivityEnvironment().run(
+        sut.backfill_slate_predictions_for_dive_activity, 65
+    )
+
+    assert n == 2
+    created_tasks = {c.kwargs["task"] for c in ls.predictions.create.call_args_list}
+    assert created_tasks == {4001, 4003}
+    # each create carries the slate-detector model version + a keypoint result
+    for call in ls.predictions.create.call_args_list:
+        assert call.kwargs["model_version"] == sut.SLATE_DETECTOR_MODEL_VERSION
+        assert call.kwargs["result"]
+        assert call.kwargs["result"][0]["type"] == "keypointlabels"
+
+
+@pytest.mark.asyncio
+async def test_idempotent_skips_tasks_with_existing_slate_prediction(monkeypatch):
+    predictions = [
+        _pred(1, points=[[100.0, 50.0]]),
+        _pred(3, points=[[200.0, 60.0]]),
+    ]
+    slate_labels = [
+        _slate_label(1, task_id=4001),
+        _slate_label(3, task_id=4003),
+    ]
+    fs = _make_fs(predictions, slate_labels)
+    # task 4001 already has a slate-detector prediction; a foreign one is ignored
+    ls = _make_ls(
+        existing_predictions=[
+            SimpleNamespace(task=4001, model_version=sut.SLATE_DETECTOR_MODEL_VERSION),
+            SimpleNamespace(task=4003, model_version="some-other-model"),
+        ]
+    )
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut, "_get_ls_client", lambda: ls)
+    monkeypatch.setattr(sut, "_slate_panel_aspect", AsyncMock(return_value=1.5))
+
+    n = await ActivityEnvironment().run(
+        sut.backfill_slate_predictions_for_dive_activity, 65
+    )
+
+    assert n == 1
+    created_tasks = {c.kwargs["task"] for c in ls.predictions.create.call_args_list}
+    assert created_tasks == {4003}
+
+
+@pytest.mark.asyncio
+async def test_no_seeded_predictions_is_noop(monkeypatch):
+    predictions = [_pred(4, points=None)]  # declined only
+    slate_labels = [_slate_label(4, task_id=4004)]
+    fs = _make_fs(predictions, slate_labels)
+    ls = _make_ls()
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut, "_get_ls_client", lambda: ls)
+    monkeypatch.setattr(sut, "_slate_panel_aspect", AsyncMock(return_value=1.5))
+
+    n = await ActivityEnvironment().run(
+        sut.backfill_slate_predictions_for_dive_activity, 65
+    )
+
+    assert n == 0
+    ls.predictions.list.assert_not_called()
+    ls.predictions.create.assert_not_called()

--- a/services/fishsense-api-workflow-worker/tests/test_backfill_slate_predictions_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_backfill_slate_predictions_workflow.py
@@ -1,0 +1,155 @@
+# pylint: disable=unused-argument
+"""Workflow contract tests for the slate-prediction backfill.
+
+Pins:
+  1. BackfillSlatePredictionsWorkflow forwards its `dive_id` to the backfill
+     activity and returns the attached-count verbatim.
+  2. PredictSlateImagesParentWorkflow calls the backfill activity for the dive
+     *after* persisting predictions, so already-populated dives surface the
+     pre-annotations.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import List, Tuple
+
+import pytest
+from temporalio import activity, workflow
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from fishsense_shared import (
+    PredictSlateImage,
+    PredictSlateImagesInput,
+    SlatePredictionResult,
+)
+from fishsense_api_workflow_worker.workflows.backfill_slate_predictions_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    BackfillSlatePredictionsWorkflow,
+)
+from fishsense_api_workflow_worker.workflows.predict_slate_images_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    DATA_PROCESSING_TASK_QUEUE,
+    PredictSlateImagesParentWorkflow,
+)
+
+
+@workflow.defn(name="PredictSlateImagesWorkflow")
+class _StubSlateChild:
+    # pylint: disable=too-few-public-methods
+    @workflow.run
+    async def run(
+        self, payload: PredictSlateImagesInput
+    ) -> List[SlatePredictionResult]:
+        return [
+            SlatePredictionResult(
+                image_id=img.image_id,
+                reference_points=[[1.0, 2.0]],
+                confidence=0.9,
+                rejected_reason=None,
+                width=10,
+                height=10,
+            )
+            for img in payload.images
+        ]
+
+
+@pytest.mark.asyncio
+async def test_forwards_dive_id_and_returns_count():
+    seen: List[int] = []
+
+    @activity.defn(name="backfill_slate_predictions_for_dive_activity")
+    async def backfill(dive_id: int) -> int:
+        seen.append(dive_id)
+        return 7
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-backfill-slate",
+            workflows=[BackfillSlatePredictionsWorkflow],
+            activities=[backfill],
+        ):
+            result = await env.client.execute_workflow(
+                BackfillSlatePredictionsWorkflow.run,
+                65,
+                id=f"backfill-slate-{uuid.uuid4()}",
+                task_queue="test-backfill-slate",
+            )
+
+    assert result == 7
+    assert seen == [65]
+
+
+def _predict_parent_stubs(calls: List[Tuple[str, int]]):
+    @activity.defn(name="select_next_high_priority_dive_for_slate_prediction_activity")
+    async def selector() -> int | None:
+        return 65
+
+    @activity.defn(name="resolve_slate_predict_inputs_activity")
+    async def resolver(dive_id: int) -> PredictSlateImagesInput:
+        return PredictSlateImagesInput(
+            dive_id=dive_id,
+            slate_id=11,
+            slate_name="V-Slate 1",
+            dpi=300.0,
+            template_points=[[0.0, 0.0]],
+            camera_matrix=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+            distortion_coefficients=[0.0, 0.0, 0.0, 0.0, 0.0],
+            images=[PredictSlateImage(image_id=1, checksum="a")],
+        )
+
+    @activity.defn(name="ensure_data_worker_running_activity")
+    async def ensure() -> None:
+        return None
+
+    @activity.defn(name="stage_raw_bytes_for_dive_activity")
+    async def stage_raw(dive_id: int) -> None:
+        return None
+
+    @activity.defn(name="stage_slate_pdf_activity")
+    async def stage_pdf(slate_id: int) -> None:
+        return None
+
+    @activity.defn(name="persist_slate_predictions_activity")
+    async def persist(results: list) -> None:
+        calls.append(("persist", len(results)))
+
+    @activity.defn(name="backfill_slate_predictions_for_dive_activity")
+    async def backfill(dive_id: int) -> int:
+        calls.append(("backfill", dive_id))
+        return 0
+
+    @activity.defn(name="cleanup_raw_bytes_for_dive_activity")
+    async def cleanup(dive_id: int) -> None:
+        return None
+
+    return [selector, resolver, ensure, stage_raw, stage_pdf, persist, backfill, cleanup]
+
+
+@pytest.mark.asyncio
+async def test_predict_parent_calls_backfill_after_persist():
+    calls: List[Tuple[str, int]] = []
+    acts = _predict_parent_stubs(calls)
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-predict-slate-parent",
+            workflows=[PredictSlateImagesParentWorkflow],
+            activities=acts,
+        ), Worker(
+            env.client,
+            task_queue=DATA_PROCESSING_TASK_QUEUE,
+            workflows=[_StubSlateChild],
+            activities=acts,
+        ):
+            result = await env.client.execute_workflow(
+                PredictSlateImagesParentWorkflow.run,
+                id=f"predict-slate-parent-{uuid.uuid4()}",
+                task_queue="test-predict-slate-parent",
+            )
+
+    assert result == 65
+    assert ("persist", 1) in calls
+    assert ("backfill", 65) in calls
+    assert calls.index(("persist", 1)) < calls.index(("backfill", 65))


### PR DESCRIPTION
## Problem

The slate detector shipped and is writing `SlatePrediction` rows in prod (dive 65: 18 seeded, 10 declined). But the predictions **aren't reaching Label Studio**: dive 65's LS project 276394 shows **0/28 tasks with predictions**.

Root cause: the dive-slate **populate seeds pre-annotations only at import time and runs exactly once per dive** (gated on the stage-9 cohort — a slate frame with no `DiveSlateLabel` row). A dive whose LS tasks were imported *before* the predictor existed (dive 65's tasks: 2026-07-30) has already dropped out of every re-import cohort, so its predictions sit in the DB unused. Even fresh dives can race (predict at +35 and populate at +45 each drain one dive/hour from overlapping cohorts).

## Fix

`backfill_slate_predictions_for_dive_activity` attaches persisted predictions to the **already-imported** LS tasks via the LS predictions API (`ls.predictions.create`) — no task re-import, so no duplicate tasks.

- Reuses the populate's photo→composite keypoint conversion (`_prediction_annotations`) via a shared `SLATE_DETECTOR_MODEL_VERSION` constant, so writeback space stays in lockstep with the sync's panel-offset strip.
- **Idempotent**: lists existing predictions per project once and skips any task already carrying a `slate-detector` prediction (LS allows multiple predictions per task, so this prevents stacking on re-runs).
- Only targets **seeded** predictions on **incomplete, non-superseded** tasks (declined predictions seed nothing; completed tasks are left alone).

The **predict parent calls it after every persist**, so newly-predicted dives surface pre-annotations automatically and race-free. **`BackfillSlatePredictionsWorkflow(dive_id)`** is the on-demand entry point to catch up dives predicted before this shipped (the current cohort dives, incl. dive 65).

## Tests (TDD)

- `_select_attach_targets` filtering (completed/superseded/declined/no-task/first-non-superseded-wins)
- Activity: attaches to the right tasks with the conversion; idempotent skip of already-attached tasks (and ignores foreign model versions); no-op when nothing seeded
- Workflow contract: standalone forwards dive_id + returns count; predict parent calls backfill after persist (ordering pinned)

340 passed locally; pylint 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)