### PR TITLE
feat(api): expose calibration provenance on dive_pipeline_status

### DIFF
--- a/services/fishsense-api/src/fishsense_api/alembic/versions/a91d4e70c3b8_add_calibration_source_to_view.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/a91d4e70c3b8_add_calibration_source_to_view.py
@@ -1,0 +1,44 @@
+"""add calibration_source to dive_pipeline_status
+
+Revision ID: a91d4e70c3b8
+Revises: f3b81c6d92a4
+Create Date: 2026-08-04 19:30:00.000000
+
+`calibrated` says a dive HAS extrinsics; `calibration_source` says whether they
+describe this dive's own rig deployment ('own') or were borrowed from another
+dive ('borrowed'). Measured against the known-length fish models, that
+distinction is worth ~1% vs -8..+2% accuracy, so downstream analysis needs it.
+
+Drop + recreate rather than CREATE OR REPLACE — Postgres is restrictive about
+column-shape changes and the view has no dependents.
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from fishsense_api.views import (
+    DIVE_PIPELINE_STATUS_VIEW_SQL,
+    DROP_DIVE_PIPELINE_STATUS_VIEW_SQL,
+)
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a91d4e70c3b8"
+down_revision: Union[str, Sequence[str], None] = "f3b81c6d92a4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Recreate the view with the calibration_source column."""
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)
+
+
+def downgrade() -> None:
+    """Recreate from whatever views.py currently defines."""
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -299,6 +299,31 @@ SELECT
         WHERE le.dive_id = d.calibration_dive_id
     )) AS calibrated,
 
+    -- WHERE the calibration came from — the strongest data-quality signal on a
+    -- measurement. `calibrated` only says a dive HAS extrinsics; provenance
+    -- says whether they describe THIS dive's rig deployment.
+    --
+    -- Measured 2026-08-04 against the known-length fish models: a dive on its
+    -- own slate measures to ~1%, while a BORROWED calibration carries an extra
+    -- rig-state systematic of -8..+2% (n=7, all seven model dives borrow).
+    -- That error is irreducible in software — laser-dot precision (~0.5%) and
+    -- the line fit (already at the label-noise floor) were both ruled out by
+    -- experiment — so downstream analysis must be able to filter or weight on
+    -- this rather than treat every measurement as equally trustworthy.
+    --
+    -- 'own' wins over 'borrowed' to mirror `get_laser_extrinsics_for_dive`'s
+    -- own-then-link resolution: a dive with its own row never uses the link.
+    CASE
+        WHEN EXISTS (
+            SELECT 1 FROM laserextrinsics le WHERE le.dive_id = d.id
+        ) THEN 'own'
+        WHEN EXISTS (
+            SELECT 1 FROM laserextrinsics le
+            WHERE le.dive_id = d.calibration_dive_id
+        ) THEN 'borrowed'
+        ELSE 'none'
+    END AS calibration_source,
+
     -- Stage 14: ≥1 measurement for the dive AND no measurable image left
     -- unmeasured. "Measurable" mirrors what measure_fish_activity
     -- actually attempts: a top-three species label whose image carries a

--- a/services/fishsense-api/tests/test_dive_pipeline_status_view.py
+++ b/services/fishsense-api/tests/test_dive_pipeline_status_view.py
@@ -1233,3 +1233,60 @@ async def test_dive_images_preprocessed_false_when_only_species_row_superseded(s
     await session.flush()
 
     assert (await _row(session, 1))["dive_images_preprocessed"] is False
+
+
+# ---------- calibration_source (provenance) ----------
+#
+# `calibrated` says whether a dive HAS extrinsics; it does not say where they
+# came from, and that distinction is the strongest data-quality signal we have.
+# Measured 2026-08-04 against the known-length fish models: a dive using its
+# OWN slate measures at ~1%, while a BORROWED calibration adds a rig-state
+# systematic of -8..+2% (n=7) that no amount of software can recover — the
+# borrow is for a different rig deployment. Downstream analysis needs to be
+# able to filter or weight on this rather than treating all rows alike.
+
+
+async def test_calibration_source_own_when_the_dive_has_its_own_extrinsics(session):
+    from fishsense_api.models.laser_extrinsics import LaserExtrinsics  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    await session.flush()
+    session.add(LaserExtrinsics(dive_id=1, camera_id=1))
+    await session.flush()
+
+    assert (await _row(session, 1))["calibration_source"] == "own"
+
+
+async def test_calibration_source_borrowed_when_only_the_link_has_extrinsics(session):
+    from fishsense_api.models.laser_extrinsics import LaserExtrinsics  # pylint: disable=import-outside-toplevel
+
+    session.add_all([_dive(2), _dive(1, calibration_dive_id=2)])
+    await session.flush()
+    session.add(LaserExtrinsics(dive_id=2, camera_id=1))
+    await session.flush()
+
+    assert (await _row(session, 1))["calibration_source"] == "borrowed"
+
+
+async def test_calibration_source_own_wins_over_a_link(session):
+    """Mirrors `get_laser_extrinsics_for_dive`: a dive with its own row uses it
+    even when `calibration_dive_id` is also set, so provenance must say 'own'."""
+    from fishsense_api.models.laser_extrinsics import LaserExtrinsics  # pylint: disable=import-outside-toplevel
+
+    session.add_all([_dive(2), _dive(1, calibration_dive_id=2)])
+    await session.flush()
+    session.add_all(
+        [LaserExtrinsics(dive_id=1, camera_id=1), LaserExtrinsics(dive_id=2, camera_id=1)]
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["calibration_source"] == "own"
+
+
+async def test_calibration_source_none_when_uncalibrated(session):
+    session.add(_dive(1))
+    await session.flush()
+
+    row = await _row(session, 1)
+    assert row["calibration_source"] == "none"
+    assert row["calibrated"] is False

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "fishsense-api"
-version = "1.41.0"
+version = "1.42.0"
 source = { editable = "services/fishsense-api" }
 dependencies = [
     { name = "alembic" },
@@ -712,7 +712,7 @@ dev = [
 
 [[package]]
 name = "fishsense-api-sdk"
-version = "1.44.0"
+version = "1.45.0"
 source = { editable = "libs/fishsense-api-sdk" }
 dependencies = [
     { name = "httpx" },
@@ -741,7 +741,7 @@ dev = [
 
 [[package]]
 name = "fishsense-api-workflow-worker"
-version = "1.48.4"
+version = "1.48.5"
 source = { editable = "services/fishsense-api-workflow-worker" }
 dependencies = [
     { name = "boto3" },
@@ -881,7 +881,7 @@ provides-extras = ["laser-detector", "rectified", "slate"]
 
 [[package]]
 name = "fishsense-data-processing-workflow-worker"
-version = "2.13.1"
+version = "2.14.0"
 source = { editable = "services/fishsense-data-processing-workflow-worker" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Why

`calibrated` says a dive **has** extrinsics. It doesn't say whether they describe *that dive's* rig deployment — and that turns out to be the strongest data-quality signal on a measurement.

Measured against the known-length fish models (2026-08-04):

| calibration | accuracy |
|---|---|
| **own slate** | ~1% |
| **borrowed** | ~1% ⊕ an extra **−8…+2%** rig-state systematic (n=7) |

Both software explanations were **ruled out by experiment**, which is what makes provenance the right thing to surface:
- **Laser-dot precision** contributes ~0.5% — good dives already scatter 0.4–0.9 px, and sub-pixel refinement bought 13%, not the hoped-for 5×.
- **The line fit** is already at the label-noise floor — refitting to minimise reprojection error produced a *better* fit (1.24 px vs 1.36 px) and *identically wrong* lengths (−7.90% vs −7.76%).

The residual is the borrow itself. No code change recovers it; the fix is operational (shoot a slate per rig deployment), and these dives predate that practice.

## Why it matters for existing data

All **425** fish-model measurements come from borrowed calibrations — every model dive is fish-only — so the benchmark has been reporting the *worst* case. **126** measurements sit on self-calibrated dives and should be materially better. Analysis needs to distinguish them rather than treat all rows alike.

## Change

`calibration_source` ∈ `{'own','borrowed','none'}`. `'own'` wins over `'borrowed'`, mirroring `get_laser_extrinsics_for_dive`'s own-then-link resolution. New alembic revision drops + recreates the view.

## Tests
own / borrowed / none, plus own-wins-over-a-link. 271 api tests pass; pylint 10/10 via CI's own invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)