### PR TITLE
fix: gate laser calibration on self-consistency + detect reflection splits

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/measure_fish_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/measure_fish_parent_workflow.py
@@ -43,14 +43,19 @@ Cluster-correctness invariants — relevant once the data-worker scales
 beyond a single replica:
 
 * The child workflow is started with a deterministic id
-  (`measure-fish-{dive_id}`) and
-  `id_reuse_policy=ALLOW_DUPLICATE_FAILED_ONLY`; a duplicate parent
-  run targeting the same dive hits `WorkflowAlreadyStarted` (whether
-  the prior child is still running or completed successfully) and
-  the parent catches it. This is now a don't-redo-work guard rather
-  than a correctness one — a duplicate dispatch would be harmless
-  since measurement is idempotent at both the write layer and in the
-  activity's skip.
+  (`measure-fish-{dive_id}`) and `id_reuse_policy=ALLOW_DUPLICATE`
+  (changed from FAILED_ONLY on 2026-08-04, mirroring the preprocess
+  children's 2026-07-23 flip and for the same reason: FAILED_ONLY
+  means a *completed* child id can never re-dispatch, so a dive whose
+  measurements were remediated — e.g. deleted after a bad borrowed
+  calibration was fixed — could never be re-measured through the
+  parent; the re-dispatch was swallowed silently. Observed live on
+  dive 59, 2026-08-04.) ALLOW_DUPLICATE is safe here: measurement is
+  idempotent at both the write layer (`post_measurement` upserts on
+  (image_id, fish_id)) and in the activity (skips already-measured
+  images). `WorkflowAlreadyStartedError` is now only raised when a
+  prior child with the same id is still *running* (a manual run
+  overlapping the schedule); the parent catches it.
 * Per-cluster `fish_id` rebinds via `put_cluster` on the activity side
   are idempotent under retry within a single child run.
 """
@@ -112,17 +117,20 @@ class MeasureFishParentWorkflow:
                 id=f"measure-fish-{dive_id}",
                 task_queue=DATA_PROCESSING_TASK_QUEUE,
                 execution_timeout=timedelta(hours=1),
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+                # ALLOW_DUPLICATE (not FAILED_ONLY): a completed child id
+                # must not block re-measurement after remediation (deleted
+                # bad measurements + fixed calibration). Safe because
+                # measurement is idempotent — upsert on (image_id, fish_id)
+                # + already-measured skip. See module docstring.
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
             )
         except WorkflowAlreadyStartedError:
-            # Not a safety gate any more — measurement is idempotent as of
-            # 2026-07-17 (`post_measurement` upserts on (image_id, fish_id)
-            # and the activity skips already-measured images), so a
-            # duplicate dispatch would be harmless. This just avoids
-            # re-doing work already done for this dive.
+            # Only reachable while a prior child with this id is still
+            # RUNNING (e.g. a manual run overlapping the schedule) — a
+            # completed child no longer blocks under ALLOW_DUPLICATE.
             workflow.logger.info(
-                "measure-fish-%d already ran successfully; skipping "
-                "duplicate dispatch (no re-work needed)",
+                "measure-fish-%d is still running; skipping duplicate "
+                "dispatch",
                 dive_id,
             )
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/perform_laser_calibration_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/perform_laser_calibration_parent_workflow.py
@@ -19,10 +19,18 @@ beyond a single replica:
   flight when the next firing arrives is dropped at the schedule level.
 * The child workflow is started with a deterministic id
   (`perform-laser-calibration-{dive_id}`) and
-  `id_reuse_policy=ALLOW_DUPLICATE_FAILED_ONLY`; if a parent run
-  somehow races past the schedule guard, the second child-workflow
-  start hits `WorkflowAlreadyStarted` and is caught — the parent
-  treats the prior success as authoritative.
+  `id_reuse_policy=ALLOW_DUPLICATE` (changed from FAILED_ONLY on
+  2026-08-04, mirroring the preprocess children's 2026-07-23 flip:
+  FAILED_ONLY means a *completed* child id can never re-dispatch, so
+  a dive whose bad calibration was remediated — labels cleaned, stale
+  extrinsics row deleted — could never be refit through the parent;
+  the re-dispatch was swallowed silently. Observed live on dive 77,
+  2026-08-04.) ALLOW_DUPLICATE is safe: the cohort only offers dives
+  with no extrinsics row, `put_laser_extrinsics` upserts on dive_id,
+  and the activity's self-consistency gate refuses to persist a fit
+  that disagrees with the dive's own laser dots.
+  `WorkflowAlreadyStartedError` is now only raised while a prior
+  child with the same id is still *running*; the parent catches it.
 * `put_laser_extrinsics` on the activity side is an upsert — even
   outright re-runs of a successful call land on the same row.
 """
@@ -86,11 +94,19 @@ class PerformLaserCalibrationParentWorkflow:
                 id=f"perform-laser-calibration-{dive_id}",
                 task_queue=DATA_PROCESSING_TASK_QUEUE,
                 execution_timeout=timedelta(minutes=15),
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+                # ALLOW_DUPLICATE (not FAILED_ONLY): a completed child id
+                # must not block a refit after remediation (bad extrinsics
+                # deleted, labels cleaned). Safe: cohort = no-extrinsics
+                # dives only, the PUT upserts on dive_id, and the activity's
+                # self-consistency gate rejects fits that disagree with the
+                # dive's own dots. See module docstring.
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
             )
         except WorkflowAlreadyStartedError:
+            # Only reachable while a prior child with this id is still
+            # RUNNING — a completed child no longer blocks.
             workflow.logger.info(
-                "perform-laser-calibration-%d already ran successfully; "
+                "perform-laser-calibration-%d is still running; "
                 "skipping duplicate dispatch",
                 dive_id,
             )

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/perform_laser_calibration_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/perform_laser_calibration_activity.py
@@ -26,6 +26,9 @@ from fishsense_core.world_point import WorldPointHandler
 from temporalio import activity
 
 from fishsense_data_processing_workflow_worker.activities.utils import get_fs_client
+from fishsense_data_processing_workflow_worker.calibration_consistency import (
+    check_fit_self_consistency,
+)
 
 INCH_TO_M = 0.0254
 MIN_LASER_POINTS = 2
@@ -113,8 +116,14 @@ async def _gather_laser_points(
     dive_slate_labels: list[DiveSlateLabel],
     slate: DiveSlate,
     camera_intrinsics: CameraIntrinsics,
-) -> list[np.ndarray]:
+) -> tuple[list[np.ndarray], list[tuple[float, float]]]:
+    """Lift each usable slate-laser observation to camera space.
+
+    Returns `(laser_points_3d, laser_dots_2d)` in lockstep — the 2D pixels
+    feed the post-fit self-consistency gate (the fitted ray must reproject
+    onto the very dots it was computed from)."""
     laser_points: list[np.ndarray] = []
+    laser_dots: list[tuple[float, float]] = []
     for label in dive_slate_labels:
         if label.image_id is None:
             activity.heartbeat()
@@ -128,8 +137,9 @@ async def _gather_laser_points(
         )
         if point is not None:
             laser_points.append(point)
+            laser_dots.append((float(laser_label.x), float(laser_label.y)))
         activity.heartbeat()
-    return laser_points
+    return laser_points, laser_dots
 
 
 @activity.defn
@@ -183,7 +193,7 @@ async def perform_laser_calibration_activity(dive_id: int) -> int | None:
                 f"camera_id={dive.camera_id} has no intrinsics"
             )
 
-        laser_points = await _gather_laser_points(
+        laser_points, laser_dots = await _gather_laser_points(
             fs, dive_slate_labels, slate, camera_intrinsics
         )
         if len(laser_points) < MIN_LASER_POINTS:
@@ -201,6 +211,18 @@ async def perform_laser_calibration_activity(dive_id: int) -> int | None:
             [float(origin[0]), float(origin[1]), 0.0], dtype=float
         )
         laser_axis = np.asarray(orientation, dtype=float)
+
+        # Self-consistency gate: the fitted ray must reproject onto the 2D
+        # dots it was computed from. Raises (no persist) when it doesn't —
+        # mixed dot populations (specular-reflection mislabels, prod dive 77)
+        # or corrupt slate poses otherwise ship a calibration whose length
+        # errors reach +137% downstream.
+        check_fit_self_consistency(
+            laser_position,
+            laser_axis,
+            camera_intrinsics.camera_matrix,
+            np.array(laser_dots, dtype=float),
+        )
 
         new_le = LaserExtrinsics(
             laser_position=laser_position,

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/validate_laser_labels_for_dive_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/validate_laser_labels_for_dive_activity.py
@@ -43,6 +43,9 @@ from fishsense_data_processing_workflow_worker.laser_label_validation.line_fit i
     fit_dive_line,
     flag_outliers,
 )
+from fishsense_data_processing_workflow_worker.laser_label_validation.reflection import (
+    detect_reflection_split,
+)
 
 __all__ = [
     "validate_laser_labels_for_dive_activity",
@@ -129,6 +132,10 @@ def _positive_xy(labels: List[LaserLabel]) -> tuple[np.ndarray, List[LaserLabel]
 
 @activity.defn
 async def validate_laser_labels_for_dive_activity(dive_id: int) -> int:
+    # pylint: disable=too-many-return-statements
+    # Flat guard -> log -> return-0 per skip reason (no labels, too few
+    # positives, no fit, reflection split, no outliers, fraction gate);
+    # reads better inline than dispersed across helpers.
     """Run RANSAC line-fit validation for `dive_id` and supersede any
     flagged outliers. Returns the number of labels superseded (0 when
     the line isn't confident or there aren't enough positives to fit).
@@ -218,6 +225,35 @@ async def validate_laser_labels_for_dive_activity(dive_id: int) -> int:
             ),
         )
         activity.heartbeat()
+
+        # Two-line (specular reflection) detection. A dive whose dots split
+        # across two coherent parallel lines — labelers clicking the laser's
+        # reflection on the slate (prod dive 77) — defeats single-line
+        # validation in exactly the wrong way: with the artifact in the
+        # majority, RANSAC anchors on the WRONG line and 3-sigma flagging
+        # would supersede the true one; with a near-even split, confidence
+        # collapses and the dive is silently skipped while stage 13 consumes
+        # the poisoned mix. Choosing which line is real needs cross-dive
+        # consensus (sibling dives, same camera), which the per-dive validator
+        # doesn't have — so on detection it logs loudly and stands down,
+        # leaving the labels for operator remediation (supersede the artifact
+        # line, delete the extrinsics, refit — see the dive-77 recipe).
+        suspect = detect_reflection_split(xy, fit)
+        if suspect is not None:
+            activity.logger.error(
+                "dive_id=%d REFLECTION SUSPECT: laser dots form two parallel "
+                "lines — primary n=%d, secondary n=%d at %.1fpx separation "
+                "(angle %.2f deg). Likely specular-reflection mislabels; "
+                "single-line validation cannot resolve which is real. "
+                "Skipping supersede; manual remediation required before this "
+                "dive's labels feed stage 13.",
+                dive_id,
+                suspect.n_primary,
+                suspect.n_secondary,
+                suspect.separation_px,
+                suspect.angle_deg,
+            )
+            return 0
 
         outlier_mask = flag_outliers(xy, fit)
         n_outliers = int(outlier_mask.sum())

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/calibration_consistency.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/calibration_consistency.py
@@ -1,0 +1,118 @@
+"""Stage-13 self-consistency gate: a laser calibration must reproject onto
+the 2D laser dots it was fit from.
+
+Motivated by prod dive 77 (2026-08-04): labelers clicked the laser's specular
+reflection on ~half the pool slate frames, so the dots formed two parallel
+lines ~45 px apart. The 3D fit split the difference — 14 deg off the dive's
+own dot line, origin far outside the fleet family — and the persisted
+calibration, borrowed by a fish-model dive, produced +31..+137% length errors.
+
+The invariant is cheap and assumption-free: the fitted 3D ray, projected
+through the camera matrix, must coincide with the total-least-squares line
+through the input dots. Fleet baseline (every good calibration, all cameras):
+<=1.6 deg / <=4 px median; the dive-77 failure was 14 deg / 17 px median.
+Reprojection error also *predicts* measurement bias (0.9 px borrow -> +-3%
+lengths; 2-4 px -> -4..-15%), so the thresholds below bound downstream
+accuracy, not just fit hygiene.
+
+Pure numpy — no cv2 — so it is unit-testable everywhere.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = [
+    "CalibrationInconsistentError",
+    "DEFAULT_MAX_ANGLE_DEG",
+    "DEFAULT_MAX_MEDIAN_OFFSET_PX",
+    "MIN_DOT_SPAN_PX",
+    "check_fit_self_consistency",
+]
+
+# Fleet-derived thresholds: good fits sit at <=1.6 deg / <=4 px median, the
+# known-bad fit at 14 deg / 17 px. The gap is wide; these sit in the middle
+# with margin for noisier-but-sane dives.
+DEFAULT_MAX_ANGLE_DEG = 3.0
+DEFAULT_MAX_MEDIAN_OFFSET_PX = 8.0
+
+# Below this dot spread the 2D line direction is numerically meaningless
+# (e.g. MIN_LASER_POINTS=2 nearly-coincident observations), so the gate
+# abstains rather than rejecting on noise.
+MIN_DOT_SPAN_PX = 50.0
+
+
+class CalibrationInconsistentError(ValueError):
+    """The fitted laser ray does not reproject onto the dots it came from."""
+
+
+def _tls_line(points: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Total-least-squares 2D line through `points` -> (centroid, unit dir)."""
+    centroid = points.mean(axis=0)
+    _, _, vt = np.linalg.svd(points - centroid)
+    return centroid, vt[0]
+
+
+def check_fit_self_consistency(
+    laser_position: np.ndarray,
+    laser_axis: np.ndarray,
+    camera_matrix: np.ndarray,
+    dots_xy: np.ndarray,
+    *,
+    max_angle_deg: float = DEFAULT_MAX_ANGLE_DEG,
+    max_median_offset_px: float = DEFAULT_MAX_MEDIAN_OFFSET_PX,
+    min_span_px: float = MIN_DOT_SPAN_PX,
+) -> None:
+    # pylint: disable=too-many-locals
+    # Flat geometric pipeline (project ray -> fit both lines -> two
+    # scalars); splitting it would smear one computation across helpers.
+    """Raise `CalibrationInconsistentError` when the fitted ray's projection
+    disagrees with the 2D laser dots it was computed from.
+
+    `dots_xy` is an (N, 2) array of the laser pixels whose observations fed
+    the fit. Abstains (returns) when N < 2 or the dots' spread is below
+    `min_span_px` — too degenerate to define a comparison line.
+    """
+    dots = np.asarray(dots_xy, dtype=float)
+    if dots.ndim != 2 or dots.shape[0] < 2:
+        return
+    span = float(np.linalg.norm(dots.max(axis=0) - dots.min(axis=0)))
+    if span < min_span_px:
+        return
+
+    origin = np.asarray(laser_position, dtype=float)
+    axis = np.asarray(laser_axis, dtype=float)
+    axis = axis / np.linalg.norm(axis)
+    k = np.asarray(camera_matrix, dtype=float)
+
+    # Project the fitted ray across the plausible working depth range.
+    depths = np.linspace(0.2, 4.0, 200)
+    ts = (depths - origin[2]) / axis[2]
+    ray_points = origin[None, :] + ts[:, None] * axis[None, :]
+    homogeneous = (k @ ray_points.T).T
+    projected = homogeneous[:, :2] / homogeneous[:, 2:3]
+
+    proj_centroid, proj_dir = _tls_line(projected)
+    _, dot_dir = _tls_line(dots)
+
+    cos_angle = min(1.0, abs(float(proj_dir @ dot_dir)))
+    angle_deg = float(np.degrees(np.arccos(cos_angle)))
+
+    normal = np.array([-proj_dir[1], proj_dir[0]])
+    median_offset_px = float(np.median(np.abs((dots - proj_centroid) @ normal)))
+
+    if angle_deg > max_angle_deg:
+        raise CalibrationInconsistentError(
+            f"fitted laser ray reprojects at angle {angle_deg:.2f} deg to the "
+            f"input dot line (gate {max_angle_deg} deg); median offset "
+            f"{median_offset_px:.1f}px. The fit disagrees with its own "
+            f"observations — mixed dot populations (e.g. specular-reflection "
+            f"mislabels) or corrupt slate poses. Refusing to persist."
+        )
+    if median_offset_px > max_median_offset_px:
+        raise CalibrationInconsistentError(
+            f"fitted laser ray reprojects with median offset "
+            f"{median_offset_px:.1f}px from the input dot line "
+            f"(gate {max_median_offset_px}px); angle {angle_deg:.2f} deg. "
+            f"Refusing to persist."
+        )

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/laser_label_validation/reflection.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/laser_label_validation/reflection.py
@@ -1,0 +1,115 @@
+"""Two-line (specular reflection) detection for laser-dot populations.
+
+Prod dive 77 (2026-08-04): pool slate photos show two bright dots — the laser
+and its specular reflection ~45 px away. Labelers clicked the reflection on 34
+of 79 frames, so the dive's dots formed two coherent PARALLEL lines. That
+population defeats the single-line RANSAC validator in exactly the wrong way:
+the split kills its confidence / trips MAX_OUTLIER_FRACTION, so it silently
+skips the dive forever — while stage 13 happily consumes the poisoned mix and
+persists a calibration that is 14 deg off both lines.
+
+This module names the failure mode: after the primary fit, look for a second
+coherent line among the off-line points. Near-parallel + well-separated =
+reflection signature. Detection only — choosing WHICH line is the real laser
+needs cross-dive consensus (sibling dives on the same camera), which is
+operator-level context the per-dive validator doesn't have. The activity logs
+the finding loudly for manual remediation (see the dive-77 recipe in project
+memory: supersede the artifact line's labels, delete the extrinsics, refit).
+
+Not vendored from the laser-detector repo (unlike ``line_fit``) — this is
+pipeline-side diagnostics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from fishsense_data_processing_workflow_worker.laser_label_validation.line_fit import (
+    LineFit,
+    MIN_POINTS_FOR_LINE,
+    RANSAC_INLIER_TOL_PX,
+    fit_dive_line,
+)
+
+__all__ = [
+    "MAX_PARALLEL_ANGLE_DEG",
+    "MIN_SEPARATION_PX",
+    "MAX_SEPARATION_PX",
+    "ReflectionSuspect",
+    "detect_reflection_split",
+]
+
+# A reflection is (near-)parallel to the true dot line — both are projections
+# of the same beam geometry. Steeper crossings are some other pathology.
+MAX_PARALLEL_ANGLE_DEG = 3.0
+
+# Separation window: closer than the RANSAC tolerance would just be label
+# noise; a reflection hundreds of px away stops looking like one (and stops
+# being clickable-by-mistake).
+MIN_SEPARATION_PX = 8.0
+MAX_SEPARATION_PX = 200.0
+
+# The secondary population must itself be line-like, not scatter.
+MIN_SECONDARY_INLIER_FRACTION = 0.6
+
+
+@dataclass
+class ReflectionSuspect:
+    """A coherent second dot line parallel to the primary."""
+
+    n_primary: int
+    n_secondary: int
+    separation_px: float
+    angle_deg: float
+
+
+def detect_reflection_split(
+    xy: np.ndarray,
+    primary: LineFit | None,
+    *,
+    tol_px: float = RANSAC_INLIER_TOL_PX,
+) -> ReflectionSuspect | None:
+    # pylint: disable=too-many-return-statements
+    # A flat chain of disqualifying guards, each returning None for its own
+    # reason; collapsing them would obscure which criterion rejected.
+    """Return a `ReflectionSuspect` when the off-line points form a second
+    coherent line parallel to `primary`, else None."""
+    if primary is None or xy.shape[0] < 2 * MIN_POINTS_FOR_LINE:
+        return None
+
+    residual = primary.perpendicular_distance(xy[:, 0], xy[:, 1])
+    off = residual >= tol_px
+    if int(off.sum()) < MIN_POINTS_FOR_LINE:
+        return None
+
+    secondary = fit_dive_line(xy[off])
+    if secondary is None:
+        return None
+    if secondary.inlier_count < MIN_POINTS_FOR_LINE:
+        return None
+    if secondary.inlier_fraction < MIN_SECONDARY_INLIER_FRACTION:
+        return None
+
+    # Line coefficients are unit-normalized (a^2 + b^2 = 1), so the normals
+    # compare directly and |c| differences are pixel distances.
+    n1 = np.array([primary.a, primary.b])
+    n2 = np.array([secondary.a, secondary.b])
+    cos_angle = min(1.0, abs(float(n1 @ n2)))
+    angle_deg = float(np.degrees(np.arccos(cos_angle)))
+    if angle_deg > MAX_PARALLEL_ANGLE_DEG:
+        return None
+
+    # Separation: median distance of the secondary population from the
+    # primary line — robust even when the lines aren't perfectly parallel.
+    separation_px = float(np.median(residual[off]))
+    if not MIN_SEPARATION_PX <= separation_px <= MAX_SEPARATION_PX:
+        return None
+
+    return ReflectionSuspect(
+        n_primary=int((~off).sum()),
+        n_secondary=int(off.sum()),
+        separation_px=separation_px,
+        angle_deg=angle_deg,
+    )

--- a/services/fishsense-data-processing-workflow-worker/tests/test_calibration_consistency.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_calibration_consistency.py
@@ -1,0 +1,91 @@
+"""Unit tests for the stage-13 self-consistency gate (pure numpy, no cv2).
+
+The gate exists because of prod dive 77 (2026-08-04): labelers clicked the
+laser's specular reflection on ~half the pool slate frames, the laser dots
+formed two parallel lines, and the 3D fit split the difference — 14 deg off
+the dive's own dot line, with a fleet-outlier origin. The bad calibration was
+persisted, borrowed by a fish-model dive, and produced +31..+137% length
+errors. A fit that cannot reproject onto the very dots it was computed from
+must never persist. Fleet baseline: every good calibration reprojects onto
+its own dots at <=1.6 deg / <=4 px median; 77-bad was 14 deg / 17 px.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from fishsense_data_processing_workflow_worker.calibration_consistency import (
+    CalibrationInconsistentError,
+    check_fit_self_consistency,
+)
+
+K = np.array(
+    [
+        [2840.0, 0.0, 2000.0],
+        [0.0, 2860.0, 1450.0],
+        [0.0, 0.0, 1.0],
+    ]
+)
+ORIGIN = np.array([-0.031, -0.099, 0.0])
+AXIS = np.array([0.01, 0.03, 0.999])
+AXIS = AXIS / np.linalg.norm(AXIS)
+
+
+def _project(p3: np.ndarray) -> tuple[float, float]:
+    q = K @ p3
+    return float(q[0] / q[2]), float(q[1] / q[2])
+
+
+def _dots_on_ray(depths, noise_px: float = 0.0, seed: int = 7) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    pts = []
+    for z in depths:
+        t = (z - ORIGIN[2]) / AXIS[2]
+        x, y = _project(ORIGIN + t * AXIS)
+        pts.append((x + rng.normal(0, noise_px), y + rng.normal(0, noise_px)))
+    return np.array(pts)
+
+
+def test_consistent_fit_passes():
+    dots = _dots_on_ray(np.linspace(0.4, 2.5, 20), noise_px=1.0)
+    # Must not raise.
+    check_fit_self_consistency(ORIGIN, AXIS, K, dots)
+
+
+def test_rotated_axis_is_rejected():
+    """A 10-deg axis error (the dive-77 class of failure) must be rejected."""
+    dots = _dots_on_ray(np.linspace(0.4, 2.5, 20), noise_px=1.0)
+    bad_axis = np.array([np.sin(np.radians(10.0)), 0.03, 0.99])
+    bad_axis = bad_axis / np.linalg.norm(bad_axis)
+    with pytest.raises(CalibrationInconsistentError, match="angle"):
+        check_fit_self_consistency(ORIGIN, bad_axis, K, dots)
+
+
+def test_two_line_mixture_is_rejected():
+    """Dots split across two parallel lines (reflection artifact): the fit
+    projects between them, so the median offset blows the gate."""
+    line_a = _dots_on_ray(np.linspace(0.4, 2.5, 12), noise_px=1.0)
+    line_b = line_a + np.array([45.0, 0.0])  # parallel artifact line
+    dots = np.vstack([line_a, line_b])
+    shifted_origin = ORIGIN + np.array([0.008, 0.0, 0.0])  # fit splits the gap
+    with pytest.raises(CalibrationInconsistentError, match="offset"):
+        check_fit_self_consistency(shifted_origin, AXIS, K, dots)
+
+
+def test_small_span_skips_gate():
+    """Two nearly-coincident dots can't determine a line direction — the gate
+    must skip (not raise) rather than reject on meaningless geometry."""
+    dots = _dots_on_ray([1.0, 1.005])
+    bad_axis = np.array([np.sin(np.radians(10.0)), 0.03, 0.99])
+    bad_axis = bad_axis / np.linalg.norm(bad_axis)
+    # Must not raise despite the bad axis: span too small to judge.
+    check_fit_self_consistency(ORIGIN, bad_axis, K, dots)
+
+
+def test_offset_fit_is_rejected():
+    """Right direction, wrong origin (parallel-shifted projection)."""
+    dots = _dots_on_ray(np.linspace(0.4, 2.5, 20), noise_px=1.0)
+    shifted = ORIGIN + np.array([0.012, 0.0, 0.0])  # ~30 px shift at ~1 m
+    with pytest.raises(CalibrationInconsistentError, match="offset"):
+        check_fit_self_consistency(shifted, AXIS, K, dots)

--- a/services/fishsense-data-processing-workflow-worker/tests/test_perform_laser_calibration_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_perform_laser_calibration_activity.py
@@ -1,3 +1,7 @@
+# pylint: disable=protected-access
+# The private kernels (`_drop_skipped`, `_laser_point_in_camera_space`) are
+# unit-tested directly — they carry the correspondence-pairing invariants that
+# a full-activity test can only exercise indirectly.
 """Unit tests for perform_laser_calibration_activity (stage 13).
 
 End-to-end synthetic-scene test pins down the math + SDK plumbing on a
@@ -301,7 +305,7 @@ async def test_reflection_contaminated_scene_is_rejected_not_persisted(monkeypat
     )
     # Contaminate: shift half the laser pixels +45px in x — the reflection
     # artifact observed on prod dive 77 (labelers clicked the specular double).
-    for i, (image_id, laser_label) in enumerate(sorted(lasers.items())):
+    for i, (_image_id, laser_label) in enumerate(sorted(lasers.items())):
         if i % 2 == 0:
             laser_label.x = float(laser_label.x) + 45.0
 

--- a/services/fishsense-data-processing-workflow-worker/tests/test_perform_laser_calibration_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_perform_laser_calibration_activity.py
@@ -276,6 +276,46 @@ async def test_recovers_known_laser_extrinsics_from_synthetic_scene(monkeypatch)
     assert pos_xy_l2 < 0.001
 
 
+@pytest.mark.asyncio
+async def test_reflection_contaminated_scene_is_rejected_not_persisted(monkeypatch):
+    """The prod-dive-77 regression: half the laser dots mislabeled onto a
+    parallel artifact line (specular reflection on the pool slate) produce a
+    fit that reprojects onto NEITHER dot population. The self-consistency
+    gate must raise and nothing may persist — the old behavior shipped the
+    broken calibration, and a borrowing fish-model dive measured +31..+137%
+    length errors."""
+    from fishsense_data_processing_workflow_worker.calibration_consistency import (  # pylint: disable=import-outside-toplevel
+        CalibrationInconsistentError,
+    )
+
+    laser_origin = np.array([-0.03, -0.10, 0.0])
+    laser_axis = np.array([0.005, -0.02, 1.0])
+    laser_axis = laser_axis / np.linalg.norm(laser_axis)
+
+    dive = _dive()
+    slate, intrinsics, labels, lasers = _build_synthetic_scene(
+        n_observations=8,
+        laser_origin_world=laser_origin,
+        laser_axis_world=laser_axis,
+        slate_distances=[0.40, 0.55, 0.70, 0.85, 1.00, 1.15, 1.30, 1.45],
+    )
+    # Contaminate: shift half the laser pixels +45px in x — the reflection
+    # artifact observed on prod dive 77 (labelers clicked the specular double).
+    for i, (image_id, laser_label) in enumerate(sorted(lasers.items())):
+        if i % 2 == 0:
+            laser_label.x = float(laser_label.x) + 45.0
+
+    fs = _make_fs(dive, [slate], labels, lasers, intrinsics)
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    with pytest.raises(CalibrationInconsistentError):
+        await ActivityEnvironment().run(
+            sut.perform_laser_calibration_activity, 42
+        )
+
+    fs.dives.put_laser_extrinsics.assert_not_called()
+
+
 # --------------------------- skipped-points (Bug 2) ---------------------------
 
 

--- a/services/fishsense-data-processing-workflow-worker/tests/test_reflection_detection.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_reflection_detection.py
@@ -1,0 +1,72 @@
+"""Unit tests for the two-line (specular reflection) detector.
+
+Prod dive 77 (2026-08-04): pool slate photos show the laser AND its specular
+reflection ~45 px apart; labelers clicked the reflection on 34 of 79 frames.
+The dots formed two coherent parallel lines — a population the RANSAC
+validator cannot handle: the two-line split kills its confidence / trips the
+MAX_OUTLIER_FRACTION refusal, so it silently skips the dive forever while
+stage 13 consumes the poisoned mix. The detector names that failure mode
+loudly instead.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from fishsense_data_processing_workflow_worker.laser_label_validation.line_fit import (
+    fit_dive_line,
+)
+from fishsense_data_processing_workflow_worker.laser_label_validation.reflection import (
+    detect_reflection_split,
+)
+
+
+def _line_points(n, x0, y0, dx, dy, noise=0.8, seed=3):
+    rng = np.random.default_rng(seed)
+    t = np.linspace(0, 900, n)
+    pts = np.stack([x0 + t * dx, y0 + t * dy], axis=1)
+    return pts + rng.normal(0, noise, pts.shape)
+
+
+def test_detects_parallel_reflection_split():
+    primary = _line_points(30, 1900.0, 800.0, 0.3, 1.0)
+    artifact = primary[:20] + np.array([45.0, 0.0])  # parallel, 45px away
+    xy = np.vstack([primary, artifact])
+    fit = fit_dive_line(xy)
+
+    suspect = detect_reflection_split(xy, fit)
+
+    assert suspect is not None
+    assert suspect.n_secondary >= 15
+    assert 30.0 < suspect.separation_px < 60.0
+    assert suspect.angle_deg < 3.0
+
+
+def test_clean_line_with_random_outliers_is_not_a_split():
+    primary = _line_points(40, 1900.0, 800.0, 0.3, 1.0)
+    rng = np.random.default_rng(11)
+    scatter = rng.uniform([1000, 500], [3000, 2500], size=(6, 2))
+    xy = np.vstack([primary, scatter])
+    fit = fit_dive_line(xy)
+
+    assert detect_reflection_split(xy, fit) is None
+
+
+def test_small_second_cluster_is_not_a_split():
+    primary = _line_points(40, 1900.0, 800.0, 0.3, 1.0)
+    artifact = primary[:3] + np.array([45.0, 0.0])  # only 3 points
+    xy = np.vstack([primary, artifact])
+    fit = fit_dive_line(xy)
+
+    assert detect_reflection_split(xy, fit) is None
+
+
+def test_crossing_line_is_not_a_reflection():
+    """A second line at a steep angle is some other pathology — the
+    reflection signature is parallelism."""
+    primary = _line_points(30, 1900.0, 800.0, 0.3, 1.0)
+    crossing = _line_points(20, 1200.0, 1500.0, 1.0, 0.05, seed=5)
+    xy = np.vstack([primary, crossing])
+    fit = fit_dive_line(xy)
+
+    assert detect_reflection_split(xy, fit) is None

--- a/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_validate_laser_labels_for_dive_activity.py
@@ -409,8 +409,14 @@ async def test_supersede_writes_run_concurrently(monkeypatch):
     n_outliers = 2 * sut.SUPERSEDE_CONCURRENCY
     labels = _colinear_labels(60)
     outlier_idxs = list(range(0, n_outliers * 2, 2))[:n_outliers]
-    for idx in outlier_idxs:
-        labels[idx].y = labels[idx].y + 50.0  # type: ignore[operator]
+    for k, idx in enumerate(outlier_idxs):
+        # Scattered offsets (varying magnitude, both sides): each is a clear
+        # 3-sigma outlier, but together they must NOT form a coherent second
+        # parallel line — that population is the reflection signature, on
+        # which the validator now deliberately stands down instead of
+        # superseding.
+        sign = 1.0 if k % 2 == 0 else -1.0
+        labels[idx].y = labels[idx].y + sign * (40.0 + (k * 37) % 97)  # type: ignore[operator]
 
     in_flight = 0
     peak_in_flight = 0
@@ -514,3 +520,35 @@ async def test_supersede_failure_propagates(monkeypatch):
     env = ActivityEnvironment()
     with pytest.raises(RuntimeError, match="simulated PUT failure"):
         await env.run(sut.validate_laser_labels_for_dive_activity, 99)
+
+
+@pytest.mark.asyncio
+async def test_reflection_split_logs_error_and_stands_down(monkeypatch, caplog):
+    """The prod-dive-77 population: dots split across two coherent parallel
+    lines (laser + its specular reflection on the pool slate). The validator
+    must name the failure loudly and must NOT supersede either line — with
+    the artifact in the majority, RANSAC anchors on the wrong line and
+    majority-vote superseding would kill the TRUE laser labels."""
+    labels = []
+    # Artifact (majority) line: 30 dots along x = 1945 + 0.3t.
+    for i in range(30):
+        t = i * 30.0
+        labels.append(_label(i, 100 + i, 1945.0 + 0.3 * t, 800.0 + t))
+    # True (minority) line: 20 dots, parallel, 45px to the left.
+    for i in range(20):
+        t = i * 45.0
+        labels.append(_label(50 + i, 200 + i, 1900.0 + 0.3 * t, 800.0 + t))
+
+    fs = _make_fs(labels)
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    with caplog.at_level("ERROR"):
+        result = await ActivityEnvironment().run(
+            sut.validate_laser_labels_for_dive_activity, 77
+        )
+
+    assert result == 0
+    fs.labels.put_laser_label.assert_not_called()
+    assert any(
+        "REFLECTION SUSPECT" in rec.getMessage() for rec in caplog.records
+    ), "two-line split must be loudly reported"

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "fishsense-api"
-version = "1.38.0"
+version = "1.39.0"
 source = { editable = "services/fishsense-api" }
 dependencies = [
     { name = "alembic" },
@@ -712,7 +712,7 @@ dev = [
 
 [[package]]
 name = "fishsense-api-sdk"
-version = "1.43.0"
+version = "1.44.0"
 source = { editable = "libs/fishsense-api-sdk" }
 dependencies = [
     { name = "httpx" },
@@ -881,7 +881,7 @@ provides-extras = ["laser-detector", "rectified", "slate"]
 
 [[package]]
 name = "fishsense-data-processing-workflow-worker"
-version = "2.12.1"
+version = "2.13.0"
 source = { editable = "services/fishsense-data-processing-workflow-worker" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Incident (prod dive 77, 2026-08-04)

Pool slate photos show two bright dots — the laser and its **specular reflection** ~45 px apart. Labelers clicked the reflection on 34/79 frames (many different labelers; the image is genuinely confusing), so the dive's laser dots formed **two coherent parallel lines**. Consequences:

- **Stage 13** consumed the mix and persisted a calibration **14° off the dive's own dot line** (origin far outside the fleet family: `[-0.001,-0.048]` vs `≈[-0.03,-0.10]` everywhere else).
- The **laser-label validator couldn't clean it**: a two-line population kills its RANSAC confidence / trips `MAX_OUTLIER_FRACTION`, so it silently skipped the dive forever.
- A borrowing fish-model dive measured **+31…+137%** errors vs known model sizes. After manual remediation (supersede the artifact line, delete the extrinsics, refit), the same dive measures at **±1–3%**.

## Changes

1. **Stage-13 self-consistency gate** (`calibration_consistency.py`, pure numpy): the fitted ray reprojected through K must coincide with the TLS line of the very dots it was fit from — fleet baseline is ≤1.6°/≤4 px median, the bad fit was 14°/17 px; gate at 3°/8 px. Raises before persist. Reprojection error also *predicts* measurement bias (0.9 px borrow → ±3% lengths; 2–4 px → −4…−15%), so this bounds accuracy, not just hygiene.
2. **Reflection-split detection** in the validator (`laser_label_validation/reflection.py`): a second coherent line, near-parallel (<3°) at 8–200 px separation, among the off-line points → log **ERROR "REFLECTION SUSPECT"** and **stand down** (no supersede — with the artifact in the majority, majority-vote superseding would kill the *true* labels; picking the real line needs cross-dive consensus).
3. **Stage-13/14 child `id_reuse_policy` → `ALLOW_DUPLICATE`** (mirrors preprocess, 2026-07-23): FAILED_ONLY meant a *completed* child id silently swallowed post-remediation refit/re-measure dispatches — observed live on both dives 77 and 59. Safe: cohorts offer only unfinished dives; extrinsics upsert on dive_id; measurement upserts + skips; the new gate rejects bad refits.

## Tests (TDD)
Pure gate: consistent passes; rotated axis, two-line mixture, parallel shift rejected; tiny-span abstains. Detector: split detected; scatter/small-cluster/crossing ignored. Activity: reflection-contaminated synthetic scene raises + nothing persisted; validator logs + stands down on a split (and the concurrency fixture now uses scattered outliers so it remains a concurrency test). 50 data-worker + 20 api-worker tests green locally; pylint 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)