### PR TITLE
feat(api): persist known fish-model lengths + measurement-accuracy view

### DIFF
--- a/services/fishsense-api/src/fishsense_api/alembic/versions/e2c9a4f70b31_add_fish_model_reference.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/e2c9a4f70b31_add_fish_model_reference.py
@@ -1,0 +1,81 @@
+"""add fishmodelreference table, seed it, and add the accuracy view
+
+Revision ID: e2c9a4f70b31
+Revises: d8b3f16c204e
+Create Date: 2026-08-04 09:00:00.000000
+
+Persists the known lengths of the physical fish models (the pipeline's
+held-out validation set, never used for calibration) and exposes
+`fish_model_measurement_accuracy` so measured-vs-known error is queryable
+from Superset. Seed data is canonical in `views.KNOWN_FISH_MODELS`.
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from fishsense_api.views import (
+    DROP_FISH_MODEL_ACCURACY_VIEW_SQL,
+    FISH_MODEL_ACCURACY_VIEW_SQL,
+    KNOWN_FISH_MODELS,
+)
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e2c9a4f70b31"
+down_revision: Union[str, Sequence[str], None] = "d8b3f16c204e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create + seed the reference table, then (re)create the accuracy view.
+
+    Table creation is idempotent against `SQLModel.metadata.create_all` (the
+    lifespan runs it first, and the model is in the registry). The seed is an
+    upsert-by-absence so re-running never duplicates and never clobbers a
+    length an operator has corrected by hand.
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("fishmodelreference"):
+        op.create_table(
+            "fishmodelreference",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("name", sa.String(), nullable=False),
+            sa.Column("known_length_m", sa.Float(), nullable=False),
+            sa.Column("notes", sa.String(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("name", name="uq_fish_model_reference_name"),
+        )
+        op.create_index(
+            "ix_fishmodelreference_name", "fishmodelreference", ["name"]
+        )
+
+    # Seed only the models that aren't present yet.
+    existing = {
+        row[0]
+        for row in bind.execute(sa.text("SELECT name FROM fishmodelreference"))
+    }
+    to_insert = [m for m in KNOWN_FISH_MODELS if m["name"] not in existing]
+    if to_insert:
+        bind.execute(
+            sa.text(
+                "INSERT INTO fishmodelreference (name, known_length_m) "
+                "VALUES (:name, :known_length_m)"
+            ),
+            to_insert,
+        )
+
+    op.execute(DROP_FISH_MODEL_ACCURACY_VIEW_SQL)
+    op.execute(FISH_MODEL_ACCURACY_VIEW_SQL)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute(DROP_FISH_MODEL_ACCURACY_VIEW_SQL)
+    op.drop_index("ix_fishmodelreference_name", table_name="fishmodelreference")
+    op.drop_table("fishmodelreference")

--- a/services/fishsense-api/src/fishsense_api/database.py
+++ b/services/fishsense-api/src/fishsense_api/database.py
@@ -33,6 +33,7 @@ from fishsense_api.models.image import Image
 from fishsense_api.models.label_studio_sync_cursor import LabelStudioSyncCursor
 from fishsense_api.models.laser_extrinsics import LaserExtrinsics
 from fishsense_api.models.laser_label import LaserLabel
+from fishsense_api.models.fish_model_reference import FishModelReference
 from fishsense_api.models.laser_prediction import LaserPrediction
 from fishsense_api.models.measurement import Measurement
 from fishsense_api.models.slate_prediction import SlatePrediction

--- a/services/fishsense-api/src/fishsense_api/models/fish_model_reference.py
+++ b/services/fishsense-api/src/fishsense_api/models/fish_model_reference.py
@@ -1,0 +1,27 @@
+"""Known-size reference for the physical fish models."""
+
+from sqlmodel import Field, SQLModel, UniqueConstraint
+
+
+class FishModelReference(SQLModel, table=True):
+    """Ground-truth length of a physical fish model, keyed by the same `name`
+    natural key stage 14 resolves model identity by (`Fish.name`).
+
+    These lengths are the pipeline's held-out **validation** set: they are
+    compared against what stage 14 measures and are NEVER fed into laser
+    calibration — doing so would make the benchmark grade itself. The
+    `fish_model_measurement_accuracy` view joins measurements to these rows.
+    """
+
+    __table_args__ = (UniqueConstraint("name", name="uq_fish_model_reference_name"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+
+    # Matches `Fish.name` / the `Fish Model, <name>` species-label leaf.
+    name: str = Field(index=True)
+
+    known_length_m: float
+
+    # Provenance: how/when the length was established (e.g. field dates,
+    # caliper session). Free text — the measurement itself is the datum.
+    notes: str | None = Field(default=None)

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -357,3 +357,63 @@ FROM dive d
 DROP_DIVE_PIPELINE_STATUS_VIEW_SQL = (
     f"DROP VIEW IF EXISTS {DIVE_PIPELINE_STATUS_VIEW_NAME}"
 )
+
+
+# ---------------------------------------------------------------------------
+# Fish-model measurement accuracy
+# ---------------------------------------------------------------------------
+
+FISH_MODEL_ACCURACY_VIEW_NAME = "fish_model_measurement_accuracy"
+
+# Ground-truth lengths of the physical fish models, in meters, as measured by
+# the team. Seeded into `fishmodelreference` by alembic; the constant is the
+# source of truth so a change is reviewable in a diff.
+#
+# These are the pipeline's held-out VALIDATION set — together with the ruler
+# (`Calibration Targets, Ruler`). They are compared against what stage 14
+# produces and are NEVER fed into laser calibration: a benchmark that
+# calibrates from its own answer key measures nothing. Calibration comes from
+# slates only.
+#
+# Field model dates: 2024-08-21 and 2024-10-16.
+KNOWN_FISH_MODELS = [
+    {"name": "Snook", "known_length_m": 0.455},
+    {"name": "Grouper", "known_length_m": 0.360},
+    {"name": "Shark", "known_length_m": 0.605},
+    {"name": "Gray Anthias", "known_length_m": 0.195},
+    {"name": "Purple Angel", "known_length_m": 0.192},
+    {"name": "Yellow Anthias", "known_length_m": 0.200},
+]
+
+# One row per fish-model measurement, with its error against the known length.
+#
+# Joins through `Fish.name` — the natural key stage 14 resolves model identity
+# by — so every new measurement lands in the view automatically. Real (wild)
+# fish carry `name IS NULL` and are excluded by the inner join; so are models
+# that have no reference row yet (ungradeable rather than compared to NULL).
+#
+# `pct_error` is signed: positive = measured long. Length is proportional to
+# the laser-derived depth, so a systematic offset here is a calibration
+# signal, not a labeling one.
+FISH_MODEL_ACCURACY_VIEW_SQL = f"""
+CREATE VIEW {FISH_MODEL_ACCURACY_VIEW_NAME} AS
+SELECT
+    m.id            AS measurement_id,
+    m.image_id      AS image_id,
+    i.dive_id       AS dive_id,
+    f.id            AS fish_id,
+    f.name          AS model_name,
+    r.known_length_m AS known_length_m,
+    m.length_m      AS length_m,
+    (m.length_m - r.known_length_m) AS error_m,
+    (100.0 * (m.length_m - r.known_length_m) / r.known_length_m) AS pct_error
+FROM measurement m
+JOIN image i ON i.id = m.image_id
+JOIN fish f ON f.id = m.fish_id
+JOIN fishmodelreference r ON r.name = f.name
+WHERE m.length_m IS NOT NULL
+"""
+
+DROP_FISH_MODEL_ACCURACY_VIEW_SQL = (
+    f"DROP VIEW IF EXISTS {FISH_MODEL_ACCURACY_VIEW_NAME}"
+)

--- a/services/fishsense-api/tests/test_fish_model_reference.py
+++ b/services/fishsense-api/tests/test_fish_model_reference.py
@@ -1,0 +1,208 @@
+"""Known-size reference for the physical fish models + the accuracy view.
+
+The models (and the ruler) are the pipeline's held-out VALIDATION set: their
+true lengths are never fed into calibration (that would be circular), only
+compared against what stage 14 measures. Persisting them here turns that
+comparison into a queryable artifact instead of a number in someone's notes,
+and backs a Superset accuracy dashboard.
+
+`fish_model_measurement_accuracy` joins measurements to the reference through
+`Fish.name` — the same natural key stage 14 resolves model identity by — so a
+new measurement shows up in the view with no extra wiring.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from fishsense_api.views import (
+    FISH_MODEL_ACCURACY_VIEW_SQL,
+    KNOWN_FISH_MODELS,
+)
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+        await conn.execute(text(FISH_MODEL_ACCURACY_VIEW_SQL))
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+# ── the seed data itself ──────────────────────────────────────────────
+
+
+def test_known_models_cover_the_labeled_taxonomy():
+    """Every `Fish Model, <name>` leaf a labeler can pick must have a known
+    length, or its measurements can never be graded."""
+    names = {m["name"] for m in KNOWN_FISH_MODELS}
+    assert {"Snook", "Grouper", "Shark", "Purple Angel"} <= names
+
+
+def test_known_lengths_are_positive_and_plausible():
+    for model in KNOWN_FISH_MODELS:
+        assert 0.05 < model["known_length_m"] < 2.0, model
+
+
+def test_known_model_names_are_unique():
+    names = [m["name"] for m in KNOWN_FISH_MODELS]
+    assert len(names) == len(set(names))
+
+
+# ── the reference table ───────────────────────────────────────────────
+
+
+async def test_reference_row_round_trips(session):
+    from fishsense_api.models.fish_model_reference import (  # pylint: disable=import-outside-toplevel
+        FishModelReference,
+    )
+
+    session.add(FishModelReference(name="Grouper", known_length_m=0.360))
+    await session.flush()
+
+    row = (
+        await session.exec(
+            select(FishModelReference).where(FishModelReference.name == "Grouper")
+        )
+    ).first()
+    assert row is not None
+    assert row.known_length_m == pytest.approx(0.360)
+
+
+# ── the accuracy view ─────────────────────────────────────────────────
+
+
+async def _seed_measurement(session, *, dive_id, image_id, model_name, length_m):
+    from datetime import datetime, timezone  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+
+    existing = (await session.exec(select(Dive).where(Dive.id == dive_id))).first()
+    if existing is None:
+        session.add(
+            Dive(
+                id=dive_id,
+                path=f"/dev/null/{dive_id}",
+                dive_datetime=datetime(2023, 8, 29, tzinfo=timezone.utc),
+                priority=Priority.HIGH,
+            )
+        )
+        await session.flush()
+    fish = (
+        await session.exec(select(Fish).where(Fish.name == model_name))
+    ).first()
+    if fish is None:
+        fish = Fish(name=model_name, species_id=None)
+        session.add(fish)
+        await session.flush()
+    session.add(
+        Image(
+            id=image_id,
+            path=f"/dev/null/img-{image_id}",
+            taken_datetime=datetime(2023, 8, 29, tzinfo=timezone.utc),
+            checksum=f"img-{image_id:032d}"[:32],
+            dive_id=dive_id,
+        )
+    )
+    await session.flush()
+    session.add(Measurement(image_id=image_id, fish_id=fish.id, length_m=length_m))
+    await session.flush()
+
+
+async def _rows(session):
+    result = await session.exec(
+        text(
+            "SELECT dive_id, model_name, known_length_m, length_m, "
+            "error_m, pct_error FROM fish_model_measurement_accuracy "
+            "ORDER BY image_id"
+        )
+    )
+    return [dict(r._mapping) for r in result]  # pylint: disable=protected-access
+
+
+async def test_accuracy_view_computes_error_against_known_length(session):
+    from fishsense_api.models.fish_model_reference import (  # pylint: disable=import-outside-toplevel
+        FishModelReference,
+    )
+
+    session.add(FishModelReference(name="Grouper", known_length_m=0.360))
+    await session.flush()
+    # Measured 10% long.
+    await _seed_measurement(
+        session, dive_id=1, image_id=11, model_name="Grouper", length_m=0.396
+    )
+
+    rows = await _rows(session)
+
+    assert len(rows) == 1
+    assert rows[0]["model_name"] == "Grouper"
+    assert rows[0]["known_length_m"] == pytest.approx(0.360)
+    assert rows[0]["error_m"] == pytest.approx(0.036, abs=1e-6)
+    assert rows[0]["pct_error"] == pytest.approx(10.0, abs=1e-4)
+
+
+async def test_accuracy_view_excludes_real_fish(session):
+    """Real (wild) fish carry name=NULL and have no reference row — they must
+    not appear, or the view stops being a model-accuracy view."""
+    from datetime import datetime, timezone  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.fish_model_reference import (  # pylint: disable=import-outside-toplevel
+        FishModelReference,
+    )
+
+    session.add(FishModelReference(name="Grouper", known_length_m=0.360))
+    session.add(
+        Dive(
+            id=1,
+            path="/dev/null/1",
+            dive_datetime=datetime(2023, 8, 29, tzinfo=timezone.utc),
+            priority=Priority.HIGH,
+        )
+    )
+    await session.flush()
+    wild = Fish(name=None, species_id=None)
+    session.add(wild)
+    await session.flush()
+    session.add(
+        Image(
+            id=11,
+            path="/dev/null/img-11",
+            taken_datetime=datetime(2023, 8, 29, tzinfo=timezone.utc),
+            checksum="c" * 32,
+            dive_id=1,
+        )
+    )
+    await session.flush()
+    session.add(Measurement(image_id=11, fish_id=wild.id, length_m=0.5))
+    await session.flush()
+
+    assert await _rows(session) == []
+
+
+async def test_accuracy_view_excludes_models_without_a_reference(session):
+    """A model nobody has measured with calipers yet can't be graded — it must
+    be absent rather than silently compared against NULL."""
+    await _seed_measurement(
+        session, dive_id=1, image_id=11, model_name="Unmeasured Model", length_m=0.4
+    )
+
+    assert await _rows(session) == []

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ dev = [
 
 [[package]]
 name = "fishsense-api-workflow-worker"
-version = "1.48.1"
+version = "1.48.2"
 source = { editable = "services/fishsense-api-workflow-worker" }
 dependencies = [
     { name = "boto3" },
@@ -881,7 +881,7 @@ provides-extras = ["laser-detector", "rectified", "slate"]
 
 [[package]]
 name = "fishsense-data-processing-workflow-worker"
-version = "2.13.0"
+version = "2.13.1"
 source = { editable = "services/fishsense-data-processing-workflow-worker" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Why

The physical fish models are the pipeline's **held-out validation set** — their true lengths grade what stage 14 measures, and are deliberately **never** fed into laser calibration (calibration comes from slates only; a benchmark that calibrates from its own answer key measures nothing). Until now those lengths lived in a chat message.

## What

- **`fishmodelreference`** — `name` natural key (matches `Fish.name` / the `Fish Model, <name>` label leaf) + `known_length_m` + `notes`. Seeded by alembic from `views.KNOWN_FISH_MODELS`, so changing a number is a reviewable diff: Snook 0.455, Grouper 0.360, Shark 0.605, Gray Anthias 0.195, Purple Angel 0.192, Yellow Anthias 0.200 (field model dates 2024-08-21 / 2024-10-16). Seed is **insert-if-absent** — re-running never duplicates, never clobbers a hand-corrected length.
- **`fish_model_measurement_accuracy` view** — one row per model measurement with `error_m` and signed `pct_error`, joined through `Fish.name` so new measurements appear automatically. Excludes real (wild) fish (`name IS NULL`) and models with no reference row (ungradeable, rather than compared against NULL). Backs a Superset dashboard.

## Accuracy this makes queryable (median vs known, today)
| dive | 59 | 61 | 58 | 60 | 66 | 76 |
|---|---|---|---|---|---|---|
| err | −1% | −1% | +2% | −3% | −6% | −8% |

Length ∝ laser depth, so a systematic offset here reads as a calibration signal — which is exactly how the dive-77 reflection artifact was caught.

## Tests
Seed invariants (covers the labeled taxonomy / plausible / unique), table round-trip, view semantics (error + pct_error math, real fish excluded, unreferenced models excluded). 259 api tests pass (incl. the alembic-upgrade test exercising the migration); pylint 10/10 via CI's own invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)