### PR TITLE
fix: only canonical images are pipeline work

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/cleanup_raw_bytes_for_dive_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/cleanup_raw_bytes_for_dive_activity.py
@@ -47,7 +47,12 @@ async def cleanup_raw_bytes_for_dive_activity(
 ) -> CleanupRawBytesResult:
     async with get_fs_client() as fs:
         images = await fs.images.get(dive_id=dive_id) or []
-
+        # Deliberately NOT filtered to canonical images, unlike staging and
+        # the resolvers. Cleanup should be broader than whatever produced the
+        # scratch, so it still evicts objects staged before the canonical gate
+        # existed. Harmless either way -- scratch is keyed by checksum, and a
+        # duplicate shares its canonical twin's key -- but broader is the safe
+        # direction for a delete that only touches Garage scratch.
     activity.logger.info(
         "cleaning up raw bytes dive_id=%d images=%d", dive_id, len(images)
     )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_laser_label_studio_project_activity.py
@@ -166,6 +166,14 @@ async def populate_laser_label_studio_project_activity(
     """
     async with get_fs_client() as fs:
         images = await fs.images.get(dive_id=dive_id) or []
+        # Canonical frames only. The same physical frames live under several
+        # dive rows (half of prod's image table is duplicate content), and
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+        # predicate exactly -- otherwise the dispatched per-image work would not
+        # match what the cohort promised, and the dive could never drain.
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+        images = [image for image in images if image.is_canonical]
         existing_labels = await fs.labels.get_laser_labels(dive_id) or []
         predictions = await fs.labels.get_laser_predictions(dive_id) or []
         predictions_by_image = {p.image_id: p for p in predictions}

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_dive_frame_clustering_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_dive_frame_clustering_inputs_activity.py
@@ -23,7 +23,14 @@ async def resolve_dive_frame_clustering_inputs_activity(
     )
     async with get_fs_client() as fs:
         images = await fs.images.get(dive_id=dive_id) or []
-
+        # Canonical frames only. The same physical frames live under several
+        # dive rows (half of prod's image table is duplicate content), and
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+        # predicate exactly -- otherwise the dispatched per-image work would not
+        # match what the cohort promised, and the dive could never drain.
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+        images = [image for image in images if image.is_canonical]
     cluster_images = [
         ClusterDiveFrameImage(
             image_id=image.id,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_headtail_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_headtail_preprocess_inputs_activity.py
@@ -63,6 +63,22 @@ async def resolve_headtail_preprocess_inputs_activity(
         ]
 
         images = await fs.images.get(dive_id=dive_id) or []
+
+        # Canonical frames only. The same physical frames live under several
+
+        # dive rows (half of prod's image table is duplicate content), and
+
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+
+        # predicate exactly -- otherwise the dispatched per-image work would not
+
+        # match what the cohort promised, and the dive could never drain.
+
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+
+        images = [image for image in images if image.is_canonical]
         checksum_by_id = {image.id: image.checksum for image in images}
         image_checksums = [
             checksum_by_id[image_id]

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_predict_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_predict_inputs_activity.py
@@ -61,6 +61,22 @@ async def resolve_laser_predict_inputs_activity(
             raise ValueError(f"camera_id={dive.camera_id} has no intrinsics")
 
         images = await fs.images.get(dive_id=dive_id) or []
+
+        # Canonical frames only. The same physical frames live under several
+
+        # dive rows (half of prod's image table is duplicate content), and
+
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+
+        # predicate exactly -- otherwise the dispatched per-image work would not
+
+        # match what the cohort promised, and the dive could never drain.
+
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+
+        images = [image for image in images if image.is_canonical]
         predictions = await fs.labels.get_laser_predictions(dive_id) or []
         labels = await fs.labels.get_laser_labels(dive_id) or []
         needing = _select_images_needing_prediction(images, predictions, labels)

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_laser_preprocess_inputs_activity.py
@@ -68,6 +68,22 @@ async def resolve_laser_preprocess_inputs_activity(
             )
 
         images = await fs.images.get(dive_id=dive_id) or []
+
+        # Canonical frames only. The same physical frames live under several
+
+        # dive rows (half of prod's image table is duplicate content), and
+
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+
+        # predicate exactly -- otherwise the dispatched per-image work would not
+
+        # match what the cohort promised, and the dive could never drain.
+
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+
+        images = [image for image in images if image.is_canonical]
         existing_labels = await fs.labels.get_laser_labels(dive_id) or []
         unlabeled = _select_unlabeled_images(images, existing_labels)
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_slate_predict_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_slate_predict_inputs_activity.py
@@ -87,6 +87,22 @@ async def resolve_slate_predict_inputs_activity(
         )
 
         images = await fs.images.get(dive_id=dive_id) or []
+
+        # Canonical frames only. The same physical frames live under several
+
+        # dive rows (half of prod's image table is duplicate content), and
+
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+
+        # predicate exactly -- otherwise the dispatched per-image work would not
+
+        # match what the cohort promised, and the dive could never drain.
+
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+
+        images = [image for image in images if image.is_canonical]
         checksum_by_id = {image.id: image.checksum for image in images}
 
         activity.logger.info(

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_slate_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_slate_preprocess_inputs_activity.py
@@ -77,6 +77,22 @@ async def resolve_slate_preprocess_inputs_activity(
         ]
 
         images = await fs.images.get(dive_id=dive_id) or []
+
+        # Canonical frames only. The same physical frames live under several
+
+        # dive rows (half of prod's image table is duplicate content), and
+
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+
+        # predicate exactly -- otherwise the dispatched per-image work would not
+
+        # match what the cohort promised, and the dive could never drain.
+
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+
+        images = [image for image in images if image.is_canonical]
         checksum_by_id = {image.id: image.checksum for image in images}
         image_checksums = [
             checksum_by_id[image_id]

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_species_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_species_preprocess_inputs_activity.py
@@ -64,6 +64,14 @@ async def resolve_species_preprocess_inputs_activity(
             or []
         )
         images = await fs.images.get(dive_id=dive_id) or []
+        # Canonical frames only. The same physical frames live under several
+        # dive rows (half of prod's image table is duplicate content), and
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+        # predicate exactly -- otherwise the dispatched per-image work would not
+        # match what the cohort promised, and the dive could never drain.
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+        images = [image for image in images if image.is_canonical]
         checksum_by_id = {image.id: image.checksum for image in images}
 
         laser_labels = await fs.labels.get_laser_labels(dive_id) or []

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/stage_raw_bytes_for_dive_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/stage_raw_bytes_for_dive_activity.py
@@ -176,7 +176,14 @@ async def stage_raw_bytes_for_dive_activity(
 ) -> StageRawBytesResult:
     async with get_fs_client() as fs:
         images = await fs.images.get(dive_id=dive_id) or []
-
+        # Canonical frames only. The same physical frames live under several
+        # dive rows (half of prod's image table is duplicate content), and
+        # `is_canonical` marks which copy is the real one. The cohort selectors
+        # gate on it, and CLAUDE.md requires resolvers to mirror the selector
+        # predicate exactly -- otherwise the dispatched per-image work would not
+        # match what the cohort promised, and the dive could never drain.
+        # This also covers on-demand/backfill runs, which bypass the cohort.
+        images = [image for image in images if image.is_canonical]
     activity.logger.info(
         "staging raw bytes dive_id=%d images=%d", dive_id, len(images)
     )

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_laser_predict_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_laser_predict_inputs_activity.py
@@ -15,8 +15,12 @@ from fishsense_api_workflow_worker.activities import (
 )
 
 
-def _image(image_id, checksum):
-    return SimpleNamespace(id=image_id, checksum=checksum)
+def _image(image_id, checksum, *, is_canonical=True):
+    # Canonical by default — the resolvers filter on it, mirroring the
+    # cohort selectors. Pass False to model a duplicate frame.
+    return SimpleNamespace(
+        id=image_id, checksum=checksum, is_canonical=is_canonical
+    )
 
 
 def _make_fs(*, camera_id=1, images=None, predictions=None, labels=None, intrinsics=True):
@@ -95,3 +99,31 @@ async def test_activity_raises_without_intrinsics(monkeypatch):
         await ActivityEnvironment().run(
             sut.resolve_laser_predict_inputs_activity, 1
         )
+
+
+async def test_duplicate_frames_are_not_dispatched_as_work(monkeypatch):
+    """Resolvers must mirror the cohort selectors, which gate on
+    `is_canonical`.
+
+    The same physical frames live under several dive rows — half of prod's
+    image table is duplicate content — and `is_canonical` marks which copy is
+    real. If a resolver dispatched a duplicate the selector had excluded, the
+    per-image work would not match what the cohort promised, and (worse) the
+    dive could never drain: no label row would ever appear for it, so the
+    cohort predicate stays true forever. That is the prod dive 60 wedge.
+    """
+    fs = _make_fs(
+        images=[
+            _image(11, "c11", is_canonical=True),
+            _image(12, "c12", is_canonical=False),
+        ]
+    )
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+
+    result = await ActivityEnvironment().run(
+        sut.resolve_laser_predict_inputs_activity, 1
+    )
+
+    dispatched = {img.checksum for img in result.images}
+    assert "c11" in dispatched
+    assert "c12" not in dispatched, "a duplicate frame was dispatched as work"

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_slate_predict_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_slate_predict_inputs_activity.py
@@ -71,8 +71,8 @@ def _make_fs():
     fs.images = MagicMock()
     fs.images.get = AsyncMock(
         return_value=[
-            SimpleNamespace(id=11, checksum="c11"),
-            SimpleNamespace(id=12, checksum="c12"),
+            SimpleNamespace(id=11, checksum="c11", is_canonical=True),
+            SimpleNamespace(id=12, checksum="c12", is_canonical=True),
         ]
     )
     fs.labels = MagicMock()

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/c3e8b1d47a52_canonical_only_pipeline_status.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/c3e8b1d47a52_canonical_only_pipeline_status.py
@@ -1,0 +1,57 @@
+"""dive_pipeline_status counts only canonical images
+
+Revision ID: c3e8b1d47a52
+Revises: a7f2c9e41b03
+Create Date: 2026-08-08 06:00:00.000000
+
+The cohort selectors now require `Image.is_canonical`, so a duplicate dive can
+never become pipeline work. This view has to use the identical predicate or the
+two drift: the dashboard would report such a dive as perpetually incomplete
+while the worker correctly does nothing with it — the exact silent
+disagreement `test_view_and_selector_agree_on_species_predicate` exists to
+catch.
+
+Drop + recreate rather than CREATE OR REPLACE: Postgres is restrictive about
+column-shape changes on replace, and the view has no dependents, so the simpler
+pattern applies (see the `dive_pipeline_status` section of CLAUDE.md).
+
+No data is touched. On prod this is a pure predicate change: every dive that
+currently has canonical images keeps identical flags, because the added
+conjunct is true for those rows. Only fully-duplicate dives change — and all
+207 of them are priority=LOW, so nothing schedules them either way.
+
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from fishsense_api.views import (
+    DIVE_PIPELINE_STATUS_VIEW_SQL,
+    DROP_DIVE_PIPELINE_STATUS_VIEW_SQL,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "c3e8b1d47a52"
+down_revision: Union[str, Sequence[str], None] = "a7f2c9e41b03"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Recreate the view with the canonical-only predicate."""
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)
+
+
+def downgrade() -> None:
+    """Recreate from whatever `views.py` currently holds.
+
+    Note this is NOT a true inverse: the SQL is imported from `views.py`, which
+    is the single source of truth, so downgrading after reverting the code
+    restores the old predicate, while downgrading without reverting is a no-op.
+    That is the same trade-off every view migration in this tree makes.
+    """
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_controller.py
@@ -45,6 +45,24 @@ from fishsense_api.server import app
 logger = logging.getLogger(__name__)
 
 
+# Every cohort selector below correlates `Image` to `Dive` and then adds
+# `Image.is_canonical == True`. That filter is not an optimisation -- it is
+# what stops a duplicate dive wedging the pipeline.
+#
+# The same physical frames legitimately live under several dive rows (half of
+# prod's image table is duplicate content; 207 of 479 dives are duplicates end
+# to end), and `is_canonical` marks which copy is the real one. Without the
+# filter, a duplicate dive promoted to HIGH satisfies "has an image with no
+# label row" forever: populate declines to make LS tasks for frames that
+# already exist elsewhere, so no label row appears, so the dive never drains --
+# re-staging its raw `.ORF`s from the NAS every hour and blocking every
+# higher-id dive behind it. That is the prod dive 60 failure.
+#
+# Duplicate dives are all LOW priority today, so this is currently latent. That
+# is a property of the data, not of the code. `test_canonical_only_pipeline_work.py`
+# pins both the behaviour and the "every selector has it" registry property.
+
+
 def _valid_laser_conditions():
     """The repo-wide definition of a *valid* laser label.
 
@@ -371,6 +389,7 @@ async def select_next_for_laser_preprocessing(
     has_image_without_real_laser_label = (
         select(Image.id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(
             ~select(LaserLabel.id)
             .where(LaserLabel.image_id == Image.id)
@@ -418,6 +437,7 @@ async def select_next_for_laser_prediction(
     has_image_needing_prediction = (
         select(Image.id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(
             ~select(LaserPrediction.id)
             .where(LaserPrediction.image_id == Image.id)
@@ -464,6 +484,7 @@ async def select_next_for_slate_prediction(
         select(SpeciesLabel.id)
         .join(Image, Image.id == SpeciesLabel.image_id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(SpeciesLabel.content_of_image == SLATE_CONTENT_MARKER)
         .where(
             ~select(SlatePrediction.id)
@@ -510,6 +531,7 @@ async def select_next_for_dive_frame_clustering(
         select(LaserLabel.id)
         .join(Image, Image.id == LaserLabel.image_id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(*_valid_laser_conditions())
         .exists()
     )
@@ -579,6 +601,7 @@ async def select_next_for_species_preprocessing(
         select(LaserLabel.id)
         .join(Image, Image.id == LaserLabel.image_id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(*_valid_laser_conditions())
         .where(
             ~select(SpeciesLabel.id)
@@ -650,6 +673,7 @@ async def select_dives_needing_species_population(
         select(LaserLabel.id)
         .join(Image, Image.id == LaserLabel.image_id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(LaserLabel.completed == True)
         .where(LaserLabel.superseded == False)
         .where(LaserLabel.x != None)
@@ -694,6 +718,7 @@ async def select_dives_needing_laser_population(
     has_predicted_incomplete_image = (
         select(Image.id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(
             select(LaserPrediction.id)
             .where(LaserPrediction.image_id == Image.id)
@@ -740,6 +765,7 @@ async def select_next_for_headtail_preprocessing(
         select(LaserLabel.id)
         .join(Image, Image.id == LaserLabel.image_id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(*_valid_laser_conditions())
         .where(
             ~select(HeadTailLabel.id)
@@ -776,6 +802,7 @@ async def select_next_for_slate_preprocessing(
         select(SpeciesLabel.id)
         .join(Image, Image.id == SpeciesLabel.image_id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(SpeciesLabel.content_of_image == SLATE_CONTENT_MARKER)
         .where(
             ~select(DiveSlateLabel.id)
@@ -811,6 +838,7 @@ async def select_next_for_laser_calibration(
         select(func.count(DiveSlateLabel.id))  # pylint: disable=not-callable
         .join(Image, Image.id == DiveSlateLabel.image_id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(DiveSlateLabel.completed == True)
         # A dead-lettered slate label doesn't count toward the calibration
         # readiness gate — same validity convention laser calibration uses.
@@ -895,6 +923,7 @@ async def select_next_for_measure_fish(
         select(SpeciesLabel.id)
         .join(Image, Image.id == SpeciesLabel.image_id)
         .where(Image.dive_id == Dive.id)
+        .where(Image.is_canonical == True)
         .where(SpeciesLabel.top_three_photos_of_group == True)
         .where(*_measurable_species_conditions())
         .where(valid_laser)

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -91,6 +91,17 @@ _IS_FISH_MODEL_SQL = (
 # incomplete-non-superseded rows. Mirrors
 # `get_dives_with_complete_laser_labeling`'s semantics so a dive with
 # zero labels of a kind doesn't vacuously read as complete.
+# Every image correlation below reads `i.dive_id = d.id AND i.is_canonical`.
+#
+# The same physical frames live under several dive rows (half of prod's image
+# table is duplicate content; 207 of 479 dives are duplicates end to end), and
+# `is_canonical` marks which copy is real. The cohort selectors in
+# `dive_controller` gate on it so a duplicate dive can never become pipeline
+# work, and this view has to use the identical predicate or the two drift:
+# the dashboard would report a dive as perpetually incomplete while the worker
+# correctly does nothing with it. `test_dive_pipeline_status_view.py` pins that
+# agreement explicitly.
+
 DIVE_PIPELINE_STATUS_VIEW_SQL = f"""
 CREATE VIEW {DIVE_PIPELINE_STATUS_VIEW_NAME} AS
 SELECT
@@ -102,10 +113,10 @@ SELECT
     -- Stage 0.1: every image in the dive has at least one LaserLabel
     -- row (any project, any state). The cohort selector is the
     -- inverse of this predicate.
-    (EXISTS (SELECT 1 FROM image i WHERE i.dive_id = d.id)
+    (EXISTS (SELECT 1 FROM image i WHERE i.dive_id = d.id AND i.is_canonical)
      AND NOT EXISTS (
          SELECT 1 FROM image i
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND NOT EXISTS (
                SELECT 1 FROM laserlabel ll WHERE ll.image_id = i.id
            )
@@ -116,14 +127,14 @@ SELECT
     (EXISTS (
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND ll.superseded = FALSE
            AND ll.completed = TRUE
      )
      AND NOT EXISTS (
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND ll.superseded = FALSE
            AND (ll.completed = FALSE OR ll.completed IS NULL)
      )) AS laser_labeling_complete,
@@ -136,13 +147,13 @@ SELECT
     (EXISTS (
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND {_VALID_LASER_SQL}
      )
      AND NOT EXISTS (
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND {_VALID_LASER_SQL}
            AND NOT EXISTS (
                SELECT 1 FROM headtaillabel htl
@@ -156,14 +167,14 @@ SELECT
     (EXISTS (
          SELECT 1 FROM headtaillabel htl
          JOIN image i ON i.id = htl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND htl.superseded = FALSE
            AND htl.completed = TRUE
      )
      AND NOT EXISTS (
          SELECT 1 FROM headtaillabel htl
          JOIN image i ON i.id = htl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND htl.superseded = FALSE
            AND (htl.completed = FALSE OR htl.completed IS NULL)
      )) AS headtail_labeling_complete,
@@ -200,7 +211,7 @@ SELECT
     (EXISTS (
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND {_VALID_LASER_SQL}
            AND EXISTS (
                SELECT 1 FROM diveframeclusterimagemapping mm
@@ -213,7 +224,7 @@ SELECT
      AND NOT EXISTS (
          SELECT 1 FROM laserlabel ll
          JOIN image i ON i.id = ll.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND {_VALID_LASER_SQL}
            AND EXISTS (
                SELECT 1 FROM diveframeclusterimagemapping mm
@@ -236,14 +247,14 @@ SELECT
     (EXISTS (
          SELECT 1 FROM specieslabel sl
          JOIN image i ON i.id = sl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND sl.superseded = FALSE
            AND sl.completed = TRUE
      )
      AND NOT EXISTS (
          SELECT 1 FROM specieslabel sl
          JOIN image i ON i.id = sl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND sl.superseded = FALSE
            AND (sl.completed = FALSE OR sl.completed IS NULL)
      )) AS species_labeling_complete,
@@ -258,13 +269,13 @@ SELECT
      AND EXISTS (
          SELECT 1 FROM specieslabel sl
          JOIN image i ON i.id = sl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND sl.content_of_image = '{_SLATE_CONTENT_MARKER}'
      )
      AND NOT EXISTS (
          SELECT 1 FROM specieslabel sl
          JOIN image i ON i.id = sl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND sl.content_of_image = '{_SLATE_CONTENT_MARKER}'
            AND NOT EXISTS (
                SELECT 1 FROM diveslatelabel dsl
@@ -278,14 +289,14 @@ SELECT
     (EXISTS (
          SELECT 1 FROM diveslatelabel dsl
          JOIN image i ON i.id = dsl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND dsl.superseded = FALSE
            AND dsl.completed = TRUE
      )
      AND NOT EXISTS (
          SELECT 1 FROM diveslatelabel dsl
          JOIN image i ON i.id = dsl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND dsl.superseded = FALSE
            AND (dsl.completed = FALSE OR dsl.completed IS NULL)
      )) AS slate_labeling_complete,
@@ -346,12 +357,12 @@ SELECT
     (EXISTS (
          SELECT 1 FROM measurement m
          JOIN image i ON i.id = m.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
      )
      AND NOT EXISTS (
          SELECT 1 FROM specieslabel sl
          JOIN image i ON i.id = sl.image_id
-         WHERE i.dive_id = d.id
+         WHERE i.dive_id = d.id AND i.is_canonical
            AND sl.top_three_photos_of_group = TRUE
            AND {_MEASURABLE_SPECIES_SQL}
            AND EXISTS (

--- a/services/fishsense-api/tests/test_canonical_only_pipeline_work.py
+++ b/services/fishsense-api/tests/test_canonical_only_pipeline_work.py
@@ -150,3 +150,83 @@ def test_every_cohort_selector_filters_on_is_canonical():
         f"{gated} `Image.is_canonical` filters — a selector is missing the "
         "gate and would wedge on a duplicate dive"
     )
+
+
+# ── the view must agree with the selectors ────────────────────────────
+
+
+async def _pipeline_row(session, dive_id: int):
+    from sqlalchemy import text  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api.views import (  # pylint: disable=import-outside-toplevel
+        DIVE_PIPELINE_STATUS_VIEW_SQL,
+    )
+
+    await session.exec(text(DIVE_PIPELINE_STATUS_VIEW_SQL))
+    result = await session.exec(
+        text(
+            "SELECT laser_preprocessed, headtail_preprocessed "
+            f"FROM dive_pipeline_status WHERE dive_id = {dive_id}"
+        )
+    )
+    row = result.first()
+    # SQLite hands back 1/0 for view booleans, not Python bools — the same
+    # coercion `test_dive_pipeline_status_view.py` does.
+    return None if row is None else tuple(bool(v) for v in row)
+
+
+async def test_the_view_ignores_duplicate_frames_like_the_selectors_do(session):
+    """The view and the cohort selectors are the same predicate in two files,
+    and CLAUDE.md requires them to stay in step.
+
+    Without this, a duplicate dive reads as perpetually incomplete on the
+    Superset dashboard while the worker correctly never picks it up — the
+    silent disagreement the cross-controller drift guard exists to catch.
+
+    A dive of only duplicate frames must look the way a dive with no images
+    looks: vacuously False, nothing outstanding.
+    """
+    session.add(_dive(1))
+    session.add(_image(11, 1, is_canonical=False))
+    await session.flush()
+
+    row = await _pipeline_row(session, 1)
+
+    # `laser_preprocessed` requires "an image exists AND none lack a label".
+    # With the duplicate excluded there is no image, so it is vacuously False —
+    # exactly as for an empty dive, and consistent with the selector returning
+    # None rather than treating it as outstanding work.
+    assert row[0] is False
+
+
+async def test_the_view_still_reports_canonical_frames(session):
+    """The gate must not blind the dashboard to real work."""
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+
+    session.add(_dive(1))
+    session.add(_image(11, 1, is_canonical=True))
+    await session.flush()
+    session.add(LaserLabel(image_id=11, label_studio_project_id=73))
+    await session.flush()
+
+    row = await _pipeline_row(session, 1)
+
+    assert row[0] is True   # every canonical image has a laser label row
+
+
+async def test_view_and_selector_agree_on_a_duplicate_dive(session):
+    """The property, stated directly: for the same dive, the view must not
+    claim outstanding work that the selector refuses to schedule."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+
+    session.add(_dive(1))
+    session.add(_image(11, 1, is_canonical=False))
+    await session.flush()
+
+    selected = await select_next_for_laser_preprocessing(session=session)
+    row = await _pipeline_row(session, 1)
+
+    assert selected is None          # worker: nothing to do
+    assert row[0] is False           # view: nothing claimed as done either

--- a/services/fishsense-api/tests/test_canonical_only_pipeline_work.py
+++ b/services/fishsense-api/tests/test_canonical_only_pipeline_work.py
@@ -1,0 +1,152 @@
+"""Only *canonical* images are pipeline work.
+
+The same physical frames legitimately live under several dive rows — prod has
+131,430 image rows over 65,981 distinct checksums, so **half the table is
+duplicate content**, and 207 of 479 dives are duplicates end to end.
+`is_canonical` marks which copy is the real one (first row for a checksum wins,
+from `9e5bc64`).
+
+Today nothing in the pipeline reads that flag: `is_canonical` appears in
+exactly one query in the whole codebase (`get_canonical_dives`). Duplicate
+dives are inert only because they all happen to be `priority=LOW`, and every
+cohort gates on HIGH. That is a coincidence of the data, not a property of the
+code — promote one duplicate dive and it starts consuming NAS bandwidth,
+preprocessing, and labeler time on frames that already exist elsewhere.
+
+**Gating populate alone would make it worse, not better.** The preprocess
+cohorts are "at least one image with no label row". If populate skipped
+non-canonical images, those rows would never get labels, so the dive would
+never drain — re-staging its raw `.ORF`s from the NAS every hour and blocking
+every higher-id dive behind it. That is the prod dive 60 wedge, verbatim. So
+the cohorts have to exclude them too, which is what these tests pin.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+def _dive(dive_id: int, **kwargs):
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+
+    kwargs.setdefault("priority", Priority.HIGH)
+    return Dive(
+        id=dive_id,
+        path=f"/dev/null/{dive_id}",
+        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        **kwargs,
+    )
+
+
+def _image(image_id: int, dive_id: int, *, is_canonical: bool):
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+
+    return Image(
+        id=image_id,
+        path=f"/dev/null/img-{image_id}",
+        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        checksum=f"{image_id:032d}",
+        is_canonical=is_canonical,
+        dive_id=dive_id,
+    )
+
+
+# ── stage 0.1: the wedge this prevents ────────────────────────────────
+
+
+async def test_a_dive_of_only_duplicate_frames_is_not_laser_preprocessing_work(session):
+    """The dive-60 wedge, in its duplicate-frame form.
+
+    Cohort is "HIGH + an image with no LaserLabel row". A promoted duplicate
+    dive satisfies it forever: populate would (correctly) decline to make LS
+    tasks for frames that already exist elsewhere, so no label row ever
+    appears, so the dive never drains — re-staging raw `.ORF`s from the NAS
+    every hour and blocking every higher-id dive.
+    """
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+
+    session.add(_dive(1))
+    session.add(_image(11, 1, is_canonical=False))
+    await session.flush()
+
+    assert await select_next_for_laser_preprocessing(session=session) is None
+
+
+async def test_a_canonical_frame_is_still_laser_preprocessing_work(session):
+    """The other half — the gate must not swallow real work."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+
+    session.add(_dive(1))
+    session.add(_image(11, 1, is_canonical=True))
+    await session.flush()
+
+    assert await select_next_for_laser_preprocessing(session=session) == 1
+
+
+async def test_a_mixed_dive_is_still_work_for_its_canonical_frames(session):
+    """A dive holding one original and one duplicate is real work. Excluding
+    the whole dive would strand the original."""
+    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_preprocessing,
+    )
+
+    session.add(_dive(1))
+    session.add(_image(11, 1, is_canonical=False))
+    session.add(_image(12, 1, is_canonical=True))
+    await session.flush()
+
+    assert await select_next_for_laser_preprocessing(session=session) == 1
+
+
+# ── the registry property: every selector, not just the one ───────────
+
+
+def test_every_cohort_selector_filters_on_is_canonical():
+    """A source-level guard, in the spirit of `controllers/__init__.py` and the
+    view registry: the failure mode is silent.
+
+    A new selector that subqueries `Image` without this filter reintroduces the
+    wedge, and nothing at runtime would say so — the dive simply never drains.
+    Every `Image.dive_id == Dive.id` correlation must be paired with an
+    `Image.is_canonical` predicate.
+    """
+    import inspect  # pylint: disable=import-outside-toplevel
+    import re  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api.controllers import (  # pylint: disable=import-outside-toplevel
+        dive_controller,
+    )
+
+    source = inspect.getsource(dive_controller)
+    correlations = len(re.findall(r"Image\.dive_id == Dive\.id", source))
+    gated = len(re.findall(r"Image\.is_canonical == True", source))
+
+    assert correlations > 0, "sanity: selectors should correlate Image to Dive"
+    assert gated >= correlations, (
+        f"{correlations} `Image.dive_id == Dive.id` correlations but only "
+        f"{gated} `Image.is_canonical` filters — a selector is missing the "
+        "gate and would wedge on a duplicate dive"
+    )

--- a/services/fishsense-api/tests/test_dive_pipeline_status_view.py
+++ b/services/fishsense-api/tests/test_dive_pipeline_status_view.py
@@ -71,14 +71,19 @@ def _dive(
     )
 
 
-def _image(image_id: int, dive_id: int):
+def _image(image_id: int, dive_id: int, *, is_canonical: bool = True):
+    """Canonical by default — the normal case. `Image.is_canonical` defaults to
+    False on the model, which made every seeded image a duplicate; harmless
+    while nothing read the flag, misleading now that the cohort selectors gate
+    on it."""
     from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
 
     return Image(
         id=image_id,
         path=f"/dev/null/img-{image_id}",
         taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"img-{image_id:032d}"[:32],
+        checksum=f"{image_id:032d}",
+        is_canonical=is_canonical,
         dive_id=dive_id,
     )
 

--- a/services/fishsense-api/tests/test_dives_with_complete_laser_labeling_endpoint.py
+++ b/services/fishsense-api/tests/test_dives_with_complete_laser_labeling_endpoint.py
@@ -49,7 +49,7 @@ def _image(image_id: int, dive_id: int):
         id=image_id,
         path=f"/dev/null/img-{image_id}",
         taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"img-{image_id:032d}"[:32],
+        checksum=f"{image_id:032d}",
         dive_id=dive_id,
     )
 

--- a/services/fishsense-api/tests/test_fish_model_mislabel_suspects.py
+++ b/services/fishsense-api/tests/test_fish_model_mislabel_suspects.py
@@ -100,7 +100,7 @@ async def _measure(session, *, dive_id, model_name, length_m):
             id=image_id,
             path=f"/dev/null/img-{image_id}",
             taken_datetime=datetime(2023, 8, 29, tzinfo=timezone.utc),
-            checksum=f"img-{image_id:032d}"[:32],
+            checksum=f"{image_id:032d}",
             dive_id=dive_id,
         )
     )

--- a/services/fishsense-api/tests/test_fish_model_reference.py
+++ b/services/fishsense-api/tests/test_fish_model_reference.py
@@ -130,7 +130,7 @@ async def _seed_measurement(session, *, dive_id, image_id, model_name, length_m)
             id=image_id,
             path=f"/dev/null/img-{image_id}",
             taken_datetime=datetime(2023, 8, 29, tzinfo=timezone.utc),
-            checksum=f"img-{image_id:032d}"[:32],
+            checksum=f"{image_id:032d}",
             dive_id=dive_id,
         )
     )

--- a/services/fishsense-api/tests/test_label_studio_project_ids_superseded.py
+++ b/services/fishsense-api/tests/test_label_studio_project_ids_superseded.py
@@ -41,7 +41,7 @@ def _image(image_id: int):
         id=image_id,
         path=f"/dev/null/img-{image_id}",
         taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"img-{image_id:032d}"[:32],
+        checksum=f"{image_id:032d}",
         dive_id=1,
     )
 

--- a/services/fishsense-api/tests/test_laser_prediction_endpoint.py
+++ b/services/fishsense-api/tests/test_laser_prediction_endpoint.py
@@ -46,7 +46,7 @@ def _image(image_id: int, dive_id: int):
         id=image_id,
         path=f"/dev/null/img-{image_id}",
         taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"img-{image_id:032d}"[:32],
+        checksum=f"{image_id:032d}",
         dive_id=dive_id,
     )
 

--- a/services/fishsense-api/tests/test_measurements_endpoint.py
+++ b/services/fishsense-api/tests/test_measurements_endpoint.py
@@ -59,7 +59,7 @@ def _image(image_id: int, dive_id: int):
         id=image_id,
         path=f"/dev/null/img-{image_id}",
         taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"img-{image_id:032d}"[:32],
+        checksum=f"{image_id:032d}",
         dive_id=dive_id,
     )
 

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -48,14 +48,24 @@ def _dive(dive_id: int, *, priority="HIGH", dive_slate_id=None, calibration_dive
     )
 
 
-def _image(image_id: int, dive_id: int):
+def _image(image_id: int, dive_id: int, *, is_canonical: bool = True):
+    """Canonical by default — the normal case, and what the cohort selectors
+    now require.
+
+    `Image.is_canonical` defaults to False on the *model*, which made every
+    image seeded here a duplicate. That was invisible while nothing read the
+    flag; now that the selectors gate on it, the default has to reflect
+    reality. Pass `is_canonical=False` to model a duplicate frame — see
+    test_canonical_only_pipeline_work.py.
+    """
     from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
 
     return Image(
         id=image_id,
         path=f"/dev/null/img-{image_id}",
         taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"img-{image_id:032d}"[:32],
+        checksum=f"{image_id:032d}",
+        is_canonical=is_canonical,
         dive_id=dive_id,
     )
 

--- a/services/fishsense-api/tests/test_slate_prediction_endpoint.py
+++ b/services/fishsense-api/tests/test_slate_prediction_endpoint.py
@@ -48,7 +48,7 @@ def _image(image_id: int, dive_id: int):
         id=image_id,
         path=f"/dev/null/img-{image_id}",
         taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"img-{image_id:032d}"[:32],
+        checksum=f"{image_id:032d}",
         dive_id=dive_id,
     )
 

--- a/services/fishsense-api/tests/test_species_slate_reads_superseded.py
+++ b/services/fishsense-api/tests/test_species_slate_reads_superseded.py
@@ -48,7 +48,7 @@ def _image(image_id, dive_id=1):
         id=image_id,
         path=f"/dev/null/{image_id}",
         taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"img-{image_id:032d}"[:32],
+        checksum=f"{image_id:032d}",
         dive_id=dive_id,
     )
 


### PR DESCRIPTION
> **Stacked on #554** — the view migration chains after that PR's index migration, so basing on `main` would create two alembic heads. **Retarget this to `main` before merging #554**, otherwise GitHub auto-closes it when the base branch is deleted (learned on #547).

## The problem

Half of prod's image table is duplicate content — **131,430 rows over 65,981 distinct checksums** — and **207 of 479 dives are duplicates end to end**. `is_canonical` marks which copy is real (first row for a checksum wins, from `9e5bc64`).

Nothing in the pipeline read that flag. Before this, `is_canonical` appeared in **exactly one query in the entire codebase** (`get_canonical_dives`).

Duplicate dives are inert today only because they all happen to be `priority=LOW` and every cohort gates on HIGH. That's a property of the *data*, not of the *code*. Promote one and it starts consuming NAS bandwidth, preprocessing and labeler time on frames that already exist elsewhere.

## Why gating populate alone would have made it worse

The obvious fix — skip duplicates when creating LS tasks — is actively harmful on its own.

The preprocess cohorts are *"at least one image with no label row"*. If populate declined to make tasks for duplicates, those rows would never get labels, so **the dive would never drain**: re-staging its raw `.ORF`s from the NAS every hour and blocking every higher-id dive behind it. That's the prod dive 60 wedge verbatim.

So the cohorts are gated too, and the resolvers with them, per CLAUDE.md's rule that selector and resolver predicates stay in step.

## What changed

- **11 cohort selectors** in `dive_controller` require `Image.is_canonical`. For stages 13/14 it's a no-op — they key on labels a duplicate never has — but it makes the intent uniform.
- **8 resolver/staging activities** filter identically. This also covers on-demand backfill runs, which bypass the cohort entirely.
- **`dive_pipeline_status`** — all 18 image correlations now read `i.dive_id = d.id AND i.is_canonical`. Without this the view and selectors genuinely disagree: the dashboard would report a duplicate dive as perpetually incomplete while the worker correctly does nothing with it. The other three views are measurement-keyed and duplicates have no measurements, so they're untouched.
- **`cleanup_raw_bytes_for_dive_activity` is deliberately NOT filtered**, and says so. Cleanup should be broader than whatever produced the scratch. Harmless either way — scratch is checksum-keyed, so a duplicate shares its twin's object — but broader is the safe direction for a delete.

A source-level registry guard asserts every `Image.dive_id == Dive.id` correlation is paired with the filter, in the spirit of `controllers/__init__.py` and the view registry: a new selector that forgets reintroduces the wedge, and nothing at runtime would say so.

## Two latent bugs surfaced on the way

**Test fixtures were creating identical checksums.** `f"img-{id:032d}"[:32]` is 36 chars truncated to 32, so the distinguishing digits fell off the end:

```
11 -> 'img-0000000000000000000000000000'
21 -> 'img-0000000000000000000000000000'
```

Invisible while nothing enforced uniqueness. #554's partial index started rejecting them, which is how it surfaced. Fixed in 11 test files.

**`Image.is_canonical` defaults to `False` on the model**, so every image the shared helpers seeded was a duplicate. Harmless while nothing read the flag; wrong now. Helpers default to canonical and take `is_canonical=False` to model a duplicate.

## Prod impact

Migration `c3e8b1d47a52` drops and recreates the view. **No data is touched.** It's a pure predicate change: every dive with canonical images keeps identical flags, because the added conjunct is true for those rows. Only fully-duplicate dives change, and all 207 are LOW.

Verified the path prod will actually take — not just the fresh-DB one, which stamps head and never runs migrations. Rewound a scratch database to prod's current revision and ran the real startup sequence:

```
alembic_version present; running upgrade head
Running upgrade d7e21b95c3a0 -> a7f2c9e41b03, at most one canonical image per checksum
created uq_image_canonical_checksum
Running upgrade a7f2c9e41b03 -> c3e8b1d47a52, dive_pipeline_status counts only canonical images
```

Ending state: `alembic_version=c3e8b1d47a52`, index present, all four views intact, view definition contains `is_canonical`.

## Verification

Unit, every package:

```
fishsense-shared 69 · fishsense-api-sdk 128 · fishsense-api 346
api-workflow-worker 351 · backup-worker 45 · data-worker 144
fishsense-lite-web 76 + typecheck
```

Integration, against the real `compose.local.yml` stack:

```
fishsense-api 9 · api-workflow-worker 6 · data-worker 11
backup-worker 1 failed — environmental (pg_dump not installed locally; CI installs postgresql-client-17)
```

pylint 10.00 on every changed file. Single alembic head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)