### PR TITLE
feat: add fish_length_estimate view (p90 over a fish's frames)

### DIFF
--- a/services/fishsense-api/src/fishsense_api/alembic/versions/d7e21b95c3a0_add_fish_length_estimate_view.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/d7e21b95c3a0_add_fish_length_estimate_view.py
@@ -1,0 +1,47 @@
+"""add fish_length_estimate view (p90 over a fish's frames)
+
+Revision ID: d7e21b95c3a0
+Revises: c5d93a17e8b4
+Create Date: 2026-08-04 23:30:00.000000
+
+Exposes the length estimate that should actually be USED for a fish, which is
+the p90 over its frames rather than the mean.
+
+Stage 14 back-projects head and tail at a single laser-derived depth, so it
+measures the fish's projection: out-of-plane angle can only ever SHORTEN it.
+Per-frame error is one-sided-negative (skew -4.87 across 437 fish-model
+frames), so the mean is biased low and a high quantile is the right estimator.
+Measured over 23 dive x model groups, mean absolute error 4.35% vs p90 2.26% —
+a halving, for free, with no change to any measurement.
+
+Additive: nothing reads this yet, and no existing view or query changes.
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from fishsense_api.views import (
+    DROP_FISH_LENGTH_ESTIMATE_VIEW_SQL,
+    FISH_LENGTH_ESTIMATE_VIEW_SQL,
+)
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d7e21b95c3a0"
+down_revision: Union[str, Sequence[str], None] = "c5d93a17e8b4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create the view (drop first so re-running is safe)."""
+    op.execute(DROP_FISH_LENGTH_ESTIMATE_VIEW_SQL)
+    op.execute(FISH_LENGTH_ESTIMATE_VIEW_SQL)
+
+
+def downgrade() -> None:
+    """Drop the view."""
+    op.execute(DROP_FISH_LENGTH_ESTIMATE_VIEW_SQL)

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -459,6 +459,78 @@ DROP_FISH_MODEL_ACCURACY_VIEW_SQL = (
 
 
 # ---------------------------------------------------------------------------
+# Per-fish length estimate
+# ---------------------------------------------------------------------------
+
+FISH_LENGTH_ESTIMATE_VIEW_NAME = "fish_length_estimate"
+
+# One row per (fish, dive) giving the length estimate to actually USE, plus the
+# alternatives for comparison.
+#
+# **Use `length_p90_m`, not the mean.** Stage 14 back-projects head and tail at
+# a single laser-derived depth, so it measures the fish's *projection*: any
+# out-of-plane angle can only ever SHORTEN it. Per-frame error is therefore
+# one-sided-negative — measured on 437 fish-model frames, the within-group IQR
+# is only 2.2pp and the median +0.3%, but the skew is -4.87, with 2.3% of
+# frames below -10pp against 0.5% above +10pp. Averaging drags the estimate
+# into that tail; a high quantile rejects it.
+#
+# Measured over 23 dive x model groups (n>=8): mean 4.35% absolute error,
+# median 3.58%, p75 2.68%, p90 2.26%. p90 rather than max because max chases
+# the single most-favourable frame and so inherits its label noise, while p90
+# keeps the one-sided-tail rejection.
+#
+# Covers every fish, not just models: `species_id` and `name` are both exposed
+# so wild fish (name NULL) and models (species_id NULL) are distinguishable.
+# `n_frames` is the honest caveat — a p90 over 2 frames is not a p90, so
+# consumers should filter on it.
+# Nearest-rank quantiles via ROW_NUMBER rather than `percentile_cont`, because
+# the view tests run on SQLite and it has no ordered-set aggregates. Integer
+# arithmetic gives ceil(q*n) portably: (9n+9)/10 = ceil(0.9n), (n+1)/2 =
+# ceil(0.5n). Nearest-rank also avoids interpolating between two frames, which
+# for a one-sided tail is the wrong thing anyway.
+#
+# Note p90 degenerates to the max for n<=8 (ceil(0.9*8)=8) — inherent to
+# nearest-rank, and the reason `n_frames` is exposed.
+FISH_LENGTH_ESTIMATE_VIEW_SQL = f"""
+CREATE VIEW {FISH_LENGTH_ESTIMATE_VIEW_NAME} AS
+WITH ranked AS (
+    SELECT
+        m.length_m   AS length_m,
+        i.dive_id    AS dive_id,
+        f.id         AS fish_id,
+        f.name       AS model_name,
+        f.species_id AS species_id,
+        ROW_NUMBER() OVER (
+            PARTITION BY f.id, i.dive_id ORDER BY m.length_m
+        ) AS rn,
+        COUNT(*) OVER (PARTITION BY f.id, i.dive_id) AS n
+    FROM measurement m
+    JOIN image i ON i.id = m.image_id
+    JOIN fish f ON f.id = m.fish_id
+    WHERE m.length_m IS NOT NULL
+)
+SELECT
+    fish_id,
+    dive_id,
+    model_name,
+    species_id,
+    n AS n_frames,
+    MAX(CASE WHEN rn = (9 * n + 9) / 10 THEN length_m END) AS length_p90_m,
+    MAX(CASE WHEN rn = (n + 1) / 2      THEN length_m END) AS length_median_m,
+    MAX(length_m) AS length_max_m,
+    MIN(length_m) AS length_min_m,
+    AVG(length_m) AS length_mean_m
+FROM ranked
+GROUP BY fish_id, dive_id, model_name, species_id, n
+"""
+
+DROP_FISH_LENGTH_ESTIMATE_VIEW_SQL = (
+    f"DROP VIEW IF EXISTS {FISH_LENGTH_ESTIMATE_VIEW_NAME}"
+)
+
+
+# ---------------------------------------------------------------------------
 # Fish-model species-mislabel suspects
 # ---------------------------------------------------------------------------
 

--- a/services/fishsense-api/tests/test_fish_length_estimate_view.py
+++ b/services/fishsense-api/tests/test_fish_length_estimate_view.py
@@ -1,0 +1,165 @@
+"""Per-fish length estimate — p90 over a fish's frames, not the mean.
+
+Stage 14 back-projects head and tail at ONE laser-derived depth, so it measures
+the fish's *projection*: any out-of-plane angle can only SHORTEN it. Per-frame
+error is therefore one-sided-negative (measured skew -4.87 over 437 fish-model
+frames), which makes the mean a biased-low estimator and a high quantile the
+right one. Switching mean -> p90 halved absolute error across 23 dive x model
+groups (4.35% -> 2.26%) with no change to the measurements themselves.
+
+These tests pin that property, so a well-meaning "just average the frames"
+refactor fails loudly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from fishsense_api.views import FISH_LENGTH_ESTIMATE_VIEW_SQL
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+
+    _SEEDED_DIVES.clear()
+    _SEEDED_FISH.clear()
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+        await conn.execute(text(FISH_LENGTH_ESTIMATE_VIEW_SQL))
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+_SEEDED_DIVES: set[int] = set()
+_SEEDED_FISH: set[int] = set()
+
+
+def _seed(session, fish_id: int, dive_id: int, lengths: list[float], base: int = 0):
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+
+    if dive_id not in _SEEDED_DIVES:
+        _SEEDED_DIVES.add(dive_id)
+        session.add(
+            Dive(
+                id=dive_id,
+                path=f"/dev/null/{dive_id}",
+                dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+                priority=Priority["HIGH"],
+            )
+        )
+    if fish_id not in _SEEDED_FISH:
+        _SEEDED_FISH.add(fish_id)
+        session.add(Fish(id=fish_id, name=f"model{fish_id}"))
+    for k, ln in enumerate(lengths):
+        iid = base + k + 1
+        session.add(
+            Image(
+                id=iid,
+                path=f"/dev/null/img-{iid}",
+                taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+                checksum=f"img-{iid:032d}"[:32],
+                dive_id=dive_id,
+            )
+        )
+        session.add(Measurement(image_id=iid, fish_id=fish_id, length_m=ln))
+
+
+async def _row(session, fish_id: int, dive_id: int):
+    res = await session.exec(
+        text(
+            "SELECT * FROM fish_length_estimate "
+            "WHERE fish_id = :f AND dive_id = :d"
+        ).bindparams(f=fish_id, d=dive_id)
+    )
+    row = res.mappings().first()
+    return dict(row) if row is not None else None
+
+
+async def test_p90_rejects_the_one_sided_foreshortening_tail(session):
+    """THE motivating case. Nine good frames plus one badly foreshortened one:
+    the mean is dragged down by the tail, p90 is not."""
+    _seed(session, 1, 1, [1.00] * 9 + [0.50])
+    await session.flush()
+
+    row = await _row(session, 1, 1)
+    assert row["n_frames"] == 10
+    assert row["length_p90_m"] == pytest.approx(1.00)
+    assert row["length_mean_m"] == pytest.approx(0.95)
+    assert row["length_min_m"] == pytest.approx(0.50), "the bad frame is still there"
+
+
+async def test_p90_is_not_simply_the_max_when_there_are_enough_frames(session):
+    """p90 must reject the top frame's label noise too, or it is just `max`
+    under another name. 20 frames -> rank ceil(0.9*20) = 18, not 20."""
+    _seed(session, 1, 1, [0.90] * 17 + [1.00, 1.10, 1.20])
+    await session.flush()
+
+    row = await _row(session, 1, 1)
+    assert row["n_frames"] == 20
+    assert row["length_max_m"] == pytest.approx(1.20)
+    assert row["length_p90_m"] == pytest.approx(1.00), "rank 18 of 20"
+
+
+async def test_p90_degenerates_to_max_for_small_n(session):
+    """Nearest-rank p90 on n<=8 IS the max — inherent, and why `n_frames` is
+    exposed so consumers can filter. Pinned so it is a known property, not a
+    surprise."""
+    _seed(session, 1, 1, [0.90, 0.95, 1.00])
+    await session.flush()
+
+    row = await _row(session, 1, 1)
+    assert row["n_frames"] == 3
+    assert row["length_p90_m"] == pytest.approx(1.00) == row["length_max_m"]
+
+
+async def test_median_is_the_nearest_rank_middle(session):
+    _seed(session, 1, 1, [0.80, 0.90, 1.00, 1.10, 1.20])
+    await session.flush()
+
+    row = await _row(session, 1, 1)
+    assert row["length_median_m"] == pytest.approx(1.00)
+
+
+async def test_one_row_per_fish_and_dive(session):
+    """A model Fish is global (one per model across dives), so grouping must
+    include dive_id or two dives' frames would be pooled into one estimate."""
+    _seed(session, 1, 1, [1.00, 1.00, 1.00], base=0)
+    _seed(session, 1, 2, [2.00, 2.00, 2.00], base=100)
+    await session.flush()
+
+    assert (await _row(session, 1, 1))["length_p90_m"] == pytest.approx(1.00)
+    assert (await _row(session, 1, 2))["length_p90_m"] == pytest.approx(2.00)
+
+
+async def test_measurements_without_a_length_are_excluded(session):
+    _seed(session, 1, 1, [1.00, 1.00])
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+
+    session.add(
+        Image(
+            id=900,
+            path="/dev/null/img-900",
+            taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            checksum="img-900",
+            dive_id=1,
+        )
+    )
+    session.add(Measurement(image_id=900, fish_id=1, length_m=None))
+    await session.flush()
+
+    assert (await _row(session, 1, 1))["n_frames"] == 2

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "fishsense-api"
-version = "1.44.0"
+version = "1.44.1"
 source = { editable = "services/fishsense-api" }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Exposes the length estimate that should actually be **used** for a fish: the **p90** over its frames, not the mean.

## Why p90
Stage 14 back-projects head and tail at a single laser-derived depth, so it measures the fish's *projection*. Out-of-plane angle can only ever **shorten** it, so per-frame error is one-sided-negative. Measured across 437 fish-model frames:

| statistic | value |
|---|---|
| within-group IQR | 2.2 pp |
| within-group median | +0.3% |
| **skew** | **−4.87** |
| frames below −10 pp | 2.3% |
| frames above +10 pp | 0.5% |

The typical frame is accurate to ~1 pp; the spread is a contaminated tail. The mean averages that tail in, a high quantile rejects it.

Over 23 dive × model groups (n≥8): **mean absolute error 4.35% vs p90 2.26%** — a halving, for free, with no change to any measurement.

p90 rather than max because max chases the single most-favourable frame and inherits its label noise.

## Implementation notes
- Nearest-rank via `ROW_NUMBER`, not `percentile_cont` — view tests run on SQLite, which has no ordered-set aggregates. Integer arithmetic gives `ceil(q*n)` portably: `(9n+9)/10`, `(n+1)/2`.
- **Known property, pinned by a test:** p90 degenerates to `max` for n≤8. Inherent to nearest-rank, and why `n_frames` is exposed so consumers can filter.
- Grouped by `(fish, dive)` — a model `Fish` is global across dives, so pooling would blend calibrations.
- Covers wild fish too (`name` NULL) alongside models (`species_id` NULL).

## Safety
Additive. Nothing reads it yet; no existing view or query changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)