### PR TITLE
fix(api-worker): stop the populate child permanently stalling preprocess cohorts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,14 +121,15 @@ laser, 5.1 → headtail, 9 → dive-slate). After
 the parent runs
 `execute_child_workflow("Populate<Stage>LabelStudioProjectWorkflow",
 dive_id, id="populate-<stage>-{dive_id}",
-id_reuse_policy=ALLOW_DUPLICATE_FAILED_ONLY)`. Steady-state behavior
-on the same cohort dive: hour 1 imports tasks; hours 2+ catch
-`WorkflowAlreadyStartedError` and no-op rather than re-importing
-duplicate LS tasks. On-demand invocation is still supported for
-backfill or operator intervention; if you trigger it manually, use a
-non-colliding workflow id (e.g. `populate-laser-393-manual`) so the
-auto-chain's deterministic id stays available for future hourly
-firings.
+id_reuse_policy=ALLOW_DUPLICATE)`. Steady-state on the same cohort
+dive: each firing re-dispatches populate, which is a cheap no-op once
+every eligible image already has a row (the activity selects only
+images without a non-sentinel label row, and
+`import_tasks_and_record_labels` dedupes by URL against tasks already
+in the project). On-demand invocation is still supported for backfill
+or operator intervention; a manual run while the scheduled one is
+in flight still needs a non-colliding id (e.g.
+`populate-laser-393-manual`).
 
 `UpdateDiveImageGroupsWorkflow(dive_id)` is the stage-6.1 on-demand
 workflow: it walks the dive's PREDICTION clusters, looks up each
@@ -161,13 +162,13 @@ work split into two workflows:
      There is no NAS archive step — the JPEGs are durable in Garage.
   6. `execute_child_workflow("Populate<Stage>LabelStudioProjectWorkflow",
      dive_id, id="populate-<stage>-{dive_id}",
-     id_reuse_policy=ALLOW_DUPLICATE_FAILED_ONLY)` — on-demand
-     populate child runs against the same task queue. The reuse
-     policy + deterministic id deduplicate against re-firings of the
-     parent on the same cohort dive — once labels start completing,
-     the dive drops out of the cohort, but if the parent fires twice
-     on the same dive_id (for whatever reason) the second populate
-     hits `WorkflowAlreadyStartedError` and the parent catches it so
+     id_reuse_policy=ALLOW_DUPLICATE)` — on-demand
+     populate child runs against the same task queue. Re-firings on
+     the same cohort dive re-dispatch and no-op at the activity level
+     (dedup is inside the child, not in the reuse policy — see the
+     cluster-correctness section). `WorkflowAlreadyStartedError` is
+     only raised while a prior populate for that dive is still
+     *running*, and the parent catches it so
      the post-cleanup run still completes successfully.
 * **Child** on data-worker (`fishsense_data_processing_queue`). Thin
   pre-input workflow that fans out per-image activities. No SDK
@@ -223,11 +224,26 @@ one replica):
   `WorkflowAlreadyStartedError` is now only raised when a prior child
   with the same id is still *running* (manual run overlapping the
   schedule); the parent catches it and continues to cleanup.
-  The **populate** child (laser/headtail/slate parents) keeps
-  `ALLOW_DUPLICATE_FAILED_ONLY` — duplicate LS `import_tasks` is the
-  task-ballooning bug, so its dedup must stay. **Note:** temporalio's
-  default child `id_reuse_policy` is `ALLOW_DUPLICATE`, so the populate
-  child's FAILED_ONLY is set explicitly.
+  The **populate** child (laser/headtail/slate parents) also uses
+  `ALLOW_DUPLICATE`. It used to be `ALLOW_DUPLICATE_FAILED_ONLY`
+  because duplicate LS `import_tasks` was the task-ballooning bug —
+  but that made a *completed* populate burn the id forever, so a dive
+  that later gained an eligible image (a laser validated after
+  populate ran, an orphan clustered afterwards) could never get an LS
+  task for it, never got a label row, and therefore **never drained
+  from the preprocess cohort** — blocking every higher-id dive behind
+  it while re-staging its raw `.ORF`s from NAS every hour. Prod dive
+  60 (2 missing images) held up dives 84/465/471 that way until
+  2026-08-04. Dedup now lives *inside* the child, where it belongs and
+  where it also protects manual runs: the populate activity selects
+  only images with no non-sentinel label row, and
+  `import_tasks_and_record_labels` dedupes by URL against tasks
+  already in the project (the #343 fix). The laser populate parent had
+  already been flipped for the same reason; headtail/slate followed.
+  If you are tempted to restore FAILED_ONLY, note that it does not
+  actually prevent duplicate imports — a manual run with a different
+  id bypasses it entirely — so the in-child dedup is load-bearing
+  either way.
 * Per-image activities are idempotent: S3 PutObject overwrites,
   SDK upserts.
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_headtail_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_headtail_images_parent_workflow.py
@@ -123,12 +123,24 @@ class PreprocessHeadtailImagesParentWorkflow:
                 dive_id,
                 id=f"populate-headtail-{dive_id}",
                 execution_timeout=timedelta(minutes=30),
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+                # ALLOW_DUPLICATE (not FAILED_ONLY): a completed populate must
+                # not burn the id, or a dive that later gains an eligible image
+                # can never get an LS task for it -> never gets a label row ->
+                # never drains from the cohort, blocking every higher-id dive
+                # behind it while re-staging raw .ORFs every hour (prod dive 60
+                # held up 84/465/471, 2026-08-04). Safe: the child is
+                # idempotent twice over — the activity selects only images with
+                # no non-sentinel label row, and `import_tasks_and_record_labels`
+                # dedupes by URL against tasks already in the project. Matches
+                # the laser populate parent, which already runs ALLOW_DUPLICATE.
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
             )
         except WorkflowAlreadyStartedError:
+            # Only reachable while a prior populate for this dive is still
+            # RUNNING (manual run overlapping the schedule).
             workflow.logger.info(
-                "populate-headtail-%d already ran in a prior hourly firing; "
-                "skipping LS task import",
+                "populate-headtail-%d is still running; skipping duplicate "
+                "dispatch",
                 dive_id,
             )
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_slate_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_slate_images_parent_workflow.py
@@ -132,12 +132,20 @@ class PreprocessSlateImagesParentWorkflow:
                 dive_id,
                 id=f"populate-dive-slate-{dive_id}",
                 execution_timeout=timedelta(minutes=30),
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+                # ALLOW_DUPLICATE (not FAILED_ONLY) — see the headtail parent:
+                # a completed populate burning the id permanently stalls any
+                # dive that later gains an eligible image, and stalls every
+                # higher-id dive behind it. Safe: the child is idempotent twice
+                # over (activity selects only images without a completed label
+                # row; `import_tasks_and_record_labels` dedupes by URL).
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
             )
         except WorkflowAlreadyStartedError:
+            # Only reachable while a prior populate for this dive is still
+            # RUNNING (manual run overlapping the schedule).
             workflow.logger.info(
-                "populate-dive-slate-%d already ran in a prior hourly firing; "
-                "skipping LS task import",
+                "populate-dive-slate-%d is still running; skipping duplicate "
+                "dispatch",
                 dive_id,
             )
 

--- a/services/fishsense-api-workflow-worker/tests/test_preprocess_headtail_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preprocess_headtail_images_parent_workflow.py
@@ -223,3 +223,62 @@ async def test_skips_child_when_no_image_checksums():
     assert result == 440
     assert not child_runs
     assert not populate_runs
+
+
+@pytest.mark.asyncio
+async def test_populate_redispatches_on_a_later_firing_for_the_same_dive():
+    """The prod stall regression (dive 60, 2026-08-04).
+
+    Under `ALLOW_DUPLICATE_FAILED_ONLY` a *completed* `populate-headtail-{id}`
+    burned the id forever, so a dive that later gained an eligible image (a
+    laser validated after populate ran, an orphan clustered afterwards) could
+    never get an LS task for it -> never got a label row -> never drained from
+    the cohort -> blocked every higher-id dive behind it, while re-staging raw
+    .ORFs from NAS every hour. Dive 60 (2 missing images) held up 84/465/471.
+
+    Re-dispatch is safe because the populate child is idempotent twice over:
+    the activity selects only images with no non-sentinel label row, and
+    `import_tasks_and_record_labels` dedupes by URL against tasks already in
+    the project. The laser populate parent already runs ALLOW_DUPLICATE for
+    exactly this reason.
+    """
+    inputs = PreprocessHeadtailImagesInput(
+        dive_id=440,
+        image_checksums=["a", "b"],
+        camera_matrix=_K,
+        distortion_coefficients=_D,
+    )
+    activities = _make_stubs(440, inputs)
+    child_runs: List[tuple] = []
+    populate_runs: List[tuple] = []
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-stage5-1-parent",
+            workflows=[
+                PreprocessHeadtailImagesParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[
+                *activities,
+                _make_populate_recording_activity(populate_runs),
+            ],
+        ), Worker(
+            env.client,
+            task_queue=DATA_PROCESSING_TASK_QUEUE,
+            workflows=[_StubChildWorkflow],
+            activities=[_make_recording_activity(child_runs)],
+        ):
+            # Two hourly firings against the same cohort dive.
+            for _ in range(2):
+                await env.client.execute_workflow(
+                    PreprocessHeadtailImagesParentWorkflow.run,
+                    id=f"test-stage5-1-parent-{uuid.uuid4()}",
+                    task_queue="test-stage5-1-parent",
+                )
+
+    assert populate_runs == [
+        ("populate-headtail-440", 440),
+        ("populate-headtail-440", 440),
+    ], "the second firing must re-dispatch populate, or the dive can never drain"

--- a/services/fishsense-api-workflow-worker/tests/test_preprocess_slate_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preprocess_slate_images_parent_workflow.py
@@ -235,3 +235,58 @@ async def test_skips_child_when_no_image_checksums():
     assert result == 440
     assert not child_runs
     assert not populate_runs
+
+
+@pytest.mark.asyncio
+async def test_populate_redispatches_on_a_later_firing_for_the_same_dive():
+    """Same stall regression as the headtail parent (prod dive 60, 2026-08-04).
+
+    `ALLOW_DUPLICATE_FAILED_ONLY` let a *completed* populate burn the child id
+    forever, so a dive that later gained an eligible image never got an LS task
+    for it, never got a label row, and never drained from the cohort — blocking
+    every higher-id dive behind it. Re-dispatch is safe: the populate activity
+    selects only images without a completed label row, and
+    `import_tasks_and_record_labels` dedupes by URL against the project.
+    """
+    inputs = PreprocessSlateImagesInput(
+        dive_id=440,
+        image_checksums=["a"],
+        slate_id=7,
+        slate_dpi=300,
+        reference_points=[(0.0, 0.0), (1.0, 1.0)],
+        camera_matrix=_K,
+        distortion_coefficients=_D,
+    )
+    activities = _make_stubs(440, inputs)
+    child_runs: List[tuple] = []
+    populate_runs: List[tuple] = []
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-stage9-parent-redispatch",
+            workflows=[
+                PreprocessSlateImagesParentWorkflow,
+                _StubPopulateWorkflow,
+            ],
+            activities=[
+                *activities,
+                _make_populate_recording_activity(populate_runs),
+            ],
+        ), Worker(
+            env.client,
+            task_queue=DATA_PROCESSING_TASK_QUEUE,
+            workflows=[_StubChildWorkflow],
+            activities=[_make_recording_activity(child_runs)],
+        ):
+            for _ in range(2):
+                await env.client.execute_workflow(
+                    PreprocessSlateImagesParentWorkflow.run,
+                    id=f"test-stage9-parent-redispatch-{uuid.uuid4()}",
+                    task_queue="test-stage9-parent-redispatch",
+                )
+
+    assert populate_runs == [
+        ("populate-dive-slate-440", 440),
+        ("populate-dive-slate-440", 440),
+    ], "the second firing must re-dispatch populate, or the dive can never drain"

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "fishsense-api"
-version = "1.39.0"
+version = "1.40.0"
 source = { editable = "services/fishsense-api" }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## The bug

The headtail (5.1) and dive-slate (9) preprocess parents dispatched their populate child with `ALLOW_DUPLICATE_FAILED_ONLY`, so a **completed** `populate-<stage>-{dive_id}` burned the id forever. A dive that later gained an eligible image (laser validated after populate ran, orphan clustered afterwards) could then **never** get an LS task for it → never got a label row → **never drained from the cohort**. And since the cohort is id-ordered and drains one dive per hourly firing, that dive **blocked every higher-id dive behind it, indefinitely** — while re-staging its raw `.ORF`s from NAS every hour for nothing.

**Observed in prod 2026-08-04:** dive 60 needed tasks for just 2 images and had been holding up dives 84/465/471 in stage 5.1, logging `populate-headtail-60 already ran in a prior hourly firing; skipping LS task import` on every firing. Unblocked operationally by running the populate child directly with a fresh id (2 tasks for dive 60, 39 for dive 84); both drained immediately after.

## The fix

Flip both to `ALLOW_DUPLICATE`. **Dedup belongs inside the child, not in the reuse policy** — and it already lives there twice over:
1. the populate activity selects only images with no non-sentinel label row, and
2. `import_tasks_and_record_labels` dedupes by URL against tasks already in the project (the #343 fix for the very task-ballooning incident that motivated FAILED_ONLY).

The **laser populate parent was already `ALLOW_DUPLICATE`** with this exact rationale — this brings headtail/slate in line with the proven pattern.

Also worth noting: FAILED_ONLY never actually prevented duplicate imports — a manual run with a different id bypasses it entirely — so the in-child dedup is load-bearing either way.

## Docs
CLAUDE.md stated this dedup "must stay". Corrected in all three places, recording the failure mode and why the original premise no longer holds, so it isn't reintroduced.

## Tests (TDD)
A failing two-firing regression test per parent: the second firing must re-dispatch populate, or the dive can never drain. Both reproduced the stall before the fix. 346 api-worker tests pass; pylint 10/10 via CI's own invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)