### PR TITLE
feat(api): dive + image create endpoints for ingest

### DIFF
--- a/docs/plans/dive-image-ingestion.md
+++ b/docs/plans/dive-image-ingestion.md
@@ -1,0 +1,967 @@
+# Plan — dive/image ingestion + the ungradeable `Weasly Fish`
+
+Status: **approved; in progress.** Two independent deliverables:
+
+* **Part 1** — ingest: API write endpoints, an api-worker Temporal workflow that
+  scans a NAS folder, and a `/portal/ingest` page.
+* **Part 2** — `Weasly Fish` reference row (small, ships independently).
+
+**Progress**
+
+| PR | Scope | State |
+|---|---|---|
+| 1 | fishsense-api write endpoints + SDK client methods (§2.1, §2.2, §4.2.1 lookup) | **landed** on `feat/dive-image-ingest-endpoints` |
+| 2 | api-worker: `NasClient` listing/ranged read, `exif.py`, 5 activities, `IngestDiveWorkflow` (§4), Temporal client in the API (§2.7) | not started |
+| 3 | `/portal/ingest` page (§5) | not started |
+| 4 | Part 2 — `Weasly Fish` reference row (§7) | blocked on the calipered widths |
+
+Read §0 first: one required verification is **blocked in this session**, and one
+finding **contradicts an assumption in the brief**.
+
+---
+
+## 0. What I verified, what I couldn't, and what contradicts the brief
+
+### 0.1 The checksum: **RESOLVED from source** — plain MD5 of the whole file
+
+The legacy repos you pointed me at settle it. The ingest tool is
+`UCSD-E4E/fishsense-data-processing-spider`, and
+`fishsense_data_processing_spider/backend.py:67`:
+
+```python
+def get_file_checksum(path: Path) -> str:
+    cksum = md5()
+    with open(path, 'rb') as handle:
+        for blob in iter(lambda: handle.read(8192), b''):
+            cksum.update(blob)
+    return cksum.hexdigest()
+```
+
+Called from `discovery.py:272` and written straight into `images.image_md5`
+(`sql/insert_image_path_dive_md5.sql`), which is the column `9e5bc64`'s migration
+copied into `Image.checksum`.
+
+**So `Image.checksum == hashlib.md5(<entire file bytes>).hexdigest()`.** The 8192-byte
+streaming is chunking, not scoping — byte-identical to hashing the whole buffer at
+once. `git log -S` over `backend.py` shows the function introduced once and never
+modified. No prefix variant, no canonicalisation, no header skipping. The prior
+plan's blocking gate is **dropped**.
+
+Two caveats worth keeping:
+
+* This proves what *spider* wrote. It does not prove every row came from spider —
+  older rows could predate it. So `tools/verify_checksum_algorithm.py` (§4.6) stays
+  in the plan, downgraded from "blocking gate" to "cheap standing net": run it over
+  a sample of existing rows whenever convenient. Not a merge blocker.
+* Ingest streams from the NAS anyway, so implement it as the same 8192-byte
+  streaming update rather than `md5(f.read())` — a 15 MB buffer per file times a
+  batch is real memory for no benefit.
+
+### 0.2 Contradiction: `NasClient` can't list, but the underlying client can
+
+The brief says a listing method "must be added". True of
+[nas.py](services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/nas.py),
+but the wheel it wraps already has it — no new dependency, no vendoring:
+
+```
+>>> [m for m in dir(synology_filestation._native.Client) if not m.startswith('_')]
+['create_folder', 'delete', 'download', 'download_to', 'exists', 'getinfo',
+ 'list_dir', 'list_shares', 'login', 'logout', 'upload', 'upload_bytes']
+```
+
+`list_dir(path)` returns dicts with `path` / `isdir` / `size` / `mtime`
+(shape confirmed from the wheel's own `fsspec.py` adapter). So `NasClient.list_dir`
+is a ~10-line wrapper in the existing style, matching `download_to` / `exists`.
+
+**Bonus that shapes the design:** `Client.download(path, *, offset=0, length=0)`
+does **ranged** reads. EXIF lives in the first ~1 MB of an ORF, so the dry-run
+pass reads ~1 MB/file instead of ~15 MB — a 500-image dive previews for ~0.5 GB
+instead of 7.5 GB. This is what makes the dry-run affordable (§3.2).
+
+### 0.3 **CONFIRMED**: `taken_datetime` is camera wall clock labelled UTC — and it is tag 0x0132, not 0x9003
+
+I had this from circumstantial evidence; the spider confirms it and corrects the
+tag I picked. `backend.py:20`:
+
+```python
+img = Image.open(path)
+exif = img.getexif()
+creation_time_str = exif.get(ExifTags.Base.DateTime)          # tag 0x0132
+creation_time = dt.datetime.strptime(creation_time_str, '%Y:%m:%d %H:%M:%S')
+return creation_time                                           # NAIVE — no tzinfo
+```
+
+Three corrections to what I had written:
+
+1. **The tag is `DateTime` (0x0132, IFD0), not `DateTimeOriginal` (0x9003).** They
+   are equal on the fixture and usually equal in practice, but they are not the same
+   field — 0x0132 is the camera's file-modify stamp. Ingest must read **0x0132** to
+   match, with 0x9003 as a fallback only when 0x0132 is absent (and log when it falls
+   back).
+2. **The datetime is naive.** Written to legacy `images.date TIMESTAMP` (no tz —
+   `2025-03-15_update_table.sql`), then copied by `9e5bc64` into
+   `Image.taken_datetime TIMESTAMPTZ`, picking up UTC. The chain is now fully
+   traced end to end. `OffsetTimeOriginal` was never read; the camera-local offset
+   was discarded at the source.
+3. My circumstantial reading (hours 6–9, `TzInfo(0)`, Florida in August) was right.
+   Nothing further to confirm against prod.
+
+**Decision unchanged:** reproduce it. Parse 0x0132, attach `timezone.utc`. Capture
+`OffsetTimeOriginal` into the report for the record and WARN when it is present and
+non-zero, but do not apply it. Correcting the column is a backfill decision across
+~111k rows, not ingest's call.
+
+**Also: don't use Pillow.** Spider pinned Pillow 11.3.0; on current Pillow (12.3.0,
+what we'd ship) `Image.open` on the real ORF fixture raises
+`cannot identify image file` — ORF's magic is `IIRO`, which `TiffImagePlugin`
+rejects. The stdlib reader in §0.7 has no such problem and I have run it against
+the real file. Reading 0x0132 instead of 0x9003 is a one-line change to it.
+
+### 0.4 Historical semantics, now traced through both repos
+
+| Field | Rule, and where it comes from | This plan |
+|---|---|---|
+| `Image.is_canonical` | `9e5bc64`: `existing_checksum is None` — first row for a checksum wins. Replaces spider's `canonical_dives` table, which keyed on a whole-dive checksum (`MD5(STRING_AGG(basename \|\| ':' \|\| image_md5))`, lowest path wins). | **Reproduce**, computed **server-side in the POST** (§2.2). A client-side check races itself. This is the dives-64/66 case. |
+| `Dive.dive_datetime` | Two different things existed: spider set `dives.date` = **mean** of image dates truncated to a DATE; `9e5bc64` **ignored that** and used `sorted(image_dates)[-1]` — the **max**. The max is what is in the column today. | **Reproduce the max.** |
+| `Dive.camera_id` | `9e5bc64`: `images[-1]["camera_sn"]` — the last image *globally*, a real bug; every dive got whatever camera the final image of the whole dump used. | **Diverge**: resolve per dive from that dive's own frames. Existing values are unreliable — audit separately, §9. |
+| multi-camera dives | Spider explicitly refused to assign a camera when a dive's frames spanned >1 serial, and wrote them to a `multiple_camera_dives` report file. | **Adopt as a hard preflight failure** — a mixed-rig folder is an operator error, and the wrong intrinsics silently corrupt stage 14. |
+| dive identity | Spider: `dive = image.parent.relative_to(data_root)` — see §4.1, this changes the workflow's shape. | **Reproduce.** |
+| dropped columns | `invalid_image`, `multiple_date`, `ignore`, `laser_task_id`, the whole `canonical_dives` table. | Not reintroduced. |
+
+### 0.5 Camera identification: **serial number** (your call), and it needs no exiftool
+
+Spider keyed on the Olympus **MakerNote** serial (`backend.py:136`,
+`et.get_tags(paths, ['MakerNotes:SerialNumber'])`), which is what populated
+`Camera.serial_number`. **Decision: key on the serial.** It is the safer key and the
+one your existing rows already use — `Camera.name` is an operator-settable label and
+EXIF `Artist` can be re-typed on the camera body; a body serial cannot.
+
+My earlier "use `Artist`, MakerNote parsing is too fragile" recommendation rested on
+a broken parse, and it was wrong. Two bugs in my first attempt:
+
+1. Olympus sub-IFD offsets are relative to the **start of the MakerNote block**, not
+   to the file.
+2. The Equipment pointer (tag `0x2010`) has **type 13** — a non-standard IFD type
+   Olympus uses — which my type-size table didn't know, so the entry was silently
+   skipped. That is why the parse "returned garbage": it never reached the sub-IFD.
+
+With both fixed, ~70 lines of stdlib extract it from the real fixture:
+
+```
+Olympus2 MakerNote @ 3092, header b'OLYMPUS\x00II\x03\x00'
+  tag=0x2010 typ=13  -> Equipment sub-IFD @ base+114
+    tag=0x0101 SerialNumber -> 'BJ6C67989'
+```
+
+`BJ6C67989` matches the serial visible in the file's raw bytes. **No exiftool, no
+Perl runtime in the api-worker image, no subprocess per batch.**
+
+Resolution order:
+
+1. Explicit `camera_id` on the request — always wins.
+2. MakerNote `SerialNumber` → `Camera.serial_number`.
+3. **No fallback.** Unreadable serial, or one matching no `Camera` row → preflight
+   **fails loudly**. Silently falling back to `Artist` is precisely the bug class
+   that yields a dive with wrong intrinsics and no error anywhere.
+
+`Artist` is still parsed, but only as a **cross-check**: if it disagrees with the
+`Camera.name` the serial resolved to, preflight warns. That catches a mislabelled
+`Camera` row, which nothing else would.
+
+Caveat stated plainly: verified against **one** TG-6 fixture. The Olympus2 format is
+shared across the TG line, but a non-Olympus body would return `None` — which fails
+preflight rather than guessing. The `camera_id` override is the escape hatch.
+
+**Lookup mechanics:** the `camera` table is tiny (a handful of rigs), so the activity
+does one `cameras.get()` and builds a `{serial_number: id}` map in memory rather than
+adding a `GET /cameras/serial/{sn}` route. Cheaper than N lookups, one less route.
+
+**Gap this exposes:** there is no endpoint to *create* a `Camera`. A genuinely new
+rig therefore cannot be ingested until someone inserts the row (DB-direct today).
+Deliberately out of scope — noted in §9.
+
+### 0.6 Security call-out — resolved
+
+The `fabricant-prod` Postgres password committed in plaintext (this repo's `9e5bc64`
+migration notebook, and cells in the spider repo) **has already been rotated** —
+confirmed 2026-08-06. Recorded so nobody re-reports it. Nothing to do.
+
+### 0.7 EXIF reader: stdlib, no new dependency
+
+`Pillow` cannot open ORF (`cannot identify image file`). `rawpy` is a data-worker
+dep and deliberately absent from the api-worker. Rather than add `exifread`, I
+wrote and **ran** a ~60-line stdlib TIFF/IFD reader against the real fixture — the
+output in §0.5 is its actual output. ORF is TIFF with magic `IIRO`; parsing IFD0
++ the Exif sub-IFD (0x8769) for tags 0x9003/0x9011/0x010F/0x0110 is all we need.
+
+Ships as `fishsense_api_workflow_worker/exif.py`, unit-tested against a small
+committed header fixture. Zero deps, and it works on ranged first-1 MB reads, which
+the dry run needs.
+
+The same module carries the Olympus MakerNote walk for `SerialNumber` (§0.5) —
+type-13 IFD pointers and base-relative offsets included, both verified against the
+real fixture.
+
+---
+
+## 1. Design decisions (direct answers)
+
+**Where the scan runs — Temporal workflow on `fishsense_api_queue`. Confirmed.**
+The api-worker is the only service with NAS creds and that is policy, not
+accident. Volume settles it: 500 × ~15 MB ≈ 7.5 GB at
+`e4e_nas.stage_concurrency` = 1 (deliberately serial — FileStation's download
+backend 502s under concurrency, krg-infra#501). Tens of minutes to hours per
+dive. The HTTP endpoint starts the workflow and reports; it never scans.
+
+**Idempotency.** Two natural keys, both unique, both upserted the resolve-then-merge
+way that #347 forced (`post_measurement` is the template):
+
+* `POST /api/v1/dives/` — if `id is None`, `SELECT Dive WHERE path = :path`; adopt
+  the id if found; then `session.merge`.
+* `POST /api/v1/dives/{dive_id}/images/` — same against `Image.path`.
+
+A blind `session.merge(..., id=None)` INSERTs and blows up on the unique index on
+the second run. Both endpoints get an explicit "run it twice" test (§6).
+
+`checksum` is deliberately **not** an idempotency key — duplicate content across
+dives is expected and legitimate (dives 64/66). It only drives `is_canonical`.
+
+**`taken_datetime`.** EXIF **`DateTime` (0x0132)** from IFD0 — the tag spider
+actually read (§0.3) — with `DateTimeOriginal` (0x9003) as a logged fallback when
+0x0132 is absent. `tzinfo=UTC` attached to the naive value, reproducing the
+existing convention. Missing or unparseable → **the image is rejected, not
+defaulted**. It lands in `IngestReport.rejected` with a reason, the workflow keeps
+going, and the final activity **refuses to flip the dive to HIGH if anything was
+rejected**. A fabricated timestamp would silently corrupt stage-1 clustering,
+which is pure timestamp math; a missing image is visible and fixable.
+
+Spider was weaker here: `get_image_date` returned the exception, the image simply
+never got a date, and the dive proceeded with `NULL` — `query_dates_from_dive`
+just skipped it. That silent-skip is the behaviour this plan deliberately does
+not reproduce.
+
+**Partial failure at image 300 of 500.** Three layers:
+
+1. *The dive is created at `priority=LOW`.* No cohort selector looks at LOW dives,
+   so a half-ingested dive cannot enter the pipeline. **`priority=HIGH` is the
+   commit flag**, set by the final activity only when every listed file is
+   persisted and nothing was rejected. This is the single most important safety
+   property in the design — it is what makes a crash inert rather than corrupting.
+2. *Batches of 25.* Images are scanned and posted in batches, one activity per
+   batch, with `activity.heartbeat(i)` per file. A crash loses at most the current
+   batch; heartbeat details let a retry resume mid-batch. Files 1–299 are already
+   persisted rows.
+3. *Re-run is resume.* Re-running with the same `dive_path` upserts the dive by
+   path, skips images whose path already exists (no download at all — the skip is
+   decided before the NAS call), and resumes at 300.
+
+**How the portal talks to Temporal.** The web app has no Temporal client and must
+not get one (that would need mTLS certs in a public-facing container). Path:
+
+```
+browser  ──"use server" action──▶  Next.js server (re-checks auth())
+         ──Basic auth fetch────▶  fishsense-api  POST /api/v1/ingest/dives
+                                     └─▶ temporalio Client.start_workflow(
+                                            "IngestDiveWorkflow", …,
+                                            task_queue="fishsense_api_queue",
+                                            id=f"ingest-dive-{slug}")
+                                  ◀── {workflow_id, run_id}
+poll 3s  ──action──▶ GET /api/v1/ingest/dives/{workflow_id}
+                                     └─▶ handle.describe()  (status)
+                                     └─▶ handle.query("progress")  (counts)
+```
+
+**Decision: the Temporal client goes in fishsense-api** (your call, 2026-08-06).
+Concretely (details in §2.7): a `temporalio` dep, an **optional** `[temporal]` config
+block, the krg-prod cert mount on the api container, and a workflow-type allowlist so
+the API can start exactly one workflow type and nothing else.
+
+The property that must hold: **the API still boots and serves every existing route
+when Temporal is unreachable or unconfigured.** Ingest is a new capability bolted
+onto a service carrying a lot of load-bearing read traffic; it must not become a new
+way for that service to fail to start. §2.7 is mostly about that.
+
+*Alternative, now dropped:* an `IngestRequest` table polled by a new schedule. It
+would have avoided the dep and the cert mount, at the cost of a table, a schedule
+slot, a state machine, up-to-N-minutes latency on a button the operator is watching,
+and a status read-back path it still needed. Recorded so the trade-off stays legible
+if this is ever revisited.
+
+**Validation that fails loudly.** All four, in a `preflight_ingest_activity` that
+runs **before any write** and raises a non-retryable `ApplicationError` carrying
+every failure at once (not first-wins — an operator should see all the problems in
+one round trip):
+
+| Check | Failure mode it prevents |
+|---|---|
+| camera resolves (override or `Artist`→`Camera.name`) **and** `GET /cameras/{id}/intrinsics/` returns 200 | stage 14 cannot measure; nothing errors, dives just never become `measured` |
+| `priority == HIGH` in the request | no cohort selector ever picks the dive up; it sits invisible forever |
+| exactly one of `calibration_dive_id` / `self_calibrates=True` given; if `calibration_dive_id`, that dive must exist | a fish-only dive with no slate frames can never be calibrated — **and this cannot be detected from the files**, so the operator must state intent at request time |
+| every `Image.path` and the `Dive.path` ≤ 255 chars | silent DB truncation / insert failure mid-run |
+| ≥1 `.ORF` found; dive path not already owned by a different dive id | empty or mis-targeted ingest |
+
+The third one deserves emphasis: it is the only one that is *unknowable* from the
+data. Making it a required field is the only way to make it loud.
+
+---
+
+## 2. API surface
+
+### 2.1 `POST /api/v1/dives/` → `int`
+
+Body is a `Dive`. Upserts on `path`. Validates: `camera_id` set, exists, and has a
+`CameraIntrinsics` row (else 422); `calibration_dive_id`, if set, exists and
+`!= id` (else 422); `len(path) <= 255` (else 422). Returns the dive id.
+
+Also serves **finalize** — the workflow POSTs the same path again with
+`dive_datetime` / `name` / `priority=HIGH` filled in.
+
+### 2.2 `POST /api/v1/dives/{dive_id}/images/` → `int`
+
+Body is an `Image`. Forces `dive_id` from the path. Upserts on `Image.path`.
+
+**`is_canonical` is computed server-side when the body omits it**: `True` iff no
+other `Image` row already carries this `checksum`. This is `9e5bc64`'s rule moved
+to where it belongs — a client-side check races itself and gets the answer wrong
+under any concurrency. An explicit value in the body still wins (operator override).
+
+Validates `len(path) <= 255`, `len(checksum) <= 32`, `taken_datetime` present.
+
+### 2.3 `POST /api/v1/ingest/dives` → `{workflow_id, run_id}`
+
+Body `IngestDiveRequest` (§3.1). Starts `IngestDiveWorkflow` on
+`fishsense_api_queue` with id `ingest-dive-{slugified dive_path}`,
+`id_reuse_policy=ALLOW_DUPLICATE` (re-ingest/resume is the normal case; a
+still-*running* ingest for the same folder raises `WorkflowAlreadyStartedError`
+→ 409, which is correct).
+
+### 2.4 `GET /api/v1/ingest/dives/{workflow_id}` → `IngestStatus`
+
+`handle.describe()` for status/timestamps + `handle.query("progress")` for counts.
+Query failure on a completed workflow degrades to describe-only rather than 500ing.
+
+### 2.5 `GET /api/v1/ingest/dives` → `List[IngestStatus]`
+
+Recent runs via `client.list_workflows('WorkflowType = "IngestDiveWorkflow"')`,
+newest 25. Backs the portal's history table.
+
+### 2.6 `POST /api/v1/ingest/dives/{workflow_id}/cancel` → 204
+
+`handle.cancel()`. A cancelled ingest leaves the dive at LOW — inert. This is why cancel is safe
+to expose.
+
+---
+
+### 2.7 Temporal client in fishsense-api — the boot-safety details
+
+Three repo-specific traps make this less trivial than "add a client":
+
+**(a) Dynaconf validates *everything* on first attribute access** — not lazily per
+setting. The CLAUDE.md worker gotcha applies to the API too, so the new validators
+must be **optional**, never `required=True`:
+
+```python
+Validator("temporal.host", cast=str, condition=validators.hostname),   # NOT required
+Validator("temporal.port", cast=int, default=7233),
+Validator("temporal.tls", cast=bool, default=False),
+Validator("temporal.namespace", cast=str, default="default"),
+Validator("temporal.client_cert", cast=str, condition=path_validator),
+Validator("temporal.client_private_key", cast=str, condition=path_validator),
+Validator("temporal.server_root_ca_cert", cast=str, condition=path_validator),
+Validator("temporal.domain", cast=str),
+```
+
+A `required=True` here would fire on the *first* `settings.postgres.host` read in
+`lifespan` and crash-loop the API on every deployment that hasn't set the temporal
+block — including local dev and the whole test suite. Same shape as the api-worker's
+optional `kubernetes.kubeconfig_path`, which no-ops when unset.
+
+**(b) Import must not require settings.**
+[test_import_without_settings.py](services/fishsense-api/tests/test_import_without_settings.py)
+pins that importing the package + controllers works with no `settings.toml` in cwd.
+So `temporal_client.py` reads settings **inside** the connect call, never at module
+scope, and `ingest_controller.py` imports it without touching config. Add
+`ingest_controller` to that test's pinned import list.
+
+**(c) Connect lazily, once, under a lock.** `Client.connect` is async and the API is
+async multi-request:
+
+```python
+_client: Client | None = None
+_lock = asyncio.Lock()
+
+async def get_temporal_client() -> Client:
+    global _client
+    if _client is None:
+        async with _lock:
+            if _client is None:                       # double-check under the lock
+                if "host" not in settings.get("temporal", {}):
+                    raise HTTPException(503, "Temporal is not configured")
+                _client = await Client.connect(
+                    f"{settings.temporal.host}:{settings.temporal.port}",
+                    namespace=temporal_namespace(settings.temporal),
+                    tls=build_tls_config(settings.temporal),
+                )
+    return _client
+```
+
+Reusing `fishsense_shared.build_tls_config` / `temporal_namespace` verbatim means no
+second TLS implementation. `build_tls_config` takes the `settings.temporal` subtree
+and returns `None` when `tls` is false, so local dev against
+`temporal server start-dev` works unchanged.
+
+**Unconfigured or unreachable → 503 on the four ingest routes only.** Every existing
+route is untouched. That is the point of connecting lazily: a Temporal outage
+degrades ingest rather than taking down the API.
+
+**(d) Allowlist the workflow type.** The endpoint never accepts a workflow name from
+the caller:
+
+```python
+_STARTABLE = {"IngestDiveWorkflow"}
+```
+
+"The API can start workflows" is the real widening here; constraining it to one
+hardcoded type keeps the blast radius at "can start an ingest".
+
+---
+
+## 3. Contracts (`libs/fishsense-shared`)
+
+Pydantic `BaseModel`s in a new `ingest_contracts.py`, re-exported from
+`fishsense_shared.__init__`. Same rationale as `preprocess_contracts`: this is the
+fishsense-api ↔ api-worker contract, and neither package may import the other.
+
+### 3.1 `IngestDiveRequest`
+
+**One request names one dive.** Not a crawl — the operator supplies the specific
+folder, and that folder *is* the dive. This also matches the legacy semantic
+(§4.1): a dive was always exactly one directory's worth of frames.
+
+```python
+dive_path: str                     # NAS path, relative to e4e_nas.raw_root_path
+dive_name: str | None = None       # default: leaf directory name
+camera_id: int | None = None       # override; else MakerNote serial -> Camera.serial_number
+priority: Priority = Priority.HIGH
+dive_slate_id: int | None = None
+calibration_dive_id: int | None = None
+self_calibrates: bool = False      # exactly one of this / calibration_dive_id
+flip_dive_slate: bool = False
+dry_run: bool = False
+verify_existing: bool = False      # re-hash + report, never write (§4.6)
+```
+
+### 3.2 `IngestPreflight`, `IngestProgress`, `IngestReport`
+
+`IngestPreflight` — `files[]` (path, size, `taken_datetime`, `artist`), `errors[]`,
+`warnings[]`, `resolved_camera_id`, `total_bytes`. **Dry-run returns this and
+writes nothing.**
+
+There is no NAS browser in the portal (the API must never touch the NAS), so the
+**dry run is the browser**: the operator types a path, previews exactly what would
+be ingested, then confirms. The ranged-read trick (§0.2) is what keeps it cheap —
+~1 MB/file instead of ~15 MB.
+
+`IngestProgress` — the query-handler shape: `state`, `dive_id`, `total`, `scanned`,
+`registered`, `skipped_existing`, `rejected`, `current_path`.
+
+`IngestReport` — the workflow return value, superset of progress plus
+`rejected_details[]` and `dive_datetime`.
+
+---
+
+## 4. Workflow + activity breakdown
+
+`IngestDiveWorkflow(IngestDiveRequest) -> IngestReport`, api-worker,
+`fishsense_api_queue`, **on-demand — no schedule** (nothing to add to
+[test_schedule_registration.py](services/fishsense-api-workflow-worker/tests/test_schedule_registration.py)'s
+stagger).
+
+### 4.1 `list_dive_folder_activity(request) -> DiveFolderListing`
+
+**Non-recursive**, by design and by precedent. The request names the dive folder;
+the images are the `.ORF` files **directly inside it** (case-insensitive match).
+
+The precedent matters here, because it is what tells us non-recursive is *correct*
+rather than merely simpler. Spider (`discovery.py:238`) walked recursively but then
+assigned `dive = image.parent.relative_to(data_root)` — so **a dive was always
+exactly one directory**, and a nested folder became its own separate dive row, never
+extra frames on the parent. Recursing and attaching children to the named dive would
+therefore merge dives that are distinct rows in prod today.
+
+So subdirectories are **not** ingested silently. Preflight lists any it finds
+containing `.ORF`s and reports them:
+
+> `101923_Alligator1_FSL06/` contains 47 `.ORF` files. Under the existing
+> convention that is a **separate dive** — submit it as its own request.
+
+That is the Olympus rollover case (the TG-6 wraps its counter at `PA199999` and
+starts a child folder; see
+[tools/scan_image_path_rollover.py](tools/scan_image_path_rollover.py)). Surfacing it
+as "here is another dive to submit" keeps the operator in control and keeps one
+request meaning one dive.
+
+Side note from the same evidence: the 303 rollover rows that tool found carry *flat*
+paths which 404. Spider's code could not have produced those, so they came from an
+earlier ingest or a hand-edit — not from the behaviour we are matching. Not ours to
+fix here.
+
+### 4.2 `preflight_ingest_activity(request, listing) -> IngestPreflight`
+
+Ranged 1 MB read per file → EXIF (§0.2 makes this ~1 MB instead of ~15 MB);
+resolves the camera from the MakerNote serial (§0.5) and runs every check in §1.
+Returns *all* errors at once, not first-wins. Non-retryable `ApplicationError` if
+`errors` is non-empty. **Zero writes.** If `dry_run`, the workflow returns here.
+
+Extra checks earned from the legacy code:
+
+* **Multi-camera dive → hard failure** (spider only wrote a report file, §0.4).
+  Mixed intrinsics silently corrupt stage 14, and one folder should be one rig.
+* **Serial resolves to a known `Camera`, or fail** — no `Artist` fallback (§0.5).
+  `Artist` disagreeing with the resolved camera's `name` is a warning.
+* **Sub-directories containing `.ORF`s are reported, not ingested** (§4.1).
+* **Duplicate detection — see §4.2.1, and NOT the MD5 aggregate.**
+
+#### 4.2.1 Duplicate-dive detection: replacing the whole-dive MD5 aggregate
+
+Spider detected duplicate dives with
+`MD5(STRING_AGG(basename || ':' || image_md5, '' ORDER BY path))`
+(`select_compute_dive_checksum_by_dive.sql`). You said it never worked as well as
+you wanted, and the reason is structural — it is worth naming, because it rules out
+"just port it and tune it":
+
+* **All-or-nothing.** One extra, missing, or re-copied frame changes the digest
+  completely. Two folders that share 54 of 55 frames look exactly as unrelated as
+  two folders sharing none. Most real duplicates are *near*-duplicates.
+* **Basename-sensitive.** It hashes `basename:md5`, so a rename — or the Olympus
+  rollover renumbering — breaks the match even when the bytes are identical.
+  Content-addressing that is defeated by filenames is self-defeating.
+* **No similarity measure.** It answers yes/no, but the operational question is
+  "how much of this already exists, and where", which is what decides whether the
+  new rows land non-canonical.
+
+Proposed replacement, two layers, cheap-first:
+
+**Layer 1 — free, runs in the dry run: leaf-name collision.** Compare the dive
+folder's leaf name against existing `Dive.path` leaves. This catches the exact prod
+case (dives 64 and 66 are both `082929_FishModels_FSL07`) at the cost of one
+`dives.get()` the preflight already makes. Warning only.
+
+**Layer 2 — exact, runs after the scan, before the commit flag: content-set
+containment.** The scan has already computed every checksum, so ask the API which of
+them exist and where, then report per overlapping dive:
+
+```
+containment = |new ∩ existing_dive| / |new|
+```
+
+`1.0` = this folder is wholly contained in that dive; `0.87` = 48 of 55 frames are
+already there. Robust to extra frames, missing frames, and renames, because it is a
+set operation on content hashes with no filename and no ordering involved. It also
+degrades gracefully: a partial overlap is *reported as* a partial overlap.
+
+Presented to the operator before `priority` flips, e.g. *"48/55 frames already exist
+in dive 64 (containment 0.87); those images will be created non-canonical."* A
+warning, never a block — re-ingesting the same frames under a second dive path is
+legitimate and already happened in prod. Optionally gate on an explicit
+`allow_duplicates` acknowledgement when containment is above, say, 0.9.
+
+Needs one new endpoint: `POST /api/v1/images/checksums/lookup` taking a checksum
+list and returning `{checksum: [{image_id, dive_id, is_canonical}]}` — a batch form
+of the existing `GET /api/v1/images/checksum/{checksum}`. Worth it regardless: it is
+also the natural way to answer "have I seen these frames before" from any tool.
+
+### 4.3 `create_dive_activity(request, preflight) -> int`
+
+`dives.post` with `priority=LOW` **regardless of the request** and `dive_datetime`
+= provisional max from preflight EXIF. Returns `dive_id`.
+
+### 4.4 `scan_and_register_images_activity(dive_id, batch, camera_id) -> BatchResult`
+
+Per file, in order: skip if `images.get(path=…)` exists (no download at all); else
+`download_to` → **streaming `md5()` in 8192-byte chunks** (§0.1, matching
+`get_file_checksum` and avoiding a 15 MB buffer per file) → EXIF `DateTime`
+(0x0132) → `images.post`. `activity.heartbeat(index)` per file; a retry resumes
+from the recorded index. Batch of 25 (`ingest.batch_size`).
+
+Reuses the NAS-error classification from
+[stage_raw_bytes_for_dive_activity](services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/stage_raw_bytes_for_dive_activity.py):
+DSM 408 → non-retryable; 502/407/402 → propagate for Temporal's bounded jittered
+retry. **No inner retry loop** — that is what tripped the NAS auto-block.
+
+### 4.5 `finalize_dive_activity(dive_id, request, totals) -> IngestReport`
+
+Refuses (non-retryable) if `rejected > 0` or `registered + skipped != total`.
+Otherwise `dives.post` again with real `dive_datetime` = **max** taken_datetime
+(§0.4), `name` = leaf directory, `camera_id`, `dive_slate_id`,
+`calibration_dive_id`, and `priority` from the request — the commit flag. Also
+carries the §4.2.1 containment report, so the duplicate picture is in front of the
+operator at the moment of commit.
+
+### 4.6 `verify_existing` mode
+
+`IngestDiveRequest.verify_existing` — for a folder whose rows already exist, re-hash
+and **report** mismatches without writing. Downgraded from the previous draft's
+blocking gate now that §0.1 is resolved from source: it is a standing net against
+rows that predate spider, not a merge requirement. Also exposed as
+`tools/verify_checksum_algorithm.py` for running over a sample of arbitrary
+existing rows.
+
+---
+
+## 5. Files to add / change
+
+### fishsense-api
+
+| File | Why |
+|---|---|
+| `controllers/dive_controller.py` | add `POST /api/v1/dives/` (upsert-by-path + validation) |
+| `controllers/image_controller.py` | add `POST /api/v1/dives/{dive_id}/images/` (upsert-by-path + server-side `is_canonical`) and `POST /api/v1/images/checksums/lookup` (batch, §4.2.1) |
+| `controllers/ingest_controller.py` **(new)** | start / status / list / cancel |
+| `controllers/__init__.py` | **route registry** — import the new controller or its routes silently never register |
+| `temporal_client.py` **(new)** | lazy locked singleton; reuses `build_tls_config` + `temporal_namespace`; workflow-type allowlist; settings read inside the call, not at import (§2.7) |
+| `config.py` | `[temporal]` validators — **all optional**, never `required=True` (§2.7a) |
+| `tests/test_import_without_settings.py` | add `ingest_controller` to the pinned import list |
+| `pyproject.toml` | `temporalio>=1.15.0` |
+
+No new SQLModel, no migration, no `database.py` change — ingest writes existing
+tables. No `test_sdk_drift.py` impact for the same reason.
+
+### fishsense-api-sdk
+
+| File | Why |
+|---|---|
+| `clients/dive_client.py` | `post(dive) -> int` |
+| `clients/image_client.py` | `post(dive_id, image) -> int` |
+
+Pydantic mirrors already exist and are field-complete, so drift stays green.
+
+### fishsense-shared
+
+| File | Why |
+|---|---|
+| `ingest_contracts.py` **(new)**, `__init__.py` | the api ↔ api-worker DTO contract |
+
+### fishsense-api-workflow-worker
+
+| File | Why |
+|---|---|
+| `nas.py` | `list_dir(path) -> list[NasEntry]`, `download_range(path, offset, length)` |
+| `exif.py` **(new)** | stdlib reader: tag 0x0132 + Olympus MakerNote serial (§0.5/§0.7). Pillow cannot open ORF |
+| `activities/list_dive_folder_activity.py` **(new)** | §4.1 — non-recursive listing + subfolder report |
+| `activities/preflight_ingest_activity.py` **(new)** | §4.2 |
+| `activities/create_dive_activity.py` **(new)** | §4.3 |
+| `activities/scan_and_register_images_activity.py` **(new)** | §4.4 |
+| `activities/finalize_dive_activity.py` **(new)** | §4.5 |
+| `workflows/ingest_dive_workflow.py` **(new)** | orchestration + `progress` query |
+| `worker.py` | register the workflow + 5 activities (no schedule) |
+| `config.py` | `ingest.batch_size` (default 25) |
+
+### fishsense-lite-web
+
+| File | Why |
+|---|---|
+| `lib/ingest.ts` **(new)** | typed fetch wrappers, `safeId`-style validation on the workflow id before it enters a URL |
+| `app/portal/ingest/page.tsx` **(new)** | **must call `auth()` itself** — there is no `middleware.ts`; `/portal` is gated per-page (a deliberate workaround for a Next 15.5 middleware-loader bug, pinned by `portal.integration.test.ts`) |
+| `app/portal/ingest/ingest-form.tsx` **(new)** | client form: path, camera override, priority, calibration intent, dry-run/confirm, 3 s progress poll |
+| `app/portal/ingest/actions.ts` **(new)** | server actions, each re-checking `auth()` (server actions are public endpoints — same pattern as [actions.ts](apps/fishsense-lite-web/app/portal/actions.ts)) |
+| `app/portal/page.tsx` | link to the ingest page |
+
+### deploy
+
+| File | Why |
+|---|---|
+| `deploy/incus/compose.yml` | mount `/run/tenant/temporal:/run/tenant/temporal:ro` on `fishsense-api` |
+| `deploy/incus/fishsense_api_volumes/config/settings.toml` | `[temporal]` → krg-prod, copied from the api-worker's stanza (same certs, same namespace) |
+| `deploy/compose.local.yml` | local Temporal for the API so the integration tests can run |
+
+---
+
+## 6. Test list — failing first, in order
+
+TDD per [CLAUDE.md](CLAUDE.md). Each bullet is a red test before its implementation.
+
+**API — `test_dive_ingest_endpoints.py`, `test_image_ingest_endpoints.py`**
+(in-memory sqlite, controller functions called directly, per
+[test_calibration_source_endpoints.py](services/fishsense-api/tests/test_calibration_source_endpoints.py)):
+
+1. `POST /dives/` creates and returns an id.
+2. **`POST /dives/` twice with the same `path` returns the same id and leaves one
+   row** ← the #347 regression; fails first against a blind merge.
+3. `POST /dives/` 422s on: missing camera, camera without intrinsics,
+   self-referential `calibration_dive_id`, `path` > 255.
+4. `POST /dives/{id}/images/` creates; forces `dive_id` from the path.
+5. **`POST` image twice with the same `path` → one row, same id.**
+6. **First image with a checksum gets `is_canonical=True`; a second image with a
+   different path and the same checksum gets `False`** ← the dives-64/66 rule.
+6b. `POST /images/checksums/lookup` returns every dive holding each checksum, and
+    `[]` for unknown ones (§4.2.1).
+7. An explicit `is_canonical` in the body overrides the computed value.
+8. Image 422s on `path` > 255 / missing `taken_datetime`.
+9. `POST /ingest/dives` calls `start_workflow` with the right type, queue and id
+   (mocked client); a `WorkflowAlreadyStartedError` surfaces as 409.
+9b. **With no `[temporal]` config, every existing route still works and the four
+    ingest routes return 503** — the boot-safety property (§2.7). Fails first
+    against a `required=True` validator or a module-scope connect.
+9c. `get_temporal_client` connects once under concurrent callers (asyncio lock).
+9d. The allowlist rejects any workflow type but `IngestDiveWorkflow`.
+10. `GET /ingest/dives/{id}` merges `describe()` + `query()`; a query failure on a
+    finished run degrades instead of 500ing.
+
+**SDK — `tests/clients/test_dive_client.py`, `test_image_client.py`**
+(`asyncio_mode="auto"`, no decorator; clients used inside `async with`):
+
+11. `dives.post` POSTs to `/api/v1/dives/` and returns the parsed int.
+12. `images.post` POSTs to `/api/v1/dives/{id}/images/`.
+13. Calling either outside `async with` raises `RuntimeError` (`ClientBase` contract).
+
+**EXIF — `test_exif.py`:**
+
+14. Parses `DateTime` (0x0132), `Artist`, `Model` from a committed ORF header fixture.
+14b. **Extracts the Olympus MakerNote `SerialNumber`** — pins base-relative offsets
+     *and* the type-13 Equipment pointer, the two bugs that made me wrongly call
+     MakerNote parsing infeasible (§0.5).
+15. **A file with no `DateTimeOriginal` returns `None` — never a default.**
+16. Works on a truncated first-1 MB buffer (the ranged-read path).
+17. Big-endian (`MM`) TIFF parses too.
+
+**NAS — `test_nas_client.py` (extend):**
+
+18. `list_dir` passes the path through and maps entries to `NasEntry`.
+19. `download_range` forwards `offset`/`length` to `Client.download`.
+20. **Tripwire: the ingest activity module imports no NAS *write* symbol** — mirrors
+    the existing cleanup-activity tripwire. NAS stays read-only.
+
+**Activities:**
+
+21. `list_dive_folder` matches `.ORF` case-insensitively, is **non-recursive**, and
+    **reports — does not ingest — a subdirectory containing `.ORF`s** (§4.1).
+22. `preflight` returns **all** errors at once, not first-wins.
+23. `preflight` fails when the camera has no intrinsics.
+24. `preflight` fails when neither `calibration_dive_id` nor `self_calibrates` is given.
+25. `preflight` fails on a >255-char path, naming the offender.
+26. `preflight` resolves camera from the **MakerNote serial**; `camera_id` overrides.
+26b. **`preflight` fails when the serial matches no `Camera` — it does NOT fall back
+     to `Artist`** (§0.5). The anti-regression test for the camera decision.
+26c. **`preflight` fails a dive whose frames span two serials** (§0.4).
+26d. `preflight` warns when `Artist` disagrees with the resolved camera's `name`.
+26e. `preflight` warns on a leaf-name collision with an existing dive (§4.2.1 L1).
+26f. **Containment is computed as a set operation**: 48/55 shared checksums reports
+     0.87 regardless of filenames or ordering — the property the MD5 aggregate
+     lacked (§4.2.1 L2).
+27. **`create_dive` forces `priority=LOW` even when the request says HIGH.**
+28. `scan_and_register` skips an existing path **without downloading**.
+29. `scan_and_register` heartbeats per file and resumes from heartbeat details.
+30. `scan_and_register` classifies DSM 408 as non-retryable, 502 as retryable.
+31. **A file with unreadable EXIF is rejected, not defaulted.**
+31b. `taken_datetime` comes from **0x0132**, falls back to 0x9003 with a log line,
+     and is UTC-stamped from the naive value (§0.3).
+31c. **Checksum equals `md5` of the whole file** — asserted against the real ORF
+     fixture, pinning §0.1's `get_file_checksum` equivalence.
+32. **`finalize` refuses when `rejected > 0` — the dive stays LOW.**
+33. `finalize` sets `dive_datetime` to the **max** taken_datetime (§0.4).
+
+**Workflow — `test_ingest_dive_workflow.py`** (in-process Temporal env, as in
+`test_preprocess_laser_images_parent_workflow.py`):
+
+34. Happy path: activities called in order, report totals correct.
+35. **`dry_run=True` returns the preflight and calls no write activity.**
+36. Batching: 60 files → 3 activity calls at batch size 25.
+37. **A crash in batch 2 leaves the dive at LOW and `finalize` uncalled.**
+38. The `progress` query returns live counts mid-run.
+39. Re-run over a fully-ingested folder: 0 downloads, dive still HIGH.
+
+**Web — vitest:**
+
+40. `lib/ingest.ts` sends Basic auth and parses the response (per `dives.test.ts`).
+41. `lib/ingest.ts` rejects a malformed workflow id before building the URL.
+42. Each server action throws when `auth()` returns no session.
+43. Integration: signed-out `GET /portal/ingest` → 307 to sign-in (mirrors
+    `portal.integration.test.ts` — the per-page gate is the only gate).
+
+---
+
+## 7. Part 2 — `Weasly Fish` is labelable but ungradeable
+
+### 7.1 Confirmed
+
+`_species_taxonomy_branch("Fish Model")` in the shipped XML
+([create_species_label_studio_project_activity.py](services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/create_species_label_studio_project_activity.py)):
+
+```
+Weasly Fish, Snook, Grouper, Shark, Gray Anthias, Purple Angel, Yellow Anthias
+```
+
+`KNOWN_FISH_MODELS` in [views.py](services/fishsense-api/src/fishsense_api/views.py):
+
+```
+Snook, Grouper, Shark, Gray Anthias, Purple Angel, Yellow Anthias, Ruler
+```
+
+`Weasly Fish` is the only Fish Model choice with no reference row, exactly as you
+said. `fish_model_measurement_accuracy` **inner**-joins `fishmodelreference` on
+`Fish.name`, so its measurements would be written and then vanish from the view
+with no error anywhere.
+
+### 7.2 Changes
+
+**a. `views.py` — add the entry.** `known_length_m: 0.30` per your figure, with a
+comment marking it **provisional, uncalipered** and naming the diagnostic:
+
+> Every other model reads *short* against truth by a consistent ladder ordered by
+> fork depth (Purple Angel −2.2 %, Shark −2.6 %, Grouper −5.1 %, Snook −9.6 %). So
+> a Weasly Fish landing inside roughly −2 % … −10 % is consistent with 30 cm being
+> right. Readings materially **more negative** than that band say the 30 cm
+> reference is too **long**; **positive** readings say it is too **short**.
+> Recalipering settles it; the view is the instrument, not the authority.
+
+**b. `notes` — the thickness experiment.** The column exists
+([fish_model_reference.py](services/fishsense-api/src/fishsense_api/models/fish_model_reference.py))
+but nothing has ever written it: both existing seed migrations insert only
+`(name, known_length_m)`.
+
+So this needs a `"notes"` key on the entry, formatted for machine re-parsing:
+
+```
+notes = "fork length provisional (uncalipered, operator estimate 2026-08-06); "
+        "width_midbody_mm=<TBD>; width_caudal_peduncle_mm=<TBD>"
+```
+
+⚠️ **INPUT NEEDED — I do not have these two numbers and will not invent them.**
+You asked for thickness to be an *independent calipered input*, not something
+inferred from measurement error, which is exactly right and is exactly why I
+cannot supply it. Give me mid-body width and caudal-peduncle width in mm and they
+go straight in. Everything else in Part 2 ships without them; I would rather land
+the row with `<TBD>` markers than a fabricated number, and the migration is
+re-runnable for the fill-in.
+
+*Compatibility check I ran:* adding a `notes` key to the shared
+`KNOWN_FISH_MODELS` list means the two **already-shipped** migrations
+(`e2c9a4f70b31`, `b4c81f60d7e2`) execute
+`INSERT … VALUES (:name, :known_length_m)` with dicts that now carry an extra key.
+I tested this — SQLAlchemy 2.0.51 ignores unbound keys in an executemany param
+list, rows insert correctly. `test_alembic_upgrade.py` covers the regression.
+
+**c. New alembic migration** (`down_revision` = current head; check `alembic
+heads` at implementation time), following the seed-only-if-absent pattern from
+both predecessors, but inserting `notes` as well:
+
+```python
+existing = {r[0] for r in bind.execute(sa.text("SELECT name FROM fishmodelreference"))}
+to_insert = [m for m in KNOWN_FISH_MODELS if m["name"] not in existing]
+if to_insert:
+    bind.execute(sa.text(
+        "INSERT INTO fishmodelreference (name, known_length_m, notes) "
+        "VALUES (:name, :known_length_m, :notes)"),
+        [{**m, "notes": m.get("notes")} for m in to_insert])
+```
+
+Seed-only-if-absent means it never clobbers a hand-corrected length — and it also
+means **it will not backfill `notes` onto a row that already exists**. Since
+`Weasly Fish` has no row in prod (0 labels, 0 Fish rows), this is fine today; a
+later width correction needs its own `UPDATE` migration. Called out so nobody is
+surprised. No view recreation needed — the accuracy view joins by name and picks
+the row up automatically.
+
+**d. Strengthen the guard so this cannot recur.**
+`test_known_models_cover_the_labeled_taxonomy` currently asserts
+`{Snook, Grouper, Shark, Purple Angel} <= names` — a hardcoded subset, which is
+precisely why the gap survived. Replace with: parse the **actual shipped XML**,
+extract every `Fish Model` child choice, assert each has a reference row.
+
+The XML lives in the api-worker package and `fishsense-api` does not depend on it
+(nor should it). Two options; I recommend the second:
+
+* *Import it.* Works in CI (uv workspace, one shared `.venv`) but creates an
+  undeclared cross-service dependency **and** trips the dynaconf gotcha — importing
+  that activity chains into `config.settings`, which eagerly validates *every*
+  `Validator` on first attribute access, so the api test suite would have to plumb
+  `E4EFS_TEMPORAL__HOST`, `E4EFS_E4E_NAS__*`, etc.
+* **Read it from disk and `ast`-parse the constant.** `REPO_ROOT =
+  Path(__file__).resolve().parents[3]` — the same idiom
+  [test_generated_sdk_models_freshness.py](services/fishsense-api/tests/test_generated_sdk_models_freshness.py)
+  already uses — then `ast.parse` the module and `literal_eval` the
+  `SPECIES_LABELING_CONFIG_XML` assignment, then `ElementTree` the XML. No import,
+  no side effects, no config plumbing. A missing/renamed file fails loudly, which
+  is the correct behaviour for a drift guard.
+
+New tests: (i) every XML `Fish Model` choice has a reference row — **red before
+the `Weasly Fish` entry lands**; (ii) `Weasly Fish` is present at 0.30 with a
+provisional marker; (iii) its `notes` carries both width keys.
+
+---
+
+## 8. Rollout
+
+Three PRs, in order, each independently deployable:
+
+1. **`feat(api): dive + image create endpoints`** + SDK methods. No behaviour change
+   until something calls them. Ships as `fishsense-api` minor → auto-deploy PR.
+2. **`feat(api-worker): NAS folder ingest workflow`** + shared contracts + Temporal
+   client in the API + compose/settings changes. The compose + settings.toml edits
+   are committed IaC; the converge force-recreates, so they take effect
+   ([CLAUDE.md](CLAUDE.md) "Committed config applies only because the converge
+   force-recreates").
+3. **`feat(web): portal ingest page`** — `apps/fishsense-lite-web` is `release-type:
+   node`; the promote job bumps its compose pin like any other in-slot service.
+
+Part 2 is a fourth, independent PR — no ordering constraint against the others.
+
+**First production ingest**: dry-run first, always. Read the file list and the
+resolved camera, confirm, then run for real. The dive sits at LOW until the last
+image lands, so a bad first attempt costs NAS bandwidth and nothing else.
+
+**SDK cascade:** PR 1 touches `libs/fishsense-api-sdk`, so release-please's
+`auto-bump-sdk-consumers` job opens an `auto-bump/fishsense-api-sdk-<v>` PR. That
+must merge before PR 2's worker image can see the new client methods.
+
+---
+
+## 9. Open items
+
+1. ~~§0.1 checksum verification~~ — **closed** by
+   `spider/backend.py:get_file_checksum`. Plain MD5 of the whole file. No prod
+   access needed.
+2. ~~§0.3 timezone convention~~ — **closed** by `spider/backend.py:get_image_date`.
+   Naive EXIF 0x0132 → `TIMESTAMP` → migrated to `TIMESTAMPTZ` as UTC. Note the tag
+   correction: 0x0132, not 0x9003.
+3. ~~Camera key~~ — **decided: MakerNote serial**, matching existing rows. stdlib
+   extraction verified on the fixture; no exiftool. Fails loudly rather than falling
+   back (§0.5).
+4. **No `POST /cameras` endpoint exists**, so a genuinely new rig blocks ingest until
+   its `Camera` row is inserted DB-direct. Out of scope; flag if a new rig is due.
+5. **Duplicate detection replaced** (§4.2.1) — leaf-name warning + content-set
+   containment, instead of the whole-dive MD5 aggregate. Confirm the containment
+   threshold (0.9?) at which you want an explicit acknowledgement.
+6. **Weasly Fish widths** — mid-body and caudal-peduncle, in mm.
+7. **Weasly Fish 30 cm** — provisional; §7.2's diagnostic band tells you when to
+   recaliper.
+8. ~~Temporal-client-in-the-API vs. polled table~~ — **decided: client in the API.**
+   Boot-safety constraints in §2.7; the load-bearing one is that the new `[temporal]`
+   validators must be optional, or the API crash-loops anywhere the block is unset.
+9. **Follow-up, deliberately out of scope:** the ingest already holds each file's
+   bytes in memory, so it could stage them to Garage `raw/{checksum}.ORF` and save
+   stage 0.1 a second 7.5 GB download. Real win, but it couples ingest to the
+   object store and to JPEG-retention policy. Separate decision.
+10. **Follow-up:** existing `Dive.camera_id` values are unreliable (§0.4 — the
+   `images[-1]` bug, now confirmed against the migration source). Worth an audit;
+   not this change.
+11. ~~Archive the legacy repos~~ — **done 2026-08-06.**
+    `fishsense-data-processing-worker` was already archived;
+    `fishsense-data-processing-spider` archived at your request. Both stay readable;
+    spider's 7 open issues are now locked to further comment. Reversible.
+    Two consequences worth naming:
+    * **Archiving is not decommissioning.** If a spider instance is still deployed
+      anywhere, it keeps crawling and writing to the *legacy* `fabricant-prod`
+      Postgres. That DB stopped being the source of truth at `9e5bc64`, so it would
+      not corrupt fishsense-api — but it would burn NAS bandwidth against the same
+      shares this ingest reads, and the fragile FileStation backend is the
+      contended resource (krg-infra#501). **Worth confirming it is actually
+      switched off before the first production ingest run.**
+    * These conventions now live only in §0 here, the memory entry, and read-only
+      GitHub. They belong in CLAUDE.md when this lands — the "Notebook port status"
+      table has no stage-0 row, and this is it.
+12. **A `MIGRATED_TO_MONOREPO.md`-style notice** was not added to either repo before
+    archiving — `worker` had already been archived bare, so I matched that. If you
+    want pointers in their READMEs it means unarchive → push → re-archive; say the
+    word and I will.

--- a/docs/plans/dive-image-ingestion.md
+++ b/docs/plans/dive-image-ingestion.md
@@ -180,6 +180,38 @@ adding a `GET /cameras/serial/{sn}` route. Cheaper than N lookups, one less rout
 rig therefore cannot be ingested until someone inserts the row (DB-direct today).
 Deliberately out of scope — noted in §9.
 
+### 0.9 Prod state, measured 2026-08-07 — the canonical invariant holds
+
+Checked directly against the prod `fishsense` DB before shipping the
+`uq_image_canonical_checksum` partial unique index, because a unique index that
+fails on existing rows would crash-loop the API (`lifespan` runs
+`run_alembic_upgrade` on startup, and there is no staging tier):
+
+```
+total_images                      = 131,430
+canonical_rows                    =  65,981
+distinct_checksums                =  65,981
+checksums_with_multiple_canonical =       0
+```
+
+`canonical_rows == distinct_checksums` with zero multi-canonical groups means
+every distinct checksum has **exactly one** canonical row. So the migration
+takes the create path, not the `REFUSING` path, and no operator repair is
+needed. (The same arithmetic rules out checksums with *zero* canonical rows —
+the counts would differ — and any NULL `is_canonical` could only sit among
+duplicates, which a `WHERE is_canonical` partial index does not constrain.)
+
+**49.8 % of image rows are duplicate content** (131,430 total vs 65,981
+distinct). That reframes two things:
+
+* `is_canonical` is not an edge case — it decides the identity of half the
+  table. The promotion-must-demote bug the constraint caught was live on a much
+  bigger surface than the dives-64/66 anecdote implied.
+* Duplicate detection (§4.2.1) will fire constantly, not rarely. It also
+  explains why the legacy whole-dive MD5 aggregate disappointed: an
+  all-or-nothing digest over a corpus that is half near-duplicates is wrong
+  most of the times it is consulted.
+
 ### 0.6 Security call-out — resolved
 
 The `fabricant-prod` Postgres password committed in plaintext (this repo's `9e5bc64`
@@ -931,8 +963,11 @@ must merge before PR 2's worker image can see the new client methods.
 4. **No `POST /cameras` endpoint exists**, so a genuinely new rig blocks ingest until
    its `Camera` row is inserted DB-direct. Out of scope; flag if a new rig is due.
 5. **Duplicate detection replaced** (§4.2.1) — leaf-name warning + content-set
-   containment, instead of the whole-dive MD5 aggregate. Confirm the containment
-   threshold (0.9?) at which you want an explicit acknowledgement.
+   containment, instead of the whole-dive MD5 aggregate. **Threshold still open,
+   and the prod numbers argue against 0.9** (see §0.9): a folder that is 60 %
+   already-present is the common case, not the exception, and that is exactly
+   when an operator wants telling. Suggest 0.5, or reporting containment always
+   and gating the acknowledgement on 1.0 (wholly contained).
 6. **Weasly Fish widths** — mid-body and caudal-peduncle, in mm.
 7. **Weasly Fish 30 cm** — provisional; §7.2's diagnostic band tells you when to
    recaliper.

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/client_base.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/client_base.py
@@ -10,7 +10,7 @@ from retry import retry
 
 
 class ClientBase(ABC):
-    # pylint: disable=too-few-public-methods
+    # pylint: disable=too-few-public-methods,too-many-instance-attributes
     """Base client for interacting with the Fishsense API."""
 
     @property
@@ -38,10 +38,17 @@ class ClientBase(ABC):
         password: str | None,
         timeout: int,
         semaphore: asyncio.Semaphore,
+        transport: httpx.AsyncBaseTransport | None = None,
     ):  # pylint: disable=too-many-arguments, too-many-positional-arguments
         self.base_url = base_url
         self.timeout = timeout
         self.semaphore = semaphore
+        # Optional httpx transport. Production leaves this None and gets the
+        # default network transport; passing `httpx.ASGITransport(app=...)`
+        # drives a FastAPI app in-process, which is how the SDK<->API contract
+        # is tested without standing up a server. Mocking `_post` cannot catch
+        # a URL or payload the API would actually reject.
+        self.transport = transport
 
         self.__token = (
             base64.b64encode(f"{username}:{password}".encode("utf-8"))
@@ -53,7 +60,11 @@ class ClientBase(ABC):
         self.__logger = getLogger(__name__)
 
     def __create_client(self) -> httpx.AsyncClient:
-        return httpx.AsyncClient(base_url=self.base_url, timeout=self.timeout)
+        return httpx.AsyncClient(
+            base_url=self.base_url,
+            timeout=self.timeout,
+            transport=self.transport,
+        )
 
     async def __aenter__(self) -> "ClientBase":
         self.logger.debug("Entering async context manager for ClientBase")

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/dive_client.py
@@ -44,6 +44,30 @@ class DiveClient(ClientBase):
 
         return [Dive.model_validate(dive) for dive in json]
 
+    async def post(self, dive: Dive) -> int:
+        """Create or update a dive, keyed on its NAS-relative `path`.
+
+        The endpoint upserts on `path`, so there is no create-vs-update
+        decision here: ingest posts a dive at `priority=LOW` when it first sees
+        the folder, then posts the same path again once every image has landed
+        to flip it to HIGH. Both calls come through this method.
+
+        `mode="json"` is required -- `dive_datetime` is a `datetime`, which
+        httpx cannot encode.
+
+        Args:
+            dive (Dive): The dive to create or update.
+
+        Returns:
+            int: The ID of the created or updated dive.
+        """
+        response = await self._post(
+            "/api/v1/dives/",
+            json=dive.model_dump(exclude_unset=True, mode="json"),
+        )
+        response.raise_for_status()
+        return response.json()
+
     async def get_canonical(self) -> List[Dive] | None:
         """Get canonical dives.
 

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/image_client.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/image_client.py
@@ -1,6 +1,6 @@
 """Client for interacting with image-related endpoints of the Fishsense API."""
 
-from typing import List
+from typing import Any, Dict, List
 
 from fishsense_api_sdk.clients.client_base import ClientBase
 from fishsense_api_sdk.models.dive_frame_cluster import DiveFrameCluster
@@ -8,7 +8,6 @@ from fishsense_api_sdk.models.image import Image
 
 
 class ImageClient(ClientBase):
-    # pylint: disable=too-few-public-methods
     """Client for interacting with image-related endpoints of the Fishsense API."""
 
     async def get(
@@ -17,6 +16,9 @@ class ImageClient(ClientBase):
         image_id: int | None = None,
         checksum: str | None = None,
     ) -> Image | List[Image] | None:
+        # pylint: disable=too-many-return-statements
+        # Three lookup modes x (404 -> None, null body -> None, hit) is
+        # inherently branchy; splitting it would change the public surface.
         """Get images from dive .
 
         Raises:
@@ -65,6 +67,68 @@ class ImageClient(ClientBase):
             return Image.model_validate(json)
 
         raise NotImplementedError("Getting all images is not supported.")
+
+    async def post(
+        self, dive_id: int, image: Image, *, set_canonical: bool = False
+    ) -> int:
+        """Create or update an image within a dive, keyed on its `path`.
+
+        **`is_canonical` is stripped from the payload by default.** The server
+        computes it -- the first row for a given checksum is canonical, later
+        duplicates are not -- and an explicit value in the body overrides that.
+        Since `Image.is_canonical` is a required field on this model, it always
+        carries *some* value, so `exclude_unset` alone cannot keep it off the
+        wire; posting it unconditionally would mark every duplicate frame
+        canonical and silently destroy the distinction that lets the same
+        physical frames live under two dive rows (prod dives 64 and 66).
+
+        Pass `set_canonical=True` only to deliberately override the server --
+        e.g. promoting a re-ingested copy after the original dive's files were
+        lost.
+
+        Args:
+            dive_id (int): The dive the image belongs to.
+            image (Image): The image to create or update.
+            set_canonical (bool): Send `is_canonical` and override the
+                server-side computation. Defaults to False.
+
+        Returns:
+            int: The ID of the created or updated image.
+        """
+        payload = image.model_dump(exclude_unset=True, mode="json")
+        if not set_canonical:
+            payload.pop("is_canonical", None)
+
+        response = await self._post(
+            f"/api/v1/dives/{dive_id}/images/",
+            json=payload,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def lookup_checksums(
+        self, checksums: List[str]
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        """Look up which dives already hold each of `checksums`.
+
+        Returns `{checksum: [{image_id, dive_id, is_canonical}, ...]}`, with an
+        empty list for checksums that aren't known. Used at ingest time to
+        report content overlap with existing dives -- e.g. "48 of 55 frames
+        already exist in dive 64, so those will land non-canonical" -- before
+        the dive is committed.
+
+        Args:
+            checksums (List[str]): MD5 hexdigests to look up.
+
+        Returns:
+            Dict[str, List[Dict[str, Any]]]: Per-checksum hits.
+        """
+        response = await self._post(
+            "/api/v1/images/checksums/lookup",
+            json=list(checksums),
+        )
+        response.raise_for_status()
+        return response.json()
 
     async def get_clusters(
         self, dive_id: int, data_source: str

--- a/libs/fishsense-api-sdk/tests/clients/test_dive_client.py
+++ b/libs/fishsense-api-sdk/tests/clients/test_dive_client.py
@@ -367,3 +367,64 @@ class TestDiveClient:
 
             async with client:
                 assert await client.get_dives_needing_species_population() == []
+
+
+class TestDiveClientPost:
+    """`dives.post` — the dive-creation half of ingest.
+
+    Ingest posts the same dive twice by design: once at `priority=LOW` when the
+    folder is first seen, then again after every image has landed to flip it to
+    HIGH. The endpoint upserts on `path`, so the client just posts; there is no
+    create-vs-update decision on this side.
+    """
+
+    async def test_post_sends_the_dive_and_returns_the_new_id(self):
+        client = _make_client()
+        mock_response = Mock()
+        mock_response.status_code = 201
+        mock_response.raise_for_status = Mock()
+        mock_response.json = Mock(return_value=42)
+
+        with patch.object(client, "_post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+            dive_id = await client.post(Dive.model_validate(_dive_payload()))
+
+        assert dive_id == 42
+        args, kwargs = mock_post.call_args
+        assert args[0] == "/api/v1/dives/"
+        assert kwargs["json"]["path"] == "/data/dives/test"
+
+    async def test_post_serialises_datetimes_for_the_wire(self):
+        """`dive_datetime` must go out as a JSON string, not a datetime object —
+        httpx cannot encode the latter and would raise at request time."""
+        client = _make_client()
+        mock_response = Mock()
+        mock_response.status_code = 201
+        mock_response.raise_for_status = Mock()
+        mock_response.json = Mock(return_value=1)
+
+        with patch.object(client, "_post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+            await client.post(Dive.model_validate(_dive_payload()))
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert isinstance(payload["dive_datetime"], str)
+        assert payload["priority"] == "HIGH"
+
+    async def test_post_raises_for_status_so_validation_failures_surface(self):
+        """The endpoint 422s on a camera with no intrinsics, an over-long path,
+        a dangling calibration source. Those must not be swallowed — a silently
+        dropped dive is the failure mode ingest exists to prevent."""
+        client = _make_client()
+        mock_response = Mock()
+        mock_response.status_code = 422
+        mock_response.raise_for_status = Mock(side_effect=RuntimeError("422"))
+
+        with patch.object(client, "_post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+            try:
+                await client.post(Dive.model_validate(_dive_payload()))
+            except RuntimeError:
+                pass
+            else:
+                raise AssertionError("post must not swallow a non-2xx response")

--- a/libs/fishsense-api-sdk/tests/clients/test_image_client.py
+++ b/libs/fishsense-api-sdk/tests/clients/test_image_client.py
@@ -1,9 +1,11 @@
 """Tests for ImageClient class."""
 
 import asyncio
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, Mock, patch
 
 from fishsense_api_sdk.clients.image_client import ImageClient
+from fishsense_api_sdk.models.image import Image
 
 
 def _make_client() -> ImageClient:
@@ -43,3 +45,110 @@ class TestImageClient:
             mock_get.return_value = _mock_404()
             async with client:
                 assert await client.get(checksum="deadbeef") is None
+
+
+class TestImageClientPost:
+    """`images.post` and `images.lookup_checksums` — the image half of ingest."""
+
+    async def test_post_sends_the_image_to_the_dive_scoped_route(self):
+        client = _make_client()
+        mock_response = Mock()
+        mock_response.status_code = 201
+        mock_response.raise_for_status = Mock()
+        mock_response.json = Mock(return_value=7)
+
+        image = Image.model_validate(
+            {
+                "id": None,
+                "path": "d/7/P8210001.ORF",
+                "taken_datetime": "2024-08-21T08:56:51Z",
+                "checksum": "45dc5a454b35601b9dafabf24822195d",
+                "is_canonical": False,
+                "dive_id": None,
+                "camera_id": 3,
+            }
+        )
+
+        with patch.object(client, "_post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+            image_id = await client.post(7, image)
+
+        assert image_id == 7
+        assert mock_post.call_args.args[0] == "/api/v1/dives/7/images/"
+
+    async def test_post_strips_is_canonical_so_the_server_computes_it(self):
+        """`is_canonical` is computed server-side (first-checksum-wins), and an
+        explicit value in the body overrides that computation.
+
+        `Image.is_canonical` is a **required** field on the SDK model, so every
+        instance carries a value and `exclude_unset` cannot keep it off the
+        wire. Posting it unconditionally would mark every duplicate frame
+        canonical and silently break the dives-64/66 distinction — so the
+        client strips it unless asked not to.
+        """
+        client = _make_client()
+        mock_response = Mock()
+        mock_response.status_code = 201
+        mock_response.raise_for_status = Mock()
+        mock_response.json = Mock(return_value=1)
+
+        image = Image(
+            id=None,
+            path="d/7/P8210001.ORF",
+            taken_datetime=datetime(2024, 8, 21, 8, 56, 51, tzinfo=timezone.utc),
+            checksum="45dc5a454b35601b9dafabf24822195d",
+            is_canonical=True,  # a plausible-looking default that must NOT ship
+            dive_id=None,
+            camera_id=3,
+        )
+
+        with patch.object(client, "_post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+            await client.post(7, image)
+
+        assert "is_canonical" not in mock_post.call_args.kwargs["json"]
+
+    async def test_post_sends_is_canonical_when_the_caller_opts_in(self):
+        """The operator override — deliberate, and it has to travel."""
+        client = _make_client()
+        mock_response = Mock()
+        mock_response.status_code = 201
+        mock_response.raise_for_status = Mock()
+        mock_response.json = Mock(return_value=1)
+
+        image = Image(
+            id=None,
+            path="d/66/P1.ORF",
+            taken_datetime=datetime(2024, 8, 21, 8, 56, 51, tzinfo=timezone.utc),
+            checksum="45dc5a454b35601b9dafabf24822195d",
+            is_canonical=True,
+            dive_id=None,
+            camera_id=3,
+        )
+
+        with patch.object(client, "_post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+            await client.post(66, image, set_canonical=True)
+
+        assert mock_post.call_args.kwargs["json"]["is_canonical"] is True
+
+    async def test_lookup_checksums_posts_the_batch_and_returns_the_mapping(self):
+        client = _make_client()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = Mock()
+        mock_response.json = Mock(
+            return_value={
+                "a" * 32: [{"image_id": 1, "dive_id": 64, "is_canonical": True}],
+                "b" * 32: [],
+            }
+        )
+
+        with patch.object(client, "_post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+            result = await client.lookup_checksums(["a" * 32, "b" * 32])
+
+        assert mock_post.call_args.args[0] == "/api/v1/images/checksums/lookup"
+        assert mock_post.call_args.kwargs["json"] == ["a" * 32, "b" * 32]
+        assert result["b" * 32] == []
+        assert result["a" * 32][0]["dive_id"] == 64

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/cleanup_raw_bytes_for_dive_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/cleanup_raw_bytes_for_dive_activity.py
@@ -47,7 +47,12 @@ async def cleanup_raw_bytes_for_dive_activity(
 ) -> CleanupRawBytesResult:
     async with get_fs_client() as fs:
         images = await fs.images.get(dive_id=dive_id) or []
-
+        # Deliberately NOT filtered to canonical images, unlike staging and
+        # the resolvers. Cleanup should be broader than whatever produced the
+        # scratch, so it still evicts objects staged before the canonical gate
+        # existed. Harmless either way -- scratch is keyed by checksum, and a
+        # duplicate shares its canonical twin's key -- but broader is the safe
+        # direction for a delete that only touches Garage scratch.
     activity.logger.info(
         "cleaning up raw bytes dive_id=%d images=%d", dive_id, len(images)
     )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_laser_label_studio_project_activity.py
@@ -166,6 +166,14 @@ async def populate_laser_label_studio_project_activity(
     """
     async with get_fs_client() as fs:
         images = await fs.images.get(dive_id=dive_id) or []
+        # Canonical frames only. The same physical frames live under several
+        # dive rows (half of prod's image table is duplicate content), and
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+        # predicate exactly -- otherwise the dispatched per-image work would not
+        # match what the cohort promised, and the dive could never drain.
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+        images = [image for image in images if image.is_canonical]
         existing_labels = await fs.labels.get_laser_labels(dive_id) or []
         predictions = await fs.labels.get_laser_predictions(dive_id) or []
         predictions_by_image = {p.image_id: p for p in predictions}

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_dive_frame_clustering_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_dive_frame_clustering_inputs_activity.py
@@ -23,7 +23,14 @@ async def resolve_dive_frame_clustering_inputs_activity(
     )
     async with get_fs_client() as fs:
         images = await fs.images.get(dive_id=dive_id) or []
-
+        # Canonical frames only. The same physical frames live under several
+        # dive rows (half of prod's image table is duplicate content), and
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+        # predicate exactly -- otherwise the dispatched per-image work would not
+        # match what the cohort promised, and the dive could never drain.
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+        images = [image for image in images if image.is_canonical]
     cluster_images = [
         ClusterDiveFrameImage(
             image_id=image.id,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_headtail_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_headtail_preprocess_inputs_activity.py
@@ -63,6 +63,22 @@ async def resolve_headtail_preprocess_inputs_activity(
         ]
 
         images = await fs.images.get(dive_id=dive_id) or []
+
+        # Canonical frames only. The same physical frames live under several
+
+        # dive rows (half of prod's image table is duplicate content), and
+
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+
+        # predicate exactly -- otherwise the dispatched per-image work would not
+
+        # match what the cohort promised, and the dive could never drain.
+
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+
+        images = [image for image in images if image.is_canonical]
         checksum_by_id = {image.id: image.checksum for image in images}
         image_checksums = [
             checksum_by_id[image_id]

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_predict_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_predict_inputs_activity.py
@@ -61,6 +61,22 @@ async def resolve_laser_predict_inputs_activity(
             raise ValueError(f"camera_id={dive.camera_id} has no intrinsics")
 
         images = await fs.images.get(dive_id=dive_id) or []
+
+        # Canonical frames only. The same physical frames live under several
+
+        # dive rows (half of prod's image table is duplicate content), and
+
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+
+        # predicate exactly -- otherwise the dispatched per-image work would not
+
+        # match what the cohort promised, and the dive could never drain.
+
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+
+        images = [image for image in images if image.is_canonical]
         predictions = await fs.labels.get_laser_predictions(dive_id) or []
         labels = await fs.labels.get_laser_labels(dive_id) or []
         needing = _select_images_needing_prediction(images, predictions, labels)

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_preprocess_inputs_activity.py
@@ -68,6 +68,22 @@ async def resolve_laser_preprocess_inputs_activity(
             )
 
         images = await fs.images.get(dive_id=dive_id) or []
+
+        # Canonical frames only. The same physical frames live under several
+
+        # dive rows (half of prod's image table is duplicate content), and
+
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+
+        # predicate exactly -- otherwise the dispatched per-image work would not
+
+        # match what the cohort promised, and the dive could never drain.
+
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+
+        images = [image for image in images if image.is_canonical]
         existing_labels = await fs.labels.get_laser_labels(dive_id) or []
         unlabeled = _select_unlabeled_images(images, existing_labels)
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_slate_predict_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_slate_predict_inputs_activity.py
@@ -87,6 +87,22 @@ async def resolve_slate_predict_inputs_activity(
         )
 
         images = await fs.images.get(dive_id=dive_id) or []
+
+        # Canonical frames only. The same physical frames live under several
+
+        # dive rows (half of prod's image table is duplicate content), and
+
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+
+        # predicate exactly -- otherwise the dispatched per-image work would not
+
+        # match what the cohort promised, and the dive could never drain.
+
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+
+        images = [image for image in images if image.is_canonical]
         checksum_by_id = {image.id: image.checksum for image in images}
 
         activity.logger.info(

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_slate_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_slate_preprocess_inputs_activity.py
@@ -77,6 +77,22 @@ async def resolve_slate_preprocess_inputs_activity(
         ]
 
         images = await fs.images.get(dive_id=dive_id) or []
+
+        # Canonical frames only. The same physical frames live under several
+
+        # dive rows (half of prod's image table is duplicate content), and
+
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+
+        # predicate exactly -- otherwise the dispatched per-image work would not
+
+        # match what the cohort promised, and the dive could never drain.
+
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+
+        images = [image for image in images if image.is_canonical]
         checksum_by_id = {image.id: image.checksum for image in images}
         image_checksums = [
             checksum_by_id[image_id]

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_species_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_species_preprocess_inputs_activity.py
@@ -64,6 +64,14 @@ async def resolve_species_preprocess_inputs_activity(
             or []
         )
         images = await fs.images.get(dive_id=dive_id) or []
+        # Canonical frames only. The same physical frames live under several
+        # dive rows (half of prod's image table is duplicate content), and
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+        # predicate exactly -- otherwise the dispatched per-image work would not
+        # match what the cohort promised, and the dive could never drain.
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+        images = [image for image in images if image.is_canonical]
         checksum_by_id = {image.id: image.checksum for image in images}
 
         laser_labels = await fs.labels.get_laser_labels(dive_id) or []

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/stage_raw_bytes_for_dive_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/stage_raw_bytes_for_dive_activity.py
@@ -176,7 +176,14 @@ async def stage_raw_bytes_for_dive_activity(
 ) -> StageRawBytesResult:
     async with get_fs_client() as fs:
         images = await fs.images.get(dive_id=dive_id) or []
-
+        # Canonical frames only. The same physical frames live under several
+        # dive rows (half of prod's image table is duplicate content), and
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+        # predicate exactly -- otherwise the dispatched per-image work would not
+        # match what the cohort promised, and the dive could never drain.
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+        images = [image for image in images if image.is_canonical]
     activity.logger.info(
         "staging raw bytes dive_id=%d images=%d", dive_id, len(images)
     )

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_laser_predict_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_laser_predict_inputs_activity.py
@@ -15,8 +15,12 @@ from fishsense_api_workflow_worker.activities import (
 )
 
 
-def _image(image_id, checksum):
-    return SimpleNamespace(id=image_id, checksum=checksum)
+def _image(image_id, checksum, *, is_canonical=True):
+    # Canonical by default — the resolvers filter on it, mirroring the
+    # cohort selectors. Pass False to model a duplicate frame.
+    return SimpleNamespace(
+        id=image_id, checksum=checksum, is_canonical=is_canonical
+    )
 
 
 def _make_fs(*, camera_id=1, images=None, predictions=None, labels=None, intrinsics=True):
@@ -95,3 +99,31 @@ async def test_activity_raises_without_intrinsics(monkeypatch):
         await ActivityEnvironment().run(
             sut.resolve_laser_predict_inputs_activity, 1
         )
+
+
+async def test_duplicate_frames_are_not_dispatched_as_work(monkeypatch):
+    """Resolvers must mirror the cohort selectors, which gate on
+    `is_canonical`.
+
+    The same physical frames live under several dive rows — half of prod's
+    image table is duplicate content — and `is_canonical` marks which copy is
+    real. If a resolver dispatched a duplicate the selector had excluded, the
+    per-image work would not match what the cohort promised, and (worse) the
+    dive could never drain: no label row would ever appear for it, so the
+    cohort predicate stays true forever. That is the prod dive 60 wedge.
+    """
+    fs = _make_fs(
+        images=[
+            _image(11, "c11", is_canonical=True),
+            _image(12, "c12", is_canonical=False),
+        ]
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.resolve_laser_predict_inputs_activity, 1
+    )
+
+    dispatched = {img.checksum for img in result.images}
+    assert "c11" in dispatched
+    assert "c12" not in dispatched, "a duplicate frame was dispatched as work"

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_slate_predict_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_slate_predict_inputs_activity.py
@@ -71,8 +71,8 @@ def _make_fs():
     fs.images = MagicMock()
     fs.images.get = AsyncMock(
         return_value=[
-            SimpleNamespace(id=11, checksum="c11"),
-            SimpleNamespace(id=12, checksum="c12"),
+            SimpleNamespace(id=11, checksum="c11", is_canonical=True),
+            SimpleNamespace(id=12, checksum="c12", is_canonical=True),
         ]
     )
     fs.labels = MagicMock()

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/a7f2c9e41b03_unique_canonical_image_per_checksum.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/a7f2c9e41b03_unique_canonical_image_per_checksum.py
@@ -1,0 +1,96 @@
+"""at most one canonical image per checksum
+
+Revision ID: a7f2c9e41b03
+Revises: d7e21b95c3a0
+Create Date: 2026-08-07 09:00:00.000000
+
+`post_image` decides `is_canonical` with a read-then-write, which under READ
+COMMITTED lets two concurrent requests both conclude they are the first row for
+a checksum. Only the database can settle that, so this adds the partial unique
+index the application logic has always assumed.
+
+**This migration never mutates data.** If existing rows already violate the
+invariant, creating the index would fail -- and because `lifespan` runs
+`run_alembic_upgrade` on startup, a failed migration crash-loops the API. So it
+checks first and, on finding violations, logs them loudly and skips. Repairing
+them is an operator decision (which copy is canonical is a judgement about
+which dive is the real one), not something a schema migration should decide
+unattended against a database with no staging counterpart.
+
+To repair, demote all but the earliest row per checksum -- `9e5bc64`'s original
+rule was "first one wins" -- then re-run this migration:
+
+    UPDATE image SET is_canonical = false
+    WHERE is_canonical AND id NOT IN (
+        SELECT MIN(id) FROM image WHERE is_canonical GROUP BY checksum
+    );
+
+"""
+# pylint: skip-file
+
+import logging
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a7f2c9e41b03"
+down_revision: Union[str, Sequence[str], None] = "d7e21b95c3a0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_log = logging.getLogger("alembic.runtime.migration")
+
+INDEX_NAME = "uq_image_canonical_checksum"
+
+_FIND_VIOLATIONS = sa.text(
+    """
+    SELECT checksum, COUNT(*) AS n
+    FROM image
+    WHERE is_canonical
+    GROUP BY checksum
+    HAVING COUNT(*) > 1
+    ORDER BY n DESC
+    """
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    if INDEX_NAME in {ix["name"] for ix in sa.inspect(bind).get_indexes("image")}:
+        _log.info("%s already present; nothing to do", INDEX_NAME)
+        return
+
+    violations = list(bind.execute(_FIND_VIOLATIONS))
+    if violations:
+        total = sum(row.n for row in violations)
+        _log.error(
+            "REFUSING to create %s: %d checksums already have more than one "
+            "canonical image (%d rows). Nothing has been changed and the "
+            "upgrade continues, so the API still starts -- but the race this "
+            "index closes remains open. See this migration's docstring for the "
+            "repair statement. Worst offenders: %s",
+            INDEX_NAME,
+            len(violations),
+            total,
+            ", ".join(f"{row.checksum}={row.n}" for row in violations[:5]),
+        )
+        return
+
+    op.create_index(
+        INDEX_NAME,
+        "image",
+        ["checksum"],
+        unique=True,
+        postgresql_where=sa.text("is_canonical"),
+        sqlite_where=sa.text("is_canonical"),
+    )
+    _log.info("created %s", INDEX_NAME)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if INDEX_NAME in {ix["name"] for ix in sa.inspect(bind).get_indexes("image")}:
+        op.drop_index(INDEX_NAME, table_name="image")

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/c3e8b1d47a52_canonical_only_pipeline_status.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/c3e8b1d47a52_canonical_only_pipeline_status.py
@@ -1,0 +1,57 @@
+"""dive_pipeline_status counts only canonical images
+
+Revision ID: c3e8b1d47a52
+Revises: a7f2c9e41b03
+Create Date: 2026-08-08 06:00:00.000000
+
+The cohort selectors now require `Image.is_canonical`, so a duplicate dive can
+never become pipeline work. This view has to use the identical predicate or the
+two drift: the dashboard would report such a dive as perpetually incomplete
+while the worker correctly does nothing with it — the exact silent
+disagreement `test_view_and_selector_agree_on_species_predicate` exists to
+catch.
+
+Drop + recreate rather than CREATE OR REPLACE: Postgres is restrictive about
+column-shape changes on replace, and the view has no dependents, so the simpler
+pattern applies (see the `dive_pipeline_status` section of CLAUDE.md).
+
+No data is touched. On prod this is a pure predicate change: every dive that
+currently has canonical images keeps identical flags, because the added
+conjunct is true for those rows. Only fully-duplicate dives change — and all
+207 of them are priority=LOW, so nothing schedules them either way.
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from fishsense_api.views import (
+    DIVE_PIPELINE_STATUS_VIEW_SQL,
+    DROP_DIVE_PIPELINE_STATUS_VIEW_SQL,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "c3e8b1d47a52"
+down_revision: Union[str, Sequence[str], None] = "a7f2c9e41b03"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Recreate the view with the canonical-only predicate."""
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)
+
+
+def downgrade() -> None:
+    """Recreate from whatever `views.py` currently holds.
+
+    Note this is NOT a true inverse: the SQL is imported from `views.py`, which
+    is the single source of truth, so downgrading after reverting the code
+    restores the old predicate, while downgrading without reverting is a no-op.
+    That is the same trade-off every view migration in this tree makes.
+    """
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -176,6 +176,11 @@ async def post_dive(
     dive: Dive,
     session: AsyncSession = Depends(get_async_session),
 ) -> int:
+    # pylint: disable=too-many-branches
+    # Each branch is one independent guard on a distinct field. Collapsing them
+    # into a helper would hide which check produced which 422 detail, and the
+    # detail strings are the point -- every one of these failures is otherwise
+    # silent in a *later* pipeline stage.
     """Create or update a dive, keyed on its NAS-relative `path`.
 
     **Upserts on `path`.** `session.merge` keys on the primary key alone, so a
@@ -217,8 +222,64 @@ async def post_dive(
             ),
         )
 
+    # Which fields did the caller actually send? Captured BEFORE
+    # `model_validate`, which rebuilds the object and marks every field as set.
+    provided = set(dive.model_fields_set)
+
+    # SQLModel `table=True` models skip pydantic coercion, so FastAPI hands us a
+    # `Dive` whose `priority` is still the raw JSON `str`. Two consequences, both
+    # fixed by coercing here rather than after `model_validate`:
+    #   * an unrecognised value reaches `model_validate` and surfaces as a bare
+    #     ValidationError -- a 500 where the caller deserves a 422;
+    #   * `jsonable_encoder` below re-serializes the uncoerced object and emits a
+    #     pydantic serializer warning on every single request.
+    if dive.priority is not None and not isinstance(dive.priority, Priority):
+        try:
+            dive.priority = Priority(dive.priority)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=422, detail=f"Unknown priority {dive.priority!r}"
+            ) from exc
+
+    if dive.dive_datetime is None:
+        # `Dive.dive_datetime` is annotated non-optional but carries
+        # `default=None`, so FastAPI's request validation happily accepts a body
+        # that omits it -- and the `model_validate` below then raises a bare
+        # ValidationError, which surfaces as a 500. Guard explicitly.
+        raise HTTPException(status_code=422, detail="dive_datetime is required")
+
     dive = Dive.model_validate(jsonable_encoder(dive))
 
+    # Natural-key upsert on `path`.
+    if dive.id is None:
+        existing = (
+            await session.exec(select(Dive).where(Dive.path == dive.path))
+        ).first()
+        if existing is not None:
+            dive.id = existing.id
+            # PARTIAL update. `session.merge` replaces every column of the
+            # target row, so merging a body that only mentioned `priority`
+            # would null `name`, `dive_slate_id` and `calibration_dive_id`.
+            # That is data loss: `dive_slate_id` is written only by the
+            # species-label sync (nulling it discards labeler work and stops
+            # stages 9/12/13), and `calibration_dive_id` is the
+            # borrowed-calibration link (nulling it stops stage 14 measuring
+            # the dive). Neither failure reports anything.
+            #
+            # So overlay only what was sent onto the row as it stands. An
+            # explicit `None` still clears a field -- it is in `provided`.
+            # `model_dump()` (python mode), NOT `jsonable_encoder`: the latter
+            # stringifies `priority`, and a table model doesn't coerce it back,
+            # so the row would end up holding a raw str in an Enum column.
+            merged = existing.model_dump()
+            for field in provided:
+                merged[field] = getattr(dive, field)
+            merged["id"] = existing.id
+            dive = Dive(**merged)
+
+    # Validation runs on the EFFECTIVE row, after the overlay -- a partial
+    # re-post that omits `camera_id` inherits the existing one and must not be
+    # rejected for a field it never intended to change.
     if dive.camera_id is None:
         raise HTTPException(
             status_code=422,
@@ -246,14 +307,6 @@ async def post_dive(
                 "measure this dive"
             ),
         )
-
-    # Natural-key upsert on `path`.
-    if dive.id is None:
-        existing = (
-            await session.exec(select(Dive).where(Dive.path == dive.path))
-        ).first()
-        if existing is not None:
-            dive.id = existing.id
 
     if dive.calibration_dive_id is not None:
         if dive.calibration_dive_id == dive.id:

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -45,6 +45,24 @@ from fishsense_api.server import app
 logger = logging.getLogger(__name__)
 
 
+# Every cohort selector below correlates `Image` to `Dive` and then adds
+# `Image.is_canonical == True`. That filter is not an optimisation -- it is
+# what stops a duplicate dive wedging the pipeline.
+#
+# The same physical frames legitimately live under several dive rows (half of
+# prod's image table is duplicate content; 207 of 479 dives are duplicates end
+# to end), and `is_canonical` marks which copy is the real one. Without the
+# filter, a duplicate dive promoted to HIGH satisfies "has an image with no
+# label row" forever: populate declines to make LS tasks for frames that
+# already exist elsewhere, so no label row appears, so the dive never drains --
+# re-staging its raw `.ORF`s from the NAS every hour and blocking every
+# higher-id dive behind it. That is the prod dive 60 failure.
+#
+# Duplicate dives are all LOW priority today, so this is currently latent. That
+# is a property of the data, not of the code. `test_canonical_only_pipeline_work.py`
+# pins both the behaviour and the "every selector has it" registry property.
+
+
 def _valid_laser_conditions():
     """The repo-wide definition of a *valid* laser label.
 
@@ -371,6 +389,7 @@ async def select_next_for_laser_preprocessing(
     has_image_without_real_laser_label = (
         select(Image.id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(
             ~select(LaserLabel.id)
             .where(LaserLabel.image_id == Image.id)
@@ -418,6 +437,7 @@ async def select_next_for_laser_prediction(
     has_image_needing_prediction = (
         select(Image.id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(
             ~select(LaserPrediction.id)
             .where(LaserPrediction.image_id == Image.id)
@@ -464,6 +484,7 @@ async def select_next_for_slate_prediction(
         select(SpeciesLabel.id)
         .join(Image, Image.id == SpeciesLabel.image_id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(SpeciesLabel.content_of_image == SLATE_CONTENT_MARKER)
         .where(
             ~select(SlatePrediction.id)
@@ -510,6 +531,7 @@ async def select_next_for_dive_frame_clustering(
         select(LaserLabel.id)
         .join(Image, Image.id == LaserLabel.image_id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(*_valid_laser_conditions())
         .exists()
     )
@@ -579,6 +601,7 @@ async def select_next_for_species_preprocessing(
         select(LaserLabel.id)
         .join(Image, Image.id == LaserLabel.image_id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(*_valid_laser_conditions())
         .where(
             ~select(SpeciesLabel.id)
@@ -650,6 +673,7 @@ async def select_dives_needing_species_population(
         select(LaserLabel.id)
         .join(Image, Image.id == LaserLabel.image_id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(LaserLabel.completed == True)
         .where(LaserLabel.superseded == False)
         .where(LaserLabel.x != None)
@@ -694,6 +718,7 @@ async def select_dives_needing_laser_population(
     has_predicted_incomplete_image = (
         select(Image.id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(
             select(LaserPrediction.id)
             .where(LaserPrediction.image_id == Image.id)
@@ -740,6 +765,7 @@ async def select_next_for_headtail_preprocessing(
         select(LaserLabel.id)
         .join(Image, Image.id == LaserLabel.image_id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(*_valid_laser_conditions())
         .where(
             ~select(HeadTailLabel.id)
@@ -776,6 +802,7 @@ async def select_next_for_slate_preprocessing(
         select(SpeciesLabel.id)
         .join(Image, Image.id == SpeciesLabel.image_id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(SpeciesLabel.content_of_image == SLATE_CONTENT_MARKER)
         .where(
             ~select(DiveSlateLabel.id)
@@ -811,6 +838,7 @@ async def select_next_for_laser_calibration(
         select(func.count(DiveSlateLabel.id))  # pylint: disable=not-callable
         .join(Image, Image.id == DiveSlateLabel.image_id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(DiveSlateLabel.completed == True)
         # A dead-lettered slate label doesn't count toward the calibration
         # readiness gate — same validity convention laser calibration uses.
@@ -895,6 +923,7 @@ async def select_next_for_measure_fish(
         select(SpeciesLabel.id)
         .join(Image, Image.id == SpeciesLabel.image_id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(SpeciesLabel.top_three_photos_of_group == True)
         .where(*_measurable_species_conditions())
         .where(valid_laser)

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -1,4 +1,12 @@
 # pylint: disable=C0121
+# pylint: disable=too-many-lines
+#   This module is a route registry: ~20 endpoints, most of them a single
+#   cohesive SELECT, plus the shared cohort predicates they splat into
+#   those selects. Adding `post_dive` tipped it past pylint's 1000-line
+#   ceiling. Splitting the stage-cohort selectors into their own module
+#   is the real fix and is worth doing, but it would move ~600 lines and
+#   every worker activity that imports them — not something to bundle
+#   into an unrelated feature PR.
 """Dive Controller for FishSense API."""
 
 import logging
@@ -12,6 +20,8 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from fishsense_api.database import get_async_session
+from fishsense_api.models.camera import Camera
+from fishsense_api.models.camera_intrinsics import CameraIntrinsics
 from fishsense_api.models.data_source import DataSource
 from fishsense_api.models.dive import Dive
 from fishsense_api.models.dive_frame_cluster import (
@@ -153,6 +163,120 @@ async def get_canonical_dives(
 
     result = await session.exec(query)
     return result.all()
+
+
+# Maximum length of `Dive.path` / `Image.path`, mirroring `max_length=255` on
+# the models. Postgres would reject an over-long value, but sqlite silently
+# stores it, so the check is explicit rather than left to the driver.
+MAX_PATH_LENGTH = 255
+
+
+@app.post("/api/v1/dives/", status_code=201)
+async def post_dive(
+    dive: Dive,
+    session: AsyncSession = Depends(get_async_session),
+) -> int:
+    """Create or update a dive, keyed on its NAS-relative `path`.
+
+    **Upserts on `path`.** `session.merge` keys on the primary key alone, so a
+    body with `id=None` always INSERTs — which trips the unique index on
+    `path` (the dive-shaped form of the #347 duplicate-key 500). Ingest
+    re-posts the same path routinely: resuming a partial scan, and the
+    finalize step re-POSTing to flip `priority` LOW -> HIGH. Resolving the
+    natural key to an existing row id first turns the merge into an UPDATE.
+
+    Validation is deliberately loud, because each of these breaks a *later*
+    stage silently rather than here:
+
+      * A dive whose camera has no `CameraIntrinsics` can never be measured by
+        stage 14. Nothing errors — the dive just never reaches `measured`.
+      * An over-long path is silently truncated by some backends, and the
+        resulting `Image.path` no longer resolves on the NAS.
+      * A self-referential or dangling `calibration_dive_id` makes
+        `get_laser_extrinsics_for_dive`'s fallback either loop or 404.
+
+    `priority` is NOT validated here: ingest deliberately creates dives at LOW
+    and flips them to HIGH only once every image has landed, so LOW is a
+    legitimate intermediate state (see the ingest workflow's commit flag).
+    """
+    logger.debug("Creating or updating dive with path=%s", dive.path)
+
+    # Path checks run BEFORE `model_validate`. SQLModel's `max_length=255`
+    # already rejects an over-long path for any normally-constructed body (so
+    # an HTTP caller gets a 422 from request validation), but a body built via
+    # `model_construct` bypasses that — and re-validating here would raise a
+    # bare ValidationError instead of a useful 422.
+    if not dive.path:
+        raise HTTPException(status_code=422, detail="Dive path is required")
+    if len(dive.path) > MAX_PATH_LENGTH:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Dive path exceeds {MAX_PATH_LENGTH} characters "
+                f"({len(dive.path)}): {dive.path}"
+            ),
+        )
+
+    dive = Dive.model_validate(jsonable_encoder(dive))
+
+    if dive.camera_id is None:
+        raise HTTPException(
+            status_code=422,
+            detail="camera_id is required; without it stage 14 cannot measure the dive",
+        )
+    camera = (
+        await session.exec(select(Camera).where(Camera.id == dive.camera_id))
+    ).first()
+    if camera is None:
+        raise HTTPException(
+            status_code=422, detail=f"Camera {dive.camera_id} does not exist"
+        )
+    intrinsics = (
+        await session.exec(
+            select(CameraIntrinsics).where(
+                CameraIntrinsics.camera_id == dive.camera_id
+            )
+        )
+    ).first()
+    if intrinsics is None:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Camera {dive.camera_id} has no intrinsics; stage 14 could never "
+                "measure this dive"
+            ),
+        )
+
+    # Natural-key upsert on `path`.
+    if dive.id is None:
+        existing = (
+            await session.exec(select(Dive).where(Dive.path == dive.path))
+        ).first()
+        if existing is not None:
+            dive.id = existing.id
+
+    if dive.calibration_dive_id is not None:
+        if dive.calibration_dive_id == dive.id:
+            raise HTTPException(
+                status_code=422, detail="A dive cannot borrow its own calibration"
+            )
+        source = (
+            await session.exec(
+                select(Dive).where(Dive.id == dive.calibration_dive_id)
+            )
+        ).first()
+        if source is None:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Calibration source dive {dive.calibration_dive_id} does not exist",
+            )
+
+    dive = await session.merge(dive)
+    await session.flush()
+
+    dive_id = dive.id
+
+    return dive_id
 
 
 # Cohort selectors used by the api-workflow-worker hourly schedules.

--- a/services/fishsense-api/src/fishsense_api/controllers/image_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/image_controller.py
@@ -77,6 +77,10 @@ async def post_image(
     image: Image,
     session: AsyncSession = Depends(get_async_session),
 ) -> int:
+    # pylint: disable=too-many-branches
+    # Same shape as `post_dive`: each branch is one guard on a distinct field,
+    # and the 422 detail it produces is the point -- every one of these
+    # failures is otherwise silent in a later pipeline stage.
     """Create or update an image, keyed on its NAS-relative `path`.
 
     **Upserts on `path`** for the same reason `post_dive` does: a resumed scan
@@ -92,10 +96,16 @@ async def post_image(
     appear under two dive rows -- prod dives 64 and 66 are both
     `082929_FishModels_FSL07` -- and `checksum` is how that is recognised.
 
-    Computing it server-side matters: a client-side "has this checksum been
-    seen yet" check races itself, and two concurrent posts would both conclude
-    they were first. An explicit `is_canonical` in the body still wins, so an
-    operator can promote a re-ingested copy.
+    Computing it server-side narrows the window but does **not** close it: this
+    is still a read-then-write, and under READ COMMITTED two concurrent
+    requests can both find no existing row and both claim canonical. The
+    `uq_image_canonical_checksum` partial unique index is what actually
+    enforces it -- the loser gets an IntegrityError, and its retry re-reads,
+    sees the winner, and writes `is_canonical=False`. So the check here is the
+    fast path and a good error message; the index is the guarantee.
+
+    An explicit `is_canonical` in the body still wins, so an operator can
+    promote a re-ingested copy.
     """
     logger.debug("Creating or updating image with path=%s", image.path)
 
@@ -163,6 +173,20 @@ async def post_image(
             merged["id"] = existing.id
             merged["dive_id"] = dive_id
             image = Image(**merged)
+
+    if explicit_is_canonical and image.is_canonical:
+        # "Promote this copy" is only coherent if it also demotes the incumbent
+        # -- there can be exactly one canonical row per checksum, and
+        # `uq_image_canonical_checksum` enforces that. Before the index existed
+        # this silently produced two canonical rows for one checksum.
+        incumbents = select(Image).where(Image.checksum == image.checksum)
+        if image.id is not None:
+            incumbents = incumbents.where(Image.id != image.id)
+        for incumbent in (await session.exec(incumbents)).all():
+            if incumbent.is_canonical:
+                incumbent.is_canonical = False
+                session.add(incumbent)
+        await session.flush()
 
     if not explicit_is_canonical:
         # "Is there already a row with this checksum that ISN'T this one?"

--- a/services/fishsense-api/src/fishsense_api/controllers/image_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/image_controller.py
@@ -81,7 +81,10 @@ async def post_image(
 
     **Upserts on `path`** for the same reason `post_dive` does: a resumed scan
     re-posts paths that already exist, and a blind `session.merge(id=None)`
-    would INSERT and trip the unique index (#347).
+    would INSERT and trip the unique index (#347). The update is *partial* --
+    only fields the caller actually sent are written -- except `path`,
+    `checksum` and `taken_datetime`, which the model cannot represent as
+    absent and so must always be supplied.
 
     **`is_canonical` is computed here, not by the caller.** The rule comes from
     the original migration (`9e5bc64`): the first row for a given checksum is
@@ -116,6 +119,11 @@ async def post_image(
             ),
         )
     if image.taken_datetime is None:
+        # Always required, even on a partial re-post: `Image.taken_datetime` is
+        # annotated non-optional, so `model_validate` below would reject a None
+        # with a bare ValidationError instead of a usable 422. Stage-1
+        # clustering is pure timestamp math, so a defaulted value would corrupt
+        # it silently anyway.
         raise HTTPException(
             status_code=422,
             detail=(
@@ -123,12 +131,14 @@ async def post_image(
                 "math, so a missing value would corrupt it silently"
             ),
         )
-
     dive = (await session.exec(select(Dive).where(Dive.id == dive_id))).first()
     if dive is None:
         raise HTTPException(status_code=422, detail=f"Dive {dive_id} does not exist")
 
-    explicit_is_canonical = "is_canonical" in image.model_fields_set
+    # Which fields did the caller actually send? Captured BEFORE
+    # `model_validate`, which marks every field as set.
+    provided = set(image.model_fields_set)
+    explicit_is_canonical = "is_canonical" in provided
 
     image = Image.model_validate(jsonable_encoder(image))
     image.dive_id = dive_id
@@ -140,6 +150,19 @@ async def post_image(
         ).first()
         if existing is not None:
             image.id = existing.id
+            # PARTIAL update, same reasoning as `post_dive`: `session.merge`
+            # replaces every column, so a resumed scan re-posting a path with a
+            # narrower body would wipe whatever it omitted (`camera_id`, and
+            # `is_canonical` itself). Overlay only what was sent.
+            # `model_dump()` (python mode), not `jsonable_encoder` -- see
+            # `post_dive`: a JSON round-trip through a table model loses typed
+            # values (datetimes, enums) because it doesn't coerce them back.
+            merged = existing.model_dump()
+            for field in provided:
+                merged[field] = getattr(image, field)
+            merged["id"] = existing.id
+            merged["dive_id"] = dive_id
+            image = Image(**merged)
 
     if not explicit_is_canonical:
         # "Is there already a row with this checksum that ISN'T this one?"

--- a/services/fishsense-api/src/fishsense_api/controllers/image_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/image_controller.py
@@ -2,7 +2,8 @@
 
 import asyncio
 import logging
-from typing import Dict, List
+import re
+from typing import Any, Dict, List
 
 from fastapi import Depends, HTTPException
 from fastapi.encoders import jsonable_encoder
@@ -16,6 +17,7 @@ from fishsense_api.models.dive_frame_cluster import (
     DiveFrameClusterImageMapping,
     DiveFrameClusterJson,
 )
+from fishsense_api.models.dive import Dive
 from fishsense_api.models.image import Image
 from fishsense_api.server import app
 
@@ -50,6 +52,164 @@ async def get_image_by_checksum(
         logger.warning("Image with checksum=%s not found", checksum)
         raise HTTPException(status_code=404, detail="Image not found")
     return image
+
+
+# Mirrors `max_length=255` on `Image.path`; see `post_dive` for why this is
+# checked explicitly rather than left to the driver.
+MAX_PATH_LENGTH = 255
+
+# `Image.checksum` is a 32-char lowercase MD5 hexdigest of the whole file --
+# `hashlib.md5(<entire file>).hexdigest()`, matching `get_file_checksum` in the
+# (now archived) fishsense-data-processing-spider, which is what wrote every
+# `image_md5` the current rows were migrated from. A value of any other shape
+# means the hashing changed underneath us, and duplicate detection would stop
+# matching *silently* -- so it is rejected rather than stored.
+_MD5_HEXDIGEST = re.compile(r"^[0-9a-f]{32}$")
+
+# Cap on one `post_checksum_lookup` batch. A dive is a few hundred frames, so
+# this is generous; it exists to stop an unbounded IN (...) from a bad caller.
+MAX_CHECKSUM_LOOKUP = 1000
+
+
+@app.post("/api/v1/dives/{dive_id}/images/", status_code=201)
+async def post_image(
+    dive_id: int,
+    image: Image,
+    session: AsyncSession = Depends(get_async_session),
+) -> int:
+    """Create or update an image, keyed on its NAS-relative `path`.
+
+    **Upserts on `path`** for the same reason `post_dive` does: a resumed scan
+    re-posts paths that already exist, and a blind `session.merge(id=None)`
+    would INSERT and trip the unique index (#347).
+
+    **`is_canonical` is computed here, not by the caller.** The rule comes from
+    the original migration (`9e5bc64`): the first row for a given checksum is
+    canonical, later duplicates are not. The same physical frames legitimately
+    appear under two dive rows -- prod dives 64 and 66 are both
+    `082929_FishModels_FSL07` -- and `checksum` is how that is recognised.
+
+    Computing it server-side matters: a client-side "has this checksum been
+    seen yet" check races itself, and two concurrent posts would both conclude
+    they were first. An explicit `is_canonical` in the body still wins, so an
+    operator can promote a re-ingested copy.
+    """
+    logger.debug("Creating or updating image with path=%s", image.path)
+
+    # Path/checksum checks run before `model_validate` -- see `post_dive`.
+    if not image.path:
+        raise HTTPException(status_code=422, detail="Image path is required")
+    if len(image.path) > MAX_PATH_LENGTH:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Image path exceeds {MAX_PATH_LENGTH} characters "
+                f"({len(image.path)}): {image.path}"
+            ),
+        )
+    if not image.checksum or not _MD5_HEXDIGEST.match(image.checksum):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "checksum must be a 32-character lowercase MD5 hexdigest of the "
+                f"whole file; got {image.checksum!r}"
+            ),
+        )
+    if image.taken_datetime is None:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "taken_datetime is required; stage-1 clustering is pure timestamp "
+                "math, so a missing value would corrupt it silently"
+            ),
+        )
+
+    dive = (await session.exec(select(Dive).where(Dive.id == dive_id))).first()
+    if dive is None:
+        raise HTTPException(status_code=422, detail=f"Dive {dive_id} does not exist")
+
+    explicit_is_canonical = "is_canonical" in image.model_fields_set
+
+    image = Image.model_validate(jsonable_encoder(image))
+    image.dive_id = dive_id
+
+    # Natural-key upsert on `path`.
+    if image.id is None:
+        existing = (
+            await session.exec(select(Image).where(Image.path == image.path))
+        ).first()
+        if existing is not None:
+            image.id = existing.id
+
+    if not explicit_is_canonical:
+        # "Is there already a row with this checksum that ISN'T this one?"
+        # Excluding self matters: a resumed scan re-posts existing paths, and
+        # without the exclusion every re-run would demote a whole dive to
+        # non-canonical by colliding with itself.
+        duplicate_query = select(Image).where(Image.checksum == image.checksum)
+        if image.id is not None:
+            duplicate_query = duplicate_query.where(Image.id != image.id)
+        duplicate = (await session.exec(duplicate_query)).first()
+        image.is_canonical = duplicate is None
+
+    image = await session.merge(image)
+    await session.flush()
+
+    image_id = image.id
+
+    return image_id
+
+
+@app.post("/api/v1/images/checksums/lookup")
+async def post_checksum_lookup(
+    checksums: List[str],
+    session: AsyncSession = Depends(get_async_session),
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Batch form of `GET /api/v1/images/checksum/{checksum}`.
+
+    Returns `{checksum: [{image_id, dive_id, is_canonical}, ...]}` with an
+    **empty list** for checksums that aren't known -- callers computing
+    `|new & existing| / |new|` shouldn't have to guard every lookup.
+
+    This backs duplicate-dive detection at ingest time. It replaces the
+    approach the legacy spider used -- a whole-dive digest,
+    `MD5(STRING_AGG(basename || ':' || image_md5 ORDER BY path))` -- which was
+    all-or-nothing (one extra frame made two near-identical folders look
+    entirely unrelated), basename-sensitive (a rename broke the match even when
+    the bytes were identical), and offered no similarity measure. A set
+    operation over content hashes has none of those properties: it is immune to
+    filenames and ordering, and it degrades gracefully to a partial overlap.
+    """
+    unique = list(dict.fromkeys(checksums))
+    if len(unique) > MAX_CHECKSUM_LOOKUP:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Too many checksums in one lookup ({len(unique)}); "
+                f"maximum is {MAX_CHECKSUM_LOOKUP}"
+            ),
+        )
+    logger.debug("Looking up %d checksums", len(unique))
+
+    result: Dict[str, List[Dict[str, Any]]] = {checksum: [] for checksum in unique}
+    if not unique:
+        return result
+
+    rows = (
+        await session.exec(
+            select(Image).where(Image.checksum.in_(unique))  # pylint: disable=no-member
+        )
+    ).all()
+    for row in rows:
+        result[row.checksum].append(
+            {
+                "image_id": row.id,
+                "dive_id": row.dive_id,
+                "is_canonical": row.is_canonical,
+            }
+        )
+
+    return result
 
 
 @app.get("/api/v1/dives/{dive_id}/images/")

--- a/services/fishsense-api/src/fishsense_api/models/image.py
+++ b/services/fishsense-api/src/fishsense_api/models/image.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 
+from sqlalchemy import Index, text
 from sqlmodel import DateTime, Field
 
 from fishsense_api.models.model_base import ModelBase
@@ -9,6 +10,33 @@ from fishsense_api.models.model_base import ModelBase
 
 class Image(ModelBase, table=True):
     """Model representing an image."""
+
+    # At most one CANONICAL row per checksum.
+    #
+    # The same physical frames legitimately appear under several dive rows
+    # (prod dives 64 and 66 are both `082929_FishModels_FSL07`), so `checksum`
+    # itself is deliberately non-unique. What must be unique is which of those
+    # copies is the canonical one.
+    #
+    # `post_image` computes that with a read-then-write ("is there already a
+    # row with this checksum?"), which under READ COMMITTED does not stop two
+    # concurrent requests from both concluding they are first. Only the
+    # database can. A losing racer gets an IntegrityError, and because the
+    # ingest activity retries, the retry re-reads, sees the winner, and
+    # correctly writes `is_canonical=False` -- so the race self-heals rather
+    # than needing a resolution path in application code.
+    #
+    # Partial index: rows with `is_canonical=False` are unconstrained, which is
+    # exactly the duplicate case. Supported by both Postgres and SQLite.
+    __table_args__ = (
+        Index(
+            "uq_image_canonical_checksum",
+            "checksum",
+            unique=True,
+            postgresql_where=text("is_canonical"),
+            sqlite_where=text("is_canonical"),
+        ),
+    )
 
     id: int | None = Field(default=None, primary_key=True)
     path: str = Field(max_length=255, unique=True, index=True)

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -91,6 +91,17 @@ _IS_FISH_MODEL_SQL = (
 # incomplete-non-superseded rows. Mirrors
 # `get_dives_with_complete_laser_labeling`'s semantics so a dive with
 # zero labels of a kind doesn't vacuously read as complete.
+# Every image correlation below reads `i.dive_id = d.id AND i.is_canonical`.
+#
+# The same physical frames live under several dive rows (half of prod's image
+# table is duplicate content; 207 of 479 dives are duplicates end to end), and
+# `is_canonical` marks which copy is real. The cohort selectors in
+# `dive_controller` gate on it so a duplicate dive can never become pipeline
+# work, and this view has to use the identical predicate or the two drift:
+# the dashboard would report a dive as perpetually incomplete while the worker
+# correctly does nothing with it. `test_dive_pipeline_status_view.py` pins that
+# agreement explicitly.
+
 DIVE_PIPELINE_STATUS_VIEW_SQL = f"""
 CREATE VIEW {DIVE_PIPELINE_STATUS_VIEW_NAME} AS
 SELECT
@@ -102,10 +113,10 @@ SELECT
     -- Stage 0.1: every image in the dive has at least one LaserLabel
     -- row (any project, any state). The cohort selector is the
     -- inverse of this predicate.
-    (EXISTS (SELECT 1 FROM image i WHERE i.dive_id = d.id)
+    (EXISTS (SELECT 1 FROM image i WHERE i.dive_id = d.id AND i.is_canonical)
      AND NOT EXISTS (
          SELECT 1 FROM image i
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND NOT EXISTS (
                SELECT 1 FROM laserlabel ll WHERE ll.image_id = i.id
            )
@@ -116,14 +127,14 @@ SELECT
     (EXISTS (
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND ll.superseded = FALSE
            AND ll.completed = TRUE
      )
      AND NOT EXISTS (
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND ll.superseded = FALSE
            AND (ll.completed = FALSE OR ll.completed IS NULL)
      )) AS laser_labeling_complete,
@@ -136,13 +147,13 @@ SELECT
     (EXISTS (
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND {_VALID_LASER_SQL}
      )
      AND NOT EXISTS (
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND {_VALID_LASER_SQL}
            AND NOT EXISTS (
                SELECT 1 FROM headtaillabel htl
@@ -156,14 +167,14 @@ SELECT
     (EXISTS (
          SELECT 1 FROM headtaillabel htl
          JOIN image i ON i.id = htl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND htl.superseded = FALSE
            AND htl.completed = TRUE
      )
      AND NOT EXISTS (
          SELECT 1 FROM headtaillabel htl
          JOIN image i ON i.id = htl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND htl.superseded = FALSE
            AND (htl.completed = FALSE OR htl.completed IS NULL)
      )) AS headtail_labeling_complete,
@@ -200,7 +211,7 @@ SELECT
     (EXISTS (
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND {_VALID_LASER_SQL}
            AND EXISTS (
                SELECT 1 FROM diveframeclusterimagemapping mm
@@ -213,7 +224,7 @@ SELECT
      AND NOT EXISTS (
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND {_VALID_LASER_SQL}
            AND EXISTS (
                SELECT 1 FROM diveframeclusterimagemapping mm
@@ -236,14 +247,14 @@ SELECT
     (EXISTS (
          SELECT 1 FROM specieslabel sl
          JOIN image i ON i.id = sl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND sl.superseded = FALSE
            AND sl.completed = TRUE
      )
      AND NOT EXISTS (
          SELECT 1 FROM specieslabel sl
          JOIN image i ON i.id = sl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND sl.superseded = FALSE
            AND (sl.completed = FALSE OR sl.completed IS NULL)
      )) AS species_labeling_complete,
@@ -258,13 +269,13 @@ SELECT
      AND EXISTS (
          SELECT 1 FROM specieslabel sl
          JOIN image i ON i.id = sl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND sl.content_of_image = '{_SLATE_CONTENT_MARKER}'
      )
      AND NOT EXISTS (
          SELECT 1 FROM specieslabel sl
          JOIN image i ON i.id = sl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND sl.content_of_image = '{_SLATE_CONTENT_MARKER}'
            AND NOT EXISTS (
                SELECT 1 FROM diveslatelabel dsl
@@ -278,14 +289,14 @@ SELECT
     (EXISTS (
          SELECT 1 FROM diveslatelabel dsl
          JOIN image i ON i.id = dsl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND dsl.superseded = FALSE
            AND dsl.completed = TRUE
      )
      AND NOT EXISTS (
          SELECT 1 FROM diveslatelabel dsl
          JOIN image i ON i.id = dsl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND dsl.superseded = FALSE
            AND (dsl.completed = FALSE OR dsl.completed IS NULL)
      )) AS slate_labeling_complete,
@@ -346,12 +357,12 @@ SELECT
     (EXISTS (
          SELECT 1 FROM measurement m
          JOIN image i ON i.id = m.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
      )
      AND NOT EXISTS (
          SELECT 1 FROM specieslabel sl
          JOIN image i ON i.id = sl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND sl.top_three_photos_of_group = TRUE
            AND {_MEASURABLE_SPECIES_SQL}
            AND EXISTS (

--- a/services/fishsense-api/tests/test_canonical_checksum_index_migration.py
+++ b/services/fishsense-api/tests/test_canonical_checksum_index_migration.py
@@ -1,0 +1,193 @@
+"""The canonical-checksum index migration must never crash-loop the API.
+
+`lifespan` runs `run_alembic_upgrade` on startup, so a migration that raises
+takes fishsense-api down on deploy — and there is no staging tier to catch it
+first. `uq_image_canonical_checksum` is a *unique* index over existing prod
+data, which is exactly the kind of DDL that can fail on rows that predate the
+invariant.
+
+So the migration checks before it creates, and on finding violations logs and
+returns rather than raising or repairing. Repair is an operator decision (which
+copy is the real one is a judgement about the dives), not something a schema
+migration should settle unattended.
+
+These tests drive the migration against real sqlite, not mocks: the point is
+whether the DDL and the guard behave against a database.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import create_engine
+
+_VERSIONS = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "fishsense_api"
+    / "alembic"
+    / "versions"
+)
+
+
+@pytest.fixture
+def migration():
+    spec = importlib.util.spec_from_file_location(
+        "canonical_index_migration",
+        _VERSIONS / "a7f2c9e41b03_unique_canonical_image_per_checksum.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _image_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "image",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("path", sa.String(255), unique=True),
+        sa.Column("taken_datetime", sa.DateTime(timezone=True)),
+        sa.Column("checksum", sa.String(32)),
+        sa.Column("is_canonical", sa.Boolean),
+    )
+
+
+@pytest.fixture
+def engine(tmp_path):
+    """File-backed sqlite: alembic's `op` needs a real connection, and the
+    inspector must see committed DDL."""
+    eng = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _image_table(metadata)
+    metadata.create_all(eng)
+    yield eng, table
+    eng.dispose()
+
+
+def _seed(conn, table, rows):
+    for image_id, checksum, canonical in rows:
+        conn.execute(
+            table.insert().values(
+                id=image_id,
+                path=f"d/{image_id}.ORF",
+                taken_datetime=datetime(2024, 8, 21, tzinfo=timezone.utc),
+                checksum=checksum,
+                is_canonical=canonical,
+            )
+        )
+
+
+def _run_upgrade(migration, conn):
+    """Drive the migration body against a live connection.
+
+    `alembic.op` is a module-level proxy bound to a MigrationContext, so the
+    migration is run through a real (if minimal) alembic context rather than by
+    monkeypatching `op`.
+    """
+    from alembic.migration import MigrationContext  # pylint: disable=import-outside-toplevel
+    from alembic.operations import Operations  # pylint: disable=import-outside-toplevel
+
+    with Operations.context(MigrationContext.configure(conn)):
+        migration.upgrade()
+
+
+def _indexes(conn) -> set[str]:
+    return {ix["name"] for ix in sa.inspect(conn).get_indexes("image")}
+
+
+def test_creates_the_index_when_existing_data_is_clean(migration, engine):
+    eng, table = engine
+    with eng.begin() as conn:
+        _seed(
+            conn,
+            table,
+            [
+                (1, "a" * 32, True),
+                (2, "a" * 32, False),   # duplicate content, correctly demoted
+                (3, "b" * 32, True),
+            ],
+        )
+        _run_upgrade(migration, conn)
+
+        assert migration.INDEX_NAME in _indexes(conn)
+
+
+def test_the_created_index_actually_rejects_a_second_canonical(migration, engine):
+    """The index has to be *partial*. A plain unique index on `checksum` would
+    also pass "was it created", while breaking the duplicate-frames case the
+    pipeline depends on."""
+    eng, table = engine
+    with eng.begin() as conn:
+        _seed(conn, table, [(1, "a" * 32, True)])
+        _run_upgrade(migration, conn)
+
+        # A second NON-canonical row with the same checksum is fine...
+        _seed(conn, table, [(2, "a" * 32, False)])
+
+        # ... a second canonical one is not.
+        with pytest.raises(sa.exc.IntegrityError):
+            _seed(conn, table, [(3, "a" * 32, True)])
+
+
+def test_skips_without_raising_when_existing_data_violates_the_invariant(
+    migration, engine, caplog
+):
+    """The crash-loop guard. Two canonical rows share a checksum, so the index
+    cannot be created — the migration must log and return, leaving the schema
+    untouched and the API able to start."""
+    eng, table = engine
+    with eng.begin() as conn:
+        _seed(conn, table, [(1, "a" * 32, True), (2, "a" * 32, True)])
+
+        with caplog.at_level("ERROR"):
+            _run_upgrade(migration, conn)   # must not raise
+
+        assert migration.INDEX_NAME not in _indexes(conn)
+        assert "REFUSING" in caplog.text
+        assert "a" * 32 in caplog.text      # names the offending checksum
+
+
+def test_leaves_the_violating_rows_untouched(migration, engine):
+    """It must not silently 'repair' prod data. Demoting the wrong copy would
+    change which dive reads as canonical, and there is no staging tier to
+    notice."""
+    eng, table = engine
+    with eng.begin() as conn:
+        _seed(conn, table, [(1, "a" * 32, True), (2, "a" * 32, True)])
+
+        _run_upgrade(migration, conn)
+
+        still_canonical = conn.execute(
+            sa.text("SELECT COUNT(*) FROM image WHERE is_canonical")
+        ).scalar()
+        assert still_canonical == 2
+
+
+def test_is_idempotent_when_the_index_already_exists(migration, engine):
+    eng, table = engine
+    with eng.begin() as conn:
+        _seed(conn, table, [(1, "a" * 32, True)])
+        _run_upgrade(migration, conn)
+        _run_upgrade(migration, conn)   # must not raise
+
+        assert migration.INDEX_NAME in _indexes(conn)
+
+
+def test_downgrade_removes_the_index_and_is_safe_when_absent(migration, engine):
+    eng, table = engine
+    with eng.begin() as conn:
+        _seed(conn, table, [(1, "a" * 32, True)])
+        _run_upgrade(migration, conn)
+
+        from alembic.migration import MigrationContext  # pylint: disable=import-outside-toplevel
+        from alembic.operations import Operations  # pylint: disable=import-outside-toplevel
+
+        with Operations.context(MigrationContext.configure(conn)):
+            migration.downgrade()
+            assert migration.INDEX_NAME not in _indexes(conn)
+            migration.downgrade()   # already gone — must not raise

--- a/services/fishsense-api/tests/test_canonical_only_pipeline_work.py
+++ b/services/fishsense-api/tests/test_canonical_only_pipeline_work.py
@@ -1,0 +1,232 @@
+"""Only *canonical* images are pipeline work.
+
+The same physical frames legitimately live under several dive rows — prod has
+131,430 image rows over 65,981 distinct checksums, so **half the table is
+duplicate content**, and 207 of 479 dives are duplicates end to end.
+`is_canonical` marks which copy is the real one (first row for a checksum wins,
+from `9e5bc64`).
+
+Today nothing in the pipeline reads that flag: `is_canonical` appears in
+exactly one query in the whole codebase (`get_canonical_dives`). Duplicate
+dives are inert only because they all happen to be `priority=LOW`, and every
+cohort gates on HIGH. That is a coincidence of the data, not a property of the
+code — promote one duplicate dive and it starts consuming NAS bandwidth,
+preprocessing, and labeler time on frames that already exist elsewhere.
+
+**Gating populate alone would make it worse, not better.** The preprocess
+cohorts are "at least one image with no label row". If populate skipped
+non-canonical images, those rows would never get labels, so the dive would
+never drain — re-staging its raw `.ORF`s from the NAS every hour and blocking
+every higher-id dive behind it. That is the prod dive 60 wedge, verbatim. So
+the cohorts have to exclude them too, which is what these tests pin.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+def _dive(dive_id: int, **kwargs):
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+
+    kwargs.setdefault("priority", Priority.HIGH)
+    return Dive(
+        id=dive_id,
+        path=f"/dev/null/{dive_id}",
+        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        **kwargs,
+    )
+
+
+def _image(image_id: int, dive_id: int, *, is_canonical: bool):
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    return Image(
+        id=image_id,
+        path=f"/dev/null/img-{image_id}",
+        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        checksum=f"{image_id:032d}",
+        is_canonical=is_canonical,
+        dive_id=dive_id,
+    )
+
+
+# ── stage 0.1: the wedge this prevents ────────────────────────────────
+
+
+async def test_a_dive_of_only_duplicate_frames_is_not_laser_preprocessing_work(session):
+    """The dive-60 wedge, in its duplicate-frame form.
+
+    Cohort is "HIGH + an image with no LaserLabel row". A promoted duplicate
+    dive satisfies it forever: populate would (correctly) decline to make LS
+    tasks for frames that already exist elsewhere, so no label row ever
+    appears, so the dive never drains — re-staging raw `.ORF`s from the NAS
+    every hour and blocking every higher-id dive.
+    """
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+
+    session.add(_dive(1))
+    session.add(_image(11, 1, is_canonical=False))
+    await session.flush()
+
+    assert await select_next_for_laser_preprocessing(session=session) is None
+
+
+async def test_a_canonical_frame_is_still_laser_preprocessing_work(session):
+    """The other half — the gate must not swallow real work."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+
+    session.add(_dive(1))
+    session.add(_image(11, 1, is_canonical=True))
+    await session.flush()
+
+    assert await select_next_for_laser_preprocessing(session=session) == 1
+
+
+async def test_a_mixed_dive_is_still_work_for_its_canonical_frames(session):
+    """A dive holding one original and one duplicate is real work. Excluding
+    the whole dive would strand the original."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+
+    session.add(_dive(1))
+    session.add(_image(11, 1, is_canonical=False))
+    session.add(_image(12, 1, is_canonical=True))
+    await session.flush()
+
+    assert await select_next_for_laser_preprocessing(session=session) == 1
+
+
+# ── the registry property: every selector, not just the one ───────────
+
+
+def test_every_cohort_selector_filters_on_is_canonical():
+    """A source-level guard, in the spirit of `controllers/__init__.py` and the
+    view registry: the failure mode is silent.
+
+    A new selector that subqueries `Image` without this filter reintroduces the
+    wedge, and nothing at runtime would say so — the dive simply never drains.
+    Every `Image.dive_id == Dive.id` correlation must be paired with an
+    `Image.is_canonical` predicate.
+    """
+    import inspect  # pylint: disable=import-outside-toplevel
+    import re  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api.controllers import (  # pylint: disable=import-outside-toplevel
+        dive_controller,
+    )
+
+    source = inspect.getsource(dive_controller)
+    correlations = len(re.findall(r"Image\.dive_id == Dive\.id", source))
+    gated = len(re.findall(r"Image\.is_canonical == True", source))
+
+    assert correlations > 0, "sanity: selectors should correlate Image to Dive"
+    assert gated >= correlations, (
+        f"{correlations} `Image.dive_id == Dive.id` correlations but only "
+        f"{gated} `Image.is_canonical` filters — a selector is missing the "
+        "gate and would wedge on a duplicate dive"
+    )
+
+
+# ── the view must agree with the selectors ────────────────────────────
+
+
+async def _pipeline_row(session, dive_id: int):
+    from sqlalchemy import text  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api.views import (  # pylint: disable=import-outside-toplevel
+        DIVE_PIPELINE_STATUS_VIEW_SQL,
+    )
+
+    await session.exec(text(DIVE_PIPELINE_STATUS_VIEW_SQL))
+    result = await session.exec(
+        text(
+            "SELECT laser_preprocessed, headtail_preprocessed "
+            f"FROM dive_pipeline_status WHERE dive_id = {dive_id}"
+        )
+    )
+    row = result.first()
+    # SQLite hands back 1/0 for view booleans, not Python bools — the same
+    # coercion `test_dive_pipeline_status_view.py` does.
+    return None if row is None else tuple(bool(v) for v in row)
+
+
+async def test_the_view_ignores_duplicate_frames_like_the_selectors_do(session):
+    """The view and the cohort selectors are the same predicate in two files,
+    and CLAUDE.md requires them to stay in step.
+
+    Without this, a duplicate dive reads as perpetually incomplete on the
+    Superset dashboard while the worker correctly never picks it up — the
+    silent disagreement the cross-controller drift guard exists to catch.
+
+    A dive of only duplicate frames must look the way a dive with no images
+    looks: vacuously False, nothing outstanding.
+    """
+    session.add(_dive(1))
+    session.add(_image(11, 1, is_canonical=False))
+    await session.flush()
+
+    row = await _pipeline_row(session, 1)
+
+    # `laser_preprocessed` requires "an image exists AND none lack a label".
+    # With the duplicate excluded there is no image, so it is vacuously False —
+    # exactly as for an empty dive, and consistent with the selector returning
+    # None rather than treating it as outstanding work.
+    assert row[0] is False
+
+
+async def test_the_view_still_reports_canonical_frames(session):
+    """The gate must not blind the dashboard to real work."""
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    session.add(_image(11, 1, is_canonical=True))
+    await session.flush()
+    session.add(LaserLabel(image_id=11, label_studio_project_id=73))
+    await session.flush()
+
+    row = await _pipeline_row(session, 1)
+
+    assert row[0] is True   # every canonical image has a laser label row
+
+
+async def test_view_and_selector_agree_on_a_duplicate_dive(session):
+    """The property, stated directly: for the same dive, the view must not
+    claim outstanding work that the selector refuses to schedule."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+
+    session.add(_dive(1))
+    session.add(_image(11, 1, is_canonical=False))
+    await session.flush()
+
+    selected = await select_next_for_laser_preprocessing(session=session)
+    row = await _pipeline_row(session, 1)
+
+    assert selected is None          # worker: nothing to do
+    assert row[0] is False           # view: nothing claimed as done either

--- a/services/fishsense-api/tests/test_dive_ingest_endpoints.py
+++ b/services/fishsense-api/tests/test_dive_ingest_endpoints.py
@@ -1,0 +1,261 @@
+"""Tests for `POST /api/v1/dives/` — the dive-creation half of ingest.
+
+Before this endpoint there was no way to create a `Dive` through this repo at
+all; rows came from `UCSD-E4E/fishsense-data-processing-spider` and were copied
+in wholesale by commit `9e5bc64`. See `docs/plans/dive-image-ingestion.md` §0
+for the conventions that archaeology established.
+
+Two behaviours carry the weight here:
+
+  * **Natural-key upsert on `path`.** `Dive.path` is unique, and a blind
+    `session.merge` with `id=None` always INSERTs — which is exactly the #347
+    duplicate-key 500. Ingest re-runs are the normal case (resume after a
+    partial scan, and the finalize step re-POSTs the same path to flip
+    `priority`), so upsert-by-path is load-bearing, not a nicety.
+  * **Validation that fails loudly.** A dive whose camera has no
+    `CameraIntrinsics` cannot ever be measured by stage 14, and nothing
+    downstream errors — the dive just silently never reaches `measured`. The
+    endpoint refuses instead.
+
+FK-less in-memory sqlite, controller functions called directly — same shape as
+test_calibration_source_endpoints.py.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+async def _seed_camera(session, camera_id: int = 1, *, with_intrinsics: bool = True):
+    from fishsense_api.models.camera import Camera  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.camera_intrinsics import (  # pylint: disable=import-outside-toplevel
+        CameraIntrinsics,
+    )
+
+    session.add(
+        Camera(id=camera_id, serial_number=f"SN{camera_id}", name=f"FSL-0{camera_id}")
+    )
+    await session.flush()
+    if with_intrinsics:
+        session.add(
+            CameraIntrinsics(
+                camera_id=camera_id,
+                camera_matrix=[[3000.0, 0.0, 2000.0], [0.0, 3000.0, 1500.0], [0.0, 0.0, 1.0]],
+                distortion_coefficients=[-0.05, 0.01, 0.0, 0.0, 0.0],
+            )
+        )
+        await session.flush()
+
+
+def _dive(path: str, **kwargs):
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+
+    kwargs.setdefault("camera_id", 1)
+    kwargs.setdefault("priority", Priority.LOW)
+    return Dive(
+        path=path,
+        dive_datetime=datetime(2024, 8, 21, 8, 56, 51, tzinfo=timezone.utc),
+        **kwargs,
+    )
+
+
+# ── creation ──────────────────────────────────────────────────────────
+
+
+async def test_post_dive_creates_a_row_and_returns_its_id(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        post_dive,
+    )
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+
+    await _seed_camera(session)
+
+    dive_id = await post_dive(_dive("2024 REEF/082124_Alligator_FSL06"), session=session)
+
+    assert isinstance(dive_id, int)
+    row = (await session.exec(select(Dive).where(Dive.id == dive_id))).first()
+    assert row is not None
+    assert row.path == "2024 REEF/082124_Alligator_FSL06"
+
+
+async def test_post_dive_is_an_upsert_on_path_not_a_duplicate_insert(session):
+    """The #347 regression, in its dive-shaped form.
+
+    Ingest re-runs the same path routinely: resuming a partial scan, and the
+    finalize step re-POSTing to flip `priority` LOW -> HIGH. A blind
+    `session.merge(id=None)` INSERTs and trips the unique index on `path`.
+    """
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        post_dive,
+    )
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+
+    await _seed_camera(session)
+    path = "2024 REEF/082124_Alligator_FSL06"
+
+    first = await post_dive(_dive(path), session=session)
+    second = await post_dive(
+        _dive(path, priority=Priority.HIGH, name="082124_Alligator_FSL06"),
+        session=session,
+    )
+
+    assert first == second
+    rows = (await session.exec(select(Dive).where(Dive.path == path))).all()
+    assert len(rows) == 1
+    # The second POST is the finalize step: its values must win.
+    assert rows[0].priority == Priority.HIGH
+    assert rows[0].name == "082124_Alligator_FSL06"
+
+
+# ── validation ────────────────────────────────────────────────────────
+
+
+async def test_post_dive_rejects_a_missing_camera_id(session):
+    """No camera means no intrinsics means stage 14 can never measure it."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        post_dive,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await post_dive(_dive("d/1", camera_id=None), session=session)
+    assert exc.value.status_code == 422
+
+
+async def test_post_dive_rejects_an_unknown_camera_id(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        post_dive,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await post_dive(_dive("d/1", camera_id=999), session=session)
+    assert exc.value.status_code == 422
+
+
+async def test_post_dive_rejects_a_camera_without_intrinsics(session):
+    """The silent-failure case this endpoint exists to make loud: the dive would
+    be created happily and then never reach `measured`, with no error anywhere."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        post_dive,
+    )
+
+    await _seed_camera(session, with_intrinsics=False)
+
+    with pytest.raises(HTTPException) as exc:
+        await post_dive(_dive("d/1"), session=session)
+    assert exc.value.status_code == 422
+    assert "intrinsics" in exc.value.detail.lower()
+
+
+def test_an_over_long_dive_path_is_rejected_when_the_body_is_validated():
+    """Where the 255 guard actually bites.
+
+    **SQLModel `table=True` models do not validate on `__init__`** — plain
+    construction happily accepts a 256-char path. Only `model_validate` (which
+    is what FastAPI runs on a request body) enforces `max_length`. So an HTTP
+    caller gets a 422 from request validation, but any in-process caller that
+    constructs a `Dive` directly sails straight past it.
+
+    That asymmetry is exactly why the endpoint keeps its own explicit check
+    (next test) rather than trusting the model.
+    """
+    from pydantic import ValidationError  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+
+    _dive("x" * 256)  # constructing is NOT validated — no raise
+
+    with pytest.raises(ValidationError):
+        Dive.model_validate(
+            {
+                "path": "x" * 256,
+                "dive_datetime": datetime(2024, 8, 21, tzinfo=timezone.utc),
+                "camera_id": 1,
+            }
+        )
+
+
+async def test_post_dive_rejects_an_over_long_path_that_bypassed_validation(session):
+    """`model_construct` skips pydantic. Postgres would reject the value, but
+    sqlite silently stores it, and a truncated `Dive.path` no longer resolves
+    on the NAS — so the endpoint checks explicitly, before re-validating."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        post_dive,
+    )
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+
+    await _seed_camera(session)
+    smuggled = Dive.model_construct(
+        path="x" * 256,
+        dive_datetime=datetime(2024, 8, 21, tzinfo=timezone.utc),
+        camera_id=1,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await post_dive(smuggled, session=session)
+    assert exc.value.status_code == 422
+    assert "255" in exc.value.detail
+
+
+async def test_post_dive_rejects_a_self_referential_calibration_source(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        post_dive,
+    )
+
+    await _seed_camera(session)
+    dive_id = await post_dive(_dive("d/1"), session=session)
+
+    with pytest.raises(HTTPException) as exc:
+        await post_dive(_dive("d/1", calibration_dive_id=dive_id), session=session)
+    assert exc.value.status_code == 422
+
+
+async def test_post_dive_rejects_an_unknown_calibration_source(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        post_dive,
+    )
+
+    await _seed_camera(session)
+
+    with pytest.raises(HTTPException) as exc:
+        await post_dive(_dive("d/1", calibration_dive_id=4242), session=session)
+    assert exc.value.status_code == 422
+
+
+async def test_post_dive_accepts_a_valid_calibration_source(session):
+    """A fish-only dive borrowing a sibling slate dive's calibration is the
+    whole point of `calibration_dive_id` — it must not be blocked."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        post_dive,
+    )
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+
+    await _seed_camera(session)
+    slate_dive = await post_dive(_dive("d/slate"), session=session)
+
+    fish_dive = await post_dive(
+        _dive("d/fish", calibration_dive_id=slate_dive), session=session
+    )
+
+    row = (await session.exec(select(Dive).where(Dive.id == fish_dive))).first()
+    assert row.calibration_dive_id == slate_dive

--- a/services/fishsense-api/tests/test_dive_ingest_endpoints.py
+++ b/services/fishsense-api/tests/test_dive_ingest_endpoints.py
@@ -259,3 +259,99 @@ async def test_post_dive_accepts_a_valid_calibration_source(session):
 
     row = (await session.exec(select(Dive).where(Dive.id == fish_dive))).first()
     assert row.calibration_dive_id == slate_dive
+
+
+# ── partial update semantics ──────────────────────────────────────────
+
+
+async def test_reposting_a_dive_preserves_fields_the_body_did_not_mention(session):
+    """The destructive-upsert regression.
+
+    `session.merge` replaces **every** column of the target row, so a second
+    POST that only cares about `priority` used to null `name`, `dive_slate_id`
+    and `calibration_dive_id`. That is data loss, not a cosmetic issue:
+
+      * `dive_slate_id` is written only by the species-label sync. Nulling it
+        discards labeler work and stops stages 9 / 12 / 13 for that dive.
+      * `calibration_dive_id` is the borrowed-calibration link. Nulling it
+        means the dive can never be calibrated, so stage 14 silently stops
+        measuring it.
+
+    Ingest itself re-POSTs the dive at finalize, so it would have tripped this
+    on its own. Only fields the caller actually sent may be written.
+    """
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        post_dive,
+    )
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+
+    await _seed_camera(session)
+    slate_dive = await post_dive(_dive("d/slate"), session=session)
+    fish_dive = await post_dive(
+        _dive(
+            "d/fish",
+            name="fish dive",
+            dive_slate_id=3,
+            calibration_dive_id=slate_dive,
+        ),
+        session=session,
+    )
+
+    # A caller that only cares about priority.
+    await post_dive(
+        Dive(
+            path="d/fish",
+            dive_datetime=datetime(2024, 8, 21, tzinfo=timezone.utc),
+            camera_id=1,
+            priority=Priority.HIGH,
+        ),
+        session=session,
+    )
+
+    row = (await session.exec(select(Dive).where(Dive.id == fish_dive))).first()
+    assert row.priority == Priority.HIGH      # what the caller asked for
+    assert row.name == "fish dive"            # ... and nothing else moved
+    assert row.dive_slate_id == 3
+    assert row.calibration_dive_id == slate_dive
+
+
+async def test_reposting_a_dive_can_still_clear_a_field_explicitly(session):
+    """Partial update must not become "you can never null anything". An
+    explicit `None` in the body is a real instruction — that is how an
+    operator drops a wrong calibration link."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        post_dive,
+    )
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+
+    await _seed_camera(session)
+    slate_dive = await post_dive(_dive("d/slate"), session=session)
+    fish_dive = await post_dive(
+        _dive("d/fish", calibration_dive_id=slate_dive), session=session
+    )
+
+    await post_dive(
+        Dive(
+            path="d/fish",
+            dive_datetime=datetime(2024, 8, 21, tzinfo=timezone.utc),
+            camera_id=1,
+            calibration_dive_id=None,
+        ),
+        session=session,
+    )
+
+    row = (await session.exec(select(Dive).where(Dive.id == fish_dive))).first()
+    assert row.calibration_dive_id is None
+
+
+async def test_post_dive_rejects_an_empty_path(session):
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        post_dive,
+    )
+
+    await _seed_camera(session)
+
+    with pytest.raises(HTTPException) as exc:
+        await post_dive(_dive(""), session=session)
+    assert exc.value.status_code == 422

--- a/services/fishsense-api/tests/test_dive_ingest_endpoints.py
+++ b/services/fishsense-api/tests/test_dive_ingest_endpoints.py
@@ -355,3 +355,21 @@ async def test_post_dive_rejects_an_empty_path(session):
     with pytest.raises(HTTPException) as exc:
         await post_dive(_dive(""), session=session)
     assert exc.value.status_code == 422
+
+
+async def test_post_dive_honours_an_explicit_id_instead_of_resolving_by_path(session):
+    """The `id is not None` branch — an update targeted by primary key, which
+    skips natural-key resolution (and so also skips the partial overlay)."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        post_dive,
+    )
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+
+    await _seed_camera(session)
+    dive_id = await post_dive(_dive("d/original"), session=session)
+
+    same = await post_dive(_dive("d/renamed", id=dive_id), session=session)
+
+    assert same == dive_id
+    row = (await session.exec(select(Dive).where(Dive.id == dive_id))).first()
+    assert row.path == "d/renamed"

--- a/services/fishsense-api/tests/test_dive_pipeline_status_view.py
+++ b/services/fishsense-api/tests/test_dive_pipeline_status_view.py
@@ -71,14 +71,19 @@ def _dive(
     )
 
 
-def _image(image_id: int, dive_id: int):
+def _image(image_id: int, dive_id: int, *, is_canonical: bool = True):
+    """Canonical by default — the normal case. `Image.is_canonical` defaults to
+    False on the model, which made every seeded image a duplicate; harmless
+    while nothing read the flag, misleading now that the cohort selectors gate
+    on it."""
     from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
 
     return Image(
         id=image_id,
         path=f"/dev/null/img-{image_id}",
         taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"img-{image_id:032d}"[:32],
+        checksum=f"{image_id:032d}",
+        is_canonical=is_canonical,
         dive_id=dive_id,
     )
 

--- a/services/fishsense-api/tests/test_dives_with_complete_laser_labeling_endpoint.py
+++ b/services/fishsense-api/tests/test_dives_with_complete_laser_labeling_endpoint.py
@@ -49,7 +49,7 @@ def _image(image_id: int, dive_id: int):
         id=image_id,
         path=f"/dev/null/img-{image_id}",
         taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"img-{image_id:032d}"[:32],
+        checksum=f"{image_id:032d}",
         dive_id=dive_id,
     )
 

--- a/services/fishsense-api/tests/test_fish_model_mislabel_suspects.py
+++ b/services/fishsense-api/tests/test_fish_model_mislabel_suspects.py
@@ -100,7 +100,7 @@ async def _measure(session, *, dive_id, model_name, length_m):
             id=image_id,
             path=f"/dev/null/img-{image_id}",
             taken_datetime=datetime(2023, 8, 29, tzinfo=timezone.utc),
-            checksum=f"img-{image_id:032d}"[:32],
+            checksum=f"{image_id:032d}",
             dive_id=dive_id,
         )
     )

--- a/services/fishsense-api/tests/test_fish_model_reference.py
+++ b/services/fishsense-api/tests/test_fish_model_reference.py
@@ -130,7 +130,7 @@ async def _seed_measurement(session, *, dive_id, image_id, model_name, length_m)
             id=image_id,
             path=f"/dev/null/img-{image_id}",
             taken_datetime=datetime(2023, 8, 29, tzinfo=timezone.utc),
-            checksum=f"img-{image_id:032d}"[:32],
+            checksum=f"{image_id:032d}",
             dive_id=dive_id,
         )
     )

--- a/services/fishsense-api/tests/test_image_ingest_endpoints.py
+++ b/services/fishsense-api/tests/test_image_ingest_endpoints.py
@@ -159,9 +159,13 @@ async def test_reposting_the_same_path_does_not_demote_it_to_non_canonical(sessi
     assert row.is_canonical is True
 
 
-async def test_an_explicit_is_canonical_in_the_body_overrides_the_computation(session):
-    """Operator override — e.g. promoting a re-ingested copy after the original
-    dive's files were lost."""
+async def test_promoting_a_copy_demotes_the_incumbent(session):
+    """Operator override — promoting a re-ingested copy after the original
+    dive's files were lost.
+
+    Promotion must be a *swap*, not an addition: exactly one row per checksum
+    is canonical. Before `uq_image_canonical_checksum` existed this endpoint
+    happily produced two, and nothing complained."""
     from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
         post_image,
     )
@@ -170,13 +174,14 @@ async def test_an_explicit_is_canonical_in_the_body_overrides_the_computation(se
     await _seed_dive(session, 64, "d/64")
     await _seed_dive(session, 66, "d/66")
 
-    await post_image(64, _image("d/64/P1.ORF", CK_A), session=session)
+    original = await post_image(64, _image("d/64/P1.ORF", CK_A), session=session)
     dupe = await post_image(
         66, _image("d/66/P1.ORF", CK_A, is_canonical=True), session=session
     )
 
-    row = (await session.exec(select(Image).where(Image.id == dupe))).first()
-    assert row.is_canonical is True
+    rows = {r.id: r for r in (await session.exec(select(Image))).all()}
+    assert rows[dupe].is_canonical is True
+    assert rows[original].is_canonical is False   # swapped, not duplicated
 
 
 # ── validation ────────────────────────────────────────────────────────
@@ -375,3 +380,63 @@ async def test_checksum_lookup_deduplicates_repeated_checksums(session):
 
     assert list(result) == [CK_A]
     assert len(result[CK_A]) == 1
+
+
+# ── the canonical invariant is enforced by the DB, not just by the read ──
+
+
+async def test_the_database_refuses_a_second_canonical_row_for_one_checksum(session):
+    """`post_image`'s "is there already a row with this checksum?" is a
+    read-then-write. Under READ COMMITTED two concurrent requests can both find
+    nothing and both claim canonical, so the application check cannot be the
+    guarantee — `uq_image_canonical_checksum` is.
+
+    This drives the constraint directly, bypassing the endpoint, because that
+    is precisely the state the endpoint's own logic cannot rule out.
+    """
+    from sqlalchemy.exc import IntegrityError  # pylint: disable=import-outside-toplevel
+
+    await _seed_dive(session, 64, "d/64")
+    session.add(_image("d/64/P1.ORF", CK_A, dive_id=64, is_canonical=True))
+    await session.flush()
+
+    session.add(_image("d/64/P2.ORF", CK_A, dive_id=64, is_canonical=True))
+    with pytest.raises(IntegrityError):
+        await session.flush()
+
+
+async def test_the_constraint_allows_many_non_canonical_rows_per_checksum(session):
+    """The duplicate case is the normal case — only *canonical* is exclusive.
+    A unique index on `checksum` alone would break dives 64/66 outright."""
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_image,
+    )
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    for dive_id in (64, 66, 70):
+        await _seed_dive(session, dive_id, f"d/{dive_id}")
+        await post_image(dive_id, _image(f"d/{dive_id}/P1.ORF", CK_A), session=session)
+
+    rows = (await session.exec(select(Image).where(Image.checksum == CK_A))).all()
+    assert len(rows) == 3
+    assert sum(1 for r in rows if r.is_canonical) == 1
+
+
+async def test_post_image_honours_an_explicit_id_instead_of_resolving_by_path(session):
+    """The `id is not None` branch — an update targeted by primary key, which
+    skips natural-key resolution entirely."""
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_image,
+    )
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    await _seed_dive(session, 7, "d/7")
+    image_id = await post_image(7, _image("d/7/P1.ORF", CK_A), session=session)
+
+    same = await post_image(
+        7, _image("d/7/renamed.ORF", CK_A, id=image_id), session=session
+    )
+
+    assert same == image_id
+    row = (await session.exec(select(Image).where(Image.id == image_id))).first()
+    assert row.path == "d/7/renamed.ORF"

--- a/services/fishsense-api/tests/test_image_ingest_endpoints.py
+++ b/services/fishsense-api/tests/test_image_ingest_endpoints.py
@@ -277,3 +277,101 @@ async def test_checksum_lookup_is_a_set_operation_not_an_ordered_digest(session)
 
     shared = [ck for ck in incoming if any(h["dive_id"] == 64 for h in result[ck])]
     assert len(shared) / len(incoming) == pytest.approx(2 / 3)
+
+
+# ── partial update semantics + remaining guards ───────────────────────
+
+
+async def test_reposting_an_image_preserves_fields_the_body_did_not_mention(session):
+    """Same destructive-upsert class as the dive endpoint. A resumed scan
+    re-posts paths it has already written; anything it omits must survive."""
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_image,
+    )
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    await _seed_dive(session, 7, "d/7")
+    path = "d/7/P8210001.ORF"
+    image_id = await post_image(7, _image(path, CK_A, camera_id=3), session=session)
+
+    await post_image(
+        7,
+        Image(
+            path=path,
+            checksum=CK_A,
+            taken_datetime=datetime(2024, 8, 21, 8, 56, 51, tzinfo=timezone.utc),
+        ),
+        session=session,
+    )
+
+    row = (await session.exec(select(Image).where(Image.id == image_id))).first()
+    assert row.camera_id == 3
+
+
+async def test_post_image_rejects_an_empty_path(session):
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_image,
+    )
+
+    await _seed_dive(session, 7, "d/7")
+
+    with pytest.raises(HTTPException) as exc:
+        await post_image(7, _image("", CK_A), session=session)
+    assert exc.value.status_code == 422
+
+
+async def test_post_image_rejects_a_missing_taken_datetime(session):
+    """Stage-1 clustering is pure timestamp math, so a defaulted or absent
+    `taken_datetime` would corrupt it with nothing to show for it."""
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_image,
+    )
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    await _seed_dive(session, 7, "d/7")
+    no_date = Image(path="d/7/P1.ORF", checksum=CK_A, taken_datetime=None)
+
+    with pytest.raises(HTTPException) as exc:
+        await post_image(7, no_date, session=session)
+    assert exc.value.status_code == 422
+
+
+async def test_checksum_lookup_rejects_an_oversized_batch(session):
+    """Unbounded `IN (...)` from a bad caller."""
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        MAX_CHECKSUM_LOOKUP,
+        post_checksum_lookup,
+    )
+
+    too_many = [f"{i:032x}" for i in range(MAX_CHECKSUM_LOOKUP + 1)]
+
+    with pytest.raises(HTTPException) as exc:
+        await post_checksum_lookup(too_many, session=session)
+    assert exc.value.status_code == 422
+
+
+async def test_checksum_lookup_handles_an_empty_batch(session):
+    """A dive folder that turned out to hold nothing new still calls this."""
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_checksum_lookup,
+    )
+
+    assert await post_checksum_lookup([], session=session) == {}
+
+
+async def test_checksum_lookup_deduplicates_repeated_checksums(session):
+    """Duplicate frames inside one folder are exactly the case this is for, so
+    the same checksum arriving twice must not double-count toward the cap or
+    produce duplicate hits."""
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_checksum_lookup,
+        post_image,
+    )
+
+    await _seed_dive(session, 64, "d/64")
+    await post_image(64, _image("d/64/P1.ORF", CK_A), session=session)
+
+    result = await post_checksum_lookup([CK_A, CK_A, CK_A], session=session)
+
+    assert list(result) == [CK_A]
+    assert len(result[CK_A]) == 1

--- a/services/fishsense-api/tests/test_image_ingest_endpoints.py
+++ b/services/fishsense-api/tests/test_image_ingest_endpoints.py
@@ -1,0 +1,279 @@
+"""Tests for `POST /api/v1/dives/{dive_id}/images/` and the batch checksum
+lookup — the image half of ingest.
+
+`is_canonical` is the subtle one. The same physical frames legitimately appear
+under two dive rows (prod dives 64 and 66 are both `082929_FishModels_FSL07`,
+55 images each), and `checksum` is how that is recognised. The rule comes from
+commit `9e5bc64`:
+
+    is_canonical = (existing_checksum is None)
+
+i.e. the first row for a given checksum is canonical, later duplicates are not.
+It is computed **server-side** here rather than by the caller: a client-side
+"does this checksum exist yet" check races itself, and two concurrent posts
+would both decide they were first.
+
+The batch lookup backs duplicate-dive detection (plan §4.2.1) — the replacement
+for spider's whole-dive MD5 aggregate, which was all-or-nothing and
+basename-sensitive.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+async def _seed_dive(session, dive_id: int, path: str):
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+
+    session.add(
+        Dive(
+            id=dive_id,
+            path=path,
+            dive_datetime=datetime(2024, 8, 21, 8, 56, 51, tzinfo=timezone.utc),
+            priority=Priority.LOW,
+            camera_id=1,
+        )
+    )
+    await session.flush()
+
+
+def _image(path: str, checksum: str, **kwargs):
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    kwargs.setdefault("camera_id", 1)
+    return Image(
+        path=path,
+        checksum=checksum,
+        taken_datetime=datetime(2024, 8, 21, 8, 56, 51, tzinfo=timezone.utc),
+        **kwargs,
+    )
+
+
+CK_A = "45dc5a454b35601b9dafabf24822195d"
+CK_B = "0b7cd4da72d54172f1f9daf40ce4047f"
+
+
+# ── creation ──────────────────────────────────────────────────────────
+
+
+async def test_post_image_creates_a_row_and_binds_it_to_the_path_dive(session):
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_image,
+    )
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    await _seed_dive(session, 7, "d/7")
+
+    # dive_id in the body is deliberately wrong — the path must win.
+    image_id = await post_image(
+        7, _image("d/7/P8210001.ORF", CK_A, dive_id=999), session=session
+    )
+
+    row = (await session.exec(select(Image).where(Image.id == image_id))).first()
+    assert row is not None
+    assert row.dive_id == 7
+    assert row.checksum == CK_A
+
+
+async def test_post_image_is_an_upsert_on_path_not_a_duplicate_insert(session):
+    """`Image.path` is unique. Resuming a partial scan re-posts paths that are
+    already there; a blind merge would 500 on the unique index."""
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_image,
+    )
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    await _seed_dive(session, 7, "d/7")
+    path = "d/7/P8210001.ORF"
+
+    first = await post_image(7, _image(path, CK_A), session=session)
+    second = await post_image(7, _image(path, CK_A), session=session)
+
+    assert first == second
+    rows = (await session.exec(select(Image).where(Image.path == path))).all()
+    assert len(rows) == 1
+
+
+# ── is_canonical ──────────────────────────────────────────────────────
+
+
+async def test_first_image_with_a_checksum_is_canonical_later_duplicates_are_not(session):
+    """The dives-64/66 rule, from `9e5bc64`."""
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_image,
+    )
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    await _seed_dive(session, 64, "d/64")
+    await _seed_dive(session, 66, "d/66")
+
+    first = await post_image(64, _image("d/64/P1.ORF", CK_A), session=session)
+    dupe = await post_image(66, _image("d/66/P1.ORF", CK_A), session=session)
+
+    rows = {
+        r.id: r
+        for r in (await session.exec(select(Image))).all()
+    }
+    assert rows[first].is_canonical is True
+    assert rows[dupe].is_canonical is False
+
+
+async def test_reposting_the_same_path_does_not_demote_it_to_non_canonical(session):
+    """A resumed scan re-posts an existing path. The row it would collide with
+    is *itself*, so 'a row with this checksum already exists' must not flip it
+    to False — that would quietly strip canonical status from a whole dive on
+    every re-run."""
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_image,
+    )
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    await _seed_dive(session, 7, "d/7")
+    path = "d/7/P8210001.ORF"
+
+    await post_image(7, _image(path, CK_A), session=session)
+    image_id = await post_image(7, _image(path, CK_A), session=session)
+
+    row = (await session.exec(select(Image).where(Image.id == image_id))).first()
+    assert row.is_canonical is True
+
+
+async def test_an_explicit_is_canonical_in_the_body_overrides_the_computation(session):
+    """Operator override — e.g. promoting a re-ingested copy after the original
+    dive's files were lost."""
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_image,
+    )
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    await _seed_dive(session, 64, "d/64")
+    await _seed_dive(session, 66, "d/66")
+
+    await post_image(64, _image("d/64/P1.ORF", CK_A), session=session)
+    dupe = await post_image(
+        66, _image("d/66/P1.ORF", CK_A, is_canonical=True), session=session
+    )
+
+    row = (await session.exec(select(Image).where(Image.id == dupe))).first()
+    assert row.is_canonical is True
+
+
+# ── validation ────────────────────────────────────────────────────────
+
+
+async def test_post_image_rejects_a_path_longer_than_the_column(session):
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_image,
+    )
+
+    await _seed_dive(session, 7, "d/7")
+
+    with pytest.raises(HTTPException) as exc:
+        await post_image(7, _image("x" * 256, CK_A), session=session)
+    assert exc.value.status_code == 422
+
+
+async def test_post_image_rejects_a_checksum_that_is_not_a_32_char_md5(session):
+    """A wrong-width checksum means the hashing changed underneath us; every
+    duplicate check downstream would silently stop matching."""
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_image,
+    )
+
+    await _seed_dive(session, 7, "d/7")
+
+    for bad in ("", "deadbeef", "z" * 32, "a" * 33):
+        with pytest.raises(HTTPException) as exc:
+            await post_image(7, _image(f"d/7/{bad or 'empty'}.ORF", bad), session=session)
+        assert exc.value.status_code == 422, bad
+
+
+async def test_post_image_rejects_an_unknown_dive(session):
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_image,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await post_image(4242, _image("d/x/P1.ORF", CK_A), session=session)
+    assert exc.value.status_code == 422
+
+
+# ── batch checksum lookup (plan §4.2.1) ───────────────────────────────
+
+
+async def test_checksum_lookup_reports_every_dive_holding_each_checksum(session):
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_checksum_lookup,
+        post_image,
+    )
+
+    await _seed_dive(session, 64, "d/64")
+    await _seed_dive(session, 66, "d/66")
+    await post_image(64, _image("d/64/P1.ORF", CK_A), session=session)
+    await post_image(66, _image("d/66/P1.ORF", CK_A), session=session)
+    await post_image(64, _image("d/64/P2.ORF", CK_B), session=session)
+
+    result = await post_checksum_lookup([CK_A, CK_B, "f" * 32], session=session)
+
+    assert {hit["dive_id"] for hit in result[CK_A]} == {64, 66}
+    assert {hit["dive_id"] for hit in result[CK_B]} == {64}
+    # Canonicality travels with the hit so the caller can explain the
+    # consequence ("these will land non-canonical") without a second query.
+    assert {hit["is_canonical"] for hit in result[CK_A]} == {True, False}
+
+
+async def test_checksum_lookup_returns_an_empty_list_for_unknown_checksums(session):
+    """Empty list, not a missing key — the caller computes
+    `|new n existing| / |new|` and should not have to guard every lookup."""
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_checksum_lookup,
+    )
+
+    result = await post_checksum_lookup([CK_A], session=session)
+
+    assert result == {CK_A: []}
+
+
+async def test_checksum_lookup_is_a_set_operation_not_an_ordered_digest(session):
+    """The property spider's whole-dive MD5 aggregate lacked (plan SS4.2.1).
+
+    A folder sharing 2 of 3 frames with an existing dive must report partial
+    overlap. The aggregate reported such a folder as simply *different*, which
+    is why it never worked well: near-duplicates are the common case, and
+    filename order changed the digest even when the bytes matched.
+    """
+    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+        post_checksum_lookup,
+        post_image,
+    )
+
+    await _seed_dive(session, 64, "d/64")
+    await post_image(64, _image("d/64/P1.ORF", CK_A), session=session)
+    await post_image(64, _image("d/64/P2.ORF", CK_B), session=session)
+
+    incoming = [CK_A, CK_B, "e" * 32]
+    result = await post_checksum_lookup(incoming, session=session)
+
+    shared = [ck for ck in incoming if any(h["dive_id"] == 64 for h in result[ck])]
+    assert len(shared) / len(incoming) == pytest.approx(2 / 3)

--- a/services/fishsense-api/tests/test_ingest_endpoints_http.py
+++ b/services/fishsense-api/tests/test_ingest_endpoints_http.py
@@ -1,0 +1,208 @@
+"""App-level tests for the ingest write endpoints.
+
+Every other ingest test calls the controller function directly, which is fast
+and precise but skips three things that only exist at the app boundary:
+
+  * **Route registration.** A controller that isn't imported in
+    `controllers/__init__.py` silently registers nothing, and a direct-call
+    test would still pass.
+  * **Request-body validation.** `Dive.path` is `max_length=255`, but SQLModel
+    `table=True` models don't validate on `__init__` — only `model_validate`
+    does, which is what FastAPI runs on a request body. So the 255 guard only
+    actually fires here.
+  * **Response serialization.** `post_checksum_lookup` returns a nested
+    `Dict[str, List[Dict[str, Any]]]`. FastAPI builds a response model from
+    that annotation, and a shape it can't encode would 500 at runtime while
+    every direct-call test stayed green.
+
+The session dependency is overridden onto in-memory sqlite. The app is used
+*without* `TestClient`'s context manager on purpose: entering it would run the
+real lifespan, which calls `create_all` against Postgres and then
+`run_alembic_upgrade`.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+CK_A = "45dc5a454b35601b9dafabf24822195d"
+CK_B = "0b7cd4da72d54172f1f9daf40ce4047f"
+
+_DIVE_DT = "2024-08-21T08:56:51Z"
+
+
+@pytest.fixture
+async def client():
+    from fastapi.testclient import TestClient  # pylint: disable=import-outside-toplevel
+
+    os.environ.setdefault("E4EFS_POSTGRES__HOST", "ignored")
+    os.environ.setdefault("E4EFS_POSTGRES__PORT", "5432")
+    os.environ.setdefault("E4EFS_POSTGRES__USERNAME", "ignored")
+    os.environ.setdefault("E4EFS_POSTGRES__PASSWORD", "ignored")
+    os.environ.setdefault("E4EFS_POSTGRES__DATABASE", "ignored")
+
+    import fishsense_api.controllers  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+    from fishsense_api.database import (  # pylint: disable=import-outside-toplevel
+        get_async_session,
+    )
+    from fishsense_api.models.camera import Camera  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.camera_intrinsics import (  # pylint: disable=import-outside-toplevel
+        CameraIntrinsics,
+    )
+    from fishsense_api.server import app  # pylint: disable=import-outside-toplevel
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    session = factory()
+    session.add(Camera(id=1, serial_number="BJ6C67989", name="FSL-07"))
+    await session.flush()
+    session.add(
+        CameraIntrinsics(
+            camera_id=1,
+            camera_matrix=[[3000.0, 0.0, 2000.0], [0.0, 3000.0, 1500.0], [0.0, 0.0, 1.0]],
+            distortion_coefficients=[-0.05, 0.01, 0.0, 0.0, 0.0],
+        )
+    )
+    await session.flush()
+
+    async def _override():
+        yield session
+
+    app.dependency_overrides[get_async_session] = _override
+    # No `with` — see the module docstring.
+    yield TestClient(app)
+    app.dependency_overrides.pop(get_async_session, None)
+
+    await session.close()
+    await engine.dispose()
+
+
+def _dive_body(path: str, **kwargs) -> dict:
+    body = {"path": path, "dive_datetime": _DIVE_DT, "camera_id": 1}
+    body.update(kwargs)
+    return body
+
+
+def _image_body(path: str, checksum: str, **kwargs) -> dict:
+    body = {"path": path, "checksum": checksum, "taken_datetime": _DIVE_DT}
+    body.update(kwargs)
+    return body
+
+
+# ── the routes exist and are reachable ────────────────────────────────
+
+
+def test_the_three_ingest_routes_are_registered(client):
+    """`controllers/__init__.py` is the route registry — a controller missing
+    from it registers nothing, and every direct-call test would still pass."""
+    paths = {
+        (route.path, method)
+        for route in client.app.routes
+        for method in getattr(route, "methods", set()) or set()
+    }
+    assert ("/api/v1/dives/", "POST") in paths
+    assert ("/api/v1/dives/{dive_id}/images/", "POST") in paths
+    assert ("/api/v1/images/checksums/lookup", "POST") in paths
+
+
+def test_the_checksum_lookup_route_does_not_shadow_the_single_checksum_get(client):
+    """`/images/checksums/lookup` sits next to `/images/checksum/{checksum}`
+    and `/images/{image_id}`. A path that got swallowed by `{image_id}` would
+    try to coerce "checksums" to an int and 422."""
+    response = client.post("/api/v1/images/checksums/lookup", json=[CK_A])
+    assert response.status_code == 200
+
+
+# ── request validation at the boundary ────────────────────────────────
+
+
+def test_an_over_long_dive_path_is_a_422_over_http(client):
+    """Where `max_length=255` actually bites: FastAPI runs `model_validate` on
+    the request body. A direct call constructing a `Dive` sails past it, which
+    is why the endpoint keeps its own check too."""
+    response = client.post("/api/v1/dives/", json=_dive_body("x" * 256))
+    assert response.status_code == 422
+
+
+def test_a_dive_body_missing_required_fields_is_a_422_over_http(client):
+    response = client.post("/api/v1/dives/", json={"path": "d/1"})
+    assert response.status_code == 422
+
+
+# ── round trip ────────────────────────────────────────────────────────
+
+
+def test_dive_then_images_then_lookup_round_trips_over_http(client):
+    """One pass of what ingest actually does, through the real stack."""
+    dive = client.post("/api/v1/dives/", json=_dive_body("2024 REEF/082124_FSL06"))
+    assert dive.status_code == 201, dive.text
+    dive_id = dive.json()
+
+    first = client.post(
+        f"/api/v1/dives/{dive_id}/images/", json=_image_body("d/P1.ORF", CK_A)
+    )
+    assert first.status_code == 201, first.text
+
+    # A second dive holding the same frame — the dives-64/66 shape.
+    other = client.post("/api/v1/dives/", json=_dive_body("2024 REEF/082124_FSL06_copy"))
+    dupe = client.post(
+        f"/api/v1/dives/{other.json()}/images/", json=_image_body("d2/P1.ORF", CK_A)
+    )
+    assert dupe.status_code == 201
+
+    lookup = client.post(
+        "/api/v1/images/checksums/lookup", json=[CK_A, CK_B]
+    )
+    assert lookup.status_code == 200, lookup.text
+    body = lookup.json()
+
+    # Serialization of the nested Dict[str, List[Dict[str, Any]]] survives.
+    assert body[CK_B] == []
+    assert {hit["dive_id"] for hit in body[CK_A]} == {dive_id, other.json()}
+    assert sorted(hit["is_canonical"] for hit in body[CK_A]) == [False, True]
+
+
+def test_reposting_a_dive_over_http_preserves_unmentioned_fields(client):
+    """The destructive-upsert regression, through the real request path — the
+    body genuinely omits the keys rather than relying on `model_fields_set`
+    being set up correctly by a direct call."""
+    created = client.post(
+        "/api/v1/dives/",
+        json=_dive_body("d/fish", name="fish dive", dive_slate_id=3),
+    )
+    dive_id = created.json()
+
+    client.post("/api/v1/dives/", json=_dive_body("d/fish", priority="HIGH"))
+
+    row = client.get(f"/api/v1/dives/{dive_id}").json()
+    assert row["priority"] == "HIGH"
+    assert row["name"] == "fish dive"
+    assert row["dive_slate_id"] == 3
+
+
+def test_priority_is_stored_as_the_enum_not_the_raw_json_string(client):
+    """SQLModel `table=True` skips pydantic coercion, so FastAPI hands the
+    endpoint a `Dive` whose `priority` is still the raw JSON `str`. Coercing it
+    up front is what keeps `jsonable_encoder` from emitting a pydantic
+    serializer warning on every request — run the suite with `-W error` and an
+    uncoerced body fails here."""
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+
+    created = client.post("/api/v1/dives/", json=_dive_body("d/p", priority="HIGH"))
+    assert created.status_code == 201
+
+    listed = client.get("/api/v1/dives/").json()
+    assert listed[0]["priority"] == Priority.HIGH.value
+
+
+def test_an_unknown_priority_is_a_422_not_a_500(client):
+    response = client.post("/api/v1/dives/", json=_dive_body("d/p", priority="URGENT"))
+    assert response.status_code == 422

--- a/services/fishsense-api/tests/test_label_studio_project_ids_superseded.py
+++ b/services/fishsense-api/tests/test_label_studio_project_ids_superseded.py
@@ -41,7 +41,7 @@ def _image(image_id: int):
         id=image_id,
         path=f"/dev/null/img-{image_id}",
         taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"img-{image_id:032d}"[:32],
+        checksum=f"{image_id:032d}",
         dive_id=1,
     )
 

--- a/services/fishsense-api/tests/test_laser_prediction_endpoint.py
+++ b/services/fishsense-api/tests/test_laser_prediction_endpoint.py
@@ -46,7 +46,7 @@ def _image(image_id: int, dive_id: int):
         id=image_id,
         path=f"/dev/null/img-{image_id}",
         taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"img-{image_id:032d}"[:32],
+        checksum=f"{image_id:032d}",
         dive_id=dive_id,
     )
 

--- a/services/fishsense-api/tests/test_measurements_endpoint.py
+++ b/services/fishsense-api/tests/test_measurements_endpoint.py
@@ -59,7 +59,7 @@ def _image(image_id: int, dive_id: int):
         id=image_id,
         path=f"/dev/null/img-{image_id}",
         taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"img-{image_id:032d}"[:32],
+        checksum=f"{image_id:032d}",
         dive_id=dive_id,
     )
 

--- a/services/fishsense-api/tests/test_sdk_api_contract.py
+++ b/services/fishsense-api/tests/test_sdk_api_contract.py
@@ -1,0 +1,214 @@
+"""Contract tests: the SDK's ingest calls against the real FastAPI app.
+
+The SDK's own client tests mock `_post`, so they pin the URL and the payload
+shape the client *intends* to send — but nothing checks the API would accept
+it. A renamed route, a field the endpoint rejects, or a response shape the
+client can't parse would leave both suites green and fail only in production.
+
+`test_sdk_drift.py` covers the other half of the same seam (field-name and type
+parity between the SQLModel and the SDK's pydantic mirror). This covers the
+wire: real routing, real request validation, real serialization, driven by the
+actual client methods over `httpx.ASGITransport` — no server, no network.
+
+The app is not entered as a context manager; that would run the real lifespan
+(`create_all` against Postgres, then `run_alembic_upgrade`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+CK_A = "45dc5a454b35601b9dafabf24822195d"
+CK_B = "0b7cd4da72d54172f1f9daf40ce4047f"
+
+
+@pytest.fixture
+async def sdk():
+    """A real `DiveClient`/`ImageClient` pair wired to the in-process app."""
+    os.environ.setdefault("E4EFS_POSTGRES__HOST", "ignored")
+    os.environ.setdefault("E4EFS_POSTGRES__PORT", "5432")
+    os.environ.setdefault("E4EFS_POSTGRES__USERNAME", "ignored")
+    os.environ.setdefault("E4EFS_POSTGRES__PASSWORD", "ignored")
+    os.environ.setdefault("E4EFS_POSTGRES__DATABASE", "ignored")
+
+    import fishsense_api.controllers  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+    from fishsense_api.database import (  # pylint: disable=import-outside-toplevel
+        get_async_session,
+    )
+    from fishsense_api.models.camera import Camera  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.camera_intrinsics import (  # pylint: disable=import-outside-toplevel
+        CameraIntrinsics,
+    )
+    from fishsense_api.server import app  # pylint: disable=import-outside-toplevel
+    from fishsense_api_sdk.clients.dive_client import (  # pylint: disable=import-outside-toplevel
+        DiveClient,
+    )
+    from fishsense_api_sdk.clients.image_client import (  # pylint: disable=import-outside-toplevel
+        ImageClient,
+    )
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    session = factory()
+    session.add(Camera(id=1, serial_number="BJ6C67989", name="FSL-07"))
+    await session.flush()
+    session.add(
+        CameraIntrinsics(
+            camera_id=1,
+            camera_matrix=[[3000.0, 0.0, 2000.0], [0.0, 3000.0, 1500.0], [0.0, 0.0, 1.0]],
+            distortion_coefficients=[-0.05, 0.01, 0.0, 0.0, 0.0],
+        )
+    )
+    await session.flush()
+
+    async def _override():
+        yield session
+
+    app.dependency_overrides[get_async_session] = _override
+
+    transport = httpx.ASGITransport(app=app)
+    kwargs = {
+        "base_url": "http://api.test",
+        "username": None,
+        "password": None,
+        "timeout": 10,
+        "semaphore": asyncio.Semaphore(4),
+        "transport": transport,
+    }
+    async with DiveClient(**kwargs) as dives, ImageClient(**kwargs) as images:
+        yield dives, images
+
+    app.dependency_overrides.pop(get_async_session, None)
+    await session.close()
+    await engine.dispose()
+
+
+def _sdk_dive(path: str, **kwargs):
+    from fishsense_api_sdk.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api_sdk.models.priority import (  # pylint: disable=import-outside-toplevel
+        Priority,
+    )
+
+    body = {
+        "id": None,
+        "name": None,
+        "path": path,
+        "dive_datetime": datetime(2024, 8, 21, 8, 56, 51, tzinfo=timezone.utc),
+        "priority": Priority.LOW,
+        "flip_dive_slate": False,
+        "camera_id": 1,
+        "dive_slate_id": None,
+        "calibration_dive_id": None,
+    }
+    body.update(kwargs)
+    return Dive(**body)
+
+
+def _sdk_image(path: str, checksum: str, **kwargs):
+    from fishsense_api_sdk.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    body = {
+        "id": None,
+        "path": path,
+        "taken_datetime": datetime(2024, 8, 21, 8, 56, 51, tzinfo=timezone.utc),
+        "checksum": checksum,
+        "is_canonical": False,
+        "dive_id": None,
+        "camera_id": 1,
+    }
+    body.update(kwargs)
+    return Image(**body)
+
+
+async def test_dives_post_is_accepted_by_the_api(sdk):
+    """The SDK serializes `dive_datetime` and `priority` itself; the endpoint
+    has to accept exactly that encoding."""
+    dives, _ = sdk
+
+    dive_id = await dives.post(_sdk_dive("2024 REEF/082124_FSL06"))
+
+    assert isinstance(dive_id, int)
+    fetched = await dives.get(dive_id=dive_id)
+    assert fetched.path == "2024 REEF/082124_FSL06"
+
+
+async def test_images_post_is_accepted_and_reaches_the_right_dive(sdk):
+    dives, images = sdk
+    dive_id = await dives.post(_sdk_dive("d/7"))
+
+    image_id = await images.post(dive_id, _sdk_image("d/7/P8210001.ORF", CK_A))
+
+    assert isinstance(image_id, int)
+    fetched = await images.get(image_id=image_id)
+    assert fetched.dive_id == dive_id
+    assert fetched.checksum == CK_A
+
+
+async def test_the_sdk_does_not_override_server_computed_canonicality(sdk):
+    """`Image.is_canonical` is required on the SDK model, so every instance
+    carries a value. If `post` shipped it, the second copy of a frame would
+    claim canonical too — which the DB now rejects outright. End to end, the
+    server must be the one deciding."""
+    dives, images = sdk
+    first_dive = await dives.post(_sdk_dive("d/64"))
+    second_dive = await dives.post(_sdk_dive("d/66"))
+
+    first = await images.post(first_dive, _sdk_image("d/64/P1.ORF", CK_A))
+    dupe = await images.post(second_dive, _sdk_image("d/66/P1.ORF", CK_A))
+
+    assert (await images.get(image_id=first)).is_canonical is True
+    assert (await images.get(image_id=dupe)).is_canonical is False
+
+
+async def test_lookup_checksums_round_trips_through_the_real_endpoint(sdk):
+    """The response is a nested dict the client parses raw — a shape change on
+    either side breaks silently under mocks."""
+    dives, images = sdk
+    dive_id = await dives.post(_sdk_dive("d/64"))
+    await images.post(dive_id, _sdk_image("d/64/P1.ORF", CK_A))
+
+    result = await images.lookup_checksums([CK_A, CK_B])
+
+    assert result[CK_B] == []
+    assert result[CK_A][0]["dive_id"] == dive_id
+    assert result[CK_A][0]["is_canonical"] is True
+
+
+async def test_reposting_a_dive_through_the_sdk_preserves_unmentioned_fields(sdk):
+    """The SDK sends `exclude_unset=True`, so a partially-populated `Dive`
+    reaches the API as a genuinely partial body. This is the combination that
+    triggers the destructive-upsert bug in production, and neither suite could
+    see it alone."""
+    from fishsense_api_sdk.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api_sdk.models.priority import (  # pylint: disable=import-outside-toplevel
+        Priority,
+    )
+
+    dives, _ = sdk
+    dive_id = await dives.post(
+        _sdk_dive("d/fish", name="fish dive", dive_slate_id=3)
+    )
+
+    await dives.post(
+        Dive.model_construct(
+            path="d/fish",
+            dive_datetime=datetime(2024, 8, 21, 8, 56, 51, tzinfo=timezone.utc),
+            camera_id=1,
+            priority=Priority.HIGH,
+        )
+    )
+
+    row = await dives.get(dive_id=dive_id)
+    assert row.priority == Priority.HIGH
+    assert row.name == "fish dive"
+    assert row.dive_slate_id == 3

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -48,14 +48,24 @@ def _dive(dive_id: int, *, priority="HIGH", dive_slate_id=None, calibration_dive
     )
 
 
-def _image(image_id: int, dive_id: int):
+def _image(image_id: int, dive_id: int, *, is_canonical: bool = True):
+    """Canonical by default — the normal case, and what the cohort selectors
+    now require.
+
+    `Image.is_canonical` defaults to False on the *model*, which made every
+    image seeded here a duplicate. That was invisible while nothing read the
+    flag; now that the selectors gate on it, the default has to reflect
+    reality. Pass `is_canonical=False` to model a duplicate frame — see
+    test_canonical_only_pipeline_work.py.
+    """
     from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
 
     return Image(
         id=image_id,
         path=f"/dev/null/img-{image_id}",
         taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"img-{image_id:032d}"[:32],
+        checksum=f"{image_id:032d}",
+        is_canonical=is_canonical,
         dive_id=dive_id,
     )
 

--- a/services/fishsense-api/tests/test_slate_prediction_endpoint.py
+++ b/services/fishsense-api/tests/test_slate_prediction_endpoint.py
@@ -48,7 +48,7 @@ def _image(image_id: int, dive_id: int):
         id=image_id,
         path=f"/dev/null/img-{image_id}",
         taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"img-{image_id:032d}"[:32],
+        checksum=f"{image_id:032d}",
         dive_id=dive_id,
     )
 

--- a/services/fishsense-api/tests/test_species_slate_reads_superseded.py
+++ b/services/fishsense-api/tests/test_species_slate_reads_superseded.py
@@ -48,7 +48,7 @@ def _image(image_id, dive_id=1):
         id=image_id,
         path=f"/dev/null/{image_id}",
         taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"img-{image_id:032d}"[:32],
+        checksum=f"{image_id:032d}",
         dive_id=dive_id,
     )
 


### PR DESCRIPTION
**PR 1 of 4** for dive/image ingestion. Plan: [`docs/plans/dive-image-ingestion.md`](docs/plans/dive-image-ingestion.md) (included here).

There is currently no way to create a `Dive` or `Image` through this repo. Every existing row was written by `UCSD-E4E/fishsense-data-processing-spider` and copied across wholesale by `9e5bc64`. This adds the write path; PRs 2–4 add the api-worker workflow, the `/portal` page, and the `Weasly Fish` reference row.

## Endpoints

| | |
|---|---|
| `POST /api/v1/dives/` | upsert on `Dive.path` |
| `POST /api/v1/dives/{dive_id}/images/` | upsert on `Image.path` |
| `POST /api/v1/images/checksums/lookup` | batch checksum → dives |

Plus `dives.post`, `images.post`, `images.lookup_checksums` on the SDK.

## Behaviour worth reviewing

**Natural-key upserts, and they're *partial*.** `session.merge` replaces every column, so a second POST that mentions only `priority` used to null `name`, `dive_slate_id` and `calibration_dive_id`. That's data loss, not cosmetics: `dive_slate_id` is written only by the species-label sync, and `calibration_dive_id` is the borrowed-calibration link — nulling either silently stops stages 9/12/13/14 for that dive. Ingest re-POSTs at finalize, so it would have tripped this on its first resume. Both endpoints now overlay only the fields the caller actually sent (`model_fields_set`, captured before `model_validate` rebuilds the object); an explicit null still clears.

**`is_canonical` is computed server-side and enforced by the database.** The rule comes from `9e5bc64`: first row for a checksum wins. That's what lets the same frames live under two dive rows — prod dives 64 and 66 are both `082929_FishModels_FSL07`. It matters more than it looks: **49.8% of prod image rows are duplicate content** (131,430 total / 65,981 distinct).

A read-then-write can't guarantee it, so this adds `uq_image_canonical_checksum`, a **partial** unique index (`WHERE is_canonical`) — partial because duplicate *non*-canonical rows are the normal case and a plain unique index on `checksum` would break dives 64/66 outright. A losing racer gets an IntegrityError; the ingest activity retries, re-reads, sees the winner, and writes `False`, so the race self-heals with no resolution code.

Verified on real Postgres 17, not just SQLite:
```
duplicate non-canonical row  -> INSERT 0 1
second canonical, same ck    -> ERROR: duplicate key value violates
                                unique constraint "uq_image_canonical_checksum"
```

The constraint immediately caught a latent bug it wasn't aimed at: the `is_canonical` operator override created a *second* canonical row rather than swapping. Promotion now demotes the incumbent in the same transaction.

**The migration never mutates data.** `lifespan` runs `run_alembic_upgrade` on startup, so a unique index failing on pre-existing rows would crash-loop the API — and there's no staging tier. It checks first and, on violations, logs loudly and skips, leaving repair as an operator decision. Checked against prod before writing it: 65,981 canonical rows over 65,981 distinct checksums, **0** with more than one canonical, so it takes the create path and no repair is needed.

**Validation is deliberately loud**, because each of these otherwise breaks a *later* stage with no error anywhere: a camera without `CameraIntrinsics` (stage 14 can never measure the dive), an over-long path (truncated, no longer resolves on the NAS), a dangling or self-referential `calibration_dive_id`, a checksum that isn't a 32-char MD5 (duplicate detection silently stops matching), a missing `taken_datetime` (stage-1 clustering is pure timestamp maths).

## Two SQLModel traps this surfaced

- **`table=True` models skip validation on `__init__`.** Only `model_validate` enforces `max_length`, and that's what FastAPI runs on a request body — so an HTTP caller gets a 422 while any in-process caller sails past. Hence the endpoints keep their own explicit checks, ahead of `model_validate`.
- **They skip coercion too**, so a JSON `"priority": "HIGH"` arrives as a raw `str`. An unrecognised value then reached `model_validate` and surfaced as a **500** rather than a 422, and `jsonable_encoder` emitted a pydantic serializer warning on *every* request. Coerced up front.

## Tests

Unit tests call controllers directly; that missed all three of the above, so there are also app-level tests through the real stack (routing, request validation, response serialization) and **SDK↔API contract tests** driving the real client methods against the real FastAPI app over `httpx.ASGITransport` — no server, no network. `ClientBase` gains an optional `transport` kwarg for that; production passes `None`.

Verified non-vacuous by mutation: renaming the **server-side** route leaves the mocked SDK suite fully green (128 passed) while the contract suite fails.

```
services/fishsense-api    339 passed  (+9 Postgres integration, run separately)
libs/fishsense-api-sdk    128 passed
```

pylint 10.00 on all 14 changed Python files. Rebased on current `main`; single alembic head (`a7f2c9e41b03`).

## Out of scope

Labeling, and any change to stages 0.1–14. Ingest ends when `Dive`/`Image` rows exist at `priority=HIGH`; the hourly schedules take it from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)