### PR TITLE
chore(api-worker): stop scheduling the slate-detector parent

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -392,22 +392,19 @@ async def schedule_workflows(client: Client):
                     overlap=ScheduleOverlapPolicy.SKIP,
                 )
             )
-            # Slate-detector (model-assisted labeling) parent: hourly at
-            # +35 min (free slot). Stages raw + slate PDF, runs the CPU
-            # board-plane estimator per unpredicted slate frame, and persists
-            # SlatePrediction rows for the dive-slate populate step to serve as
-            # LS pre-annotations. SKIP overlap; drains one dive per firing.
-            tg.create_task(
-                schedule_workflow(
-                    client,
-                    "predict-slate-images-workflow-schedule",
-                    PredictSlateImagesParentWorkflow,
-                    timedelta(hours=1),
-                    offset=timedelta(minutes=35),
-                    run_timeout=timedelta(hours=2),
-                    overlap=ScheduleOverlapPolicy.SKIP,
-                )
-            )
+            # Slate-detector (model-assisted labeling) parent is deliberately
+            # NOT scheduled. The fishsense-core slate estimator's ECC gate was
+            # calibrated only on clear-water reef dives and does not transfer to
+            # out-of-distribution conditions: pool calibration frames produce
+            # high-ECC (0.93-0.97) *false* fits that pass the 0.80 gate and land
+            # off the tape corners, so automated seeding would put wrong
+            # pre-annotations in front of labelers. Until the detector is
+            # validated on those conditions (pool data + recalibration /
+            # retrain, upstream in slate_training/fishsense-core), the parent
+            # runs on-demand only. `PredictSlateImagesParentWorkflow` and
+            # `BackfillSlatePredictionsWorkflow` stay registered so it can be
+            # re-enabled without a code change once it's trustworthy.
+            #
             # Laser populate parent: hourly at +12 min, just after the +10
             # laser-detector predict parent has written LaserPrediction rows.
             # Decoupled from the stage-0.1 preprocess parent (which no longer

--- a/services/fishsense-api-workflow-worker/tests/test_schedule_registration.py
+++ b/services/fishsense-api-workflow-worker/tests/test_schedule_registration.py
@@ -28,7 +28,6 @@ from fishsense_api_workflow_worker import worker as sut
 _DIVE_SELECTING_PARENT_SCHEDULE_IDS = (
     "preprocess-laser-images-workflow-schedule",
     "predict-laser-images-workflow-schedule",
-    "predict-slate-images-workflow-schedule",
     "populate-laser-labels-workflow-schedule",
     "cluster-dive-frames-workflow-schedule",
     "preprocess-species-images-workflow-schedule",
@@ -76,10 +75,13 @@ async def test_laser_predict_is_scheduled_hourly_at_10(registered):
     assert _offset(schedule) == timedelta(minutes=10)
 
 
-async def test_slate_predict_is_scheduled_hourly_at_35(registered):
-    schedule = registered["predict-slate-images-workflow-schedule"]
-    assert _every(schedule) == timedelta(hours=1)
-    assert _offset(schedule) == timedelta(minutes=35)
+async def test_slate_predict_is_not_scheduled(registered):
+    """Deliberately unscheduled: the slate estimator's ECC gate was calibrated
+    only on clear-water reef and produces high-ECC false fits on out-of-
+    distribution frames (e.g. pool calibration dives), so automated seeding is
+    off until the detector is validated on those conditions. The parent stays
+    registered for on-demand use; only the schedule is withheld."""
+    assert "predict-slate-images-workflow-schedule" not in registered
 
 
 async def test_laser_populate_is_scheduled_hourly_at_12(registered):

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ dev = [
 
 [[package]]
 name = "fishsense-api-workflow-worker"
-version = "1.47.0"
+version = "1.48.0"
 source = { editable = "services/fishsense-api-workflow-worker" }
 dependencies = [
     { name = "boto3" },
@@ -881,7 +881,7 @@ provides-extras = ["laser-detector", "rectified", "slate"]
 
 [[package]]
 name = "fishsense-data-processing-workflow-worker"
-version = "2.12.0"
+version = "2.12.1"
 source = { editable = "services/fishsense-data-processing-workflow-worker" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Why

The fishsense-core slate estimator's ECC gate was calibrated only on 8 clear-water reef dives and **does not transfer out of distribution**. Pool calibration frames produce high-ECC (0.93–0.97) *false* fits that clear the 0.80 gate and land off the tape corners — so automated seeding puts wrong pre-annotations in front of labelers in any unvalidated condition, and no threshold fixes it (the false fits outscore any reef threshold).

Verified in prod on dives 65 and 71 (both pool calibration, Tic-Tac-Toe 1):
- LS task 279891383 (dive 71): ECC **0.926**, `rejected_reason` NULL → seeded, points miss the tape corners.
- Dive 71 seeded cluster: ECC 0.926–0.965; both seeded dives so far are pool → 100% of what was seeded was out-of-distribution.

## What

- Remove the `predict-slate-images-workflow-schedule` registration so the detector no longer runs automatically.
- `PredictSlateImagesParentWorkflow` and `BackfillSlatePredictionsWorkflow` **stay registered** for on-demand use, so it can be re-enabled without a code change once validated on the target conditions (pool data + recalibration/retrain, upstream in `slate_training`/`fishsense-core`).
- `test_schedule_registration`: drop predict-slate from the dive-selecting stagger set; assert it is **not** registered (pins the decision).

Operationally already done (this PR just makes it durable — stops the schedule being re-created on the next worker start): the live Temporal schedule was deleted, and the 37 already-seeded pool predictions (dives 65/71) were removed from Label Studio (verified 0 predictions on both projects, tasks intact). Postgres `SlatePrediction` rows are left as an inert record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)