### PR TITLE
feat: make physical fish models measurable with per-model Fish identity

### DIFF
--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/fish_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/fish_client.py
@@ -39,6 +39,32 @@ class FishClient(ClientBase):
 
         return [Fish.model_validate(fish) for fish in json]
 
+    async def get_by_name(self, name: str) -> Fish | None:
+        """Retrieve a fish by its `name` natural key (physical fish models).
+
+        Returns None on 404 (no model with that name yet), mirroring
+        `get_species_by_scientific_name`. Stage 14 uses this to resolve-or-create
+        one Fish per model across dives.
+
+        Args:
+            name (str): The model name to look up.
+
+        Returns:
+            Fish | None: The fish if found, otherwise None.
+        """
+        response = await self._get(f"/api/v1/fish/by-name/{name}")
+        if response.status_code == 404:
+            self.logger.debug("No fish found with name %s", name)
+            return None
+        response.raise_for_status()
+
+        json = response.json()
+        if json is None:
+            self.logger.debug("No fish found with name %s", name)
+            return None
+
+        return Fish.model_validate(json)
+
     async def post(self, fish: Fish) -> int:
         """Create a new fish entry in the Fishsense API.
 

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
@@ -136,6 +136,7 @@ class Fish(BaseModel):
     """
 
     id: int | None = Field(None, title='Id')
+    name: str | None = Field(None, title='Name')
     species_id: int | None = Field(None, title='Species Id')
 
 

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/fish.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/fish.py
@@ -8,4 +8,8 @@ class Fish(BaseModel):
 
     id: int | None
 
+    # Natural key for a physical fish model; NULL for real fish. Mirrors the
+    # API SQLModel's nullable-unique `name`.
+    name: str | None = None
+
     species_id: int | None

--- a/libs/fishsense-api-sdk/tests/clients/test_fish_client.py
+++ b/libs/fishsense-api-sdk/tests/clients/test_fish_client.py
@@ -61,6 +61,54 @@ class TestFishClient:
                 fish = await client.get(fish_id=999)
                 assert fish is None
 
+    async def test_get_by_name_returns_fish(self):
+        """get_by_name resolves a model Fish by its name natural key."""
+        semaphore = asyncio.Semaphore(10)
+        client = FishClient(
+            base_url="http://test.com",
+            username="testuser",
+            password="testpass",
+            timeout=10,
+            semaphore=semaphore,
+        )
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": 7, "name": "Grouper", "species_id": None}
+        mock_response.raise_for_status = Mock()
+
+        with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            async with client:
+                fish = await client.get_by_name("Grouper")
+                assert isinstance(fish, Fish)
+                assert fish.id == 7
+                assert fish.name == "Grouper"
+                assert fish.species_id is None
+                mock_get.assert_called_once_with("/api/v1/fish/by-name/Grouper")
+
+    async def test_get_by_name_returns_none_on_404(self):
+        """No model with that name yet -> None, not an error."""
+        semaphore = asyncio.Semaphore(10)
+        client = FishClient(
+            base_url="http://test.com",
+            username="testuser",
+            password="testpass",
+            timeout=10,
+            semaphore=semaphore,
+        )
+
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status = Mock()
+
+        with patch.object(client, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            async with client:
+                assert await client.get_by_name("Nope") is None
+
     async def test_get_single_fish_returns_none_on_404(self):
         """A 404 from GET /fish/{id} returns None instead of raising."""
         semaphore = asyncio.Semaphore(10)

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/c7f2a9d14b83_add_fish_name.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/c7f2a9d14b83_add_fish_name.py
@@ -1,0 +1,45 @@
+"""add nullable-unique fish.name
+
+Revision ID: c7f2a9d14b83
+Revises: a3d0440cda27
+Create Date: 2026-08-04 00:00:00.000000
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c7f2a9d14b83"
+down_revision: Union[str, Sequence[str], None] = "a3d0440cda27"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add `fish.name` + a nullable-unique constraint.
+
+    Idempotent against `SQLModel.metadata.create_all` (the lifespan runs it
+    before alembic upgrade): on a fresh DB the column + constraint already
+    exist from the ORM model, so skip; on an existing prod DB `fish` predates
+    the column, so add it. Existing rows keep name=NULL, and multiple NULLs are
+    allowed under a UNIQUE constraint, so the constraint applies cleanly.
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = {c["name"] for c in inspector.get_columns("fish")}
+    if "name" not in columns:
+        op.add_column("fish", sa.Column("name", sa.String(), nullable=True))
+    constraints = {c["name"] for c in inspector.get_unique_constraints("fish")}
+    if "uq_fish_name" not in constraints:
+        op.create_unique_constraint("uq_fish_name", "fish", ["name"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint("uq_fish_name", "fish", type_="unique")
+    op.drop_column("fish", "name")

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/d8b3f16c204e_measurable_fish_models_in_pipeline_view.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/d8b3f16c204e_measurable_fish_models_in_pipeline_view.py
@@ -1,0 +1,43 @@
+"""make fish models measurable in dive_pipeline_status
+
+Revision ID: d8b3f16c204e
+Revises: c7f2a9d14b83
+Create Date: 2026-08-04 00:10:00.000000
+
+`dive_pipeline_status.measured` now counts physical fish-model images
+(`content_of_image LIKE 'Fish Model,%'`) as measurable, and waives the
+LABEL_STUDIO-cluster requirement for them (models carry no grouping labels and
+so no cluster). Canonical SQL lives in `views.py`; drop + recreate rather than
+CREATE OR REPLACE — Postgres is restrictive about it and the view has no
+dependents.
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from fishsense_api.views import (
+    DIVE_PIPELINE_STATUS_VIEW_SQL,
+    DROP_DIVE_PIPELINE_STATUS_VIEW_SQL,
+)
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d8b3f16c204e"
+down_revision: Union[str, Sequence[str], None] = "c7f2a9d14b83"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Recreate the view with the fish-model-aware `measured` predicate."""
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)
+
+
+def downgrade() -> None:
+    """Recreate the view from whatever `views.py` currently defines."""
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -73,9 +73,27 @@ def _measurable_species_conditions():
     re-selected every hour forever. That is the same never-goes-false shape
     that blocked scheduling stage 14 before 2026-07-17.
 
+    Two measurable branches: real fish carry the `Common (Scientific)` shape
+    (parens); physical fish models carry a `Fish Model, <name>` prefix (no
+    parens) — `measure_fish_activity` resolves those to a name-keyed Fish.
+    Calibration Targets stay unmeasurable.
+
     Mirrors `views._MEASURABLE_SPECIES_SQL` — keep the two in step.
     """
-    return (SpeciesLabel.content_of_image.like("%(%)"),)  # pylint: disable=no-member
+    return (  # pylint: disable=no-member
+        or_(
+            SpeciesLabel.content_of_image.like("%(%)"),
+            SpeciesLabel.content_of_image.like("Fish Model,%"),
+        ),
+    )
+
+
+def _is_fish_model_condition():
+    """A physical fish-model species row. Models carry no grouping labels and
+    thus no LABEL_STUDIO cluster, so the stage-14 cohort waives the cluster
+    requirement for them (identity is the model name; length uses only
+    laser/head-tail/calibration). Mirrors `views._IS_FISH_MODEL_SQL`."""
+    return SpeciesLabel.content_of_image.like("Fish Model,%")  # pylint: disable=no-member
 
 
 def _valid_headtail_conditions():
@@ -699,7 +717,9 @@ async def select_next_for_measure_fish(
         .where(*_measurable_species_conditions())
         .where(valid_laser)
         .where(valid_headtail)
-        .where(in_label_studio_cluster)
+        # Real fish need a LABEL_STUDIO cluster; fish models carry none and
+        # need none (see `_is_fish_model_condition`).
+        .where(or_(in_label_studio_cluster, _is_fish_model_condition()))
         .where(~is_measured)
         .exists()
     )

--- a/services/fishsense-api/src/fishsense_api/controllers/fish_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/fish_controller.py
@@ -44,13 +44,48 @@ async def get_fish(
     return fish
 
 
+@app.get("/api/v1/fish/by-name/{name}")
+async def get_fish_by_name(
+    name: str, session: AsyncSession = Depends(get_async_session)
+) -> Fish | None:
+    """Retrieve a fish by its `name` natural key (physical fish models).
+
+    404s when absent, matching `get_species_by_scientific_name`. Real fish carry
+    `name=None` and are not reachable here — only named models are.
+    """
+    logger.debug("Retrieving fish with name=%s", name)
+    query = select(Fish).where(Fish.name == name)
+
+    fish = (await session.exec(query)).first()
+    if fish is None:
+        logger.warning("Fish with name=%s not found", name)
+        raise HTTPException(status_code=404, detail="Fish not found")
+    return fish
+
+
 @app.post("/api/v1/fish", status_code=201)
 async def post_fish(
     fish: Fish,
     session: AsyncSession = Depends(get_async_session),
 ) -> int:
-    """Create a new fish."""
+    """Create or update a fish, upserting on the `name` natural key.
+
+    `session.merge` keys on the primary key alone, so a body with `id=None`
+    always INSERTs — which would hit `uq_fish_name` the second time the same
+    model is measured. Resolving a named row to its existing id first turns the
+    merge into an UPDATE (mirrors `post_measurement`). Real fish (`name=None`)
+    skip the lookup and always insert — multiple NULLs are allowed under the
+    unique constraint, so per-cluster real-fish identity is unaffected.
+    """
     logger.debug("Creating a new fish")
+
+    if fish.id is None and fish.name is not None:
+        existing = (
+            await session.exec(select(Fish).where(Fish.name == fish.name))
+        ).first()
+        if existing is not None:
+            fish.id = existing.id
+
     fish = await session.merge(fish)
     await session.flush()
 

--- a/services/fishsense-api/src/fishsense_api/models/fish.py
+++ b/services/fishsense-api/src/fishsense_api/models/fish.py
@@ -1,11 +1,22 @@
 """Fish model for the FishSense API."""
 
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field, SQLModel, UniqueConstraint
 
 
 class Fish(SQLModel, table=True):
     """Fish model representing a fish in the database."""
 
+    # `name` is the natural key for a *physical fish model* (Grouper, Purple
+    # Angel, …): the same model photographed across dives/cameras/time resolves
+    # to ONE Fish, so its measurements accumulate under one identity. Real
+    # (wild) fish leave `name` NULL and keep their per-cluster identity — and
+    # Postgres/SQLite both allow multiple NULLs under a UNIQUE constraint, so
+    # unnamed real fish never collide. `species_id` is NULL for models (there is
+    # no Species row for a model).
+    __table_args__ = (UniqueConstraint("name", name="uq_fish_name"),)
+
     id: int | None = Field(default=None, primary_key=True)
+
+    name: str | None = Field(default=None)
 
     species_id: int | None = Field(default=None, foreign_key="species.id")

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -67,7 +67,21 @@ _VALID_HEADTAIL_SQL = """htl.completed = TRUE
 # `dive_controller._measurable_species_conditions`.
 #
 # Assumes the enclosing subquery aliases specieslabel as `sl`.
-_MEASURABLE_SPECIES_SQL = "sl.content_of_image LIKE '%(%)'"
+#
+# Two measurable branches: real fish carry a `Common (Scientific)` name
+# (parens); physical fish models carry a `Fish Model, <name>` prefix (no
+# parens) — measure_fish_activity resolves those to a name-keyed Fish. Any
+# other branch (Calibration Targets) stays unmeasurable. Mirrors
+# `dive_controller._measurable_species_conditions` and
+# `measure_fish_activity` (`_parse_species_names` / `_parse_model_name`).
+_MEASURABLE_SPECIES_SQL = (
+    "(sl.content_of_image LIKE '%(%)' "
+    "OR sl.content_of_image LIKE 'Fish Model,%')"
+)
+
+# A fish-model row (no cluster required — models carry no grouping labels).
+# Assumes the enclosing subquery aliases specieslabel as `sl`.
+_IS_FISH_MODEL_SQL = "sl.content_of_image LIKE 'Fish Model,%'"
 
 # "Complete" everywhere = ≥1 completed-non-superseded row AND zero
 # incomplete-non-superseded rows. Mirrors
@@ -321,12 +335,15 @@ SELECT
                WHERE htl.image_id = i.id
                  AND {_VALID_HEADTAIL_SQL}
            )
-           AND EXISTS (
-               SELECT 1 FROM diveframeclusterimagemapping mm
-               JOIN diveframecluster dfc
-                 ON dfc.id = mm.dive_frame_cluster_id
-               WHERE mm.image_id = i.id
-                 AND dfc.data_source = 'LABEL_STUDIO'
+           AND (
+               EXISTS (
+                   SELECT 1 FROM diveframeclusterimagemapping mm
+                   JOIN diveframecluster dfc
+                     ON dfc.id = mm.dive_frame_cluster_id
+                   WHERE mm.image_id = i.id
+                     AND dfc.data_source = 'LABEL_STUDIO'
+               )
+               OR {_IS_FISH_MODEL_SQL}
            )
            AND NOT EXISTS (
                SELECT 1 FROM measurement m

--- a/services/fishsense-api/tests/test_dive_pipeline_status_view.py
+++ b/services/fishsense-api/tests/test_dive_pipeline_status_view.py
@@ -989,6 +989,58 @@ def _measurement(image_id: int, fish_id: int = 100):
     return Measurement(image_id=image_id, fish_id=fish_id, length_m=0.3)
 
 
+def _fish_model_measurable_image(session, image_id: int, dive_id: int):
+    """Seed a fish-model image the way prod has it: top-three species label
+    (`Fish Model, <name>`) + valid laser + valid headtail, but **no**
+    LABEL_STUDIO cluster (models carry no grouping labels). Stage 14 measures
+    these by waiving the cluster gate, so `measured` must too."""
+    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_image(image_id, dive_id))
+    session.add(
+        LaserLabel(image_id=image_id, completed=True, superseded=False, x=1.0, y=2.0)
+    )
+    session.add(
+        HeadTailLabel(
+            image_id=image_id, completed=True, superseded=False,
+            head_x=1.0, head_y=2.0, tail_x=3.0, tail_y=4.0,
+        )
+    )
+    session.add(
+        SpeciesLabel(
+            image_id=image_id, top_three_photos_of_group=True,
+            completed=True, superseded=False, label_studio_project_id=70,
+            content_of_image="Fish Model, Grouper",
+        )
+    )
+
+
+async def test_measured_true_for_fish_model_image_without_a_cluster(session):
+    """A fish-model dive drains: no LABEL_STUDIO cluster, but the model image
+    is measurable and, once measured, `measured` flips true."""
+    session.add(_dive(1))
+    await session.flush()
+    _fish_model_measurable_image(session, 11, 1)
+    await session.flush()
+    session.add(_measurement(11))
+    await session.flush()
+
+    assert (await _row(session, 1))["measured"] is True
+
+
+async def test_measured_false_for_unmeasured_fish_model_image(session):
+    """Same fish-model image, no measurement yet -> not measured (so the
+    stage-14 cohort keeps offering it)."""
+    session.add(_dive(1))
+    await session.flush()
+    _fish_model_measurable_image(session, 11, 1)
+    await session.flush()
+
+    assert (await _row(session, 1))["measured"] is False
+
+
 async def test_measured_true_when_every_measurable_image_has_a_measurement(session):
     session.add(_dive(1))
     await session.flush()
@@ -1077,18 +1129,19 @@ async def test_measured_ignores_non_top_three_images(session):
 async def test_measured_ignores_species_rows_without_a_scientific_name(session):
     """`measured` must mirror what stage 14 can actually measure.
 
-    A `Fish Model` / `Calibration Targets` row carries no
-    "Common (Scientific)" name, so `measure_fish_activity` skips it and no
+    A `Calibration Targets` row carries neither a "Common (Scientific)" name
+    nor a `Fish Model,` prefix, so `measure_fish_activity` skips it and no
     Measurement is ever written. Counting it as a measurable-but-unmeasured
     image pinned `measured` false forever — the same never-goes-false shape
-    b7c2e4d81a09 fixed one layer up, for unbound clusters.
+    b7c2e4d81a09 fixed one layer up, for unbound clusters. (Fish models ARE
+    measurable now — covered by test_measured_true_for_fish_model_image_*.)
     """
     session.add(_dive(1))
     await session.flush()
-    # One real fish (measured) + one Fish Model rig (never measurable).
+    # One real fish (measured) + one Calibration Targets row (never measurable).
     real = _measurable_image(session, 11, 1, cluster_id=1)
     rig = _measurable_image(
-        session, 12, 1, cluster_id=2, content_of_image="Fish Model, Weasly Fish"
+        session, 12, 1, cluster_id=2, content_of_image="Calibration Targets, Ruler"
     )
     await session.flush()
     session.add_all([real, rig])
@@ -1096,7 +1149,7 @@ async def test_measured_ignores_species_rows_without_a_scientific_name(session):
     await session.flush()
 
     assert (await _row(session, 1))["measured"] is True, (
-        "the Fish Model rig must not hold `measured` false"
+        "the Calibration Targets row must not hold `measured` false"
     )
 
 

--- a/services/fishsense-api/tests/test_fish_controller.py
+++ b/services/fishsense-api/tests/test_fish_controller.py
@@ -1,0 +1,112 @@
+"""Fish identity endpoints: lookup + upsert on the `name` natural key.
+
+Physical fish models are keyed by `name` so the same model resolves to one
+Fish across dives. Stage 14 resolves-or-creates that Fish, so:
+  * `GET /api/v1/fish/by-name/{name}` must find it (or 404 cleanly), and
+  * `POST /api/v1/fish` must UPSERT on `name` — a blind insert would hit the
+    `uq_fish_name` constraint and 500 the second time a model is measured
+    (this repo has been bitten by blind-merge duplicate-key 500s before).
+Real fish keep `name=None` and must never collide on the nullable-unique key.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+def _fish(name=None, species_id=None, fish_id=None):
+    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
+
+    return Fish(id=fish_id, name=name, species_id=species_id)
+
+
+async def _get_by_name(session, name: str):
+    from fishsense_api.controllers.fish_controller import (  # pylint: disable=import-outside-toplevel
+        get_fish_by_name,
+    )
+
+    return await get_fish_by_name(name, session=session)
+
+
+async def _post(session, fish):
+    from fishsense_api.controllers.fish_controller import (  # pylint: disable=import-outside-toplevel
+        post_fish,
+    )
+
+    return await post_fish(fish, session=session)
+
+
+# ── GET /api/v1/fish/by-name/{name} ──────────────────────────────────
+
+
+async def test_get_fish_by_name_returns_match(session):
+    session.add_all([_fish(name="Grouper"), _fish(name="Shark")])
+    await session.flush()
+
+    fish = await _get_by_name(session, "Grouper")
+
+    assert fish is not None
+    assert fish.name == "Grouper"
+
+
+async def test_get_fish_by_name_404s_when_absent(session):
+    with pytest.raises(Exception):  # HTTPException 404
+        await _get_by_name(session, "Nonexistent Model")
+
+
+# ── POST /api/v1/fish upserts on name ────────────────────────────────
+
+
+async def test_post_fish_creates_named(session):
+    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
+
+    new_id = await _post(session, _fish(name="Grouper"))
+    await session.flush()
+
+    rows = (await session.exec(select(Fish))).all()
+    assert len(rows) == 1
+    assert new_id is not None
+    assert rows[0].name == "Grouper"
+
+
+async def test_post_fish_upserts_on_name(session):
+    """Second POST of the same model name must not insert a duplicate."""
+    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
+
+    first = await _post(session, _fish(name="Grouper"))
+    await session.flush()
+    second = await _post(session, _fish(name="Grouper"))
+    await session.flush()
+
+    rows = (await session.exec(select(Fish))).all()
+    assert len(rows) == 1, "re-posting the same name must upsert, not insert"
+    assert first == second
+
+
+async def test_post_fish_null_names_do_not_collide(session):
+    """Real fish (name=None) must both insert under the nullable-unique key."""
+    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
+
+    await _post(session, _fish(name=None, species_id=None))
+    await session.flush()
+    await _post(session, _fish(name=None, species_id=None))
+    await session.flush()
+
+    rows = (await session.exec(select(Fish))).all()
+    assert len(rows) == 2

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -1608,6 +1608,58 @@ async def test_measure_fish_requires_extrinsics_and_an_unmeasured_measurable_ima
     assert await select_next_for_measure_fish(session=session) == 3
 
 
+def _fish_model_measurable_image(session, image_id: int, dive_id: int):
+    """A fish-model image the way prod has it: top-three `Fish Model, <name>`
+    species label + valid laser + valid headtail, but NO LABEL_STUDIO cluster
+    (models carry no grouping labels). The cohort must still select it."""
+    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_image(image_id, dive_id))
+    session.add(
+        LaserLabel(image_id=image_id, completed=True, superseded=False, x=1.0, y=2.0)
+    )
+    session.add(
+        HeadTailLabel(
+            image_id=image_id, completed=True, superseded=False,
+            head_x=1.0, head_y=2.0, tail_x=3.0, tail_y=4.0,
+        )
+    )
+    session.add(
+        SpeciesLabel(
+            image_id=image_id, top_three_photos_of_group=True,
+            completed=True, superseded=False, label_studio_project_id=70,
+            content_of_image="Fish Model, Grouper",
+        )
+    )
+
+
+async def test_measure_fish_selects_fish_model_dive_without_cluster(session):
+    """A borrowed-calibration fish-model dive with no LABEL_STUDIO cluster is
+    selected once it has an unmeasured model image (the cluster gate is waived
+    for models)."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_measure_fish,
+    )
+    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+        LaserExtrinsics,
+    )
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(LaserExtrinsics(dive_id=1, camera_id=1))
+    _fish_model_measurable_image(session, 11, 1)
+    await session.flush()
+
+    assert await select_next_for_measure_fish(session=session) == 1
+
+    # …and it drops out once the model image is measured.
+    session.add(_measurement(11))
+    await session.flush()
+    assert await select_next_for_measure_fish(session=session) is None
+
+
 async def test_measure_fish_returns_none_when_everything_measurable_is_measured(
     session,
 ):
@@ -1842,8 +1894,9 @@ async def test_species_preprocessing_still_excludes_live_real_species_row(sessio
 
 
 async def test_measure_fish_skips_species_rows_without_a_scientific_name(session):
-    """Fish Model / Calibration Targets rows must not hold a dive in the
-    cohort — nothing downstream can ever measure them."""
+    """Calibration Targets / nameless rows must not hold a dive in the cohort —
+    nothing downstream can ever measure them. (Fish models ARE measurable now —
+    see test_measure_fish_selects_fish_model_dive_without_cluster.)"""
     from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
         select_next_for_measure_fish,
     )
@@ -1851,7 +1904,7 @@ async def test_measure_fish_skips_species_rows_without_a_scientific_name(session
         LaserExtrinsics,
     )
 
-    for content in ("Fish Model, Weasly Fish", "Calibration Targets, Ruler", None):
+    for content in ("Calibration Targets, Ruler", None):
         session.add(_dive(1))
         await session.flush()
         session.add(LaserExtrinsics(dive_id=1, camera_id=1))

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/measure_fish_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/measure_fish_activity.py
@@ -10,10 +10,14 @@ covered by synthetic-geometry tests in
 Lives on the data-processing worker for the same reason as stage 13 —
 it pulls in fishsense-core math kernels; the api-worker stays thin.
 
-Upstream dependency: clusters with `data_source=LABEL_STUDIO` must
-exist for the dive (stage 6.1). Species labels whose image isn't in
-any cluster are skipped with a warning — handles the partial-port
-case gracefully.
+Upstream dependency (real fish only): clusters with
+`data_source=LABEL_STUDIO` must exist for the dive (stage 6.1). A
+real-fish species label whose image isn't in any cluster is skipped
+with a warning. Physical fish models (`content_of_image = "Fish Model,
+<name>"`) are exempt — they carry no grouping labels and thus no
+cluster, their identity is the model name (not the cluster), and the
+length math uses only laser/head-tail/calibration; so the cluster gate
+is waived for them.
 """
 
 from __future__ import annotations
@@ -62,6 +66,29 @@ class MeasureFishResult:
 
 
 __all__ = ["MeasureFishResult", "measure_fish_activity"]
+
+
+# Taxonomy prefix for physical fish models. The leaf after it (e.g. "Grouper")
+# is the model's identity — the `name` natural key on Fish. Mirrors the
+# `LIKE 'Fish Model,%'` clause in `views._MEASURABLE_SPECIES_SQL` and
+# `dive_controller._measurable_species_conditions`; keep the three in step.
+_FISH_MODEL_PREFIX = "Fish Model,"
+
+
+def _parse_model_name(content_of_image: str | None) -> str | None:
+    """Return the model name for a `Fish Model, <name>` row, else None.
+
+    Real fish (`..., Common (Scientific)`) and other branches (Calibration
+    Targets) return None. An empty leaf ("Fish Model," with nothing after)
+    returns None — nothing to identify — matching the "skip rather than write a
+    malformed row" posture of `_parse_species_names`.
+    """
+    if not content_of_image:
+        return None
+    if not content_of_image.startswith(_FISH_MODEL_PREFIX):
+        return None
+    name = content_of_image[len(_FISH_MODEL_PREFIX):].strip()
+    return name or None
 
 
 def _parse_species_names(content_of_image: str | None) -> tuple[str, str] | None:
@@ -113,6 +140,29 @@ async def _ensure_fish(
         cluster.fish_id = fish.id
         await fs.images.put_cluster(cluster.dive_id, cluster.id, cluster)
 
+    return fish
+
+
+async def _ensure_model_fish(
+    fs: Client,
+    name: str,
+    cache: dict[str, Fish],
+) -> Fish:
+    """Find-or-create the Fish for a physical model, keyed GLOBALLY by name.
+
+    Unlike `_ensure_fish`, identity is the model name, not the cluster: the same
+    model resolves to one Fish across dives/cameras/time, and two models in one
+    cluster resolve to two Fish. `cluster.fish_id` is never touched. `cache`
+    dedups within a single dive run; `get_by_name` dedups across runs; and
+    `post` upserts on name, so a concurrent create still converges to one row.
+    """
+    if name in cache:
+        return cache[name]
+    fish = await fs.fish.get_by_name(name)
+    if fish is None:
+        fish = Fish(id=None, name=name, species_id=None)
+        fish.id = await fs.fish.post(fish)
+    cache[name] = fish
     return fish
 
 
@@ -244,6 +294,8 @@ async def measure_fish_activity(dive_id: int) -> MeasureFishResult:
             missing_cluster=0,
             skipped_already_measured=0,
         )
+        # Name -> Fish for physical models, deduped within this dive run.
+        model_fish_cache: dict[str, Fish] = {}
 
         for species_label in top_three:
             image_id = species_label.image_id
@@ -256,8 +308,28 @@ async def measure_fish_activity(dive_id: int) -> MeasureFishResult:
                 result.skipped_already_measured += 1
                 continue
 
+            # Classify the taxonomy branch first. Real fish carry a
+            # "Common (Scientific)" name; models carry a "Fish Model, <name>"
+            # prefix. Anything else (Calibration Targets, empty) is not
+            # measurable.
+            names = _parse_species_names(species_label.content_of_image)
+            model_name = _parse_model_name(species_label.content_of_image)
+            if names is None and model_name is None:
+                activity.logger.info(
+                    "dive_id=%d image_id=%d: content_of_image=%r is neither a "
+                    "'Common (Scientific)' name nor a 'Fish Model,' row; not "
+                    "measurable, skipping",
+                    dive_id, image_id, species_label.content_of_image,
+                )
+                result.skipped_unmeasurable_species += 1
+                continue
+
+            # Real fish anchor identity to their LABEL_STUDIO cluster, so a
+            # missing cluster is a hard skip. Models are keyed by name and use
+            # no cluster (they carry none — no grouping labels), so the gate is
+            # waived for them.
             cluster = cluster_by_image.get(image_id)
-            if cluster is None:
+            if names is not None and cluster is None:
                 activity.logger.warning(
                     "dive_id=%d image_id=%d: no LABEL_STUDIO cluster; skipping",
                     dive_id, image_id,
@@ -275,25 +347,12 @@ async def measure_fish_activity(dive_id: int) -> MeasureFishResult:
                 result.missing_laser_or_headtail += 1
                 continue
 
-            names = _parse_species_names(species_label.content_of_image)
-            if names is None:
-                # Expected for the non-`Fish` taxonomy branches (Fish Model,
-                # Calibration Targets) — they carry no scientific name, so
-                # there is nothing to measure against. Info rather than
-                # warning, and its own counter: this used to increment
-                # `missing_laser_or_headtail`, which sent anyone reading the
-                # result at the labels rather than at the taxonomy branch.
-                activity.logger.info(
-                    "dive_id=%d image_id=%d: content_of_image=%r carries no "
-                    "'Common (Scientific)' name; not measurable, skipping",
-                    dive_id, image_id, species_label.content_of_image,
-                )
-                result.skipped_unmeasurable_species += 1
-                continue
-            common, scientific = names
-
-            species = await _ensure_species(fs, common, scientific)
-            fish = await _ensure_fish(fs, cluster, species)
+            if names is not None:
+                common, scientific = names
+                species = await _ensure_species(fs, common, scientific)
+                fish = await _ensure_fish(fs, cluster, species)
+            else:
+                fish = await _ensure_model_fish(fs, model_name, model_fish_cache)
 
             length_m = _measure_length(
                 laser_label, headtail_label, laser_extrinsics, camera_intrinsics

--- a/services/fishsense-data-processing-workflow-worker/tests/test_measure_fish_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_measure_fish_activity.py
@@ -176,6 +176,7 @@ def _make_fs(  # pylint: disable=too-many-arguments
     headtail_labels: dict[int, HeadTailLabel | None],
     clusters: List[DiveFrameCluster],
     species_lookup: dict[str, Species] | None = None,
+    model_fish_lookup: dict[str, Fish] | None = None,
     new_species_id: int = 500,
     new_fish_id: int = 700,
     existing_measurements: List[Measurement] | None = None,
@@ -211,6 +212,7 @@ def _make_fs(  # pylint: disable=too-many-arguments
     )
     fs.fish.post_species = AsyncMock(return_value=new_species_id)
     fs.fish.get = AsyncMock(return_value=None)
+    fs.fish.get_by_name = AsyncMock(side_effect=(model_fish_lookup or {}).get)
     fs.fish.post = AsyncMock(return_value=new_fish_id)
     fs.fish.post_measurement = AsyncMock(return_value=None)
     # `None` is the SDK's "dive has no measurements yet" signal (404).
@@ -547,12 +549,13 @@ async def test_measurements_are_fetched_once_per_dive(monkeypatch):
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "content",
-    ["Fish Model, Weasly Fish", "Calibration Targets, Ruler", None],
-    ids=["fish-model", "calibration-target", "empty"],
+    ["Calibration Targets, Ruler", None],
+    ids=["calibration-target", "empty"],
 )
 async def test_skips_species_rows_that_carry_no_scientific_name(monkeypatch, content):
-    """The non-`Fish` taxonomy branches have no "Common (Scientific)" name,
-    so there is nothing to measure against.
+    """Taxonomy branches with neither a "Common (Scientific)" name nor a
+    `Fish Model,` prefix have nothing to measure against (Calibration Targets,
+    empty). Fish models ARE measurable now (see the model-branch tests below).
 
     These land in their own counter rather than `missing_laser_or_headtail`
     — they used to inflate that one, which pointed anyone reading the result
@@ -580,3 +583,165 @@ async def test_skips_species_rows_that_carry_no_scientific_name(monkeypatch, con
     assert result.skipped_unmeasurable_species == 1
     assert result.missing_laser_or_headtail == 0, "must not inflate the label counter"
     fs.fish.post_measurement.assert_not_called()
+
+
+# ── fish-model branch: name-keyed identity, cluster-independent ───────
+#
+# Models are labeled `content_of_image = "Fish Model, <name>"` (no parens),
+# carry no grouping labels, and so have no LABEL_STUDIO cluster. Identity is
+# the model name (one Fish per model across dives), and length uses only
+# laser/head-tail/calibration — no cluster. So the model branch: resolves the
+# Fish by name (find-or-create), waives the cluster gate, and never binds
+# `cluster.fish_id`.
+
+
+def _model_observation():
+    le = _laser_extrinsics()
+    head_pix, tail_pix, laser_pix = _build_observation(
+        le, np.array([-0.10, 0.00, 1.20]), np.array([0.20, 0.00, 1.20]), 1.20
+    )
+    return le, head_pix, tail_pix, laser_pix
+
+
+@pytest.mark.asyncio
+async def test_measures_a_fish_model_without_a_cluster(monkeypatch):
+    """The key case: a model image with NO LABEL_STUDIO cluster is still
+    measured. It creates a name-keyed Fish (species_id=None) and never binds a
+    cluster."""
+    image_id = 100
+    le, head_pix, tail_pix, laser_pix = _model_observation()
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_camera_intrinsics(),
+        laser_extrinsics=le,
+        species_labels=[_species_label(image_id, content="Fish Model, Grouper")],
+        laser_labels={image_id: _laser_label(image_id, *laser_pix)},
+        headtail_labels={image_id: _headtail_label(image_id, head_pix, tail_pix)},
+        clusters=[],  # <-- no clusters at all
+        model_fish_lookup={},  # not seen before -> create
+        new_fish_id=700,
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(sut.measure_fish_activity, 42)
+
+    assert result.measured == 1
+    assert result.missing_cluster == 0, "models don't require a cluster"
+    # Created a name-keyed model Fish, no Species.
+    fs.fish.post_species.assert_not_called()
+    fs.fish.post.assert_awaited_once()
+    created = fs.fish.post.call_args.args[0]
+    assert created.name == "Grouper"
+    assert created.species_id is None
+    # Never binds a cluster (there is none, and identity isn't per-cluster).
+    fs.images.put_cluster.assert_not_called()
+    fish_id, measurement = fs.fish.post_measurement.call_args.args
+    assert fish_id == 700
+    assert measurement.image_id == image_id
+
+
+@pytest.mark.asyncio
+async def test_reuses_existing_model_fish_by_name(monkeypatch):
+    """Same model across dives/cameras resolves to ONE Fish — get_by_name hit
+    means no new Fish is created."""
+    image_id = 100
+    le, head_pix, tail_pix, laser_pix = _model_observation()
+    existing = Fish(id=900, name="Grouper", species_id=None)
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_camera_intrinsics(),
+        laser_extrinsics=le,
+        species_labels=[_species_label(image_id, content="Fish Model, Grouper")],
+        laser_labels={image_id: _laser_label(image_id, *laser_pix)},
+        headtail_labels={image_id: _headtail_label(image_id, head_pix, tail_pix)},
+        clusters=[_cluster([image_id])],
+        model_fish_lookup={"Grouper": existing},
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(sut.measure_fish_activity, 42)
+
+    assert result.measured == 1
+    fs.fish.post.assert_not_called()  # reused, not created
+    fs.images.put_cluster.assert_not_called()
+    fish_id, _ = fs.fish.post_measurement.call_args.args
+    assert fish_id == 900
+
+
+@pytest.mark.asyncio
+async def test_two_models_in_one_cluster_resolve_to_distinct_fish(monkeypatch):
+    """The mixed-group case: two different models sharing a cluster must NOT
+    collapse to one Fish (the old per-cluster identity bug). Name-keyed
+    resolution keeps them distinct."""
+    img_g, img_s = 100, 101
+    le, head_pix, tail_pix, laser_pix = _model_observation()
+
+    ids_by_name = {"Grouper": 701, "Shark": 702}
+
+    async def _post(fish):
+        return ids_by_name[fish.name]
+
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_camera_intrinsics(),
+        laser_extrinsics=le,
+        species_labels=[
+            _species_label(img_g, content="Fish Model, Grouper"),
+            _species_label(img_s, content="Fish Model, Shark"),
+        ],
+        laser_labels={
+            img_g: _laser_label(img_g, *laser_pix),
+            img_s: _laser_label(img_s, *laser_pix),
+        },
+        headtail_labels={
+            img_g: _headtail_label(img_g, head_pix, tail_pix),
+            img_s: _headtail_label(img_s, head_pix, tail_pix),
+        },
+        clusters=[_cluster([img_g, img_s], fish_id=None)],  # one shared cluster
+        model_fish_lookup={},
+    )
+    fs.fish.post = AsyncMock(side_effect=_post)
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(sut.measure_fish_activity, 42)
+
+    assert result.measured == 2
+    fish_ids = {c.args[0] for c in fs.fish.post_measurement.call_args_list}
+    assert fish_ids == {701, 702}, "two models -> two distinct Fish"
+    fs.images.put_cluster.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_same_model_across_clusters_resolves_to_one_fish(monkeypatch):
+    """Same model in two different clusters -> one Fish (name-keyed, cached
+    within the run so it isn't re-created per cluster)."""
+    img_a, img_b = 100, 101
+    le, head_pix, tail_pix, laser_pix = _model_observation()
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_camera_intrinsics(),
+        laser_extrinsics=le,
+        species_labels=[
+            _species_label(img_a, content="Fish Model, Grouper"),
+            _species_label(img_b, content="Fish Model, Grouper"),
+        ],
+        laser_labels={
+            img_a: _laser_label(img_a, *laser_pix),
+            img_b: _laser_label(img_b, *laser_pix),
+        },
+        headtail_labels={
+            img_a: _headtail_label(img_a, head_pix, tail_pix),
+            img_b: _headtail_label(img_b, head_pix, tail_pix),
+        },
+        clusters=[_cluster([img_a], 1), _cluster([img_b], 2)],
+        model_fish_lookup={},
+        new_fish_id=700,
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(sut.measure_fish_activity, 42)
+
+    assert result.measured == 2
+    fs.fish.post.assert_awaited_once()  # created once, reused for the second
+    fish_ids = {c.args[0] for c in fs.fish.post_measurement.call_args_list}
+    assert fish_ids == {700}, "same model -> one Fish"

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ dev = [
 
 [[package]]
 name = "fishsense-api-workflow-worker"
-version = "1.48.0"
+version = "1.48.1"
 source = { editable = "services/fishsense-api-workflow-worker" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Problem
Fish-model dives (Grouper, Purple Angel, Shark, …) produce **zero** measurements. Three blockers:

1. **Unmeasurable by taxonomy.** Stage 14 only measured `Common (Scientific)` species rows (parens = the gate); model rows are `content_of_image = "Fish Model, <name>"` and were skipped.
2. **No persistent per-model identity.** `Fish` was `id`+`species_id`, and stage 14 bound identity to the *cluster* (`cluster.fish_id`) — so two models in one group would collapse to a single Fish.
3. **No LABEL_STUDIO clusters (the operative one).** The real fish-model dives carry no grouping labels → stage 6.1 makes no clusters. The activity's cluster gate fires *before* the species gate, so they skipped on `missing_cluster` and never reached the species gate. Models don't need a cluster (identity is the name; length uses only laser/head-tail/calibration), so the cluster requirement is **waived** for the model branch — in the activity *and* every mirrored measurable predicate.

## Changes
- **Schema:** `Fish.name` nullable-unique (`uq_fish_name`) on the API SQLModel + SDK mirror + regenerated `_generated.py`; idempotent alembic migration. Model Fish = `{name, species_id=None}`; real fish keep `name=None` (multiple NULLs → no collision).
- **measure_fish_activity:** branch on taxonomy. Real fish unchanged (per-cluster `_ensure_fish`). Models resolve a name-keyed Fish globally (find-or-create, cached per run), write the Measurement, never bind `cluster.fish_id`, and waive the cluster gate.
- **API + SDK:** `GET /api/v1/fish/by-name/{name}` + `fish.get_by_name`; `POST /api/v1/fish` upserts on the `name` natural key (resolve-then-merge, like `post_measurement`).
- **Measurable predicate (3 mirrors in step):** species clause → `LIKE '%(%)' OR LIKE 'Fish Model,%'`; the LABEL_STUDIO-cluster requirement is OR'd with the fish-model condition in `views.measured` and the stage-14 cohort. New alembic revision drops+recreates the view. Calibration Targets stay unmeasurable.

## Behavior
- Two models in one cluster → **two** distinct Fish. Same model across dives/cameras → **one** Fish (measurements accumulate under it).
- A fish-model dive with no cluster is now selected by stage 14, measured, and **drains** from the cohort.

## Tests (TDD)
Model-branch activity (measured without a cluster; two-in-cluster → distinct; same across clusters → one; calib targets skipped; real-fish unchanged); fish controller by-name + upsert-on-name; SDK `get_by_name`; view `measured` flips for a cluster-less fish-model dive; cohort selects + drains it; drift + generated-freshness. API 252, SDK 120, measure 21; pylint 10/10. (Local cv2 tests can't collect here — missing `libxcb.so.1`; CI has the libs.)

## Prod rollout (no staging)
Productionizes into the hourly stage-14 schedule. After deploy: run one model dive via an on-demand `MeasureFishParentWorkflow` (non-colliding id), eyeball lengths vs known model sizes, confirm zero duplicates + the dive drops out of the cohort, then let the schedule take over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)