### PR TITLE
fix(api-worker): gate headtail + slate populate on JPEG presence

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_dive_slate_label_studio_project_activity.py
@@ -128,6 +128,33 @@ def _select_target_image_ids(
     ]
 
 
+async def _gate_on_jpeg_presence(images: List[Image]) -> List[Image]:
+    """Keep only images whose stage-9 slate JPEG is already in Garage.
+
+    A task whose `s3://` URI has no object behind it shows the labeler a
+    missing image, and recording the row also drops the dive out of the
+    stage-9 cohort so the JPEG can never be rendered afterwards. Deferring
+    costs nothing — the image returns on a later run. Mirrors species and
+    headtail populate; see the dive-84 incident (2026-08-04).
+    """
+    if not images:
+        return images
+    store = open_object_store_client()
+    present: List[Image] = []
+    for image in images:
+        if await store.has_processed_jpeg(DIVE_SLATE_FOLDER, image.checksum):
+            present.append(image)
+        else:
+            activity.logger.info(
+                "slate JPEG not yet in Garage for image %d (checksum=%s); "
+                "deferring to a later populate run",
+                image.id,
+                image.checksum,
+            )
+        activity.heartbeat()
+    return present
+
+
 def _build_task(image: Image, prediction=None, panel_width: float = 0.0) -> dict:
     """Build an LS task. Emits both `image` and `img` keys to satisfy legacy LS
     labeling-config XML across prod projects. Seeds a keypoint pre-annotation
@@ -171,6 +198,8 @@ async def populate_dive_slate_label_studio_project_activity(
             if image is not None:
                 images.append(image)
             activity.heartbeat()
+
+        images = await _gate_on_jpeg_presence(images)
 
         if images:
             def _task(image: Image) -> dict:

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_headtail_label_studio_project_activity.py
@@ -36,6 +36,7 @@ from fishsense_api_workflow_worker.activities.populate_utils import (
     publish_label_studio_project,
 )
 from fishsense_api_workflow_worker.activities.utils import get_fs_client
+from fishsense_api_workflow_worker.object_store import open_object_store_client
 
 # Physical Garage prefix the data-worker writes head/tail JPEGs to
 # (stage 5.1). Was the nginx virtual name "headtail_jpeg".
@@ -78,6 +79,36 @@ def _select_target_images(
     return selected
 
 
+async def _gate_on_jpeg_presence(images: List[Image]) -> List[Image]:
+    """Keep only images whose stage-5.1 head/tail JPEG is already in Garage.
+
+    A task whose `s3://` URI has no object behind it shows the labeler a
+    missing image — and because recording it writes a non-sentinel row, the
+    dive also drops out of the stage-5.1 cohort, so the JPEG can never be
+    rendered afterwards. Prod dive 84 wedged exactly that way on 2026-08-04
+    (36 of 39 tasks pointed at nothing) after populate was run standalone.
+    Deferring costs nothing: the image is picked up on a later run once
+    preprocess has written it, and this is a no-op when populate is chained
+    right after preprocess. Mirrors species populate's gate.
+    """
+    if not images:
+        return images
+    store = open_object_store_client()
+    present: List[Image] = []
+    for image in images:
+        if await store.has_processed_jpeg(HEADTAIL_FOLDER, image.checksum):
+            present.append(image)
+        else:
+            activity.logger.info(
+                "headtail JPEG not yet in Garage for image %d (checksum=%s); "
+                "deferring to a later populate run",
+                image.id,
+                image.checksum,
+            )
+        activity.heartbeat()
+    return present
+
+
 def _build_task(image: Image) -> dict:
     """Build an LS task. Emits both `image` and `img` keys to satisfy
     legacy LS labeling-config XML across prod projects — see
@@ -116,6 +147,8 @@ async def populate_headtail_label_studio_project_activity(
         targets = _select_target_images(
             laser_labels, images_by_id, existing_headtail
         )
+        # Never seed a task for an image the data-worker hasn't rendered.
+        targets = await _gate_on_jpeg_presence(targets)
 
         new_count = 0
         if targets:

--- a/services/fishsense-api-workflow-worker/tests/test_populate_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_dive_slate_label_studio_project_activity.py
@@ -77,6 +77,15 @@ def _slate_label(image_id: int, *, completed: bool) -> DiveSlateLabel:
     )
 
 
+@pytest.fixture(autouse=True)
+def _all_jpegs_present(monkeypatch):
+    """Default the JPEG gate to "present"; the gate test overrides it."""
+    store = MagicMock()
+    store.has_processed_jpeg = AsyncMock(return_value=True)
+    monkeypatch.setattr(sut, "open_object_store_client", lambda: store)
+    return store
+
+
 def test_select_targets_filters_by_slate_marker_and_completion():
     species = [
         _species_label(1, content=sut.SLATE_CONTENT_MARKER),
@@ -295,3 +304,32 @@ def test_build_task_seeds_prediction_only_when_present():
     seeded = sut._build_task(_image(11, "c11"), pred, 4967.5)
     assert seeded["predictions"] and seeded["predictions"][0]["result"]
     assert not sut._build_task(_image(12, "c12"))["predictions"]
+
+
+@pytest.mark.asyncio
+async def test_defers_images_whose_jpeg_is_not_in_garage(monkeypatch):
+    """Same gate as species/headtail: never seed a task for an unrendered
+    image, or the labeler sees a missing image and the dive leaves the
+    stage-9 cohort that would have rendered it."""
+    species = [
+        _species_label(1, content=sut.SLATE_CONTENT_MARKER),
+        _species_label(3, content=sut.SLATE_CONTENT_MARKER),
+    ]
+    images_by_id = {1: _image(1, "a"), 3: _image(3, "c")}
+    fs = _make_fs_client(species, existing_slate=[], images_by_id=images_by_id)
+    ls = _make_ls_client(returned_task_ids=[6001])
+
+    store = MagicMock()
+    store.has_processed_jpeg = AsyncMock(side_effect=lambda folder, checksum: checksum == "a")
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+    monkeypatch.setattr(sut, "open_object_store_client", lambda: store)
+
+    n = await ActivityEnvironment().run(
+        sut.populate_dive_slate_label_studio_project_activity, 42, 66
+    )
+
+    assert n == 1
+    written = [c.args[1] for c in fs.labels.put_dive_slate_label.await_args_list]
+    assert {w.image_id for w in written} == {1}

--- a/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
@@ -91,6 +91,17 @@ def _headtail_label(
     )
 
 
+@pytest.fixture(autouse=True)
+def _all_jpegs_present(monkeypatch):
+    """Default the JPEG gate to "present" so activity tests exercise the
+    import path; the gate test overrides this with a selective fake.
+    Mirrors the species populate test harness."""
+    store = MagicMock()
+    store.has_processed_jpeg = AsyncMock(return_value=True)
+    monkeypatch.setattr(sut, "open_object_store_client", lambda: store)
+    return store
+
+
 def test_select_targets_filters_by_valid_laser_and_drops_completed():
     laser = [
         _laser(1),                             # valid + completed headtail -> drop
@@ -358,3 +369,41 @@ async def test_stale_rows_for_non_target_images_are_still_superseded(monkeypatch
     written = [c.args[1] for c in fs.labels.put_headtail_label.await_args_list]
     superseded = [w for w in written if w.id is not None and w.superseded]
     assert {w.image_id for w in superseded} == {2}
+
+
+@pytest.mark.asyncio
+async def test_defers_images_whose_jpeg_is_not_in_garage(monkeypatch):
+    """Never seed a task for an image the data-worker hasn't rendered yet.
+
+    A task whose `s3://` URI has no object behind it shows the labeler a
+    missing image, and — because the new row is non-sentinel — it also drops
+    the dive out of the stage-5.1 cohort, so the JPEG can never be rendered.
+    Prod dive 84 landed in exactly that state on 2026-08-04 (36 of 39 tasks
+    pointed at nothing) after populate was run standalone to unblock it.
+    Species populate has gated on JPEG presence for this reason; headtail
+    didn't. Deferring is safe: the image returns on a later run.
+    """
+    laser = [_laser(1), _laser(2)]
+    images_by_id = {1: _image(1, "a"), 2: _image(2, "b")}
+
+    fs = _make_fs_client(laser, [], images_by_id)
+    ls = _make_ls_client(returned_task_ids=[5001])
+
+    # Only image 1's JPEG exists.
+    class _Store:
+        async def has_processed_jpeg(self, folder, checksum):
+            assert folder == sut.HEADTAIL_FOLDER
+            return checksum == "a"
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+    store = _Store()
+    monkeypatch.setattr(sut, "open_object_store_client", lambda: store)
+
+    n = await ActivityEnvironment().run(
+        sut.populate_headtail_label_studio_project_activity, 42, 71
+    )
+
+    assert n == 1, "only the image with a rendered JPEG is seeded"
+    written = [c.args[1] for c in fs.labels.put_headtail_label.await_args_list]
+    assert {w.image_id for w in written} == {1}

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ dev = [
 
 [[package]]
 name = "fishsense-api-workflow-worker"
-version = "1.48.3"
+version = "1.48.4"
 source = { editable = "services/fishsense-api-workflow-worker" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Why

Species populate refuses to seed a task for an image whose JPEG isn't in Garage yet. **Head/tail and slate populate had no such gate**, so they can create LS tasks pointing at objects that don't exist — the labeler opens the task and sees a missing image.

Worse, it's **self-wedging**: recording the task writes a non-sentinel label row, which drops the dive out of the preprocess cohort, so the JPEG can never be rendered afterwards.

**Prod dive 84 hit exactly this on 2026-08-04** — 36 of 39 head/tail tasks pointed at nothing (found by clicking a task and seeing a blank image). Recovery required manually superseding the pending rows so the dive would re-enter the cohort and render.

## Why it's reachable

Populate's selection (*"no completed label"*) is **broader** than the preprocess resolver's (*"no non-sentinel row"*), so populate can always be handed images the data-worker never rendered — via a manual unblock run, or via any future decoupling of populate from preprocess. That's precisely why species, already on its own schedule, needed this gate first.

## Behaviour

Deferring costs nothing — the image returns on a later run once preprocess has written the JPEG — and the gate is a no-op when populate is chained straight after preprocess.

## Tests (TDD)
An image with no JPEG is not seeded and gets no label row, for both head/tail and slate (both reproduced failing first). Existing activity tests get an autouse "all JPEGs present" fixture mirroring the species test harness.

350 api-worker tests pass; pylint 10/10 via CI's own invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)