### PR TITLE
feat: invalidate stale measurement bindings after a species relabel

### DIFF
--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/fish_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/fish_client.py
@@ -123,6 +123,24 @@ class FishClient(ClientBase):
         response.raise_for_status()
         return response.json()
 
+    async def delete_measurement(self, fish_id: int, image_id: int) -> None:
+        """Delete the measurement binding `image_id` to `fish_id`.
+
+        Used by stage 14 to invalidate a measurement whose fish identity went
+        stale after a species relabel. Re-measuring alone can't fix that:
+        `post_measurement` upserts on `(image_id, fish_id)`, so the corrected
+        binding would be added alongside the old one. Idempotent server-side —
+        deleting an absent binding is a no-op.
+
+        Args:
+            fish_id (int): The fish the stale measurement is bound to.
+            image_id (int): The image whose binding should be removed.
+        """
+        response = await self._delete(
+            f"/api/v1/fish/{fish_id}/measurements/{image_id}"
+        )
+        response.raise_for_status()
+
     async def get_species_by_scientific_name(
         self, scientific_name: str
     ) -> Species | None:

--- a/libs/fishsense-api-sdk/tests/clients/test_fish_client.py
+++ b/libs/fishsense-api-sdk/tests/clients/test_fish_client.py
@@ -411,3 +411,27 @@ class TestFishClient:
 
             async with client:
                 assert await client.get_measurements(999) is None
+
+    async def test_delete_measurement(self):
+        """Stage 14 invalidates a stale (image, fish) binding after a relabel."""
+        semaphore = asyncio.Semaphore(10)
+        client = FishClient(
+            base_url="http://test.com",
+            username="testuser",
+            password="testpass",
+            timeout=10,
+            semaphore=semaphore,
+        )
+
+        mock_response = Mock()
+        mock_response.status_code = 204
+        mock_response.raise_for_status = Mock()
+
+        with patch.object(client, "_delete", new_callable=AsyncMock) as mock_delete:
+            mock_delete.return_value = mock_response
+
+            async with client:
+                await client.delete_measurement(101, 11)
+                mock_delete.assert_called_once_with(
+                    "/api/v1/fish/101/measurements/11"
+                )

--- a/services/fishsense-api/src/fishsense_api/controllers/fish_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/fish_controller.py
@@ -155,6 +155,46 @@ async def post_measurement(
     return measurement_id
 
 
+@app.delete("/api/v1/fish/{fish_id}/measurements/{image_id}", status_code=204)
+async def delete_measurement(
+    fish_id: int,
+    image_id: int,
+    session: AsyncSession = Depends(get_async_session),
+) -> None:
+    """Delete the measurement binding `image_id` to `fish_id`.
+
+    Exists so stage 14 can invalidate a measurement whose fish identity went
+    stale — a species relabel (e.g. `Fish Model, Snook` -> `Fish Model,
+    Grouper`) leaves the row bound to the old model's Fish, and re-measuring
+    cannot fix it: `post_measurement` upserts on `(image_id, fish_id)`, so the
+    corrected binding would be ADDED alongside and the image double-counted.
+
+    Keyed on the same natural key as the upsert, not on `image_id` alone, so a
+    frame holding two fish only loses the binding named here. Idempotent: a
+    missing row is already the desired state, so no 404 — that keeps activity
+    retries safe.
+    """
+    logger.debug(
+        "Deleting measurement for image_id=%d fish_id=%d", image_id, fish_id
+    )
+    existing = (
+        await session.exec(
+            select(Measurement)
+            .where(Measurement.image_id == image_id)
+            .where(Measurement.fish_id == fish_id)
+        )
+    ).first()
+    if existing is None:
+        logger.debug(
+            "No measurement for image_id=%d fish_id=%d; nothing to delete",
+            image_id,
+            fish_id,
+        )
+        return
+    await session.delete(existing)
+    await session.flush()
+
+
 @app.get("/api/v1/fish/species/{scientific_name}")
 async def get_species_by_scientific_name(
     scientific_name: str, session: AsyncSession = Depends(get_async_session)

--- a/services/fishsense-api/tests/test_measurements_endpoint.py
+++ b/services/fishsense-api/tests/test_measurements_endpoint.py
@@ -202,3 +202,54 @@ async def test_post_measurement_binds_fish_id_from_path(session):
 
     rows = (await session.exec(select(Measurement))).all()
     assert rows[0].fish_id == 101
+
+
+# ── DELETE: invalidating a stale (image, fish) binding ───────────────
+#
+# A species relabel (e.g. "Fish Model, Snook" -> "Fish Model, Grouper") leaves
+# the measurement bound to the OLD model's Fish. It can't be fixed by
+# re-measuring: `post_measurement` upserts on (image_id, fish_id), so writing
+# the corrected binding ADDS a second row and the image is double-counted.
+# The stale row has to be deleted. Happened for real on prod images
+# 4375/4664/4868 (2026-08-04), fixed by hand.
+
+
+async def _delete(session, fish_id: int, image_id: int):
+    from fishsense_api.controllers.fish_controller import (  # pylint: disable=import-outside-toplevel
+        delete_measurement,
+    )
+
+    return await delete_measurement(fish_id, image_id, session=session)
+
+
+async def test_delete_measurement_removes_only_that_binding(session):
+    """Two fish in one frame is legitimate — deleting one must leave the other."""
+    await _seed_dive(session, 1, [11])
+    session.add_all([_fish(101), _fish(102)])
+    await session.flush()
+    session.add_all(
+        [_measurement(1, 11, 101, 0.30), _measurement(2, 11, 102, 0.40)]
+    )
+    await session.flush()
+
+    await _delete(session, 101, 11)
+    await session.flush()
+
+    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+
+    rows = (await session.exec(select(Measurement))).all()
+    assert [(r.image_id, r.fish_id) for r in rows] == [(11, 102)]
+
+
+async def test_delete_measurement_is_idempotent(session):
+    """Deleting an absent binding is a no-op, so a retry can't fail."""
+    await _seed_dive(session, 1, [11])
+    session.add_all([_fish(101)])
+    await session.flush()
+
+    await _delete(session, 101, 11)  # nothing there — must not raise
+    await session.flush()
+
+    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+
+    assert (await session.exec(select(Measurement))).all() == []

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/measure_fish_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/measure_fish_activity.py
@@ -63,6 +63,11 @@ class MeasureFishResult:
     # previously tallied as `missing_laser_or_headtail`, which pointed
     # debugging at the labels instead of at the taxonomy branch.
     skipped_unmeasurable_species: int = 0
+    # Measurements deleted because their Fish binding no longer matches the
+    # image's species label — a model relabel (e.g. Snook -> Grouper) leaves
+    # the row bound to the old model's Fish, and `post_measurement` upserts on
+    # (image_id, fish_id) so re-measuring would ADD a row rather than replace.
+    invalidated_stale_binding: int = 0
 
 
 __all__ = ["MeasureFishResult", "measure_fish_activity"]
@@ -215,14 +220,20 @@ def _filter_top_three(
     ]
 
 
-async def _fetch_measured_image_ids(fs, dive_id: int) -> set[int]:
-    """Image ids in this dive that already carry a Measurement.
+async def _fetch_measurements_by_image(fs, dive_id: int) -> dict[int, list]:
+    """Existing measurements for this dive, grouped by image id.
 
     One fetch per dive, not per image — the caller loops over every
     top-three label. `None` is the SDK's "no measurements yet" signal.
+    Grouped (rather than a bare id set) so the caller can also check WHICH
+    Fish each row is bound to and invalidate stale bindings.
     """
     existing = await fs.fish.get_measurements(dive_id) or []
-    return {m.image_id for m in existing if m.image_id is not None}
+    by_image: dict[int, list] = {}
+    for measurement in existing:
+        if measurement.image_id is not None:
+            by_image.setdefault(measurement.image_id, []).append(measurement)
+    return by_image
 
 
 def _has_complete_keypoints(laser_label, headtail_label) -> bool:
@@ -241,7 +252,7 @@ def _has_complete_keypoints(laser_label, headtail_label) -> bool:
 
 @activity.defn
 async def measure_fish_activity(dive_id: int) -> MeasureFishResult:
-    # pylint: disable=too-many-locals,too-many-statements
+    # pylint: disable=too-many-locals,too-many-statements,too-many-branches
     # Orchestration function — gathers dive/camera/laser/cluster/label
     # context plus per-iteration locals. Splitting it would just push
     # the same state into a parameter list of a helper. The same applies
@@ -285,7 +296,7 @@ async def measure_fish_activity(dive_id: int) -> MeasureFishResult:
         # `post_measurement` upserts on (image_id, fish_id) so a duplicate
         # can't be recorded, but re-measuring still means re-deriving a
         # length and re-binding a fish for work already done — skip it.
-        already_measured = await _fetch_measured_image_ids(fs, dive_id)
+        measurements_by_image = await _fetch_measurements_by_image(fs, dive_id)
 
         result = MeasureFishResult(
             measured=0,
@@ -300,18 +311,11 @@ async def measure_fish_activity(dive_id: int) -> MeasureFishResult:
         for species_label in top_three:
             image_id = species_label.image_id
 
-            if image_id in already_measured:
-                activity.logger.info(
-                    "dive_id=%d image_id=%d: already measured; skipping",
-                    dive_id, image_id,
-                )
-                result.skipped_already_measured += 1
-                continue
-
-            # Classify the taxonomy branch first. Real fish carry a
-            # "Common (Scientific)" name; models carry a "Fish Model, <name>"
-            # prefix. Anything else (Calibration Targets, empty) is not
-            # measurable.
+            # Classify the taxonomy branch first — the stale-binding check
+            # below needs to know which Fish this image *should* map to.
+            # Real fish carry a "Common (Scientific)" name; models carry a
+            # "Fish Model, <name>" prefix. Anything else (Calibration
+            # Targets, empty) is not measurable.
             names = _parse_species_names(species_label.content_of_image)
             model_name = _parse_model_name(species_label.content_of_image)
             if names is None and model_name is None:
@@ -322,6 +326,40 @@ async def measure_fish_activity(dive_id: int) -> MeasureFishResult:
                     dive_id, image_id, species_label.content_of_image,
                 )
                 result.skipped_unmeasurable_species += 1
+                continue
+
+            existing_measurements = measurements_by_image.get(image_id, [])
+            if model_name is not None and existing_measurements:
+                # Model identity is the name, so the correct Fish is knowable
+                # up front. Any row bound to a different Fish is stale — the
+                # image was measured under a previous species label. Delete it
+                # rather than re-measuring around it: `post_measurement`
+                # upserts on (image_id, fish_id), so a corrected binding would
+                # be ADDED alongside and the image counted twice.
+                expected = await _ensure_model_fish(fs, model_name, model_fish_cache)
+                stale = [
+                    m for m in existing_measurements if m.fish_id != expected.id
+                ]
+                for measurement in stale:
+                    activity.logger.info(
+                        "dive_id=%d image_id=%d: measurement bound to fish_id=%s "
+                        "but the label now says %r (fish_id=%s); invalidating "
+                        "the stale binding",
+                        dive_id, image_id, measurement.fish_id,
+                        model_name, expected.id,
+                    )
+                    await fs.fish.delete_measurement(measurement.fish_id, image_id)
+                    result.invalidated_stale_binding += 1
+                existing_measurements = [
+                    m for m in existing_measurements if m.fish_id == expected.id
+                ]
+
+            if existing_measurements:
+                activity.logger.info(
+                    "dive_id=%d image_id=%d: already measured; skipping",
+                    dive_id, image_id,
+                )
+                result.skipped_already_measured += 1
                 continue
 
             # Real fish anchor identity to their LABEL_STUDIO cluster, so a

--- a/services/fishsense-data-processing-workflow-worker/tests/test_measure_fish_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_measure_fish_activity.py
@@ -213,6 +213,7 @@ def _make_fs(  # pylint: disable=too-many-arguments
     fs.fish.post_species = AsyncMock(return_value=new_species_id)
     fs.fish.get = AsyncMock(return_value=None)
     fs.fish.get_by_name = AsyncMock(side_effect=(model_fish_lookup or {}).get)
+    fs.fish.delete_measurement = AsyncMock(return_value=None)
     fs.fish.post = AsyncMock(return_value=new_fish_id)
     fs.fish.post_measurement = AsyncMock(return_value=None)
     # `None` is the SDK's "dive has no measurements yet" signal (404).
@@ -745,3 +746,104 @@ async def test_same_model_across_clusters_resolves_to_one_fish(monkeypatch):
     fs.fish.post.assert_awaited_once()  # created once, reused for the second
     fish_ids = {c.args[0] for c in fs.fish.post_measurement.call_args_list}
     assert fish_ids == {700}, "same model -> one Fish"
+
+
+@pytest.mark.asyncio
+async def test_stale_model_binding_is_invalidated_and_remeasured(monkeypatch):
+    """A species relabel leaves the measurement bound to the OLD model's Fish.
+
+    Stage 14 skips already-measured images, so without this the wrong binding
+    is frozen forever — and it can't be fixed by re-measuring alone, because
+    `post_measurement` upserts on (image_id, fish_id) and would ADD the
+    corrected row alongside the stale one, double-counting the image.
+    Happened on prod images 4375/4664/4868 (2026-08-04), fixed by hand.
+
+    Here the image is now labeled Grouper but carries a measurement bound to
+    the Snook Fish: delete the stale binding, then measure against Grouper.
+    """
+    image_id = 100
+    le, head_pix, tail_pix, laser_pix = _model_observation()
+    snook = Fish(id=901, name="Snook", species_id=None)
+    grouper = Fish(id=902, name="Grouper", species_id=None)
+
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_camera_intrinsics(),
+        laser_extrinsics=le,
+        species_labels=[_species_label(image_id, content="Fish Model, Grouper")],
+        laser_labels={image_id: _laser_label(image_id, *laser_pix)},
+        headtail_labels={image_id: _headtail_label(image_id, head_pix, tail_pix)},
+        clusters=[],
+        model_fish_lookup={"Snook": snook, "Grouper": grouper},
+        existing_measurements=[
+            Measurement(id=1, length_m=0.44, image_id=image_id, fish_id=snook.id)
+        ],
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(sut.measure_fish_activity, 42)
+
+    fs.fish.delete_measurement.assert_awaited_once_with(snook.id, image_id)
+    assert result.invalidated_stale_binding == 1
+    assert result.measured == 1
+    fish_id, _ = fs.fish.post_measurement.call_args.args
+    assert fish_id == grouper.id, "re-measured against the corrected model"
+
+
+@pytest.mark.asyncio
+async def test_correct_model_binding_is_left_alone(monkeypatch):
+    """The common case must stay a cheap skip: binding already matches the
+    label, so no delete and no re-measure."""
+    image_id = 100
+    le, head_pix, tail_pix, laser_pix = _model_observation()
+    grouper = Fish(id=902, name="Grouper", species_id=None)
+
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_camera_intrinsics(),
+        laser_extrinsics=le,
+        species_labels=[_species_label(image_id, content="Fish Model, Grouper")],
+        laser_labels={image_id: _laser_label(image_id, *laser_pix)},
+        headtail_labels={image_id: _headtail_label(image_id, head_pix, tail_pix)},
+        clusters=[],
+        model_fish_lookup={"Grouper": grouper},
+        existing_measurements=[
+            Measurement(id=1, length_m=0.36, image_id=image_id, fish_id=grouper.id)
+        ],
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(sut.measure_fish_activity, 42)
+
+    fs.fish.delete_measurement.assert_not_awaited()
+    assert result.skipped_already_measured == 1
+    assert result.measured == 0
+
+
+@pytest.mark.asyncio
+async def test_real_fish_bindings_are_never_invalidated(monkeypatch):
+    """Real (wild) fish carry name=None and their identity is per-CLUSTER, not
+    per-label, so a species change doesn't invalidate the binding. Only named
+    model Fish are eligible for this self-heal."""
+    image_id = 100
+    le, head_pix, tail_pix, laser_pix = _model_observation()
+    wild = Fish(id=88, name=None, species_id=42)
+
+    fs = _make_fs(
+        dive=_dive(),
+        intrinsics=_camera_intrinsics(),
+        laser_extrinsics=le,
+        species_labels=[_species_label(image_id)],  # real "Common (Sci)" label
+        laser_labels={image_id: _laser_label(image_id, *laser_pix)},
+        headtail_labels={image_id: _headtail_label(image_id, head_pix, tail_pix)},
+        clusters=[_cluster([image_id], fish_id=wild.id)],
+        existing_measurements=[
+            Measurement(id=1, length_m=0.30, image_id=image_id, fish_id=wild.id)
+        ],
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(sut.measure_fish_activity, 42)
+
+    fs.fish.delete_measurement.assert_not_awaited()
+    assert result.skipped_already_measured == 1


### PR DESCRIPTION
## The gap

Correcting a species label never reached the measurement. Stage 14 skips already-measured images, so a frame relabeled `Fish Model, Snook` → `Fish Model, Grouper` kept its `Measurement` bound to the **Snook** Fish forever — and the accuracy view kept grading it against the wrong known length. Hit on prod images 4375/4664/4868 (2026-08-04); all three fixed by hand.

**Re-measuring alone can't fix it:** `post_measurement` upserts on `(image_id, fish_id)` — deliberately, since one frame can hold two fish — so writing the corrected binding *adds* a row and double-counts the image. The stale row must be deleted, and there was no delete path.

## Changes

- **api** — `DELETE /api/v1/fish/{fish_id}/measurements/{image_id}`. Keyed on the same natural key as the upsert (not `image_id` alone), so a two-fish frame only loses the binding named. Idempotent: absent row → 204, no 404, so activity retries are safe.
- **sdk** — `fish.delete_measurement(fish_id, image_id)`; `_generated.py` regenerated.
- **measure_fish_activity** — measurements fetched grouped by image instead of as a bare id set; for a model-labeled image, any row bound to a Fish other than the expected name-keyed one is deleted before the already-measured skip, then re-measured. Reported as `MeasureFishResult.invalidated_stale_binding`.

## Why model-only

A model's correct Fish is knowable from the label alone, so a mismatch is unambiguous. Real (wild) fish carry `name=None` and take identity from the **LABEL_STUDIO cluster**, not the species label — a species change there doesn't invalidate the binding, and deleting cluster-bound rows would risk more than it fixes.

## Tests (TDD)
Stale binding deleted + re-measured against the corrected model (reproduced failing first); matching binding stays a cheap skip with no delete; real-fish bindings never touched; endpoint deletes only the named pair and is idempotent; SDK hits the right route.

api 267 / sdk 121 / measure 24 pass; pylint 10/10 via CI's own invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)