### PR TITLE
fix(api): create views on a fresh DB; Postgres integration tests; coverage ratchet

### DIFF
--- a/libs/fishsense-shared/pyproject.toml
+++ b/libs/fishsense-shared/pyproject.toml
@@ -21,6 +21,30 @@ dev = [
 testpaths = ["tests"]
 asyncio_mode = "auto"
 
+# Coverage is ratcheted at 100%. The point isn't the number — it's that
+# anything genuinely not worth covering has to be *declared* here, so a real
+# gap can't hide behind a comfortable-looking 94%. If a new line can't
+# sensibly be tested, add it to `exclude_also` (or mark it `# pragma: no
+# cover`) with a reason, rather than lowering the bar.
+#
+# `branch = true` because line coverage answers "did this run", and the bugs
+# in this repo have been "did the *other* side of the if run" — the
+# E4EFS_DOCKER footgun was on a line executed by every single test.
+[tool.coverage.run]
+branch = true
+source = ["src/fishsense_shared"]
+
+[tool.coverage.report]
+fail_under = 100
+show_missing = true
+exclude_also = [
+    # Never executed at runtime; TYPE_CHECKING blocks exist for the checker.
+    "if TYPE_CHECKING:",
+    # Abstract methods have no body to exercise.
+    "raise NotImplementedError",
+    "@(abc\\.)?abstractmethod",
+]
+
 [build-system]
 requires = ["uv_build>=0.8.12,<0.9.0"]
 build-backend = "uv_build"

--- a/libs/fishsense-shared/tests/test_build_tls_config.py
+++ b/libs/fishsense-shared/tests/test_build_tls_config.py
@@ -1,0 +1,169 @@
+"""`build_tls_config` is the single mTLS implementation for the whole repo.
+
+Every service that talks to Temporal builds its client identity through this
+one function, so a mistake here doesn't degrade a feature — it disconnects all
+four workers from krg-prod at once, and only in production, because local dev
+runs `temporal server start-dev` with `tls = false` and never reaches the
+interesting branches.
+
+It was entirely uncovered until this file.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class _Settings:
+    """Stand-in for the `settings.temporal` subtree.
+
+    Dynaconf boxes support both attribute access and `in`, and
+    `build_tls_config` uses both (`temporal_settings.tls` /
+    `"domain" in temporal_settings`), so the double has to as well —
+    a plain namespace would pass attribute access and silently fail
+    the membership tests.
+    """
+
+    def __init__(self, **values):
+        self._values = values
+        for key, value in values.items():
+            setattr(self, key, value)
+
+    def __contains__(self, key):
+        return key in self._values
+
+
+@pytest.fixture
+def certs(tmp_path):
+    client_cert = tmp_path / "client.crt"
+    client_key = tmp_path / "client.key"
+    root_ca = tmp_path / "ca.crt"
+    client_cert.write_bytes(b"-----BEGIN CERTIFICATE-----client")
+    client_key.write_bytes(b"-----BEGIN PRIVATE KEY-----key")
+    root_ca.write_bytes(b"-----BEGIN CERTIFICATE-----ca")
+    return client_cert, client_key, root_ca
+
+
+def test_tls_disabled_returns_none_so_local_dev_connects_plaintext():
+    """`temporal server start-dev` has no TLS; returning None is what lets the
+    same call site work in both environments."""
+    from fishsense_shared.temporal import (  # pylint: disable=import-outside-toplevel
+        build_tls_config,
+    )
+
+    assert build_tls_config(_Settings(tls=False)) is None
+
+
+def test_reads_the_cert_files_from_disk_as_bytes(certs):
+    """The certs are paths in settings but bytes on the wire — passing the path
+    through would produce a TLSConfig that fails at connect time, far from
+    here."""
+    from fishsense_shared.temporal import (  # pylint: disable=import-outside-toplevel
+        build_tls_config,
+    )
+
+    client_cert, client_key, _ = certs
+    result = build_tls_config(
+        _Settings(
+            tls=True,
+            client_cert=str(client_cert),
+            client_private_key=str(client_key),
+        )
+    )
+
+    assert result is not None
+    assert result.client_cert == b"-----BEGIN CERTIFICATE-----client"
+    assert result.client_private_key == b"-----BEGIN PRIVATE KEY-----key"
+
+
+def test_server_root_ca_is_read_when_present(certs):
+    from fishsense_shared.temporal import (  # pylint: disable=import-outside-toplevel
+        build_tls_config,
+    )
+
+    client_cert, client_key, root_ca = certs
+    result = build_tls_config(
+        _Settings(
+            tls=True,
+            client_cert=str(client_cert),
+            client_private_key=str(client_key),
+            server_root_ca_cert=str(root_ca),
+        )
+    )
+
+    assert result.server_root_ca_cert == b"-----BEGIN CERTIFICATE-----ca"
+
+
+def test_server_root_ca_is_none_when_absent(certs):
+    """Optional: a public CA needs no explicit root. The key thing is that the
+    absence is detected by membership, not by reading a missing file."""
+    from fishsense_shared.temporal import (  # pylint: disable=import-outside-toplevel
+        build_tls_config,
+    )
+
+    client_cert, client_key, _ = certs
+    result = build_tls_config(
+        _Settings(
+            tls=True,
+            client_cert=str(client_cert),
+            client_private_key=str(client_key),
+        )
+    )
+
+    assert result.server_root_ca_cert is None
+
+
+def test_domain_is_passed_through_when_present(certs):
+    """`domain` is the serverName the client verifies against. krg-prod's cert
+    is issued for a name that isn't the connection host, so dropping this
+    fails the handshake."""
+    from fishsense_shared.temporal import (  # pylint: disable=import-outside-toplevel
+        build_tls_config,
+    )
+
+    client_cert, client_key, _ = certs
+    result = build_tls_config(
+        _Settings(
+            tls=True,
+            client_cert=str(client_cert),
+            client_private_key=str(client_key),
+            domain="krg-prod.ucsd.edu",
+        )
+    )
+
+    assert result.domain == "krg-prod.ucsd.edu"
+
+
+def test_domain_is_none_when_absent(certs):
+    from fishsense_shared.temporal import (  # pylint: disable=import-outside-toplevel
+        build_tls_config,
+    )
+
+    client_cert, client_key, _ = certs
+    result = build_tls_config(
+        _Settings(
+            tls=True,
+            client_cert=str(client_cert),
+            client_private_key=str(client_key),
+        )
+    )
+
+    assert result.domain is None
+
+
+def test_a_missing_cert_file_raises_rather_than_connecting_without_tls(tmp_path):
+    """Fail loud. Silently degrading to no client identity would connect to
+    Temporal unauthenticated (or not at all) with nothing pointing at the
+    missing file."""
+    from fishsense_shared.temporal import (  # pylint: disable=import-outside-toplevel
+        build_tls_config,
+    )
+
+    with pytest.raises(FileNotFoundError):
+        build_tls_config(
+            _Settings(
+                tls=True,
+                client_cert=str(tmp_path / "absent.crt"),
+                client_private_key=str(tmp_path / "absent.key"),
+            )
+        )

--- a/libs/fishsense-shared/tests/test_logging_and_paths.py
+++ b/libs/fishsense-shared/tests/test_logging_and_paths.py
@@ -1,0 +1,195 @@
+"""Coverage for the remaining `fishsense_shared` surface: log/config paths,
+the dynaconf validators, and the standard logging setup.
+
+None of this is glamorous, but all of it runs at import time in every service,
+so a break here takes down all four workers at once rather than degrading one
+feature. `configure_logging` in particular runs before any of them can log
+about the fact that it didn't work.
+"""
+
+from __future__ import annotations
+
+import logging
+import logging.handlers
+import time
+from pathlib import Path
+
+import pytest
+
+from fishsense_shared import config as config_module
+from fishsense_shared import logging as logging_module
+
+
+# ── get_log_path ──────────────────────────────────────────────────────
+
+
+def test_log_path_outside_docker_uses_platformdirs_and_creates_it(monkeypatch, tmp_path):
+    """The non-Docker branch has a side effect — it creates the directory —
+    which is what makes `configure_logging` able to open a file handler on a
+    dev box that has never run the service before."""
+    monkeypatch.setattr(config_module, "IS_DOCKER", False)
+
+    target = tmp_path / "nested" / "logs"
+
+    class _Dirs:  # pylint: disable=too-few-public-methods
+        user_log_path = target
+
+    monkeypatch.setattr(config_module.platformdirs, "PlatformDirs", lambda _: _Dirs())
+
+    result = config_module.get_log_path("svc")
+
+    assert result == target
+    assert target.is_dir()
+
+
+def test_log_path_creation_is_idempotent(monkeypatch, tmp_path):
+    monkeypatch.setattr(config_module, "IS_DOCKER", False)
+    target = tmp_path / "logs"
+    target.mkdir()
+
+    class _Dirs:  # pylint: disable=too-few-public-methods
+        user_log_path = target
+
+    monkeypatch.setattr(config_module.platformdirs, "PlatformDirs", lambda _: _Dirs())
+
+    assert config_module.get_log_path("svc") == target   # must not raise
+
+
+def test_log_path_in_docker_does_not_touch_the_filesystem(monkeypatch):
+    """`/e4efs/logs` is a mounted volume owned by the image; creating it here
+    would mask a missing mount."""
+    monkeypatch.setattr(config_module, "IS_DOCKER", True)
+
+    assert config_module.get_log_path("svc") == Path("/e4efs/logs")
+
+
+# ── validators ────────────────────────────────────────────────────────
+
+
+def test_path_validator_accepts_an_existing_path(tmp_path):
+    assert config_module.path_validator(str(tmp_path)) is True
+
+
+def test_path_validator_rejects_a_missing_path(tmp_path):
+    assert config_module.path_validator(str(tmp_path / "nope")) is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://fishsense-api:8000",     # docker DNS, no TLD
+        "http://static_file_server",     # underscore
+        "https://api.fishsense.e4e.ucsd.edu",
+        "http://garage:3900",
+    ],
+)
+def test_url_condition_accepts_the_hostnames_this_repo_actually_uses(url):
+    """`validators.url` rejects every one of these, which is why this exists.
+    See the docstring in config.py — don't switch back."""
+    assert config_module.url_condition(url) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["fishsense-api:8000", "ftp://host/x", "", "://nohost", "http://"],
+)
+def test_url_condition_still_rejects_malformed_urls(value):
+    assert config_module.url_condition(value) is False
+
+
+@pytest.mark.parametrize("value", [None, 8000, b"http://x", ["http://x"]])
+def test_url_condition_rejects_non_strings(value):
+    """Dynaconf will hand over whatever is in the settings file, so a
+    non-string must return False rather than raising inside validation."""
+    assert config_module.url_condition(value) is False
+
+
+# ── configure_logging ─────────────────────────────────────────────────
+
+
+@pytest.fixture
+def clean_root_logger():
+    """`configure_logging` mutates the root logger and the global Formatter
+    converter. Restore both, or every later test inherits the handlers."""
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    saved_converter = logging.Formatter.converter
+    root.handlers = []
+    yield root
+    for handler in root.handlers:
+        handler.close()
+    root.handlers = saved_handlers
+    root.setLevel(saved_level)
+    logging.Formatter.converter = saved_converter
+
+
+def test_configure_logging_installs_a_rotating_file_handler_and_a_console_handler(
+    monkeypatch, tmp_path, clean_root_logger
+):
+    monkeypatch.setattr(logging_module, "get_log_path", lambda _: tmp_path)
+
+    logging_module.configure_logging("svc")
+
+    kinds = [type(h) for h in clean_root_logger.handlers]
+    assert logging.handlers.TimedRotatingFileHandler in kinds
+    assert logging.StreamHandler in kinds
+    assert clean_root_logger.level == logging.DEBUG
+
+
+@pytest.mark.usefixtures("clean_root_logger")
+def test_configure_logging_defaults_the_filename_to_the_app_name(monkeypatch, tmp_path):
+    monkeypatch.setattr(logging_module, "get_log_path", lambda _: tmp_path)
+
+    logging_module.configure_logging("my-worker")
+
+    assert (tmp_path / "my-worker.log").exists()
+
+
+@pytest.mark.usefixtures("clean_root_logger")
+def test_configure_logging_honours_an_explicit_filename(monkeypatch, tmp_path):
+    monkeypatch.setattr(logging_module, "get_log_path", lambda _: tmp_path)
+
+    logging_module.configure_logging("my-worker", log_filename="custom.log")
+
+    assert (tmp_path / "custom.log").exists()
+    assert not (tmp_path / "my-worker.log").exists()
+
+
+@pytest.mark.usefixtures("clean_root_logger")
+def test_configure_logging_switches_timestamps_to_utc(monkeypatch, tmp_path):
+    """Every service's logs are read side by side against Temporal's UTC
+    timestamps; a local-time handler makes correlating an incident guesswork."""
+    monkeypatch.setattr(logging_module, "get_log_path", lambda _: tmp_path)
+
+    logging_module.configure_logging("svc")
+
+    assert logging.Formatter.converter is time.gmtime
+
+
+def test_configure_log_handler_sets_debug_and_the_shared_format():
+    handler = logging.StreamHandler()
+
+    logging_module.configure_log_handler(handler)
+
+    assert handler.level == logging.DEBUG
+    assert handler.formatter is not None
+    # Millisecond precision + trailing Z — the format the log-shipping side
+    # parses.
+    assert ".%(msecs)03dZ" in handler.formatter._fmt  # pylint: disable=protected-access
+
+
+def test_log_lines_render_in_the_expected_shape(
+    monkeypatch, tmp_path, clean_root_logger
+):
+    """End to end: a real record through the real handler onto disk."""
+    monkeypatch.setattr(logging_module, "get_log_path", lambda _: tmp_path)
+    logging_module.configure_logging("svc")
+
+    logging.getLogger("some.module").warning("hello %s", "world")
+    for handler in clean_root_logger.handlers:
+        handler.flush()
+
+    written = (tmp_path / "svc.log").read_text(encoding="utf-8")
+    assert "some.module - WARNING - hello world" in written
+    assert "Z - " in written          # UTC marker survived formatting

--- a/services/fishsense-api/src/fishsense_api/database.py
+++ b/services/fishsense-api/src/fishsense_api/database.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from fishsense_api import views
 from fishsense_api.config import pg_connection_string
 from fishsense_api.models.camera import Camera
 from fishsense_api.models.camera_intrinsics import CameraIntrinsics
@@ -86,6 +87,22 @@ async def _has_alembic_version_table() -> bool:
         await engine.dispose()
 
 
+async def _create_all_views() -> None:
+    """(Re)create every view in `views.ALL_VIEW_DDL`.
+
+    Only needed on the fresh-DB path — see `run_alembic_upgrade`. Each entry
+    is DROP-then-CREATE, so this is idempotent and safe to re-run.
+    """
+    engine = create_async_engine(pg_connection_string())
+    try:
+        async with engine.begin() as conn:
+            for drop_sql, create_sql in views.ALL_VIEW_DDL:
+                await conn.execute(sa.text(drop_sql))
+                await conn.execute(sa.text(create_sql))
+    finally:
+        await engine.dispose()
+
+
 def run_alembic_upgrade() -> None:
     """Apply pending migrations OR stamp head on a fresh DB.
 
@@ -135,6 +152,15 @@ def run_alembic_upgrade() -> None:
             "alembic_version missing; stamping head (fresh DB after create_all)"
         )
         alembic_command.stamp(cfg, "head")
+        # Stamping marks every migration as applied without running any of
+        # them, so the views those migrations create are never made. They
+        # aren't in `SQLModel.metadata` either, so `create_all` didn't make
+        # them. Without this a fresh environment ends up with every table and
+        # no views, and never recovers: the next restart sees `alembic_version`
+        # and finds nothing to upgrade.
+        _log.info("creating views for fresh DB")
+        asyncio.run(_create_all_views())
+        _log.info("views created")
 
 
 _session_factory: sessionmaker | None = None  # pylint: disable=invalid-name

--- a/services/fishsense-api/src/fishsense_api/database.py
+++ b/services/fishsense-api/src/fishsense_api/database.py
@@ -87,17 +87,47 @@ async def _has_alembic_version_table() -> bool:
         await engine.dispose()
 
 
-async def _create_all_views() -> None:
-    """(Re)create every view in `views.ALL_VIEW_DDL`.
+async def _missing_views() -> list[str]:
+    """Which of `views.ALL_VIEW_NAMES` are absent from the database."""
+    engine = create_async_engine(pg_connection_string())
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(
+                sa.text(
+                    "SELECT table_name FROM information_schema.views "
+                    "WHERE table_schema = current_schema()"
+                )
+            )
+            present = {row[0] for row in result}
+        return [name for name in views.ALL_VIEW_NAMES if name not in present]
+    finally:
+        await engine.dispose()
 
-    Only needed on the fresh-DB path — see `run_alembic_upgrade`. Each entry
-    is DROP-then-CREATE, so this is idempotent and safe to re-run.
+
+async def _create_all_views() -> None:
+    """(Re)create every view in `views.ALL_VIEW_DDL`, idempotently.
+
+    **Drop every view first, in reverse registry order, then create them in
+    forward order.** Interleaving drop-and-create per view fails as soon as one
+    view depends on another: `fish_model_species_mislabel_suspects` selects
+    from `fish_model_measurement_accuracy`, so dropping the latter while the
+    former still exists raises `DependentObjectsStillExistError`. Two phases
+    means every dependent is gone before its dependency is touched.
+
+    That makes `ALL_VIEW_DDL`'s order load-bearing: it must be dependency
+    order, dependents last.
+
+    Deliberately NOT `DROP ... CASCADE`. Cascade would succeed by silently
+    destroying anything *outside* this registry that depends on these views —
+    a Superset-created view over `dive_pipeline_status`, say. Failing loudly on
+    an unexpected dependent is the better outcome.
     """
     engine = create_async_engine(pg_connection_string())
     try:
         async with engine.begin() as conn:
-            for drop_sql, create_sql in views.ALL_VIEW_DDL:
+            for drop_sql, _create_sql in reversed(views.ALL_VIEW_DDL):
                 await conn.execute(sa.text(drop_sql))
+            for _drop_sql, create_sql in views.ALL_VIEW_DDL:
                 await conn.execute(sa.text(create_sql))
     finally:
         await engine.dispose()
@@ -147,20 +177,37 @@ def run_alembic_upgrade() -> None:
         _log.info("alembic_version present; running upgrade head")
         alembic_command.upgrade(cfg, "head")
         _log.info("alembic upgrade complete")
+
+        # Repair, not routine maintenance. Databases bootstrapped by the older
+        # stamp path were marked fully-migrated without ever creating the
+        # views, and nothing brought them back — this is the only thing that
+        # will. Gated on something actually being absent so a healthy database
+        # doesn't drop and rebuild its views on every restart while Superset is
+        # querying them.
+        missing = asyncio.run(_missing_views())
+        if missing:
+            _log.warning(
+                "views missing after upgrade (%s); recreating", ", ".join(missing)
+            )
+            asyncio.run(_create_all_views())
     else:
         _log.info(
-            "alembic_version missing; stamping head (fresh DB after create_all)"
+            "alembic_version missing; fresh DB after create_all"
         )
-        alembic_command.stamp(cfg, "head")
-        # Stamping marks every migration as applied without running any of
-        # them, so the views those migrations create are never made. They
-        # aren't in `SQLModel.metadata` either, so `create_all` didn't make
-        # them. Without this a fresh environment ends up with every table and
-        # no views, and never recovers: the next restart sees `alembic_version`
-        # and finds nothing to upgrade.
+        # Views BEFORE the stamp, deliberately. Stamping marks every migration
+        # as applied without running any of them, so the views those migrations
+        # create are never made — and they aren't in `SQLModel.metadata`
+        # either, so `create_all` didn't make them.
+        #
+        # Order matters for failure, not success: if view creation raises,
+        # `alembic_version` is still absent, so the next restart retries this
+        # whole path. Stamping first would leave the database marked
+        # fully-migrated with no views and no way back, which is precisely the
+        # non-self-healing failure this exists to fix.
         _log.info("creating views for fresh DB")
         asyncio.run(_create_all_views())
-        _log.info("views created")
+        _log.info("views created; stamping head")
+        alembic_command.stamp(cfg, "head")
 
 
 _session_factory: sessionmaker | None = None  # pylint: disable=invalid-name

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -603,3 +603,37 @@ WHERE f.best_fit_model <> a.model_name
 DROP_FISH_MODEL_MISLABEL_SUSPECTS_VIEW_SQL = (
     f"DROP VIEW IF EXISTS {FISH_MODEL_MISLABEL_SUSPECTS_VIEW_NAME}"
 )
+
+
+# ---------------------------------------------------------------------------
+# Every view, for the fresh-database bootstrap
+# ---------------------------------------------------------------------------
+
+# `(drop_sql, create_sql)` for each view, in creation order.
+#
+# Views are raw SQL owned by migrations, NOT part of `SQLModel.metadata`, so
+# `create_all` cannot produce them. On a fresh database `run_alembic_upgrade`
+# *stamps* head instead of upgrading (the historical migrations aren't
+# idempotent against `create_all`), which used to leave every table present and
+# every view missing — and because head was stamped, the next restart found
+# nothing to do and it never self-healed. `database.create_all_views` replays
+# this list on that path.
+#
+# Adding a view means adding it here as well as in its migration, or a fresh
+# environment silently won't have it.
+ALL_VIEW_DDL = (
+    (DROP_DIVE_PIPELINE_STATUS_VIEW_SQL, DIVE_PIPELINE_STATUS_VIEW_SQL),
+    (DROP_FISH_MODEL_ACCURACY_VIEW_SQL, FISH_MODEL_ACCURACY_VIEW_SQL),
+    (DROP_FISH_LENGTH_ESTIMATE_VIEW_SQL, FISH_LENGTH_ESTIMATE_VIEW_SQL),
+    (
+        DROP_FISH_MODEL_MISLABEL_SUSPECTS_VIEW_SQL,
+        FISH_MODEL_MISLABEL_SUSPECTS_VIEW_SQL,
+    ),
+)
+
+ALL_VIEW_NAMES = (
+    DIVE_PIPELINE_STATUS_VIEW_NAME,
+    FISH_MODEL_ACCURACY_VIEW_NAME,
+    FISH_LENGTH_ESTIMATE_VIEW_NAME,
+    FISH_MODEL_MISLABEL_SUSPECTS_VIEW_NAME,
+)

--- a/services/fishsense-api/tests/test_alembic_upgrade.py
+++ b/services/fishsense-api/tests/test_alembic_upgrade.py
@@ -30,14 +30,23 @@ def _patch_run_alembic(has_alembic_version: bool):
     fake_cfg = MagicMock()
     fake_config_cls.return_value = fake_cfg
 
+    # The fresh-DB branch also (re)creates the views, which would otherwise
+    # open a real connection. Record the calls so tests can assert on them.
+    views_created = MagicMock()
+
+    async def _fake_create_views():
+        views_created()
+
     return (
         fake_command,
         fake_cfg,
+        views_created,
         patch.multiple(
             database,
             alembic_command=fake_command,
             AlembicConfig=fake_config_cls,
             _has_alembic_version_table=_fake_check,
+            _create_all_views=_fake_create_views,
         ),
     )
 
@@ -57,12 +66,17 @@ def _assert_script_location_set(fake_cfg):
 def test_run_alembic_upgrade_existing_db_invokes_upgrade_to_head():
     """When alembic_version exists, this is an existing DB — apply any
     new pending migrations via `alembic upgrade head`."""
-    fake_command, fake_cfg, patcher = _patch_run_alembic(has_alembic_version=True)
+    fake_command, fake_cfg, views_created, patcher = _patch_run_alembic(
+        has_alembic_version=True
+    )
     with patcher:
         database.run_alembic_upgrade()
 
     fake_command.upgrade.assert_called_once_with(fake_cfg, "head")
     fake_command.stamp.assert_not_called()
+    # The migrations themselves own the views on this path; re-creating them
+    # here would drop and rebuild every view on every restart.
+    views_created.assert_not_called()
     _assert_script_location_set(fake_cfg)
 
 
@@ -72,13 +86,22 @@ def test_run_alembic_upgrade_fresh_db_stamps_head_without_running_ddl():
     head to mark the DB as fully migrated — running the historical
     migration tail on top would crash on every pre-existing column /
     table / constraint that `add_column` / `create_table` /
-    `create_unique_constraint` ops try to (re-)add."""
-    fake_command, fake_cfg, patcher = _patch_run_alembic(has_alembic_version=False)
+    `create_unique_constraint` ops try to (re-)add.
+
+    Stamping means those migrations never run, so anything they create that
+    `create_all` cannot — the views — has to be created explicitly here.
+    Without that a fresh environment ends up with every table and no views,
+    and never recovers: the next restart finds `alembic_version` present and
+    nothing to upgrade."""
+    fake_command, fake_cfg, views_created, patcher = _patch_run_alembic(
+        has_alembic_version=False
+    )
     with patcher:
         database.run_alembic_upgrade()
 
     fake_command.stamp.assert_called_once_with(fake_cfg, "head")
     fake_command.upgrade.assert_not_called()
+    views_created.assert_called_once()
     _assert_script_location_set(fake_cfg)
 
 

--- a/services/fishsense-api/tests/test_alembic_upgrade.py
+++ b/services/fishsense-api/tests/test_alembic_upgrade.py
@@ -15,7 +15,7 @@ import pytest
 from fishsense_api import database
 
 
-def _patch_run_alembic(has_alembic_version: bool):
+def _patch_run_alembic(has_alembic_version: bool, missing_views=()):
     """Helper: mock the alembic deps + the fresh-vs-existing detector.
 
     Returns the (fake_command, fake_cfg) so the caller can assert on
@@ -30,23 +30,31 @@ def _patch_run_alembic(has_alembic_version: bool):
     fake_cfg = MagicMock()
     fake_config_cls.return_value = fake_cfg
 
-    # The fresh-DB branch also (re)creates the views, which would otherwise
-    # open a real connection. Record the calls so tests can assert on them.
-    views_created = MagicMock()
+    # Both branches can touch the views, which would otherwise open a real
+    # connection. Record calls in order so tests can assert on sequencing as
+    # well as on whether they happened at all.
+    calls = []
+    views_created = MagicMock(side_effect=lambda: calls.append("create_views"))
+    fake_command.stamp.side_effect = lambda *_a, **_kw: calls.append("stamp")
 
     async def _fake_create_views():
         views_created()
+
+    async def _fake_missing_views():
+        return list(missing_views)
 
     return (
         fake_command,
         fake_cfg,
         views_created,
+        calls,
         patch.multiple(
             database,
             alembic_command=fake_command,
             AlembicConfig=fake_config_cls,
             _has_alembic_version_table=_fake_check,
             _create_all_views=_fake_create_views,
+            _missing_views=_fake_missing_views,
         ),
     )
 
@@ -66,7 +74,7 @@ def _assert_script_location_set(fake_cfg):
 def test_run_alembic_upgrade_existing_db_invokes_upgrade_to_head():
     """When alembic_version exists, this is an existing DB — apply any
     new pending migrations via `alembic upgrade head`."""
-    fake_command, fake_cfg, views_created, patcher = _patch_run_alembic(
+    fake_command, fake_cfg, views_created, _calls, patcher = _patch_run_alembic(
         has_alembic_version=True
     )
     with patcher:
@@ -74,10 +82,28 @@ def test_run_alembic_upgrade_existing_db_invokes_upgrade_to_head():
 
     fake_command.upgrade.assert_called_once_with(fake_cfg, "head")
     fake_command.stamp.assert_not_called()
-    # The migrations themselves own the views on this path; re-creating them
-    # here would drop and rebuild every view on every restart.
+    # Nothing is missing, so the views are left alone. The migrations own them
+    # on this path, and rebuilding on every restart would drop them out from
+    # under whatever Superset is querying.
     views_created.assert_not_called()
     _assert_script_location_set(fake_cfg)
+
+
+def test_run_alembic_upgrade_repairs_an_existing_db_that_is_missing_views():
+    """The stamped-and-viewless databases the old code left behind.
+
+    They have `alembic_version`, so they take the upgrade branch and alembic
+    finds nothing to do — nothing would ever recreate their views. This is the
+    only thing that repairs them.
+    """
+    fake_command, fake_cfg, views_created, _calls, patcher = _patch_run_alembic(
+        has_alembic_version=True, missing_views=["dive_pipeline_status"]
+    )
+    with patcher:
+        database.run_alembic_upgrade()
+
+    fake_command.upgrade.assert_called_once_with(fake_cfg, "head")
+    views_created.assert_called_once()
 
 
 def test_run_alembic_upgrade_fresh_db_stamps_head_without_running_ddl():
@@ -93,7 +119,7 @@ def test_run_alembic_upgrade_fresh_db_stamps_head_without_running_ddl():
     Without that a fresh environment ends up with every table and no views,
     and never recovers: the next restart finds `alembic_version` present and
     nothing to upgrade."""
-    fake_command, fake_cfg, views_created, patcher = _patch_run_alembic(
+    fake_command, fake_cfg, views_created, calls, patcher = _patch_run_alembic(
         has_alembic_version=False
     )
     with patcher:
@@ -102,7 +128,27 @@ def test_run_alembic_upgrade_fresh_db_stamps_head_without_running_ddl():
     fake_command.stamp.assert_called_once_with(fake_cfg, "head")
     fake_command.upgrade.assert_not_called()
     views_created.assert_called_once()
+    # Views BEFORE the stamp. If creation fails, `alembic_version` stays
+    # absent and the next restart retries the whole path; stamping first would
+    # mark the DB fully-migrated with no views and no way back.
+    assert calls == ["create_views", "stamp"]
     _assert_script_location_set(fake_cfg)
+
+
+def test_a_failure_creating_views_leaves_the_database_unstamped():
+    """So the next restart retries rather than inheriting a permanent gap."""
+    fake_command, _fake_cfg, _views_created, _calls, patcher = _patch_run_alembic(
+        has_alembic_version=False
+    )
+
+    async def _boom():
+        raise RuntimeError("view DDL failed")
+
+    with patcher, patch.object(database, "_create_all_views", _boom):
+        with pytest.raises(RuntimeError):
+            database.run_alembic_upgrade()
+
+    fake_command.stamp.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-api/tests/test_api_postgres_integration.py
+++ b/services/fishsense-api/tests/test_api_postgres_integration.py
@@ -1,0 +1,250 @@
+"""fishsense-api against a real Postgres — the startup path a deploy takes.
+
+Every other test in this package runs on in-memory SQLite, which means the
+`lifespan` sequence has never been exercised against the database it actually
+runs on. That sequence *is* the deploy: `create_all`, then
+`run_alembic_upgrade`. It has taken the API down before (the `laserprediction`
+duplicate-table crash-loop), and `runtime-import` only imports the module — it
+never starts it.
+
+Two things only Postgres can tell us:
+
+  * whether the four views in `views.py` exist after startup. They are raw SQL
+    in migrations, not `SQLModel.metadata`, so `create_all` cannot produce
+    them.
+  * whether their SQL is even valid Postgres. `DISTINCT ON`, `FILTER (WHERE
+    ...)`, `PERCENTILE_CONT` and friends parse differently or not at all on
+    SQLite, so a broken view can pass the whole unit suite.
+
+Run with the local stack up (`docker compose -f deploy/compose.local.yml up -d
+postgres`) via `./check.sh integration`, or point `FISHSENSE_POSTGRES_*` at any
+Postgres 17.
+
+The module creates and drops its own scratch database and never touches
+`fishsense`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+# Must be set BEFORE anything imports `fishsense_api.config`: dynaconf reads
+# the environment on first attribute access and caches it, and
+# `run_alembic_upgrade` resolves its URL through `pg_connection_string()`.
+_PG_HOST = os.environ.get("FISHSENSE_POSTGRES_HOST", "postgres")
+_PG_PORT = os.environ.get("FISHSENSE_POSTGRES_PORT", "5432")
+_PG_USER = os.environ.get("FISHSENSE_POSTGRES_USER", "postgres")
+_PG_PASSWORD = os.environ.get("FISHSENSE_POSTGRES_PASSWORD", "fishsense_local")
+_SCRATCH_DB = os.environ.get("FISHSENSE_POSTGRES_ITEST_DB", "fishsense_api_itest")
+
+os.environ["E4EFS_POSTGRES__HOST"] = _PG_HOST
+os.environ["E4EFS_POSTGRES__PORT"] = _PG_PORT
+os.environ["E4EFS_POSTGRES__USERNAME"] = _PG_USER
+os.environ["E4EFS_POSTGRES__PASSWORD"] = _PG_PASSWORD
+os.environ["E4EFS_POSTGRES__DATABASE"] = _SCRATCH_DB
+
+pytestmark = pytest.mark.integration
+
+
+def _admin_dsn(dbname: str = "postgres") -> str:
+    return (
+        f"host={_PG_HOST} port={_PG_PORT} user={_PG_USER} "
+        f"password={_PG_PASSWORD} dbname={dbname}"
+    )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def scratch_database():
+    """A database of our own, dropped afterwards. Never `fishsense`."""
+    import psycopg  # pylint: disable=import-outside-toplevel
+
+    with psycopg.connect(_admin_dsn(), autocommit=True) as conn:
+        conn.execute(f'DROP DATABASE IF EXISTS "{_SCRATCH_DB}" WITH (FORCE)')
+        conn.execute(f'CREATE DATABASE "{_SCRATCH_DB}"')
+    yield
+    with psycopg.connect(_admin_dsn(), autocommit=True) as conn:
+        conn.execute(f'DROP DATABASE IF EXISTS "{_SCRATCH_DB}" WITH (FORCE)')
+
+
+@pytest.fixture
+def empty_schema():
+    """Reset to a genuinely empty database between tests.
+
+    Dropping the schema rather than the database keeps the connection string
+    (and therefore dynaconf's cached settings) stable.
+    """
+    import psycopg  # pylint: disable=import-outside-toplevel
+
+    with psycopg.connect(_admin_dsn(_SCRATCH_DB), autocommit=True) as conn:
+        conn.execute("DROP SCHEMA public CASCADE")
+        conn.execute("CREATE SCHEMA public")
+    yield
+
+
+def _run_lifespan_sequence() -> None:
+    """Exactly what `fishsense_api.server.lifespan` does, in order."""
+    from fishsense_api.database import (  # pylint: disable=import-outside-toplevel
+        run_alembic_upgrade,
+        setup_database,
+    )
+
+    async def _startup():
+        database = setup_database()
+        async with database.engine.begin() as conn:
+            await database.init_database(conn)
+        await asyncio.to_thread(run_alembic_upgrade)
+        await database.engine.dispose()
+
+    asyncio.run(_startup())
+
+
+def _query(sql: str):
+    import psycopg  # pylint: disable=import-outside-toplevel
+
+    with psycopg.connect(_admin_dsn(_SCRATCH_DB)) as conn:
+        return conn.execute(sql).fetchall()
+
+
+def _views() -> set[str]:
+    return {
+        row[0]
+        for row in _query(
+            "SELECT table_name FROM information_schema.views "
+            "WHERE table_schema='public'"
+        )
+    }
+
+
+def _tables() -> set[str]:
+    return {
+        row[0]
+        for row in _query(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema='public' AND table_type='BASE TABLE'"
+        )
+    }
+
+
+# ── startup ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.usefixtures("empty_schema")
+def test_startup_on_a_fresh_database_creates_the_tables():
+    _run_lifespan_sequence()
+
+    tables = _tables()
+    assert "dive" in tables
+    assert "image" in tables
+    assert "alembic_version" in tables
+
+
+@pytest.mark.usefixtures("empty_schema")
+def test_startup_on_a_fresh_database_creates_every_view():
+    """The gap this module was written to find.
+
+    On a fresh DB `run_alembic_upgrade` *stamps* head rather than upgrading,
+    because the historical migrations aren't idempotent against `create_all`.
+    But the views live only in those migrations and are not part of
+    `SQLModel.metadata`, so stamping leaves a database with every table and no
+    views — and because head is stamped, it never self-heals: the next restart
+    sees `alembic_version`, runs `upgrade head`, and finds nothing to do.
+
+    Prod is unaffected (its DB predates this and has the views), but any fresh
+    environment — the local stack, integration CI, a disaster-recovery restore
+    into an empty database — silently loses every Superset dashboard.
+    """
+    from fishsense_api.views import (  # pylint: disable=import-outside-toplevel
+        DIVE_PIPELINE_STATUS_VIEW_NAME,
+        FISH_LENGTH_ESTIMATE_VIEW_NAME,
+        FISH_MODEL_ACCURACY_VIEW_NAME,
+        FISH_MODEL_MISLABEL_SUSPECTS_VIEW_NAME,
+    )
+
+    _run_lifespan_sequence()
+
+    assert _views() >= {
+        DIVE_PIPELINE_STATUS_VIEW_NAME,
+        FISH_MODEL_ACCURACY_VIEW_NAME,
+        FISH_LENGTH_ESTIMATE_VIEW_NAME,
+        FISH_MODEL_MISLABEL_SUSPECTS_VIEW_NAME,
+    }
+
+
+@pytest.mark.usefixtures("empty_schema")
+def test_every_view_is_actually_queryable_on_postgres():
+    """Existing is not the same as valid. These views use Postgres-only
+    constructs that SQLite either parses differently or not at all, so a
+    malformed one can pass the entire unit suite."""
+    from fishsense_api.views import (  # pylint: disable=import-outside-toplevel
+        DIVE_PIPELINE_STATUS_VIEW_NAME,
+        FISH_LENGTH_ESTIMATE_VIEW_NAME,
+        FISH_MODEL_ACCURACY_VIEW_NAME,
+        FISH_MODEL_MISLABEL_SUSPECTS_VIEW_NAME,
+    )
+
+    _run_lifespan_sequence()
+
+    for view in (
+        DIVE_PIPELINE_STATUS_VIEW_NAME,
+        FISH_MODEL_ACCURACY_VIEW_NAME,
+        FISH_LENGTH_ESTIMATE_VIEW_NAME,
+        FISH_MODEL_MISLABEL_SUSPECTS_VIEW_NAME,
+    ):
+        assert _query(f"SELECT * FROM {view} LIMIT 1") == []
+
+
+@pytest.mark.usefixtures("empty_schema")
+def test_startup_is_idempotent():
+    """`create_all` runs before `run_alembic_upgrade` on *every* restart, not
+    just the first. A restart must be a no-op, not a crash — this is the shape
+    of the laserprediction duplicate-table outage."""
+    _run_lifespan_sequence()
+    _run_lifespan_sequence()
+    _run_lifespan_sequence()
+
+    assert "dive" in _tables()
+    assert len(_views()) >= 4
+
+
+@pytest.mark.usefixtures("empty_schema")
+def test_a_second_startup_takes_the_upgrade_path_not_the_stamp_path():
+    """First run stamps (fresh DB); subsequent runs must find
+    `alembic_version` and upgrade. Pins that the branch is chosen on the
+    table's presence, so a restart never re-stamps over pending migrations."""
+    _run_lifespan_sequence()
+    first = _query("SELECT version_num FROM alembic_version")
+
+    _run_lifespan_sequence()
+
+    assert _query("SELECT version_num FROM alembic_version") == first
+
+
+# ── the views mean what the unit tests claim ──────────────────────────
+
+
+@pytest.mark.usefixtures("empty_schema")
+def test_dive_pipeline_status_reports_a_seeded_dive_on_postgres():
+    """The predicates are asserted extensively on SQLite. This checks the same
+    SQL against the engine it runs on, with one row through it end to end."""
+    _run_lifespan_sequence()
+
+    import psycopg  # pylint: disable=import-outside-toplevel
+
+    with psycopg.connect(_admin_dsn(_SCRATCH_DB), autocommit=True) as conn:
+        conn.execute(
+            "INSERT INTO dive (id, path, dive_datetime, priority) "
+            "VALUES (1, 'd/1', '2024-08-21 08:56:51+00', 'HIGH')"
+        )
+
+    rows = _query(
+        "SELECT dive_id, laser_preprocessed, measured "
+        "FROM dive_pipeline_status WHERE dive_id = 1"
+    )
+
+    assert len(rows) == 1
+    # Vacuous truth reads as False throughout — a dive with no labels at all is
+    # not "complete". Same rule the SQLite tests pin.
+    assert rows[0][2] is False

--- a/services/fishsense-api/tests/test_api_postgres_integration.py
+++ b/services/fishsense-api/tests/test_api_postgres_integration.py
@@ -31,22 +31,44 @@ import os
 
 import pytest
 
-# Must be set BEFORE anything imports `fishsense_api.config`: dynaconf reads
-# the environment on first attribute access and caches it, and
-# `run_alembic_upgrade` resolves its URL through `pg_connection_string()`.
 _PG_HOST = os.environ.get("FISHSENSE_POSTGRES_HOST", "postgres")
 _PG_PORT = os.environ.get("FISHSENSE_POSTGRES_PORT", "5432")
 _PG_USER = os.environ.get("FISHSENSE_POSTGRES_USER", "postgres")
 _PG_PASSWORD = os.environ.get("FISHSENSE_POSTGRES_PASSWORD", "fishsense_local")
 _SCRATCH_DB = os.environ.get("FISHSENSE_POSTGRES_ITEST_DB", "fishsense_api_itest")
 
-os.environ["E4EFS_POSTGRES__HOST"] = _PG_HOST
-os.environ["E4EFS_POSTGRES__PORT"] = _PG_PORT
-os.environ["E4EFS_POSTGRES__USERNAME"] = _PG_USER
-os.environ["E4EFS_POSTGRES__PASSWORD"] = _PG_PASSWORD
-os.environ["E4EFS_POSTGRES__DATABASE"] = _SCRATCH_DB
-
 pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _point_settings_at_the_scratch_database():
+    """Repoint dynaconf at the scratch DB, but only while these tests run.
+
+    Emphatically NOT module-level `os.environ[...] = ...`: pytest imports every
+    test module during collection, including on a default `-m 'not
+    integration'` run, so that would overwrite the session's Postgres settings
+    for suites that never asked for it — and the sibling modules' deliberate
+    `os.environ.setdefault(..., "ignored")` would then silently no-op, pointing
+    them at a real database.
+
+    Dynaconf caches on first attribute access, so setting the environment isn't
+    enough on its own; `reload()` re-runs the loaders. Both are undone
+    afterwards so the rest of the session sees what it did before.
+    """
+    from _pytest.monkeypatch import MonkeyPatch  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api.config import settings  # pylint: disable=import-outside-toplevel
+
+    monkeypatch = MonkeyPatch()
+    monkeypatch.setenv("E4EFS_POSTGRES__HOST", _PG_HOST)
+    monkeypatch.setenv("E4EFS_POSTGRES__PORT", _PG_PORT)
+    monkeypatch.setenv("E4EFS_POSTGRES__USERNAME", _PG_USER)
+    monkeypatch.setenv("E4EFS_POSTGRES__PASSWORD", _PG_PASSWORD)
+    monkeypatch.setenv("E4EFS_POSTGRES__DATABASE", _SCRATCH_DB)
+    settings.reload()
+    yield
+    monkeypatch.undo()
+    settings.reload()
 
 
 def _admin_dsn(dbname: str = "postgres") -> str:
@@ -248,3 +270,78 @@ def test_dive_pipeline_status_reports_a_seeded_dive_on_postgres():
     # Vacuous truth reads as False throughout — a dive with no labels at all is
     # not "complete". Same rule the SQLite tests pin.
     assert rows[0][2] is False
+
+
+# ── regressions found by review of the first cut ──────────────────────
+
+
+@pytest.mark.usefixtures("empty_schema")
+def test_recreating_the_views_when_they_already_exist_does_not_fail():
+    """`fish_model_species_mislabel_suspects` selects from
+    `fish_model_measurement_accuracy`, so dropping the latter while the former
+    exists raises `DependentObjectsStillExistError`.
+
+    The original per-view drop-then-create loop hit exactly that on any second
+    run, which meant the "safe to re-run" claim was false and a startup on a
+    database with views but no `alembic_version` would crash-loop the API.
+    Dropping everything in reverse order first fixes it — and this is the test
+    that would have caught it, because SQLite has no such dependency tracking.
+    """
+    from fishsense_api.database import (  # pylint: disable=import-outside-toplevel
+        _create_all_views,
+    )
+
+    _run_lifespan_sequence()
+    assert len(_views()) >= 4
+
+    asyncio.run(_create_all_views())      # must not raise
+    asyncio.run(_create_all_views())
+
+    assert len(_views()) >= 4
+
+
+@pytest.mark.usefixtures("empty_schema")
+def test_an_already_stamped_database_with_no_views_is_repaired():
+    """The state the previous implementation left behind.
+
+    `alembic_version` is present, so startup takes the upgrade branch and
+    alembic finds nothing to do. Without an explicit repair those databases
+    stay viewless permanently.
+    """
+    import psycopg  # pylint: disable=import-outside-toplevel
+
+    _run_lifespan_sequence()
+
+    with psycopg.connect(_admin_dsn(_SCRATCH_DB), autocommit=True) as conn:
+        for view in ("fish_model_species_mislabel_suspects", "dive_pipeline_status"):
+            conn.execute(f"DROP VIEW {view}")
+    assert "dive_pipeline_status" not in _views()
+
+    _run_lifespan_sequence()
+
+    assert "dive_pipeline_status" in _views()
+    assert "fish_model_species_mislabel_suspects" in _views()
+
+
+@pytest.mark.usefixtures("empty_schema")
+def test_a_healthy_database_is_not_rebuilt_on_every_restart():
+    """The repair must be conditional. Dropping and recreating every view on
+    each startup would break whatever Superset had mid-query, for no reason."""
+    from fishsense_api import database as db_module  # pylint: disable=import-outside-toplevel
+
+    _run_lifespan_sequence()
+
+    calls = []
+    original = db_module._create_all_views  # pylint: disable=protected-access
+
+    async def _counting():
+        calls.append(1)
+        await original()
+
+    db_module._create_all_views = _counting  # pylint: disable=protected-access
+    try:
+        _run_lifespan_sequence()
+    finally:
+        db_module._create_all_views = original  # pylint: disable=protected-access
+
+    assert not calls

--- a/services/fishsense-api/tests/test_view_bootstrap_registry.py
+++ b/services/fishsense-api/tests/test_view_bootstrap_registry.py
@@ -1,0 +1,54 @@
+"""`views.ALL_VIEW_DDL` must list every view, or fresh environments lose it.
+
+Views are raw SQL owned by migrations and are not part of
+`SQLModel.metadata`. On a fresh database `run_alembic_upgrade` stamps head
+rather than upgrading, so the migrations that create them never run — and the
+stamped version means it never self-heals. `database._create_all_views` covers
+that by replaying `ALL_VIEW_DDL`.
+
+Which makes that tuple a registry with the same failure mode as
+`controllers/__init__.py` and `database.py`'s model imports: forget to add
+your entry and nothing complains, it just silently isn't there. This test is
+the complaint.
+"""
+
+from __future__ import annotations
+
+import re
+
+from fishsense_api import views
+
+
+def _declared_view_names() -> set[str]:
+    """Every `*_VIEW_NAME` constant declared in views.py."""
+    return {
+        getattr(views, name)
+        for name in dir(views)
+        if name.endswith("_VIEW_NAME")
+    }
+
+
+def test_every_declared_view_is_in_the_bootstrap_registry():
+    missing = _declared_view_names() - set(views.ALL_VIEW_NAMES)
+    assert not missing, (
+        f"{sorted(missing)} declared in views.py but absent from ALL_VIEW_NAMES; "
+        "a fresh database would silently not have it"
+    )
+
+
+def test_the_registry_has_one_ddl_pair_per_name():
+    assert len(views.ALL_VIEW_DDL) == len(views.ALL_VIEW_NAMES)
+
+
+def test_every_registry_entry_drops_then_creates_the_same_view():
+    """A mismatched pair would drop one view and create another, which reads
+    as working right up until the wrong one goes missing."""
+    for (drop_sql, create_sql), name in zip(
+        views.ALL_VIEW_DDL, views.ALL_VIEW_NAMES, strict=True
+    ):
+        assert re.search(rf"DROP VIEW IF EXISTS {name}\b", drop_sql), (drop_sql, name)
+        assert re.search(rf"CREATE VIEW {name}\b", create_sql), name
+
+
+def test_registry_names_are_unique():
+    assert len(set(views.ALL_VIEW_NAMES)) == len(views.ALL_VIEW_NAMES)

--- a/services/fishsense-backup-worker/tests/test_prune_database_backups_activity.py
+++ b/services/fishsense-backup-worker/tests/test_prune_database_backups_activity.py
@@ -1,0 +1,205 @@
+# pylint: disable=protected-access
+"""Unit tests for the prune activity — the only code in this repo that
+*deletes* backups.
+
+The pure retention maths (`filenames_to_prune`) is covered in
+`test_backup_naming_and_pruning.py`. This module is the I/O wrapper around it,
+and it was at 0% coverage: nothing checked which directory it listed, or which
+paths it handed to `delete`. Those are the two ways this can destroy data
+rather than merely fail — deleting from the wrong folder, or deleting a
+filename resolved against the wrong root.
+
+CLAUDE.md: the nightly backup *is* the rollback mechanism for a system with no
+staging tier. There is nothing behind it.
+"""
+
+from __future__ import annotations
+
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch):
+    """Dynaconf validates every Validator on first access; seed placeholders so
+    importing the activity module doesn't fail first."""
+    monkeypatch.setenv("E4EFS_TEMPORAL__HOST", "temporal")
+    monkeypatch.setenv("E4EFS_E4E_NAS__URL", "https://nas.example.com:6021")
+    monkeypatch.setenv("E4EFS_E4E_NAS__USERNAME", "u")
+    monkeypatch.setenv("E4EFS_E4E_NAS__PASSWORD", "p")
+    monkeypatch.setenv("E4EFS_POSTGRES__HOST", "postgres")
+    monkeypatch.setenv("E4EFS_POSTGRES__USERNAME", "backup")
+    monkeypatch.setenv("E4EFS_POSTGRES__PASSWORD", "secret")
+    yield
+
+
+@pytest.fixture
+def nas(monkeypatch):
+    """A stand-in NAS whose `list_filenames`/`delete` calls are recorded."""
+    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+        prune_database_backups as sut,
+    )
+
+    client = MagicMock()
+    client.list_filenames.return_value = []
+    monkeypatch.setattr(sut, "NasBackupClient", lambda **_kwargs: client)
+    return client
+
+
+def _prune(**kwargs):
+    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+        prune_database_backups as sut,
+    )
+
+    return sut._prune(**kwargs)
+
+
+# ── which directory it touches ────────────────────────────────────────
+
+
+def test_lists_the_per_database_subdirectory_not_the_root(nas):
+    """Backups are laid out `<root>/<db_name>/<file>`. Listing the root instead
+    would return every database's files and prune across databases."""
+    _prune(db_name="fishsense", nas_root_path="/backups", keep=3)
+
+    nas.list_filenames.assert_called_once_with(folder_path="/backups/fishsense")
+
+
+def test_a_trailing_slash_on_the_root_does_not_produce_a_double_slash(nas):
+    """`//` resolves fine on some filesystems and 404s on FileStation, so a
+    config value with a trailing slash must not change the path."""
+    _prune(db_name="fishsense", nas_root_path="/backups/", keep=3)
+
+    nas.list_filenames.assert_called_once_with(folder_path="/backups/fishsense")
+
+
+# ── what it deletes ───────────────────────────────────────────────────
+
+
+def test_deletes_each_pruned_file_by_full_path(nas, monkeypatch):
+    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+        prune_database_backups as sut,
+    )
+
+    nas.list_filenames.return_value = ["a.dump", "b.dump", "c.dump"]
+    monkeypatch.setattr(sut, "filenames_to_prune", lambda _files, keep: ["a.dump"])
+
+    pruned = _prune(db_name="superset", nas_root_path="/backups", keep=2)
+
+    nas.delete.assert_called_once_with(file_path="/backups/superset/a.dump")
+    assert pruned == ["a.dump"]
+
+
+def test_deletes_nothing_when_retention_says_nothing_to_prune(nas, monkeypatch):
+    """The steady state on a fresh install. A wrapper that deleted on an empty
+    prune list would clear the whole directory."""
+    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+        prune_database_backups as sut,
+    )
+
+    nas.list_filenames.return_value = ["a.dump", "b.dump"]
+    monkeypatch.setattr(sut, "filenames_to_prune", lambda _files, keep: [])
+
+    assert _prune(db_name="fishsense", nas_root_path="/backups", keep=5) == []
+    nas.delete.assert_not_called()
+
+
+def test_deletes_only_what_the_retention_helper_returned(nas, monkeypatch):
+    """The wrapper must not re-derive the set. Everything the helper didn't
+    name has to survive."""
+    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+        prune_database_backups as sut,
+    )
+
+    nas.list_filenames.return_value = [f"{i}.dump" for i in range(10)]
+    monkeypatch.setattr(
+        sut, "filenames_to_prune", lambda _files, keep: ["0.dump", "1.dump"]
+    )
+
+    _prune(db_name="fishsense", nas_root_path="/backups", keep=8)
+
+    deleted = [c.kwargs["file_path"] for c in nas.delete.call_args_list]
+    assert deleted == ["/backups/fishsense/0.dump", "/backups/fishsense/1.dump"]
+
+
+@pytest.mark.usefixtures("nas")
+def test_passes_keep_through_to_the_retention_helper(monkeypatch):
+    """`keep` is the retention window. Dropping or defaulting it silently
+    changes how much history survives."""
+    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+        prune_database_backups as sut,
+    )
+
+    seen: List[int] = []
+
+    def _spy(files, keep):  # pylint: disable=unused-argument
+        seen.append(keep)
+        return []
+
+    monkeypatch.setattr(sut, "filenames_to_prune", _spy)
+
+    _prune(db_name="fishsense", nas_root_path="/backups", keep=14)
+
+    assert seen == [14]
+
+
+def test_only_the_listed_files_are_considered(nas, monkeypatch):
+    """The helper sees exactly what the NAS reported — no synthesised names."""
+    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+        prune_database_backups as sut,
+    )
+
+    nas.list_filenames.return_value = ["x.dump", "y.dump"]
+    seen: List[List[str]] = []
+
+    def _spy(files, keep):  # pylint: disable=unused-argument
+        seen.append(list(files))
+        return []
+
+    monkeypatch.setattr(sut, "filenames_to_prune", _spy)
+
+    _prune(db_name="fishsense", nas_root_path="/backups", keep=3)
+
+    assert seen == [["x.dump", "y.dump"]]
+
+
+# ── the activity wrapper ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_activity_accepts_an_already_typed_payload(nas, monkeypatch):
+    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+        prune_database_backups as sut,
+    )
+    from fishsense_backup_worker.workflows.backup_databases_workflow import (  # pylint: disable=import-outside-toplevel
+        PruneDatabaseBackupsInput,
+    )
+
+    monkeypatch.setattr(sut, "filenames_to_prune", lambda _files, keep: [])
+
+    await sut.prune_database_backups(
+        PruneDatabaseBackupsInput(
+            db_name="fishsense", nas_root_path="/backups", keep=3
+        )
+    )
+
+    nas.list_filenames.assert_called_once_with(folder_path="/backups/fishsense")
+
+
+@pytest.mark.asyncio
+async def test_activity_validates_a_dict_payload(nas, monkeypatch):
+    """Temporal hands the activity whatever the data converter produced; a
+    plain dict must be coerced rather than attribute-errored."""
+    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+        prune_database_backups as sut,
+    )
+
+    monkeypatch.setattr(sut, "filenames_to_prune", lambda _files, keep: [])
+
+    await sut.prune_database_backups(
+        {"db_name": "superset", "nas_root_path": "/backups", "keep": 4}
+    )
+
+    nas.list_filenames.assert_called_once_with(folder_path="/backups/superset")

--- a/services/fishsense-backup-worker/tests/test_worker_wiring.py
+++ b/services/fishsense-backup-worker/tests/test_worker_wiring.py
@@ -1,0 +1,148 @@
+"""The backup worker's startup wiring.
+
+Not glamorous, but the failure mode is: the worker starts, the schedule fires,
+and the workflow fails at runtime because an activity was never registered.
+Nothing catches that at import time, and the only signal is a Temporal task
+failure on a nightly job nobody is watching — for the service whose whole job
+is being the rollback mechanism.
+
+`main()` is driven with Temporal mocked out, so this asserts the wiring
+(what got registered, under which id, on which queue) without a cluster.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch):
+    monkeypatch.setenv("E4EFS_TEMPORAL__HOST", "temporal")
+    monkeypatch.setenv("E4EFS_E4E_NAS__URL", "https://nas.example.com:6021")
+    monkeypatch.setenv("E4EFS_E4E_NAS__USERNAME", "u")
+    monkeypatch.setenv("E4EFS_E4E_NAS__PASSWORD", "p")
+    monkeypatch.setenv("E4EFS_POSTGRES__HOST", "postgres")
+    monkeypatch.setenv("E4EFS_POSTGRES__USERNAME", "backup")
+    monkeypatch.setenv("E4EFS_POSTGRES__PASSWORD", "secret")
+    yield
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """Run `main()` with Temporal replaced; hand back the recorded calls."""
+    from fishsense_backup_worker import worker as sut  # pylint: disable=import-outside-toplevel
+
+    client = MagicMock()
+    connect = AsyncMock(return_value=client)
+    monkeypatch.setattr(sut.Client, "connect", connect)
+
+    ensure_schedule = AsyncMock()
+    monkeypatch.setattr(sut, "ensure_schedule", ensure_schedule)
+    monkeypatch.setattr(sut, "build_tls_config", lambda _s: None)
+    monkeypatch.setattr(sut, "configure_logging", lambda: None)
+
+    worker_instance = MagicMock()
+    worker_instance.run = AsyncMock()
+    worker_cls = MagicMock(return_value=worker_instance)
+    monkeypatch.setattr(sut, "Worker", worker_cls)
+
+    return sut, connect, ensure_schedule, worker_cls, worker_instance
+
+
+@pytest.mark.asyncio
+async def test_registers_both_activities_and_the_workflow(wired):
+    """The runtime failure this guards: a schedule that fires into a worker
+    which cannot execute what the workflow calls."""
+    sut, _connect, _ensure, worker_cls, _instance = wired
+    from fishsense_backup_worker.activities.pg_dump_database import (  # pylint: disable=import-outside-toplevel
+        pg_dump_database,
+    )
+    from fishsense_backup_worker.activities.prune_database_backups import (  # pylint: disable=import-outside-toplevel
+        prune_database_backups,
+    )
+    from fishsense_backup_worker.workflows.backup_databases_workflow import (  # pylint: disable=import-outside-toplevel
+        BackupDatabasesWorkflow,
+    )
+
+    await sut.main()
+
+    kwargs = worker_cls.call_args.kwargs
+    assert set(kwargs["activities"]) == {pg_dump_database, prune_database_backups}
+    assert kwargs["workflows"] == [BackupDatabasesWorkflow]
+
+
+@pytest.mark.asyncio
+async def test_listens_on_its_own_task_queue(wired):
+    """Deliberately separate from the data-processing worker so the backup
+    worker doesn't need to share Postgres credentials — see CLAUDE.md."""
+    sut, _connect, _ensure, worker_cls, _instance = wired
+
+    await sut.main()
+
+    assert worker_cls.call_args.kwargs["task_queue"] == sut.settings.backup.task_queue
+
+
+@pytest.mark.asyncio
+async def test_registers_the_daily_schedule_idempotently_on_startup(wired):
+    """First deploy creates the cadence with no manual ops; later deploys must
+    hit `ensure_schedule`'s already-exists path rather than re-creating it."""
+    sut, _connect, ensure_schedule, _worker_cls, _instance = wired
+
+    await sut.main()
+
+    ensure_schedule.assert_awaited_once()
+    assert (
+        ensure_schedule.await_args.kwargs["schedule_id"]
+        == sut.settings.backup.schedule_id
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_schedule_carries_the_configured_databases_and_retention(wired):
+    """Retention and the DB list are the two settings an operator actually
+    changes; if they don't reach the schedule the override silently no-ops."""
+    sut, _connect, ensure_schedule, _worker_cls, _instance = wired
+
+    await sut.main()
+
+    schedule = ensure_schedule.await_args.kwargs["schedule"]
+    payload = schedule.action.args[0]
+    assert payload.databases == list(sut.settings.backup.databases)
+    assert payload.retention_count == int(sut.settings.backup.retention_count)
+
+
+@pytest.mark.asyncio
+async def test_connects_with_the_shared_tls_and_namespace_helpers(wired):
+    """One mTLS implementation across every service — see
+    fishsense_shared.build_tls_config."""
+    sut, connect, _ensure, _worker_cls, _instance = wired
+
+    await sut.main()
+
+    connect.assert_awaited_once()
+    assert connect.await_args.args[0] == (
+        f"{sut.settings.temporal.host}:{sut.settings.temporal.port}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_worker_is_actually_started(wired):
+    sut, _connect, _ensure, _worker_cls, instance = wired
+
+    await sut.main()
+
+    instance.run.assert_awaited_once()
+
+
+def test_run_drives_main_under_asyncio(monkeypatch):
+    from fishsense_backup_worker import worker as sut  # pylint: disable=import-outside-toplevel
+
+    called = []
+    monkeypatch.setattr(sut.asyncio, "run", called.append)
+    monkeypatch.setattr(sut, "main", lambda: "coro")
+
+    sut.run()
+
+    assert called == ["coro"]

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "fishsense-api"
-version = "1.44.1"
+version = "1.45.0"
 source = { editable = "services/fishsense-api" }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Supersedes #547, which GitHub auto-closed when its base branch (`fix/ci-test-gaps`, now merged as #546) was deleted. Same content, rebased onto `main`; the full review discussion is on #547.

## 1. A fresh database got every table and no views

`fishsense-api` had **zero** integration tests — its whole suite runs on in-memory SQLite, so the `lifespan` sequence had never been exercised against the database it actually runs on. That sequence *is* the deploy (`create_all`, then `run_alembic_upgrade`). Writing the test found a live bug:

```
tables: 22
views:  (none)
alembic_version: d7e21b95c3a0
```

On a fresh DB `run_alembic_upgrade` **stamps** head rather than upgrading (historical migrations aren't idempotent against `create_all`). The four views live only in those migrations and aren't in `SQLModel.metadata`, so nothing creates them — and head being stamped means it never self-heals.

Prod is unaffected (its DB predates this and has all four — verified). What's affected is every *fresh* environment: the local stack, integration CI, and a disaster-recovery restore into an empty database, which is the documented rollback path. Superset reads these views.

**Fix:** `views.ALL_VIEW_DDL` lists each view; the fresh-DB branch creates them before stamping, and the upgrade branch repairs any that are missing.

## 2. Review findings on the first cut (all fixed)

`/code-review` caught four issues, two of which were bugs I introduced:

- **Dependent views made the drop loop fail** — reproduced: `fish_model_species_mislabel_suspects` selects from `fish_model_measurement_accuracy`, so per-view drop-then-create raised `DependentObjectsStillExistError` on any second run. Now drops all in reverse registry order, then creates forward. Deliberately **not** `CASCADE`: that would succeed by silently destroying anything outside the registry depending on these views (a Superset view over `dive_pipeline_status`, say).
- **Views were created after the stamp** — a mid-creation failure left the DB stamped with no views and no way back, the exact non-self-healing failure being fixed. Views now precede the stamp.
- **No repair for already-stamped viewless databases** — the upgrade branch now recreates missing views, gated on something actually being absent so a healthy DB isn't rebuilt on every restart.
- **Test module clobbered session Postgres settings** at collection — moved into a module-scoped fixture with `settings.reload()`. Verified: importing the module now has no env side effect.

## 3. Coverage ratchet

100% with anything genuinely uncoverable *declared*, so a real gap can't hide behind a comfortable 90%.

**`fishsense-shared`: 82% → 100%** (branch coverage, no exclusions), `fail_under = 100` enforcing. Newly covered: **`build_tls_config`** — the single mTLS implementation for the repo, previously untested, where a mistake disconnects all four workers from krg-prod and only in production; plus `configure_logging` and the config-path branches.

**`fishsense-backup-worker`: 62% → 90%.** `prune_database_backups` 0% → 100% — the only code that *deletes* backups, with nothing checking which directory it listed or which paths it deleted. `worker.py` 0% → 100% — its failure mode is a schedule firing into a worker that never registered the activity.

Not yet at 100%, stated plainly: `fishsense-api-sdk` (76%), `fishsense-api-workflow-worker` (91%), `fishsense-api`, and the data-worker.

## Prod impact

Verified before merge: prod has all four views, so `_missing_views()` returns empty and startup performs **no DDL**. The only prod-visible change is one extra `information_schema.views` query at startup.

## Verification

```
libs/fishsense-shared                     69 passed (100% coverage)
libs/fishsense-api-sdk                   121 passed
services/fishsense-api                   286 passed + 9 integration
services/fishsense-api-workflow-worker   350 passed
services/fishsense-backup-worker          45 passed
```

Integration suite run against a real Postgres 17. pylint 10.00 on every changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)