### PR TITLE
fix(ci): run every package's tests; fix E4EFS_DOCKER; cover the portal auth gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Keep in step with PACKAGES in check.sh — that list is what a
+        # developer runs locally as `./check.sh unit`, and what
+        # integration.yml drives via `./check.sh integration`. This matrix
+        # had drifted from it: fishsense-shared and fishsense-backup-worker
+        # carried 50 passing tests that CI never executed, so a regression
+        # in either would have reached main silently. fishsense-shared is
+        # the worst place for that — every service depends on it.
         include:
           - package: libs/fishsense-api-sdk
             cov: fishsense_api_sdk
+          - package: libs/fishsense-shared
+            cov: fishsense_shared
           - package: services/fishsense-api
             cov: fishsense_api
           - package: services/fishsense-api-workflow-worker
             cov: fishsense_api_workflow_worker
+          - package: services/fishsense-backup-worker
+            cov: fishsense_backup_worker
           - package: services/fishsense-data-processing-workflow-worker
             cov: fishsense_data_processing_workflow_worker
     name: pytest (${{ matrix.package }})

--- a/apps/fishsense-lite-web/app/portal/actions.test.ts
+++ b/apps/fishsense-lite-web/app/portal/actions.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted so the module mocks below can reference them.
+const { auth, setCalibrationSource, clearCalibrationSource, revalidatePath } =
+  vi.hoisted(() => ({
+    auth: vi.fn(),
+    setCalibrationSource: vi.fn(),
+    clearCalibrationSource: vi.fn(),
+    revalidatePath: vi.fn(),
+  }));
+
+vi.mock("@/auth", () => ({ auth }));
+vi.mock("@/lib/dives", () => ({ setCalibrationSource, clearCalibrationSource }));
+vi.mock("next/cache", () => ({ revalidatePath }));
+
+import {
+  clearCalibrationSourceAction,
+  setCalibrationSourceAction,
+} from "./actions";
+
+const SIGNED_IN = { user: { name: "Alice", email: "a@e.com" } };
+
+beforeEach(() => {
+  auth.mockResolvedValue(SIGNED_IN);
+  setCalibrationSource.mockResolvedValue(undefined);
+  clearCalibrationSource.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── the auth gate ─────────────────────────────────────────────────────
+//
+// Server actions are ordinary public HTTP endpoints. `/portal/page.tsx`
+// redirecting signed-out users does NOT protect them — anyone can POST an
+// action directly. If `requireSession` regressed, these would become
+// unauthenticated writes to fishsense-api and nothing would fail loudly.
+
+describe("auth gate", () => {
+  it("refuses to set a calibration source when there is no session", async () => {
+    auth.mockResolvedValue(null);
+
+    const result = await setCalibrationSourceAction(9, 5);
+
+    expect(result).toEqual({ ok: false, error: "Not authenticated" });
+    expect(setCalibrationSource).not.toHaveBeenCalled();
+  });
+
+  it("refuses to clear a calibration source when there is no session", async () => {
+    auth.mockResolvedValue(null);
+
+    const result = await clearCalibrationSourceAction(9);
+
+    expect(result).toEqual({ ok: false, error: "Not authenticated" });
+    expect(clearCalibrationSource).not.toHaveBeenCalled();
+  });
+
+  it("refuses when a session exists but carries no user", async () => {
+    auth.mockResolvedValue({ expires: "later" });
+
+    expect(await setCalibrationSourceAction(9, 5)).toEqual({
+      ok: false,
+      error: "Not authenticated",
+    });
+    expect(setCalibrationSource).not.toHaveBeenCalled();
+  });
+
+  it("checks the session BEFORE touching the API, not after", async () => {
+    // Ordering matters: a check that ran after the write would still return
+    // an error while having already mutated prod.
+    auth.mockResolvedValue(null);
+
+    await setCalibrationSourceAction(9, 5);
+    await clearCalibrationSourceAction(9);
+
+    expect(auth).toHaveBeenCalledTimes(2);
+    expect(setCalibrationSource).not.toHaveBeenCalled();
+    expect(clearCalibrationSource).not.toHaveBeenCalled();
+  });
+});
+
+// ── the happy path + guards ───────────────────────────────────────────
+
+describe("setCalibrationSourceAction", () => {
+  it("links the dive and revalidates the portal", async () => {
+    const result = await setCalibrationSourceAction(9, 5);
+
+    expect(result).toEqual({ ok: true });
+    expect(setCalibrationSource).toHaveBeenCalledWith(9, 5);
+    expect(revalidatePath).toHaveBeenCalledWith("/portal");
+  });
+
+  it("rejects a dive borrowing its own calibration", async () => {
+    // Self-reference would make laser-extrinsics resolution loop or 404, and
+    // the dive would silently never become measurable.
+    const result = await setCalibrationSourceAction(9, 9);
+
+    expect(result).toEqual({
+      ok: false,
+      error: "A dive cannot be its own calibration source",
+    });
+    expect(setCalibrationSource).not.toHaveBeenCalled();
+  });
+
+  it("returns the failure instead of throwing when the API rejects it", async () => {
+    setCalibrationSource.mockRejectedValue(new Error("500 Internal Server Error"));
+
+    const result = await setCalibrationSourceAction(9, 5);
+
+    expect(result).toEqual({ ok: false, error: "500 Internal Server Error" });
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("does not revalidate when the write failed", async () => {
+    setCalibrationSource.mockRejectedValue(new Error("nope"));
+
+    await setCalibrationSourceAction(9, 5);
+
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+});
+
+describe("clearCalibrationSourceAction", () => {
+  it("clears the link and revalidates the portal", async () => {
+    const result = await clearCalibrationSourceAction(9);
+
+    expect(result).toEqual({ ok: true });
+    expect(clearCalibrationSource).toHaveBeenCalledWith(9);
+    expect(revalidatePath).toHaveBeenCalledWith("/portal");
+  });
+
+  it("returns the failure instead of throwing when the API rejects it", async () => {
+    clearCalibrationSource.mockRejectedValue(new Error("503"));
+
+    expect(await clearCalibrationSourceAction(9)).toEqual({
+      ok: false,
+      error: "503",
+    });
+  });
+
+  it("reports a non-Error rejection without crashing", async () => {
+    clearCalibrationSource.mockRejectedValue("a bare string");
+
+    expect(await clearCalibrationSourceAction(9)).toEqual({
+      ok: false,
+      error: "Failed",
+    });
+  });
+});

--- a/apps/fishsense-lite-web/vitest.config.ts
+++ b/apps/fishsense-lite-web/vitest.config.ts
@@ -9,7 +9,13 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["lib/**/*.test.ts"],
+    // `app/**` as well as `lib/**`: server actions live under app/ and are
+    // real logic, not rendering — `app/portal/actions.ts` re-checks the
+    // session on every call because server actions are public endpoints.
+    // While this pattern was lib-only, a test placed next to such a module
+    // was silently never collected. `tests/integration/**` stays out; it has
+    // its own config and needs a running container.
+    include: ["lib/**/*.test.ts", "app/**/*.test.ts"],
     restoreMocks: true,
     unstubEnvs: true,
     unstubGlobals: true,

--- a/libs/fishsense-shared/src/fishsense_shared/config.py
+++ b/libs/fishsense-shared/src/fishsense_shared/config.py
@@ -12,7 +12,23 @@ from urllib.parse import urlparse
 
 import platformdirs
 
-IS_DOCKER = bool(os.environ.get("E4EFS_DOCKER", False))
+# True only when E4EFS_DOCKER is an explicitly-truthy value. NOT
+# `bool(os.environ.get("E4EFS_DOCKER"))` — that treats *any* non-empty string
+# as true, so `E4EFS_DOCKER=false` would (wrongly) read as Docker mode and send
+# config/log paths to `/e4efs/*` even where those don't exist. That is not
+# hypothetical: `deploy/compose.local.yml` sets it to "false" on the
+# devcontainer. Anything unrecognised fails safe to local-dev paths.
+#
+# This is the implementation CLAUDE.md has always described. It reached main
+# late: the fix was written in 4978163 but only ever landed on
+# `feat/data-worker-nrp` and `docs/claude-md-plumbing-gotchas`, so main carried
+# the footgun the docs warned about. See tests/test_config.py.
+IS_DOCKER = os.environ.get("E4EFS_DOCKER", "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
 
 
 def get_config_path() -> Path:

--- a/libs/fishsense-shared/tests/test_config.py
+++ b/libs/fishsense-shared/tests/test_config.py
@@ -1,0 +1,94 @@
+"""`E4EFS_DOCKER` decides where every service reads config and writes logs.
+
+The footgun, spelled out in CLAUDE.md: `bool(os.environ.get("E4EFS_DOCKER"))`
+treats *any* non-empty string as true, so `E4EFS_DOCKER=false` reads as Docker
+mode and sends paths to `/e4efs/*` on a machine that has no such directories.
+`deploy/compose.local.yml` sets exactly that value on the devcontainer, so this
+is not hypothetical.
+
+It has to be a module-level constant (services import `IS_DOCKER` directly and
+Dynaconf reads `get_config_path()` at import time), so the environment is only
+consulted once — which is why these tests reload the module rather than
+monkeypatching an attribute.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def _reload_with(monkeypatch, value: str | None):
+    """Re-import `fishsense_shared.config` with `E4EFS_DOCKER` set to `value`."""
+    from fishsense_shared import config  # pylint: disable=import-outside-toplevel
+
+    if value is None:
+        monkeypatch.delenv("E4EFS_DOCKER", raising=False)
+    else:
+        monkeypatch.setenv("E4EFS_DOCKER", value)
+    return importlib.reload(config)
+
+
+@pytest.fixture(autouse=True)
+def _restore_module():
+    """Leave the module as the rest of the suite found it."""
+    yield
+    from fishsense_shared import config  # pylint: disable=import-outside-toplevel
+
+    importlib.reload(config)
+
+
+# ── the values that must read as Docker mode ──────────────────────────
+
+
+@pytest.mark.parametrize("value", ["true", "True", "TRUE", "1", "yes", "on", " true "])
+def test_explicitly_truthy_values_enable_docker_mode(monkeypatch, value):
+    config = _reload_with(monkeypatch, value)
+
+    assert config.IS_DOCKER is True
+    assert config.get_config_path() == config.Path("/e4efs/config")
+    assert config.get_log_path("svc") == config.Path("/e4efs/logs")
+
+
+# ── and the ones that must NOT ────────────────────────────────────────
+
+
+@pytest.mark.parametrize("value", ["false", "False", "FALSE", "0", "no", "off", ""])
+def test_explicitly_falsy_values_do_not_enable_docker_mode(monkeypatch, value):
+    """The regression this file exists for.
+
+    `E4EFS_DOCKER=false` is a real configuration — `deploy/compose.local.yml`
+    sets it on the devcontainer — and it must mean "not Docker". Under
+    `bool(os.environ.get(...))` every one of these reads as True and config
+    resolution jumps to `/e4efs/config`, which doesn't exist outside an image.
+    """
+    config = _reload_with(monkeypatch, value)
+
+    assert config.IS_DOCKER is False
+    assert config.get_config_path() == config.Path(".")
+
+
+def test_unset_is_not_docker_mode(monkeypatch):
+    config = _reload_with(monkeypatch, None)
+
+    assert config.IS_DOCKER is False
+    assert config.get_config_path() == config.Path(".")
+
+
+def test_an_unrecognised_value_is_not_docker_mode(monkeypatch):
+    """Fail safe. An unexpected value should degrade to the local-dev path,
+    which is merely wrong, rather than to `/e4efs/*`, which doesn't exist and
+    fails at import."""
+    config = _reload_with(monkeypatch, "maybe")
+
+    assert config.IS_DOCKER is False
+
+
+def test_the_compose_local_devcontainer_value_is_honoured(monkeypatch):
+    """Pins the concrete consumer: `deploy/compose.local.yml` sets
+    `E4EFS_DOCKER: "false"` on the dev service and expects cwd-relative
+    config."""
+    config = _reload_with(monkeypatch, "false")
+
+    assert config.get_config_path() == config.Path(".")


### PR DESCRIPTION
Three gaps found while auditing test coverage outside the in-progress ingest work. They're independent of it, hence a separate PR off `main`.

## 1. Two packages' tests never ran in CI

`check.sh`'s `PACKAGES` lists all six workspace packages, and `integration.yml` drives it — but `test.yml`'s matrix had drifted to four:

| Package | Tests | Ran in CI |
|---|---|---|
| `libs/fishsense-shared` | 21 | **no** |
| `services/fishsense-backup-worker` | 29 | **no** |

Both are green on disk, so nothing was broken — but a regression in either would have reached `main` silently. `fishsense-shared` is the worst place for that: every service depends on it. Confirmed against run [30959035283](https://github.com/UCSD-E4E/fishsense-lite/actions/runs/30959035283), which has no job for either.

Odd asymmetry this also resolves: backup-worker's *integration* test did run (via `check.sh` in `integration.yml`) while its unit tests did not.

## 2. `E4EFS_DOCKER` read `"false"` as Docker mode

CLAUDE.md documents this exact footgun and states the implementation guards against it. It did not:

```python
IS_DOCKER = bool(os.environ.get("E4EFS_DOCKER", False))
```

so `E4EFS_DOCKER=false` → `IS_DOCKER=True` → config and logs resolve to `/e4efs/*`, which doesn't exist outside an image. Not hypothetical — `deploy/compose.local.yml:327` sets exactly `"false"` on the devcontainer.

Measured before the fix:

```
E4EFS_DOCKER=false  -> IS_DOCKER = True | config path = /e4efs/config
E4EFS_DOCKER=no     -> IS_DOCKER = True | config path = /e4efs/config
```

The fix was written in `4978163` but only ever landed on `feat/data-worker-nrp` and `docs/claude-md-plumbing-gotchas` — **never `main`**. So the docs described a fix that existed only on unmerged branches. This ports it with the tests that would have caught it (8 of them fail against the old implementation), which change 1 is what makes CI actually run.

## 3. The portal's server-action auth gate was untested

`app/portal/actions.ts` re-checks the session on every call because server actions are ordinary public HTTP endpoints — `/portal/page.tsx` redirecting signed-out users does **not** protect them. Nothing covered it, partly because `vitest.config.ts`'s `include` was `lib/**`, so a test placed next to the module would never have been collected.

Widens `include` to `app/**` and adds coverage. Verified non-vacuous by mutation: dropping `requireSession` fails three tests.

## Verification

All six Python packages as CI will now run them, plus the web suite:

```
libs/fishsense-api-sdk                    121 passed
libs/fishsense-shared                      38 passed   (21 -> 38, +17 new)
services/fishsense-api                    280 passed
services/fishsense-api-workflow-worker    350 passed
services/fishsense-backup-worker           29 passed
apps/fishsense-lite-web                    76 passed   (8 files, was 7)
```

pylint 10.00 on changed Python; web typecheck and ESLint clean (one pre-existing `postcss.config.mjs` warning, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)