### PR TITLE
fix: correct the ruler reference to the labeled 13.5 in span

### DIFF
--- a/services/fishsense-api/src/fishsense_api/alembic/versions/c5d93a17e8b4_ruler_reference_13p5in.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/c5d93a17e8b4_ruler_reference_13p5in.py
@@ -1,0 +1,65 @@
+"""correct the ruler reference from 14 in to the labeled 13.5 in span
+
+Revision ID: c5d93a17e8b4
+Revises: b4c81f60d7e2
+Create Date: 2026-08-04 22:15:00.000000
+
+b4c81f60d7e2 seeded the ruler at 0.3556 m (14 in, its nominal size). That is the
+wrong reference: labelers do not click a physical zero, they click the first
+*printed* graduation — the 0.5 mark, the leftmost thing on the scale — and the
+14 mark. The labeled span is therefore 0.5->14 = 13.5 in = 0.3429 m.
+
+Measured off the ruler's own inch ticks on four frames: 13.500 / 13.505 /
+13.481 / 13.468 in (SD 0.13%), corroborated by a second, independent method
+(half-inch ticks fitted with a 1D projective map, which also removes
+perspective). The 14 in figure survived a photo check only because the photo
+confirmed the TAIL end; nobody had looked at the head end.
+
+No re-measurement is needed — `fish_model_measurement_accuracy` derives
+pct_error from this row at query time, so the existing ruler measurements
+re-grade themselves (roughly -5.4% -> -2.4% on the best frames).
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c5d93a17e8b4"
+down_revision: Union[str, Sequence[str], None] = "b4c81f60d7e2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_OLD = 0.3556
+_NEW = 0.3429
+
+
+def upgrade() -> None:
+    """Point the ruler reference at the labeled span.
+
+    Guarded on the old value so this never clobbers a length an operator has
+    since corrected by hand — the same posture as the original seed, which only
+    inserted names that were absent.
+    """
+    op.get_bind().execute(
+        sa.text(
+            "UPDATE fishmodelreference SET known_length_m = :new "
+            "WHERE name = 'Ruler' AND abs(known_length_m - :old) < 1e-6"
+        ),
+        {"new": _NEW, "old": _OLD},
+    )
+
+
+def downgrade() -> None:
+    """Restore the nominal 14 in value."""
+    op.get_bind().execute(
+        sa.text(
+            "UPDATE fishmodelreference SET known_length_m = :old "
+            "WHERE name = 'Ruler' AND abs(known_length_m - :new) < 1e-6"
+        ),
+        {"new": _NEW, "old": _OLD},
+    )

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -413,12 +413,15 @@ KNOWN_FISH_MODELS = [
     {"name": "Purple Angel", "known_length_m": 0.192},
     {"name": "Yellow Anthias", "known_length_m": 0.200},
     # The ruler is a rigid known-length target measured through the same
-    # name-keyed path as the models. CAVEAT: this is the 14-inch span, which is
-    # what every head/tail label on a ruler frame currently marks. If labelers
-    # start marking a different span the reference is wrong for those frames —
-    # they would surface in `fish_model_species_mislabel_suspects` rather than
-    # silently skewing accuracy, but the reference would need splitting by span.
-    {"name": "Ruler", "known_length_m": 0.3556},
+    # name-keyed path as the models. 13.5 in, NOT the ruler's nominal 14 in:
+    # labelers click the first *printed* graduation (the 0.5 mark) and the 14
+    # mark, so the labeled span is 0.5->14. Measured off the ruler's own inch
+    # ticks on 4 frames: 13.500/13.505/13.481/13.468 in (SD 0.13%), and a
+    # second method (half-inch ticks + 1D projective fit, which also removes
+    # perspective) independently agreed. Do NOT "correct" this back to 14 in
+    # without re-instructing labelers to click a physical 0 that the scale does
+    # not print.
+    {"name": "Ruler", "known_length_m": 0.3429},
 ]
 
 # One row per fish-model measurement, with its error against the known length.

--- a/services/fishsense-api/tests/test_fish_model_reference.py
+++ b/services/fishsense-api/tests/test_fish_model_reference.py
@@ -49,13 +49,20 @@ def test_known_models_cover_the_labeled_taxonomy():
     assert {"Snook", "Grouper", "Shark", "Purple Angel"} <= names
 
 
-def test_ruler_is_seeded_at_the_fourteen_inch_span():
-    """Every head/tail label on a ruler frame currently marks the 14-inch span,
-    so the ruler grades as a fixed-length reference. It is the only reference
-    with unambiguous endpoints, which is what lets it separate calibration
-    error from the models' tail-landmark convention."""
+def test_ruler_is_seeded_at_the_labeled_span_not_the_nominal_length():
+    """The ruler is a 14-inch ruler, but the LABELED span is 13.5 in.
+
+    Labelers click the first printed graduation — the 0.5 mark, the leftmost
+    thing on the scale — and the 14 mark. Measuring the ruler's own inch ticks
+    across 4 frames gave 13.500/13.505/13.481/13.468 in (SD 0.13%).
+
+    Pinned as a regression because 14 in is the intuitive-but-wrong value, and
+    getting it wrong cost a whole false explanation (an invented 22-degree tilt)
+    before anyone checked the head end of the scale.
+    """
     ruler = next(m for m in KNOWN_FISH_MODELS if m["name"] == "Ruler")
-    assert ruler["known_length_m"] == pytest.approx(0.3556)  # 14 in
+    assert ruler["known_length_m"] == pytest.approx(0.3429)  # 13.5 in
+    assert ruler["known_length_m"] != pytest.approx(0.3556), "14 in is the trap"
 
 
 def test_known_lengths_are_positive_and_plausible():

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "fishsense-api"
-version = "1.43.0"
+version = "1.44.0"
 source = { editable = "services/fishsense-api" }
 dependencies = [
     { name = "alembic" },
@@ -881,7 +881,7 @@ provides-extras = ["laser-detector", "rectified", "slate"]
 
 [[package]]
 name = "fishsense-data-processing-workflow-worker"
-version = "2.14.0"
+version = "2.15.0"
 source = { editable = "services/fishsense-data-processing-workflow-worker" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
The ruler reference was seeded at **0.3556 m (14 in)** — its nominal size. That isn't what labelers mark.

They don't click a physical zero. They click the **first printed graduation**, which is the **0.5 mark** (the leftmost thing on the scale), and the **14 mark**. Labeled span = 0.5→14 = **13.5 in = 0.3429 m**.

## Evidence
Measured off the ruler's own inch ticks across four frames:

| Frame | span |
|---|---|
| 4731 | 13.500 in |
| 4732 | 13.505 in |
| 4733 | 13.481 in |
| 4734 | 13.468 in |

Mean 13.4885 in, **SD 0.13%**. An independent method — half-inch ticks fitted with a 1D projective map, which also removes perspective — agreed to within a millimetre.

## Why 14 in survived a photo check
The photo confirmed the *tail* end, and it was correct: green sits exactly on the 14 tick. Nobody looked at the head end. That 2.9% reference error then manufactured a false explanation (an invented ~22° tilt) for a shortfall that was never in the measurement.

## Impact
No re-measurement needed — `fish_model_measurement_accuracy` derives `pct_error` from this row at query time, so the 27 existing ruler measurements re-grade themselves: roughly **−5.4% → −2.4%** on best frames, moving the ruler from extreme outlier to mid-pack against the fish models.

Migration is guarded on the old value so it can't clobber an operator's hand-set length, matching the original seed's posture. Test pins 13.5 and explicitly rejects 14 as "the trap".

🤖 Generated with [Claude Code](https://claude.com/claude-code)