### PR TITLE
fix(api-worker): actively retire the slate-detector schedule on startup

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -22,6 +22,7 @@ from temporalio.client import (
     ScheduleSpec,
     ScheduleState,
 )
+from temporalio.service import RPCError, RPCStatusCode
 from temporalio.worker import Worker
 
 from fishsense_api_workflow_worker.activities.reconcile_labeling_configs_activity import (  # pylint: disable=line-too-long
@@ -302,11 +303,36 @@ async def schedule_workflow(
     await ensure_schedule(client, schedule_id=schedule_id, schedule=schedule)
 
 
+# Schedules that must NOT exist. Removing a schedule's registration only stops
+# it from being (re)created; a prior deploy may already have created it. We
+# actively delete these on startup so a deliberately-unscheduled parent can't
+# keep firing from a stale schedule. `predict-slate-images-workflow-schedule`
+# is retired because the slate estimator's ECC gate does not transfer to
+# out-of-distribution conditions (high-ECC false fits on pool frames); see the
+# predict-slate note below.
+_RETIRED_SCHEDULE_IDS = ("predict-slate-images-workflow-schedule",)
+
+
+async def retire_schedule(client: Client, schedule_id: str) -> None:
+    """Delete a schedule that must not exist. Idempotent: a missing schedule is
+    the desired state, so NOT_FOUND is a success, not an error."""
+    log = logging.getLogger(__name__)
+    try:
+        await client.get_schedule_handle(schedule_id).delete()
+        log.info("retired schedule %s (must not exist)", schedule_id)
+    except RPCError as exc:
+        if exc.status == RPCStatusCode.NOT_FOUND:
+            return
+        raise
+
+
 async def schedule_workflows(client: Client):
     """Schedule workflows for the worker."""
 
     log = logging.getLogger(__name__)
     log.info("registering Temporal schedules")
+    for schedule_id in _RETIRED_SCHEDULE_IDS:
+        await retire_schedule(client, schedule_id)
     async with ExceptionGroupErrorLogging(log):
         async with asyncio.TaskGroup() as tg:
             tg.create_task(
@@ -401,9 +427,12 @@ async def schedule_workflows(client: Client):
             # pre-annotations in front of labelers. Until the detector is
             # validated on those conditions (pool data + recalibration /
             # retrain, upstream in slate_training/fishsense-core), the parent
-            # runs on-demand only. `PredictSlateImagesParentWorkflow` and
+            # runs on-demand only, and any stale schedule from a prior deploy is
+            # actively deleted on startup (see `_RETIRED_SCHEDULE_IDS`).
+            # `PredictSlateImagesParentWorkflow` and
             # `BackfillSlatePredictionsWorkflow` stay registered so it can be
-            # re-enabled without a code change once it's trustworthy.
+            # re-enabled (drop it from `_RETIRED_SCHEDULE_IDS` + re-add the
+            # schedule) once it's trustworthy.
             #
             # Laser populate parent: hourly at +12 min, just after the +10
             # laser-detector predict parent has written LaserPrediction rows.

--- a/services/fishsense-api-workflow-worker/tests/test_schedule_registration.py
+++ b/services/fishsense-api-workflow-worker/tests/test_schedule_registration.py
@@ -15,10 +15,11 @@ nothing here talks to Temporal.
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from temporalio.client import ScheduleOverlapPolicy
+from temporalio.service import RPCError, RPCStatusCode
 
 from fishsense_api_workflow_worker import worker as sut
 
@@ -48,7 +49,11 @@ async def registered(monkeypatch):
     async def _fake_ensure_schedule(_client, *, schedule_id, schedule):
         captured[schedule_id] = schedule
 
+    async def _fake_retire_schedule(_client, _schedule_id):
+        return None
+
     monkeypatch.setattr(sut, "ensure_schedule", _fake_ensure_schedule)
+    monkeypatch.setattr(sut, "retire_schedule", _fake_retire_schedule)
     await sut.schedule_workflows(MagicMock())
     return captured
 
@@ -82,6 +87,58 @@ async def test_slate_predict_is_not_scheduled(registered):
     off until the detector is validated on those conditions. The parent stays
     registered for on-demand use; only the schedule is withheld."""
     assert "predict-slate-images-workflow-schedule" not in registered
+
+
+async def test_slate_predict_schedule_is_actively_retired(monkeypatch):
+    """Not-created isn't enough: a prior deploy may already have created the
+    schedule, so startup must actively delete it (idempotently) or a stale
+    schedule keeps firing. Pins that `schedule_workflows` retires it."""
+    retired: list[str] = []
+
+    async def _fake_ensure_schedule(_client, *, schedule_id, schedule):
+        # pylint: disable=unused-argument
+        return None
+
+    async def _fake_retire_schedule(_client, schedule_id):
+        retired.append(schedule_id)
+
+    monkeypatch.setattr(sut, "ensure_schedule", _fake_ensure_schedule)
+    monkeypatch.setattr(sut, "retire_schedule", _fake_retire_schedule)
+    await sut.schedule_workflows(MagicMock())
+
+    assert "predict-slate-images-workflow-schedule" in retired
+
+
+def _handle_raising(exc):
+    handle = MagicMock()
+    handle.delete = AsyncMock(side_effect=exc)
+    client = MagicMock()
+    client.get_schedule_handle = MagicMock(return_value=handle)
+    return client, handle
+
+
+async def test_retire_schedule_deletes_when_present():
+    handle = MagicMock()
+    handle.delete = AsyncMock()
+    client = MagicMock()
+    client.get_schedule_handle = MagicMock(return_value=handle)
+
+    await sut.retire_schedule(client, "some-schedule")
+
+    client.get_schedule_handle.assert_called_once_with("some-schedule")
+    handle.delete.assert_awaited_once()
+
+
+async def test_retire_schedule_is_idempotent_on_not_found():
+    client, _ = _handle_raising(RPCError("missing", RPCStatusCode.NOT_FOUND, b""))
+    # Absent schedule is the desired state -> no raise.
+    await sut.retire_schedule(client, "some-schedule")
+
+
+async def test_retire_schedule_reraises_other_rpc_errors():
+    client, _ = _handle_raising(RPCError("boom", RPCStatusCode.INTERNAL, b""))
+    with pytest.raises(RPCError):
+        await sut.retire_schedule(client, "some-schedule")
 
 
 async def test_laser_populate_is_scheduled_hourly_at_12(registered):


### PR DESCRIPTION
## Why

#497 removed the `predict-slate-images-workflow-schedule` registration, but that alone doesn't deploy or guarantee removal:

1. It was a `chore:` commit → release-please cut no release → no new image → **nothing deployed**. The running v1.48.0 image still registers the schedule.
2. Removing registration only stops *creation*. A worker on the prior image re-creates the schedule on any stack force-recreate (e.g. another service's in-slot deploy), and it resumes firing the OOD-unsafe predictor.

## What

- Add `retire_schedule(client, id)` and delete every id in `_RETIRED_SCHEDULE_IDS` on worker startup. Idempotent — `NOT_FOUND` is the desired state.
- `predict-slate-images-workflow-schedule` is retired: the fishsense-core estimator's ECC gate doesn't transfer out of distribution — pool frames produce high-ECC (0.93–0.97) **false** fits that clear the 0.80 gate and miss the tape corners (verified in prod, dives 65/71, e.g. LS task 279891383 @ ECC 0.926). No threshold fixes it.
- Parent + `BackfillSlatePredictionsWorkflow` stay registered for on-demand use; re-enable = drop from `_RETIRED_SCHEDULE_IDS` + re-add the schedule.
- Self-healing: any stray re-creation (old replica, manual) is cleaned on the next start.

Being a `fix:`, this also triggers the release that finally deploys the removal.

## Tests
- `schedule_workflows` retires the predict-slate schedule; predict-slate is not registered.
- `retire_schedule`: deletes when present, idempotent on NOT_FOUND, re-raises other RPC errors.

16 passing; pylint 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)