### PR TITLE
feat: grade the ruler as a known-length reference target

### DIFF
--- a/services/fishsense-api/src/fishsense_api/alembic/versions/b4c81f60d7e2_make_ruler_measurable.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/b4c81f60d7e2_make_ruler_measurable.py
@@ -1,0 +1,68 @@
+"""seed the ruler reference and make ruler frames measurable
+
+Revision ID: b4c81f60d7e2
+Revises: a91d4e70c3b8
+Create Date: 2026-08-04 21:00:00.000000
+
+Every head/tail label on a ruler frame currently marks the same 14-inch span,
+so the ruler is a fixed-length reference like the fish models and measures
+through the same name-keyed path.
+
+It is worth more than a second data point: a fish model's tail landmark is
+ambiguous (fork vs tip, worth ~5pp), while a ruler's endpoints are not. Grading
+the ruler therefore separates calibration error from labeling convention, which
+no model can do.
+
+Recreates `dive_pipeline_status` because the measurable predicate widened; the
+accuracy view is untouched (it joins `fishmodelreference` on `Fish.name`, so
+"Ruler" flows through unchanged once the reference row exists).
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from fishsense_api.views import (
+    DIVE_PIPELINE_STATUS_VIEW_SQL,
+    DROP_DIVE_PIPELINE_STATUS_VIEW_SQL,
+    KNOWN_FISH_MODELS,
+)
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b4c81f60d7e2"
+down_revision: Union[str, Sequence[str], None] = "a91d4e70c3b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Seed the ruler reference row, then widen the measurable predicate."""
+    bind = op.get_bind()
+    existing = {
+        row[0]
+        for row in bind.execute(sa.text("SELECT name FROM fishmodelreference"))
+    }
+    to_insert = [m for m in KNOWN_FISH_MODELS if m["name"] not in existing]
+    if to_insert:
+        bind.execute(
+            sa.text(
+                "INSERT INTO fishmodelreference (name, known_length_m) "
+                "VALUES (:name, :known_length_m)"
+            ),
+            to_insert,
+        )
+
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)
+
+
+def downgrade() -> None:
+    """Narrow the predicate back. The seeded row is left in place — it is inert
+    without the predicate and dropping it would discard a hand-corrected span.
+    """
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -84,6 +84,7 @@ def _measurable_species_conditions():
         or_(
             SpeciesLabel.content_of_image.like("%(%)"),
             SpeciesLabel.content_of_image.like("Fish Model,%"),
+            SpeciesLabel.content_of_image == "Calibration Targets, Ruler",
         ),
     )
 
@@ -93,7 +94,11 @@ def _is_fish_model_condition():
     thus no LABEL_STUDIO cluster, so the stage-14 cohort waives the cluster
     requirement for them (identity is the model name; length uses only
     laser/head-tail/calibration). Mirrors `views._IS_FISH_MODEL_SQL`."""
-    return SpeciesLabel.content_of_image.like("Fish Model,%")  # pylint: disable=no-member
+    # pylint: disable=no-member
+    return or_(
+        SpeciesLabel.content_of_image.like("Fish Model,%"),
+        SpeciesLabel.content_of_image == "Calibration Targets, Ruler",
+    )
 
 
 def _valid_headtail_conditions():

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -76,12 +76,16 @@ _VALID_HEADTAIL_SQL = """htl.completed = TRUE
 # `measure_fish_activity` (`_parse_species_names` / `_parse_model_name`).
 _MEASURABLE_SPECIES_SQL = (
     "(sl.content_of_image LIKE '%(%)' "
-    "OR sl.content_of_image LIKE 'Fish Model,%')"
+    "OR sl.content_of_image LIKE 'Fish Model,%' "
+    "OR sl.content_of_image = 'Calibration Targets, Ruler')"
 )
 
 # A fish-model row (no cluster required — models carry no grouping labels).
 # Assumes the enclosing subquery aliases specieslabel as `sl`.
-_IS_FISH_MODEL_SQL = "sl.content_of_image LIKE 'Fish Model,%'"
+_IS_FISH_MODEL_SQL = (
+    "(sl.content_of_image LIKE 'Fish Model,%' "
+    "OR sl.content_of_image = 'Calibration Targets, Ruler')"
+)
 
 # "Complete" everywhere = ≥1 completed-non-superseded row AND zero
 # incomplete-non-superseded rows. Mirrors
@@ -408,6 +412,13 @@ KNOWN_FISH_MODELS = [
     {"name": "Gray Anthias", "known_length_m": 0.195},
     {"name": "Purple Angel", "known_length_m": 0.192},
     {"name": "Yellow Anthias", "known_length_m": 0.200},
+    # The ruler is a rigid known-length target measured through the same
+    # name-keyed path as the models. CAVEAT: this is the 14-inch span, which is
+    # what every head/tail label on a ruler frame currently marks. If labelers
+    # start marking a different span the reference is wrong for those frames —
+    # they would surface in `fish_model_species_mislabel_suspects` rather than
+    # silently skewing accuracy, but the reference would need splitting by span.
+    {"name": "Ruler", "known_length_m": 0.3556},
 ]
 
 # One row per fish-model measurement, with its error against the known length.

--- a/services/fishsense-api/tests/test_dive_pipeline_status_view.py
+++ b/services/fishsense-api/tests/test_dive_pipeline_status_view.py
@@ -989,7 +989,12 @@ def _measurement(image_id: int, fish_id: int = 100):
     return Measurement(image_id=image_id, fish_id=fish_id, length_m=0.3)
 
 
-def _fish_model_measurable_image(session, image_id: int, dive_id: int):
+def _fish_model_measurable_image(
+    session,
+    image_id: int,
+    dive_id: int,
+    content_of_image: str = "Fish Model, Grouper",
+):
     """Seed a fish-model image the way prod has it: top-three species label
     (`Fish Model, <name>`) + valid laser + valid headtail, but **no**
     LABEL_STUDIO cluster (models carry no grouping labels). Stage 14 measures
@@ -1012,8 +1017,44 @@ def _fish_model_measurable_image(session, image_id: int, dive_id: int):
         SpeciesLabel(
             image_id=image_id, top_three_photos_of_group=True,
             completed=True, superseded=False, label_studio_project_id=70,
-            content_of_image="Fish Model, Grouper",
+            content_of_image=content_of_image,
         )
+    )
+
+
+async def test_measured_counts_a_ruler_image_like_a_fish_model(session):
+    """The ruler is a known-length target measured through the same path, so a
+    ruler frame is measurable and holds `measured` false until it is measured.
+
+    Its value is that its endpoints are unambiguous: it grades pure calibration
+    error, with none of the fork-vs-tip uncertainty a fish model carries."""
+    session.add(_dive(1))
+    await session.flush()
+    _fish_model_measurable_image(
+        session, 11, 1, content_of_image="Calibration Targets, Ruler"
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["measured"] is False
+
+    session.add(_measurement(11))
+    await session.flush()
+    assert (await _row(session, 1))["measured"] is True
+
+
+async def test_measured_ignores_the_slate_marker(session):
+    """Promoting the ruler must not promote its sibling slate branches — the
+    stage-9 marker stays unmeasurable, so it can never hold a dive in the
+    stage-14 cohort forever."""
+    session.add(_dive(1))
+    await session.flush()
+    _fish_model_measurable_image(
+        session, 11, 1, content_of_image="Slate, Laser on slate"
+    )
+    await session.flush()
+
+    assert (await _row(session, 1))["measured"] is False, (
+        "vacuous: no measurable image, so nothing to measure"
     )
 
 
@@ -1129,19 +1170,20 @@ async def test_measured_ignores_non_top_three_images(session):
 async def test_measured_ignores_species_rows_without_a_scientific_name(session):
     """`measured` must mirror what stage 14 can actually measure.
 
-    A `Calibration Targets` row carries neither a "Common (Scientific)" name
-    nor a `Fish Model,` prefix, so `measure_fish_activity` skips it and no
-    Measurement is ever written. Counting it as a measurable-but-unmeasured
-    image pinned `measured` false forever — the same never-goes-false shape
-    b7c2e4d81a09 fixed one layer up, for unbound clusters. (Fish models ARE
-    measurable now — covered by test_measured_true_for_fish_model_image_*.)
+    A slate row carries neither a "Common (Scientific)" name nor a known-length
+    target name, so `measure_fish_activity` skips it and no Measurement is ever
+    written. Counting it as a measurable-but-unmeasured image pinned `measured`
+    false forever — the same never-goes-false shape b7c2e4d81a09 fixed one layer
+    up, for unbound clusters. (Fish models and the ruler ARE measurable — see
+    test_measured_true_for_fish_model_image_* and
+    test_measured_counts_a_ruler_image_like_a_fish_model.)
     """
     session.add(_dive(1))
     await session.flush()
-    # One real fish (measured) + one Calibration Targets row (never measurable).
+    # One real fish (measured) + one slate row (never measurable).
     real = _measurable_image(session, 11, 1, cluster_id=1)
     rig = _measurable_image(
-        session, 12, 1, cluster_id=2, content_of_image="Calibration Targets, Ruler"
+        session, 12, 1, cluster_id=2, content_of_image="Slate, Laser on slate"
     )
     await session.flush()
     session.add_all([real, rig])
@@ -1149,7 +1191,7 @@ async def test_measured_ignores_species_rows_without_a_scientific_name(session):
     await session.flush()
 
     assert (await _row(session, 1))["measured"] is True, (
-        "the Calibration Targets row must not hold `measured` false"
+        "the slate row must not hold `measured` false"
     )
 
 

--- a/services/fishsense-api/tests/test_fish_model_reference.py
+++ b/services/fishsense-api/tests/test_fish_model_reference.py
@@ -49,6 +49,15 @@ def test_known_models_cover_the_labeled_taxonomy():
     assert {"Snook", "Grouper", "Shark", "Purple Angel"} <= names
 
 
+def test_ruler_is_seeded_at_the_fourteen_inch_span():
+    """Every head/tail label on a ruler frame currently marks the 14-inch span,
+    so the ruler grades as a fixed-length reference. It is the only reference
+    with unambiguous endpoints, which is what lets it separate calibration
+    error from the models' tail-landmark convention."""
+    ruler = next(m for m in KNOWN_FISH_MODELS if m["name"] == "Ruler")
+    assert ruler["known_length_m"] == pytest.approx(0.3556)  # 14 in
+
+
 def test_known_lengths_are_positive_and_plausible():
     for model in KNOWN_FISH_MODELS:
         assert 0.05 < model["known_length_m"] < 2.0, model

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -1608,7 +1608,12 @@ async def test_measure_fish_requires_extrinsics_and_an_unmeasured_measurable_ima
     assert await select_next_for_measure_fish(session=session) == 3
 
 
-def _fish_model_measurable_image(session, image_id: int, dive_id: int):
+def _fish_model_measurable_image(
+    session,
+    image_id: int,
+    dive_id: int,
+    content_of_image: str = "Fish Model, Grouper",
+):
     """A fish-model image the way prod has it: top-three `Fish Model, <name>`
     species label + valid laser + valid headtail, but NO LABEL_STUDIO cluster
     (models carry no grouping labels). The cohort must still select it."""
@@ -1630,7 +1635,7 @@ def _fish_model_measurable_image(session, image_id: int, dive_id: int):
         SpeciesLabel(
             image_id=image_id, top_three_photos_of_group=True,
             completed=True, superseded=False, label_studio_project_id=70,
-            content_of_image="Fish Model, Grouper",
+            content_of_image=content_of_image,
         )
     )
 
@@ -1904,7 +1909,7 @@ async def test_measure_fish_skips_species_rows_without_a_scientific_name(session
         LaserExtrinsics,
     )
 
-    for content in ("Calibration Targets, Ruler", None):
+    for content in ("Slate, Laser on slate", "Calibration Targets, Slate", None):
         session.add(_dive(1))
         await session.flush()
         session.add(LaserExtrinsics(dive_id=1, camera_id=1))

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/measure_fish_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/measure_fish_activity.py
@@ -79,17 +79,31 @@ __all__ = ["MeasureFishResult", "measure_fish_activity"]
 # `dive_controller._measurable_species_conditions`; keep the three in step.
 _FISH_MODEL_PREFIX = "Fish Model,"
 
+# The ruler is a rigid known-length target like the models, so it measures
+# through the same name-keyed path. Its span is currently always the 14-inch
+# one (0.3556 m, seeded in `fishmodelreference`) — see the caveat there if
+# labelers ever start marking a different span.
+_RULER_CONTENT = "Calibration Targets, Ruler"
+_RULER_NAME = "Ruler"
+
 
 def _parse_model_name(content_of_image: str | None) -> str | None:
-    """Return the model name for a `Fish Model, <name>` row, else None.
+    """Return the target name for a known-length rigid target, else None.
 
-    Real fish (`..., Common (Scientific)`) and other branches (Calibration
-    Targets) return None. An empty leaf ("Fish Model," with nothing after)
-    returns None — nothing to identify — matching the "skip rather than write a
-    malformed row" posture of `_parse_species_names`.
+    Covers `Fish Model, <name>` and the ruler (`Calibration Targets, Ruler` ->
+    "Ruler"). Real fish (`..., Common (Scientific)`) and every other branch
+    return None. An empty leaf ("Fish Model," with nothing after) returns None
+    — nothing to identify — matching the "skip rather than write a malformed
+    row" posture of `_parse_species_names`.
+
+    The ruler earns its place here because, unlike a fish model, its endpoints
+    are unambiguous: it carries no tail-landmark (fork vs tip) uncertainty, so
+    it isolates calibration error from labeling convention.
     """
     if not content_of_image:
         return None
+    if content_of_image.strip() == _RULER_CONTENT:
+        return _RULER_NAME
     if not content_of_image.startswith(_FISH_MODEL_PREFIX):
         return None
     name = content_of_image[len(_FISH_MODEL_PREFIX):].strip()

--- a/services/fishsense-data-processing-workflow-worker/tests/test_measure_fish_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_measure_fish_activity.py
@@ -550,13 +550,15 @@ async def test_measurements_are_fetched_once_per_dive(monkeypatch):
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "content",
-    ["Calibration Targets, Ruler", None],
-    ids=["calibration-target", "empty"],
+    ["Slate, Laser on slate", "Calibration Targets, Slate", None],
+    ids=["slate-marker", "calibration-target", "empty"],
 )
 async def test_skips_species_rows_that_carry_no_scientific_name(monkeypatch, content):
     """Taxonomy branches with neither a "Common (Scientific)" name nor a
-    `Fish Model,` prefix have nothing to measure against (Calibration Targets,
-    empty). Fish models ARE measurable now (see the model-branch tests below).
+    `Fish Model,` prefix have nothing to measure against. `Slate, Laser on
+    slate` is the important one — it is stage 9's marker and measuring it would
+    be nonsense. Fish models and the ruler ARE measurable (see the
+    known-length-target tests below).
 
     These land in their own counter rather than `missing_laser_or_headtail`
     — they used to inflate that one, which pointed anyone reading the result
@@ -594,6 +596,23 @@ async def test_skips_species_rows_that_carry_no_scientific_name(monkeypatch, con
 # laser/head-tail/calibration — no cluster. So the model branch: resolves the
 # Fish by name (find-or-create), waives the cluster gate, and never binds
 # `cluster.fish_id`.
+
+
+# pylint: disable=protected-access
+def test_parse_model_name_maps_the_ruler_to_a_named_target():
+    """The ruler is a rigid known-length target, so it measures through the
+    same name-keyed path as the models — and unlike a model it carries no
+    fork-vs-tip landmark ambiguity, which is why it is worth grading."""
+    assert sut._parse_model_name("Calibration Targets, Ruler") == "Ruler"
+
+
+def test_parse_model_name_ignores_other_calibration_targets():
+    """Only the ruler is promoted; the slate branches stay unmeasurable."""
+    assert sut._parse_model_name("Calibration Targets, Slate") is None
+    assert sut._parse_model_name("Slate, Laser on slate") is None
+
+
+# pylint: enable=protected-access
 
 
 def _model_observation():

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "fishsense-api"
-version = "1.42.0"
+version = "1.43.0"
 source = { editable = "services/fishsense-api" }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
The ruler's head/tail labels all mark the same 14-inch span (0.3556 m), so it grades as a fixed-length reference through the same name-keyed path as the fish models.

**Why this is worth more than another data point.** A fish model's tail landmark is ambiguous — fork vs tip, ~5 pp, currently the largest unexplained term in the error budget. A ruler's endpoints aren't. So the ruler separates *calibration* error from *labeling convention*, which no model can do. If it reads at its dive's calibration bias (dive 60 ≈ −3.4%), the models' extra offset is landmark-related and the caliper question is answered.

29 already-labeled frames unlock immediately (23 on dive 60, 6 on dive 66), both borrowed-calibration.

The ruler remains a **validation** reference only — never a calibration input.

## Changes
- `_parse_model_name` maps `Calibration Targets, Ruler` -> `"Ruler"`
- measurable predicate widened in all three mirrors (`views`, `dive_controller`, activity)
- `Ruler` @ 0.3556 m seeded into `fishmodelreference`; migration recreates `dive_pipeline_status`
- accuracy view untouched — it joins on `Fish.name`, so "Ruler" flows through

## Deliberately not promoted
Only the ruler leaf. `Slate, Laser on slate` is stage 9's marker; measuring it would be nonsense *and* would pin `measured` false forever. Tests that used the ruler as their unmeasurable example now use the slate marker — the case actually worth pinning.

## Caveat
If labelers ever mark a different span, that frame grades against the wrong length. It'd surface in `fish_model_species_mislabel_suspects` rather than silently skewing accuracy, but the reference would need splitting by span. Recorded at the seed row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)