### PR TITLE
fix(api-worker): stop the populate supersede pass clobbering its own import

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_dive_slate_label_studio_project_activity.py
@@ -217,10 +217,20 @@ async def populate_dive_slate_label_studio_project_activity(
                 dive_id,
             )
 
-        # Supersede pass: retire previously-incomplete slate rows so new ones
-        # are canonical (mirrors headtail/species). Only already-persisted rows.
+        refreshed_image_ids = {image.id for image in images}
+
+        # Supersede pass: dead-letter incomplete slate rows belonging to a
+        # DIFFERENT (legacy) project so this project's rows are canonical.
+        # Rows for images this run just imported are exempt:
+        # `put_dive_slate_label` upserts on `image_id`, so the "old" row IS
+        # the one the import just refreshed —
+        # superseding it undoes this run's own work, and alternates run to run
+        # because the snapshot predates the import. Same bug hit headtail on
+        # prod dive 341 (2026-08-04); mirrors species populate's guard.
         for old in existing_slate:
             if old.completed or old.superseded or old.id is None:
+                continue
+            if old.image_id in refreshed_image_ids:
                 continue
             old.superseded = True
             await fs.labels.put_dive_slate_label(old.image_id, old)

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_headtail_label_studio_project_activity.py
@@ -152,13 +152,26 @@ async def populate_headtail_label_studio_project_activity(
                 dive_id,
             )
 
-        # Supersede pass: mark all previously-incomplete headtail labels
-        # for this dive as superseded so newly-created rows are canonical.
-        # Mirrors the notebook's behavior. Only acts on rows with an `id`
-        # (i.e. already-persisted) — newly-inserted rows from the import
-        # block above don't yet have one in this scope.
+        refreshed_image_ids = {image.id for image in targets}
+
+        # Supersede pass: dead-letter incomplete headtail rows that belong to
+        # a DIFFERENT (legacy, pre-per-dive) project, so this project's rows
+        # are canonical. Only acts on rows with an `id` (already persisted).
+        #
+        # Rows for images THIS RUN just imported are exempt.
+        # `put_headtail_label` upserts on `image_id`, so there is only ever one
+        # row per image — the "old" row here IS the row the import refreshed.
+        # Superseding it undoes this run's own work, and because the pass
+        # reads a snapshot taken BEFORE the import (and skips already-
+        # superseded rows), the outcome ALTERNATES run to run: live ->
+        # superseded -> live... Prod dive 341 oscillated that way on every
+        # hourly firing and activity retry, so its images never held a usable
+        # pending row and the dive never drained from the stage-5.1 cohort.
+        # Mirrors the guard species populate already carries.
         for old in existing_headtail:
             if old.completed or old.superseded or old.id is None:
+                continue
+            if old.image_id in refreshed_image_ids:
                 continue
             old.superseded = True
             await fs.labels.put_headtail_label(old.image_id, old)

--- a/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
@@ -186,11 +186,11 @@ def _make_ls_client(returned_task_ids: List[int]):
 
 @pytest.mark.asyncio
 async def test_imports_targets_and_supersedes_incomplete_old_rows(monkeypatch):
-    """Image 1 has a completed old row -> skip. Image 2 has an
-    incomplete old row with id -> get a new task AND old row gets
-    superseded. Image 3 is fresh -> get a new task. Image 4 has an
-    incomplete old row but no `id` -> superseded skipped (can't
-    update without an id) but the new task still goes through."""
+    """Image 1 has a completed old row -> skip. Image 2 has an incomplete old
+    row with id IN THIS PROJECT -> re-imported, and must NOT be superseded
+    (see the flip-flop regression below). Image 3 is fresh -> new task.
+    Image 4 has an incomplete old row but no `id` -> superseded skipped
+    (can't update without an id) but the new task still goes through."""
     laser = [
         _laser(1),
         _laser(2),
@@ -226,7 +226,10 @@ async def test_imports_targets_and_supersedes_incomplete_old_rows(monkeypatch):
     superseded_writes = [w for w in written if w.id is not None and w.superseded]
 
     assert {w.image_id for w in new_writes} == {2, 3, 4}
-    assert {w.image_id for w in superseded_writes} == {2}
+    assert not superseded_writes, (
+        "rows in the project being populated were just refreshed by the "
+        "import; superseding them undoes this run's own work"
+    )
 
 
 @pytest.mark.asyncio
@@ -290,3 +293,68 @@ async def test_does_not_publish_empty_project(monkeypatch):
     )
 
     ls.projects.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_running_twice_does_not_flip_rows_back_to_superseded(monkeypatch):
+    """The prod flip-flop (dive 341, 2026-08-04).
+
+    `put_headtail_label` upserts on `image_id`, so there is only ever ONE row
+    per image — meaning the "old" row the supersede pass retires IS the row the
+    import just created. The pass reads a snapshot taken BEFORE the import and
+    skips rows already superseded, so the outcome ALTERNATES between runs:
+    superseded -> live -> superseded -> ... Each hourly firing (and each
+    activity retry) toggled it, so the dive oscillated in and out of the
+    stage-5.1 cohort and its labeler tasks flickered between live and
+    dead-lettered.
+
+    Second run must be a no-op on the row state. Mirrors the guard species
+    populate already has (`old.label_studio_project_id == project_id`).
+    """
+    laser = [_laser(1)]
+    images_by_id = {1: _image(1, "a")}
+    # State after a first populate: a live, incomplete row in THIS project.
+    existing = [_headtail_label(1, completed=False, has_id=True)]
+
+    fs = _make_fs_client(laser, existing, images_by_id)
+    ls = _make_ls_client(returned_task_ids=[4001])
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+
+    await ActivityEnvironment().run(
+        sut.populate_headtail_label_studio_project_activity, 42, 71
+    )
+
+    written = [c.args[1] for c in fs.labels.put_headtail_label.await_args_list]
+    assert not [w for w in written if w.superseded], (
+        "a re-run must leave the pending row live, or the dive never drains"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stale_rows_for_non_target_images_are_still_superseded(monkeypatch):
+    """The supersede pass keeps its job. Image 2's laser is no longer valid, so
+    it is NOT re-imported this run — its lingering incomplete row is genuinely
+    stale and must be dead-lettered. Only images the import just refreshed are
+    exempt."""
+    laser = [_laser(1), _laser(2, superseded=True)]
+    images_by_id = {1: _image(1, "a"), 2: _image(2, "b")}
+    existing = [
+        _headtail_label(1, completed=False, has_id=True),  # target -> exempt
+        _headtail_label(2, completed=False, has_id=True),  # not a target -> stale
+    ]
+
+    fs = _make_fs_client(laser, existing, images_by_id)
+    ls = _make_ls_client(returned_task_ids=[4002])
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+
+    await ActivityEnvironment().run(
+        sut.populate_headtail_label_studio_project_activity, 42, 71
+    )
+
+    written = [c.args[1] for c in fs.labels.put_headtail_label.await_args_list]
+    superseded = [w for w in written if w.id is not None and w.superseded]
+    assert {w.image_id for w in superseded} == {2}

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "fishsense-api"
-version = "1.40.0"
+version = "1.41.0"
 source = { editable = "services/fishsense-api" }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## The bug

Head/tail and dive-slate populate end with a pass that supersedes "previously-incomplete" rows so new ones are canonical. But `put_*_label` **upserts on `image_id`** — there is only ever one row per image, so the "old" row being retired **is the row the import just created**.

The pass reads a snapshot taken *before* the import and skips already-superseded rows, so the result **alternates every run**: superseded → live → superseded → …

**Caught live in prod (dive 341):** 145 completed rows, 50 superseded-incomplete, and **zero usable pending rows**. Its 16 outstanding images never held a live task, so the dive never drained from the stage-5.1 cohort and its labeler tasks flickered between live and dead-lettered. Running populate once by hand flipped exactly those 16 back to live — confirming the mechanism.

## Fix

Exempt images the run just imported (`refreshed_image_ids`). The pass keeps its real job: dead-lettering incomplete rows for images that were **not** re-imported (laser later superseded, or a legacy shared-project row) — still covered by the existing no-valid-targets test. **Species populate already had an equivalent guard**; headtail and slate never got one.

## Relationship to #516

Pre-existing — activity retries alone trigger it (dive 341's populate failed 3× then succeeded, toggling each attempt). But #516 raised exposure from a one-off parity lottery to an **hourly oscillation**, so it went from latent to actively harmful. Worth noting the pair: #516 let populate re-run; this makes re-running idempotent, which is what #516 assumed.

## Tests (TDD)
Second run leaves pending rows live (flip-flop regression, reproduced failing first); stale rows for non-target images still superseded; the existing import test no longer asserts the buggy self-supersede.

348 api-worker tests pass; pylint 10/10 via CI's own invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)