### PR TITLE
fix: code-review sweep — dead SDK retry, racy model caches, cohort wedge, portal authz

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,62 @@ integration + parity, see the data-worker activity pattern section)
 is the gold standard; smaller modules don't need all four legs but do
 need a failing test before the implementation lands.
 
+**Never suppress `duplicate-code` / `R0801`.** The check is **enabled**
+workspace-wide — confirm with
+`uv run python -m pylint --list-msgs-enabled | grep duplicate-code`,
+which reports it under *Enabled*. Do not add
+`# pylint: disable=duplicate-code` (or its `R0801` alias) anywhere.
+
+It was blanket-disabled in the root `pyproject.toml` for years, which
+made the 14 inline pragmas scattered through the SDK/API label models
+and sync workflows no-ops — they suppressed nothing, while making it
+look like an otherwise-live check had been consciously waived at those
+spots. The global entry is gone, all 14 pragmas are deleted (removing
+them added zero findings, which is how we know they were dead weight),
+and the tuned knobs live in `[tool.pylint.similarities]`:
+`ignore-comments/docstrings/imports/signatures` so a hit means
+duplicated *logic*, and `min-similarity-lines = 12`, calibrated against
+the six package source roots rather than guessed. Re-measure before
+changing it; the command is in a comment above the setting.
+
+Two limits worth knowing:
+
+* `duplicate-code` only compares files within a single pylint
+  invocation, and `check.sh lint` (like CI) passes only the files
+  changed since `origin/main`. It therefore fires when both copies of a
+  clone move in the same PR — useful, but not a safety net. Clones
+  shorter than 12 lines after stripping boilerplate never fire at all.
+* It is genuinely noisy on tests, where fixture boilerplate is repeated
+  by design. The `src/`-only invocation above is the one to use when
+  sweeping for clones by hand.
+* **It is textual, so systematic renames are invisible to it.** The four
+  `put_*_label` handlers in `label_controller.py` were ~35 near-identical
+  lines each and scored zero, because `LaserLabel.image_id == image_id`
+  and `SpeciesLabel.image_id == image_id` are different strings. That is
+  the shape most duplication in this repo takes — one model or DTO swapped
+  throughout — so a green `duplicate-code` says nothing about it. Those
+  four now share `_resolve_label_natural_key`; the class is worth watching
+  for by hand.
+
+When duplication is flagged, extract the shared part (helper, base
+class, parameterized factory) or change the design. Where duplication
+is genuinely load-bearing — the per-image data-worker overlay
+activities are the standing example (distinct overlay shapes and DTOs,
+see "Data-worker activity pattern") — record *why* the shapes must stay
+separate in an ordinary comment, and put any lint exemption in the root
+`pyproject.toml` where it is reviewable in one place. Never inline.
+
+This is not a style rule. Copied files kept their source's comments:
+`preprocess_laser_images_parent_workflow` documented an
+`ALLOW_DUPLICATE_FAILED_ONLY` policy its own code contradicted and a
+populate child that had been decoupled, and the measurable-species
+predicate was spelled three times with its cross-references pointing at
+`dive_controller._measurable_species_conditions`, a symbol that had
+moved to `dive_cohort_controller`. Unpoliced copy-paste is how those
+landed; the clones behind them are now collapsed into
+`workflows/_dispatch.py`, `activities/cohort_selection.py`,
+`fishsense_shared.object_store` and `fishsense_shared.taxonomy`.
+
 ## Service map
 
 | Service | Purpose | Task queue |
@@ -67,11 +123,19 @@ DB (negligible). To add or remove, override
 
 Create and populate are split into separate workflows per stage. LS
 projects are now **per-dive**: each dive gets its own LS project
-titled `"{dive.name} - <Stage> Labeling"` (e.g. `"2024-08-21 reef
-dive 3 - HeadTail Labeling"`), with `f"Dive {dive_id}"` as a
-fallback when `Dive.name` is NULL. Per-dive scoping lets labelers
-track per-dive progress and keeps each project's task list focused
-on one cohort.
+titled `"{dive.name} #{dive_id} - <Stage> Labeling"` (e.g.
+`"2024-08-21 reef dive 3 #412 - HeadTail Labeling"`), falling back to
+`"#{dive_id} - <Stage> Labeling"` when `Dive.name` is NULL. Per-dive
+scoping lets labelers track per-dive progress and keeps each project's
+task list focused on one cohort.
+
+The `#{dive_id}` is **always** present and is not decoration: dive
+names are not unique in prod (mislabelled captures, duplicate-named
+dives, same-site/same-camera repeats), and the create activity finds
+its project by title — so keying on the name alone silently merged two
+dives into one LS project. `dive.name` is what gets truncated to fit
+LS's 50-char cap, never the id tail. See
+`populate_utils.build_per_dive_title`.
 
 * **`Create<Stage>LabelStudioProjectWorkflow(dive_id)`** — calls
   `create_<stage>_label_studio_project_activity(dive_id)` which
@@ -146,6 +210,25 @@ manually drop the existing LABEL_STUDIO clusters first.
 The api-worker is the brains; the data-worker is the executor. Stages
 that need both SDK-side decision-making *and* CPU-heavy per-image
 work split into two workflows:
+
+The six dispatch parents (preprocess laser / species / headtail / slate,
+predict laser / slate) share their steps via
+[workflows/_dispatch.py](services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/_dispatch.py)
+— `select_dive`, `resolve_inputs`, `wake_data_worker`, `stage_raw`,
+`stage_slate_pdf`, `dispatch_child`, `run_sdk_activity`, `cleanup_raw`,
+`dispatch_populate`. They were copy-pasted from each other until
+2026-08-11 and had drifted badly: the laser parent's docstring described
+an `ALLOW_DUPLICATE_FAILED_ONLY` policy its code hadn't used in months,
+its inline comment referenced a populate child that had been decoupled,
+and its `except` branch logged an archive step that no longer existed.
+
+**The helpers emit the same Temporal commands, in the same order, that
+the inlined code did** — a workflow's command sequence is its replay
+contract, so runs in flight at deploy still replay. Per-stage timeouts
+are therefore parameters, not constants, and keep their existing values
+even where they look arbitrary (slate-PDF staging is 5 min in the
+preprocess parent, 15 min in the predict parent). If you unify those,
+do it as a deliberate, separate change and drain the queue first.
 
 * **Parent** on api-worker (`fishsense_api_queue`). Hourly schedule.
   Activity calls per dive, bracketing the data-worker child plus the
@@ -330,6 +413,50 @@ species sync activity's laser-keypoint/slate-upside-down extraction
 paths are stripped accordingly. New labels write only the still-
 present columns; historical species rows keep whatever they had.
 
+## `content_of_image` taxonomy vocabulary
+
+`SpeciesLabel.content_of_image` is a ", "-joined Label Studio taxonomy
+path, and four things read it: `measure_fish_activity` (Python,
+data-worker), the stage-14 cohort selector (SQLAlchemy, api), the
+`dive_pipeline_status` view (raw SQL, api), and the stage-9 slate
+cohort. The markers and parsers live **once**, in
+[fishsense_shared.taxonomy](libs/fishsense-shared/src/fishsense_shared/taxonomy.py):
+
+| Branch | Meaning |
+|---|---|
+| `"Fish, Hogfish (Lachnolaimus maximus)"` | real fish — `Common (Scientific)` leaf |
+| `"Fish Model, Weasly Fish"` | rigid model, name-keyed |
+| `"Calibration Targets, Ruler"` | the ruler, name-keyed |
+| `"Slate, Laser on slate"` | stage-9 slate frame (not measurable) |
+
+`taxonomy.is_measurable` is the **definition of record**: measurable
+means `measure_fish_activity` will actually bind a Measurement. The
+`LIKE` predicates in the view and the cohort selector are
+approximations of it — the view has to run on Postgres in prod and
+SQLite under test, which rules out the string functions an exact port
+would need. Both are built from
+`taxonomy.measurable_species_sql` / `rigid_target_sql`, and
+`test_dive_pipeline_status_view.py` runs the real SQL and the Python
+over the shared `taxonomy.MEASURABILITY_CORPUS` and asserts they select
+the same rows.
+
+That parity test is not ceremony. Before it existed the three copies
+were kept in step by comments, and the comments had drifted into
+claiming fish models and the ruler were *unmeasurable* — six lines
+above code matching both. It also immediately found a live bug:
+`LIKE 'Fish Model,%'` matched the **empty leaf** `"Fish Model,"` (a
+labeler picking the parent node and no model), which
+`parse_model_name` rejects. Cohort says measurable, activity says skip
+→ no Measurement is ever written → the dive is re-selected every hour
+forever. Fixed by the `AND TRIM(...) <> 'Fish Model,'` guard in
+`rigid_target_sql` (migration `a2f7c31d9e64`).
+
+**When adding a taxonomy branch**: add the literal + any parser to
+`fishsense_shared.taxonomy`, add a row to `MEASURABILITY_CORPUS`, and
+let the parity test tell you whether the SQL approximation still
+holds. Do not spell a marker inline in a controller, a view, or an
+activity.
+
 ## `dive_pipeline_status` view
 
 Postgres view that exposes a wide row per dive with one boolean
@@ -512,8 +639,15 @@ is messier than four small, self-contained activities.
 
 One bucket (`object_store.bucket`), content-type prefixes — the
 cross-worker key contract (the analog of the old file-exchange URL
-contract). Defined by the key helpers in each worker's
-`object_store.py`:
+contract). Defined **once**, by the key helpers in
+[fishsense_shared.object_store](libs/fishsense-shared/src/fishsense_shared/object_store.py)
+— it lives beside `preprocess_contracts.py` for the same reason those
+DTOs do: it is an agreement *between* the two workers, so neither owns
+it. Each worker's own `object_store.py` is now just its permitted method
+subset (`BaseObjectStoreClient` subclass) — the api-worker stages and
+deletes scratch, the data-worker reads scratch and writes JPEGs. That
+asymmetry is a real safety boundary, which is why the base class holds
+the primitives and the subclasses hold the vocabulary:
 
 ```
 raw/{checksum}.ORF            # api-worker stages (PUT), data-worker reads (GET); scratch
@@ -523,11 +657,24 @@ slate_pdf/{slate_id}.pdf      # api-worker stages (PUT), data-worker reads (GET)
 
 `{jpeg_prefix}` ∈ {`preprocess_jpeg`, `preprocess_groups_jpeg`,
 `preprocess_headtail_jpeg`, `preprocess_slate_images_jpeg`}. Adding a
-new convention is an `object_store.py` change only.
+new convention is a `fishsense_shared/object_store.py` change only.
+
+The two copies were merged 2026-08-11 after `duplicate-code` was
+re-enabled and flagged ~92 duplicated lines. They had already drifted:
+only the data-worker's `_get` closed the botocore `StreamingBody`, so
+the api-worker leaked a pooled HTTP connection on every
+`download_slate_pdf`. The shared `_get` closes it, and
+`libs/fishsense-shared/tests/test_object_store.py` pins that so one side
+can't regress alone. The api-worker's `processed_jpeg_key` and the
+data-worker's `jpeg_key` — same body, different name — are now the one
+`jpeg_key`.
 
 **Auth + addressing.** Garage uses S3 access keys (work from any IP)
 and **path-style** addressing (no virtual-host bucket DNS) — both set
-in `object_store.build_s3_client`. The api-worker key needs
+in `fishsense_shared.object_store.build_s3_client`, and the
+settings→client mapping in `open_client` (each worker keeps a thin
+`open_object_store_client()` so the `config` import stays function-local
+— see the Dynaconf eager-validation gotcha). The api-worker key needs
 rw+delete on `raw/`+`slate_pdf/` and write on the JPEG prefixes; the
 data-worker key needs read on scratch + write on JPEGs; Label Studio
 gets a read-only key (optional `object_store.presign_*`) to presign
@@ -589,7 +736,10 @@ image instead calls `run_alembic_upgrade` programmatically — see
 [libs/fishsense-api-sdk/pyproject.toml](libs/fishsense-api-sdk/pyproject.toml)
 sets `asyncio_mode = "auto"` — async tests do **not** need the
 `@pytest.mark.asyncio` decorator. All clients inherit `ClientBase`
-(httpx + retry on `HTTPStatusError`) and **must be used inside
+(httpx + a real async retry: GET/PUT/DELETE replay 5xx and transport
+errors 3× with backoff; POST replays only `ConnectError`, because
+`post_species`/`post_fish`/`post_cluster` create rows and a 5xx can come
+from a server that already committed) and **must be used inside
 `async with`** — instantiating a raw client and calling a method
 outside the context manager raises `RuntimeError`.
 
@@ -1038,6 +1188,28 @@ After the first successful release-please run cuts a release PR + tag,
 this becomes self-maintaining (release-please uses its own tags as the
 walk floor) and bootstrap-sha can stay pinned forever or be removed.
 
+## Dormant: the slate detector (stage "predict slate")
+
+Model-assisted dive-slate labeling shipped 2026-08-02 and was **shut
+down 2026-08-03**. The ECC >= 0.80 acceptance gate doesn't transfer out
+of distribution — pool dives produced high-ECC (0.93-0.97) *false* fits
+that passed it (prod dives 65/71/77/80/83, all pool) — and the team
+declined an active-learning loop.
+
+`predict-slate-images-workflow-schedule` is now **actively deleted** at
+api-worker startup (`worker._RETIRED_SCHEDULE_IDS` -> `retire_schedule`),
+and the 130 seeded LS predictions were removed.
+
+The code is still registered on both workers so a future evaluation can
+start it by hand: `PredictSlateImagesParentWorkflow`,
+`BackfillSlatePredictionsWorkflow`, `predict_slate_image`,
+`resolve_slate_predict_inputs_activity`,
+`persist_slate_predictions_activity`,
+`backfill_slate_predictions_activity`. Every one of those modules now
+carries a `RETIRED 2026-08-03` banner in its docstring — dormant, not
+dead, and not part of the live pipeline. If you are tracing why a slate
+frame has no prediction, this is why; nothing is broken.
+
 ## Operational ground truth (read before touching prod)
 
 ### No staging / test environment
@@ -1193,7 +1365,7 @@ runs.
 Eight workflows: Create + Populate × {Laser, Species, HeadTail,
 DiveSlate}. Populate self-bootstraps: it calls the matching Create
 activity inside the workflow body to materialize the per-dive
-project (titled `"{dive.name} - <Stage> Labeling"`), then runs the
+project (titled `"{dive.name} #{dive_id} - <Stage> Labeling"`), then runs the
 populate activity against that one project. The four
 `<STAGE>_LABELING_CONFIG_XML` constants are real pasted-from-prod
 XML (species XML refreshed 2026-05-05 — laser keypoints removed,

--- a/apps/fishsense-lite-web/app/portal/actions.test.ts
+++ b/apps/fishsense-lite-web/app/portal/actions.test.ts
@@ -18,9 +18,17 @@ import {
   setCalibrationSourceAction,
 } from "./actions";
 
-const SIGNED_IN = { user: { name: "Alice", email: "a@e.com" } };
+const ALLOWED_GROUP = "fishsense-portal-admin";
+const SIGNED_IN = {
+  user: { name: "Alice", email: "a@e.com", groups: [ALLOWED_GROUP] },
+};
+/** Signed in, but in no group the portal permits. */
+const SIGNED_IN_UNAUTHORIZED = {
+  user: { name: "Mallory", email: "m@e.com", groups: ["some-other-team"] },
+};
 
 beforeEach(() => {
+  process.env.PORTAL_ALLOWED_GROUPS = ALLOWED_GROUP;
   auth.mockResolvedValue(SIGNED_IN);
   setCalibrationSource.mockResolvedValue(undefined);
   clearCalibrationSource.mockResolvedValue(undefined);
@@ -34,10 +42,47 @@ afterEach(() => {
 //
 // Server actions are ordinary public HTTP endpoints. `/portal/page.tsx`
 // redirecting signed-out users does NOT protect them — anyone can POST an
-// action directly. If `requireSession` regressed, these would become
-// unauthenticated writes to fishsense-api and nothing would fail loudly.
+// action directly. If `requireAuthorized` regressed, these would become
+// unauthenticated (or merely realm-authenticated) writes to fishsense-api,
+// and nothing would fail loudly.
+//
+// Authentication alone is not enough: the Authentik realm is the whole SSO
+// population, so a signed-in stranger must still be refused.
 
 describe("auth gate", () => {
+  it("refuses to set a calibration source for a signed-in user in no allowed group", async () => {
+    auth.mockResolvedValue(SIGNED_IN_UNAUTHORIZED);
+
+    const result = await setCalibrationSourceAction(9, 5);
+
+    expect(result).toEqual({ ok: false, error: "Not authorized" });
+    expect(setCalibrationSource).not.toHaveBeenCalled();
+  });
+
+  it("refuses to clear a calibration source for a signed-in user in no allowed group", async () => {
+    auth.mockResolvedValue(SIGNED_IN_UNAUTHORIZED);
+
+    const result = await clearCalibrationSourceAction(9);
+
+    expect(result).toEqual({ ok: false, error: "Not authorized" });
+    expect(clearCalibrationSource).not.toHaveBeenCalled();
+  });
+
+  it("refuses every write when PORTAL_ALLOWED_GROUPS is unset (fails closed)", async () => {
+    delete process.env.PORTAL_ALLOWED_GROUPS;
+
+    expect(await setCalibrationSourceAction(9, 5)).toEqual({
+      ok: false,
+      error: "Not authorized",
+    });
+    expect(await clearCalibrationSourceAction(9)).toEqual({
+      ok: false,
+      error: "Not authorized",
+    });
+    expect(setCalibrationSource).not.toHaveBeenCalled();
+    expect(clearCalibrationSource).not.toHaveBeenCalled();
+  });
+
   it("refuses to set a calibration source when there is no session", async () => {
     auth.mockResolvedValue(null);
 

--- a/apps/fishsense-lite-web/app/portal/actions.ts
+++ b/apps/fishsense-lite-web/app/portal/actions.ts
@@ -2,16 +2,24 @@
 
 import { revalidatePath } from "next/cache";
 import { auth } from "@/auth";
+import { isPortalAuthorized } from "@/lib/authz";
 import { clearCalibrationSource, setCalibrationSource } from "@/lib/dives";
 
 export type ActionResult = { ok: true } | { ok: false; error: string };
 
-/** Server actions are public endpoints — re-check the session on every call
- * rather than trusting that the client only renders for signed-in users. */
-async function requireSession(): Promise<void> {
+/** Server actions are public endpoints — re-check on every call rather than
+ * trusting that the client only renders them for permitted users.
+ *
+ * Checks authorization, not just authentication. The page-level guard is a
+ * rendering decision; this is the one that actually protects the write, since
+ * a server action can be invoked directly by anyone who can reach the app. */
+async function requireAuthorized(): Promise<void> {
   const session = await auth();
   if (!session?.user) {
     throw new Error("Not authenticated");
+  }
+  if (!isPortalAuthorized(session)) {
+    throw new Error("Not authorized");
   }
 }
 
@@ -20,7 +28,7 @@ export async function setCalibrationSourceAction(
   sourceId: number,
 ): Promise<ActionResult> {
   try {
-    await requireSession();
+    await requireAuthorized();
     if (diveId === sourceId) {
       return { ok: false, error: "A dive cannot be its own calibration source" };
     }
@@ -36,7 +44,7 @@ export async function clearCalibrationSourceAction(
   diveId: number,
 ): Promise<ActionResult> {
   try {
-    await requireSession();
+    await requireAuthorized();
     await clearCalibrationSource(diveId);
     revalidatePath("/portal");
     return { ok: true };

--- a/apps/fishsense-lite-web/app/portal/page.tsx
+++ b/apps/fishsense-lite-web/app/portal/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { auth, signOut } from "@/auth";
+import { isPortalAuthorized, portalAllowedGroups } from "@/lib/authz";
 import { getDives } from "@/lib/dives";
 import { CalibrationLinks } from "./calibration-links";
 
@@ -11,6 +12,40 @@ export default async function PortalPage() {
     redirect(`/api/auth/signin?callbackUrl=${encodeURIComponent("/portal")}`);
   }
   const user = session.user;
+
+  // Authenticated is not authorized: signing in only proves an account in
+  // the Authentik realm. Render a dead end rather than redirecting to
+  // sign-in, which would loop forever for a user who is already signed in
+  // and simply lacks the group.
+  if (!isPortalAuthorized(session)) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-12">
+        <h1 className="text-2xl font-semibold tracking-tight">Portal</h1>
+        <p className="mt-4 text-sm text-slate-600 dark:text-slate-400">
+          Signed in as {user?.email ?? "unknown"}, but this account is not in a
+          group permitted to use the portal.
+        </p>
+        <p className="mt-2 text-sm text-slate-500">
+          {portalAllowedGroups().length === 0
+            ? "No portal groups are configured (PORTAL_ALLOWED_GROUPS is unset), so access is denied for everyone. An operator needs to set it."
+            : `Ask an operator to add you to one of: ${portalAllowedGroups().join(", ")}.`}
+        </p>
+        <form
+          action={async () => {
+            "use server";
+            await signOut({ redirectTo: "/" });
+          }}
+        >
+          <button
+            type="submit"
+            className="mt-6 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium shadow-sm transition hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800"
+          >
+            Sign out
+          </button>
+        </form>
+      </main>
+    );
+  }
 
   let dives: Awaited<ReturnType<typeof getDives>> = [];
   let divesError: string | null = null;

--- a/apps/fishsense-lite-web/app/portal/page.tsx
+++ b/apps/fishsense-lite-web/app/portal/page.tsx
@@ -28,19 +28,19 @@ export default async function PortalPage() {
         <p className="mt-2 text-sm text-slate-500">
           {portalAllowedGroups().length === 0
             ? "No portal groups are configured (PORTAL_ALLOWED_GROUPS is unset), so access is denied for everyone. An operator needs to set it."
-            : `Ask an operator to add you to one of: ${portalAllowedGroups().join(", ")}.`}
+            : `If you were recently added to ${portalAllowedGroups().join(", ")}, sign out and back in — group membership is read from your sign-in token, so a session started before the change still carries the old, empty list. Otherwise, ask an operator to add you.`}
         </p>
         <form
           action={async () => {
             "use server";
-            await signOut({ redirectTo: "/" });
+            await signOut({ redirectTo: "/portal" });
           }}
         >
           <button
             type="submit"
             className="mt-6 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium shadow-sm transition hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800"
           >
-            Sign out
+            Sign out and retry
           </button>
         </form>
       </main>

--- a/apps/fishsense-lite-web/auth.ts
+++ b/apps/fishsense-lite-web/auth.ts
@@ -9,16 +9,22 @@ import { env } from "@/lib/env";
 export const { auth, handlers, signIn, signOut } = NextAuth(() => ({
   secret: env.authSecret,
   trustHost: true,
-  // Temporary diagnostic — surfaces internal NextAuth events
-  // (cookie decode failures, OAuth callback flow, jwt encode/decode)
-  // to stdout. Remove once the /portal session-null issue is resolved.
-  debug: true,
   session: { strategy: "jwt" },
   providers: [
     Authentik({
       clientId: env.authAuthentikId,
       clientSecret: env.authAuthentikSecret,
       issuer: env.authAuthentikIssuer,
+      // `groups` must be requested explicitly — the provider's default scope
+      // is `openid profile email`, so without this the userinfo response
+      // carries no groups, `session.user.groups` is always `[]`, and the
+      // portal's authorization check would deny everyone. This is why the
+      // portal used to render "no groups" for every signed-in user.
+      //
+      // Requires a matching scope + property mapping on the FishSense OIDC
+      // application in Authentik, exactly as the Superset app needs (see
+      // `superset_config.py`'s `'scope': 'openid email profile groups'`).
+      authorization: { params: { scope: "openid email profile groups" } },
     }),
   ],
   callbacks: {

--- a/apps/fishsense-lite-web/lib/api-auth.ts
+++ b/apps/fishsense-lite-web/lib/api-auth.ts
@@ -1,0 +1,15 @@
+import { env } from "./env";
+
+/** `Authorization` header for fishsense-api's HTTP Basic auth.
+ *
+ * SSR reaches the API on the interior docker network (`http://fishsense-api:8000`),
+ * bypassing the traefik forwardAuth gate — see the FISHSENSE_API_URL comment in
+ * `deploy/incus/compose.yml`. Built per call rather than cached at module load
+ * so `env`'s per-request lazy read still applies.
+ */
+export function fishsenseApiAuthHeader(): string {
+  const token = Buffer.from(
+    `${env.fishsenseApiUsername}:${env.fishsenseApiPassword}`,
+  ).toString("base64");
+  return `Basic ${token}`;
+}

--- a/apps/fishsense-lite-web/lib/auth-callbacks.ts
+++ b/apps/fishsense-lite-web/lib/auth-callbacks.ts
@@ -18,23 +18,6 @@ export async function jwtCallback({
   profile,
   user,
 }: JwtCallbackArgs): Promise<JWT> {
-  // Temporary diagnostic for the empty /portal user-info problem.
-  // Logs every invocation (initial sign-in *and* subsequent SSR
-  // calls) so we can see whether the callback runs at all, and what
-  // shape the token / profile is in. Remove once /portal is reliably
-  // populating session.user.
-  console.log("[auth] jwtCallback", {
-    hasAccount: !!account,
-    accountProvider: account?.provider,
-    accountType: account?.type,
-    profileKeys: profile ? Object.keys(profile) : null,
-    profile,
-    user,
-    tokenSub: token.sub,
-    tokenName: token.name,
-    tokenEmail: token.email,
-    tokenGroupsCount: Array.isArray(token.groups) ? token.groups.length : null,
-  });
   if (account) {
     if (typeof account.access_token === "string") {
       token.accessToken = account.access_token;
@@ -56,14 +39,6 @@ interface SessionCallbackArgs {
 }
 
 export async function sessionCallback({ session, token }: SessionCallbackArgs): Promise<Session> {
-  // Temporary diagnostic — see jwtCallback comment above.
-  console.log("[auth] sessionCallback", {
-    tokenSub: token.sub,
-    tokenName: token.name,
-    tokenEmail: token.email,
-    tokenGroupsCount: Array.isArray(token.groups) ? token.groups.length : null,
-    hasAccessToken: typeof token.accessToken === "string",
-  });
   if (typeof token.accessToken === "string") {
     session.accessToken = token.accessToken;
   }

--- a/apps/fishsense-lite-web/lib/authz.test.ts
+++ b/apps/fishsense-lite-web/lib/authz.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { Session } from "next-auth";
+import { isPortalAuthorized, portalAllowedGroups } from "./authz";
+
+const ORIGINAL = process.env.PORTAL_ALLOWED_GROUPS;
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.PORTAL_ALLOWED_GROUPS;
+  else process.env.PORTAL_ALLOWED_GROUPS = ORIGINAL;
+});
+
+function session(groups: string[] | undefined): Session {
+  return { user: { groups }, expires: "" } as unknown as Session;
+}
+
+describe("portalAllowedGroups", () => {
+  it("parses a comma-separated list", () => {
+    process.env.PORTAL_ALLOWED_GROUPS = "fishsense-portal-admin,fishsense-portal-editor";
+    expect(portalAllowedGroups()).toEqual([
+      "fishsense-portal-admin",
+      "fishsense-portal-editor",
+    ]);
+  });
+
+  it("trims whitespace and drops empty entries", () => {
+    process.env.PORTAL_ALLOWED_GROUPS = " a , ,b, ";
+    expect(portalAllowedGroups()).toEqual(["a", "b"]);
+  });
+
+  it("is empty when unset", () => {
+    delete process.env.PORTAL_ALLOWED_GROUPS;
+    expect(portalAllowedGroups()).toEqual([]);
+  });
+});
+
+describe("isPortalAuthorized", () => {
+  it("denies when PORTAL_ALLOWED_GROUPS is unset", () => {
+    // Fail CLOSED. An authorization check that defaults to open is not an
+    // authorization check — and the portal writes `calibration_dive_id`,
+    // which changes measured fish lengths. Matches Superset's posture: a
+    // user in none of the mapped groups gets no access.
+    delete process.env.PORTAL_ALLOWED_GROUPS;
+    expect(isPortalAuthorized(session(["fishsense-portal-admin"]))).toBe(false);
+  });
+
+  it("denies when the allowlist is present but empty", () => {
+    process.env.PORTAL_ALLOWED_GROUPS = "   ";
+    expect(isPortalAuthorized(session(["fishsense-portal-admin"]))).toBe(false);
+  });
+
+  it("allows a user in an allowed group", () => {
+    process.env.PORTAL_ALLOWED_GROUPS = "fishsense-portal-admin";
+    expect(isPortalAuthorized(session(["other", "fishsense-portal-admin"]))).toBe(true);
+  });
+
+  it("denies an authenticated user in no allowed group", () => {
+    // The whole point: authentication is realm-wide, so every Authentik
+    // account could reach the portal before this existed.
+    process.env.PORTAL_ALLOWED_GROUPS = "fishsense-portal-admin";
+    expect(isPortalAuthorized(session(["some-other-team"]))).toBe(false);
+  });
+
+  it("denies when the token carried no groups at all", () => {
+    // The `groups` OIDC scope has to be requested AND mapped on the
+    // Authentik application. If either is missing every session arrives with
+    // no groups, and denying is the correct response.
+    process.env.PORTAL_ALLOWED_GROUPS = "fishsense-portal-admin";
+    expect(isPortalAuthorized(session(undefined))).toBe(false);
+    expect(isPortalAuthorized(session([]))).toBe(false);
+  });
+
+  it("denies when there is no session or no user", () => {
+    process.env.PORTAL_ALLOWED_GROUPS = "fishsense-portal-admin";
+    expect(isPortalAuthorized(null)).toBe(false);
+    expect(isPortalAuthorized({ expires: "" } as unknown as Session)).toBe(false);
+  });
+
+  it("matches group names exactly", () => {
+    // Authentik group names are case-sensitive; a loose match would let
+    // "Fishsense-Portal-Admin" through and make the allowlist advisory.
+    process.env.PORTAL_ALLOWED_GROUPS = "fishsense-portal-admin";
+    expect(isPortalAuthorized(session(["Fishsense-Portal-Admin"]))).toBe(false);
+    expect(isPortalAuthorized(session(["fishsense-portal-admin-extra"]))).toBe(false);
+  });
+});

--- a/apps/fishsense-lite-web/lib/authz.ts
+++ b/apps/fishsense-lite-web/lib/authz.ts
@@ -1,0 +1,45 @@
+import type { Session } from "next-auth";
+
+/**
+ * Authorization for `/portal`.
+ *
+ * Signing in proves only that someone holds an account in the Authentik
+ * realm — which is the whole university SSO population, not the FishSense
+ * team. Before this existed the portal checked authentication and nothing
+ * else, so any realm account could rewrite `calibration_dive_id` on any dive.
+ * That is a live pipeline input: a dive measured off a borrowed calibration
+ * runs -8..+2% error against ~1% for its own, so the link changes reported
+ * fish lengths.
+ *
+ * `session.user.groups` was already plumbed profile -> JWT -> session, and was
+ * only ever rendered as text. This is the missing consumer.
+ */
+
+/** Groups permitted to use the portal, from `PORTAL_ALLOWED_GROUPS`. */
+export function portalAllowedGroups(): string[] {
+  return (process.env.PORTAL_ALLOWED_GROUPS ?? "")
+    .split(",")
+    .map((group) => group.trim())
+    .filter(Boolean);
+}
+
+/**
+ * True iff `session` belongs to a signed-in user in an allowed group.
+ *
+ * **Fails closed.** An unset or empty `PORTAL_ALLOWED_GROUPS` denies
+ * everyone rather than admitting everyone: a check that defaults to open is
+ * not a check, and a misconfigured deploy should lock the portal, not
+ * silently reopen the hole. This mirrors the Superset posture already running
+ * in this deployment — a user in none of the mapped groups gets Public, i.e.
+ * no access (`superset_config.AUTH_ROLES_MAPPING`).
+ *
+ * Group names are matched exactly. Authentik's are case-sensitive, and a
+ * loose match would make the allowlist advisory.
+ */
+export function isPortalAuthorized(session: Session | null): boolean {
+  if (!session?.user) return false;
+  const allowed = portalAllowedGroups();
+  if (allowed.length === 0) return false;
+  const groups = session.user.groups ?? [];
+  return groups.some((group) => allowed.includes(group));
+}

--- a/apps/fishsense-lite-web/lib/dives.ts
+++ b/apps/fishsense-lite-web/lib/dives.ts
@@ -1,3 +1,4 @@
+import { fishsenseApiAuthHeader } from "./api-auth";
 import { env } from "./env";
 
 /** The dive fields the portal needs. The API returns more (path, camera_id,
@@ -10,13 +11,6 @@ export type Dive = {
   dive_slate_id: number | null;
   calibration_dive_id: number | null;
 };
-
-function basicAuthHeader(): string {
-  const token = Buffer.from(
-    `${env.fishsenseApiUsername}:${env.fishsenseApiPassword}`,
-  ).toString("base64");
-  return `Basic ${token}`;
-}
 
 /** Validate a dive id before it goes into a request URL.
  *
@@ -38,7 +32,7 @@ function safeId(value: number, label: string): number {
 export async function getDives(revalidate = 0): Promise<Dive[]> {
   const url = `${env.fishsenseApiUrl}/api/v1/dives/`;
   const response = await fetch(url, {
-    headers: { Authorization: basicAuthHeader() },
+    headers: { Authorization: fishsenseApiAuthHeader() },
     next: { revalidate },
   });
 
@@ -64,7 +58,7 @@ export async function setCalibrationSource(
   const url = `${env.fishsenseApiUrl}/api/v1/dives/${safeId(diveId, "diveId")}/calibration-source/${safeId(sourceId, "sourceId")}`;
   const response = await fetch(url, {
     method: "PUT",
-    headers: { Authorization: basicAuthHeader() },
+    headers: { Authorization: fishsenseApiAuthHeader() },
     cache: "no-store",
   });
 
@@ -85,7 +79,7 @@ export async function clearCalibrationSource(diveId: number): Promise<void> {
   const url = `${env.fishsenseApiUrl}/api/v1/dives/${safeId(diveId, "diveId")}/calibration-source/`;
   const response = await fetch(url, {
     method: "DELETE",
-    headers: { Authorization: basicAuthHeader() },
+    headers: { Authorization: fishsenseApiAuthHeader() },
     cache: "no-store",
   });
 

--- a/apps/fishsense-lite-web/lib/fishsense-api.ts
+++ b/apps/fishsense-lite-web/lib/fishsense-api.ts
@@ -1,23 +1,15 @@
+import { fishsenseApiAuthHeader } from "./api-auth";
 import { env } from "./env";
 
 type LabelKind = "laser" | "species" | "headtail" | "dive-slate";
 
-const KIND_TO_PATH: Record<LabelKind, string> = {
-  laser: "laser",
-  species: "species",
-  headtail: "headtail",
-  "dive-slate": "dive-slate",
-};
-
 async function getProjectIds(kind: LabelKind, revalidate: number): Promise<number[]> {
-  const path = KIND_TO_PATH[kind];
-  const url = `${env.fishsenseApiUrl}/api/v1/labels/${path}/label-studio-project-ids?incomplete=true`;
-  const auth = Buffer.from(
-    `${env.fishsenseApiUsername}:${env.fishsenseApiPassword}`,
-  ).toString("base64");
+  // `LabelKind` values are the URL segments verbatim — there was a
+  // `KIND_TO_PATH` map here that mapped each key to itself.
+  const url = `${env.fishsenseApiUrl}/api/v1/labels/${kind}/label-studio-project-ids?incomplete=true`;
 
   const response = await fetch(url, {
-    headers: { Authorization: `Basic ${auth}` },
+    headers: { Authorization: fishsenseApiAuthHeader() },
     next: { revalidate },
   });
 

--- a/deploy/incus/compose.yml
+++ b/deploy/incus/compose.yml
@@ -84,6 +84,23 @@ services:
       # flag must never reach main ahead of the image that supports it.
       LABEL_STUDIO_ENABLED: "true"
       AUTH_URL: https://fishsense.e4e.ucsd.edu
+      # Authorization for /portal. Signing in only proves an account in the
+      # Authentik realm; the portal writes `calibration_dive_id`, which changes
+      # measured fish lengths, so it is gated on group membership as well.
+      #
+      # Comma-separated Authentik group names. `lib/authz.ts` FAILS CLOSED —
+      # unset or empty denies everyone, matching Superset's posture (a user in
+      # none of the mapped groups gets Public / no access).
+      #
+      # OPERATOR PREREQUISITES, both required before this can admit anyone:
+      #   1. The group below must exist in Authentik and hold the FishSense
+      #      team. Naming follows `fishsense-superset-{admin,editor,viewer}`.
+      #   2. The FishSense OIDC application needs the `groups` scope + property
+      #      mapping, same as the analytics app. Without it every session
+      #      arrives with no groups and the portal denies everyone.
+      # Until both are done the portal shows a "not in a permitted group"
+      # page rather than silently allowing the whole realm.
+      PORTAL_ALLOWED_GROUPS: fishsense-portal-admin
     env_file:
       - /run/tenant/secrets/app.env
     expose: ["3000"]

--- a/libs/fishsense-api-sdk/pyproject.toml
+++ b/libs/fishsense-api-sdk/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "httpx>=0.28.1",
     "numpy>=2",
     "pydantic>=2.12.2",
-    "retry>=0.9.2",
 ]
 
 [dependency-groups]

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/client_base.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/clients/client_base.py
@@ -6,12 +6,53 @@ from abc import ABC
 from logging import Logger, getLogger
 
 import httpx
-from retry import retry
+
+# Retry tuning. Module-level so tests can zero the delay without sleeping.
+_MAX_ATTEMPTS = 3
+_INITIAL_DELAY_S = 2.0
+_BACKOFF = 2.0
+
+# Server-side failures worth replaying. 5xx only — a 4xx is an answer, and
+# retrying it just adds latency before the same result.
+_RETRYABLE_STATUS = frozenset({500, 502, 503, 504})
+
+# Transport failures worth replaying for an idempotent request: the response
+# never arrived, so the outcome is unknown but replaying is harmless.
+_RETRYABLE_TRANSPORT = (httpx.TransportError,)
+
+# For a non-idempotent request only a `ConnectError` is safe: it proves the
+# connection was never established, so the server cannot have applied the
+# write. A `ReadTimeout` proves nothing — the request may well have been
+# committed before the response was lost.
+_RETRYABLE_TRANSPORT_UNSAFE_METHOD = (httpx.ConnectError,)
 
 
 class ClientBase(ABC):
     # pylint: disable=too-few-public-methods,too-many-instance-attributes
-    """Base client for interacting with the Fishsense API."""
+    """Base client for interacting with the Fishsense API.
+
+    **Retries.** `_get` / `_put` / `_delete` replay transient failures — 5xx
+    responses and transport errors — up to `_MAX_ATTEMPTS` with exponential
+    backoff. `_post` does not: `post_species` / `post_fish` / `post_cluster`
+    create rows, and a 5xx can be returned by a server that already committed,
+    so a blind replay would duplicate the write. POST retries only on
+    `ConnectError`, where nothing can have reached the server.
+
+    Exhausting retries on a status returns the failing response rather than
+    raising — callers inspect `status_code` themselves (`dive_client.get`
+    treats 404 as "no such dive") and call `raise_for_status()` when they want
+    the exception. A transport error that never yields a response is re-raised.
+
+    This replaces four `@retry(exceptions=httpx.HTTPStatusError, tries=3)`
+    decorators that never fired. `retry` is synchronous, so wrapping an
+    `async def` returned the coroutine before it could raise — measured at one
+    attempt, not three — and `HTTPStatusError` is raised only by
+    `raise_for_status()`, which lives in the subclasses, never in the
+    decorated methods. The dead decorators mattered because
+    `_retry_policies.SDK_FAIL_FAST_RETRY_POLICY` marks `HTTPStatusError`
+    non-retryable on the strength of them, so a single transient 5xx failed a
+    whole activity with no retry at any layer.
+    """
 
     @property
     def __client(self) -> httpx.AsyncClient:
@@ -66,6 +107,80 @@ class ClientBase(ABC):
             transport=self.transport,
         )
 
+    def __headers(self) -> dict:
+        if self.__token is None:
+            return {}
+        return {"Authorization": f"Basic {self.__token.decode('utf-8')}"}
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        json: dict | None = None,
+        idempotent: bool,
+    ) -> httpx.Response:
+        """Issue one request, replaying transient failures.
+
+        The semaphore is held only for the call itself — backoff sleeps
+        happen outside it, so a retrying request doesn't occupy a concurrency
+        slot while it waits.
+        """
+        retryable_exc = (
+            _RETRYABLE_TRANSPORT if idempotent else _RETRYABLE_TRANSPORT_UNSAFE_METHOD
+        )
+        delay = _INITIAL_DELAY_S
+
+        for attempt in range(1, _MAX_ATTEMPTS + 1):
+            last_attempt = attempt == _MAX_ATTEMPTS
+            try:
+                async with self.semaphore:
+                    self.logger.debug("%s %s (attempt %d)", method, endpoint, attempt)
+                    response = await self.__client.request(
+                        method, endpoint, json=json, headers=self.__headers()
+                    )
+            except retryable_exc as exc:
+                if last_attempt:
+                    raise
+                self.logger.warning(
+                    "%s %s failed (%s); retrying in %.1fs",
+                    method,
+                    endpoint,
+                    exc.__class__.__name__,
+                    delay,
+                )
+            else:
+                retryable_status = idempotent and response.status_code in (
+                    _RETRYABLE_STATUS
+                )
+                if not retryable_status or last_attempt:
+                    return response
+                self.logger.warning(
+                    "%s %s returned %d; retrying in %.1fs",
+                    method,
+                    endpoint,
+                    response.status_code,
+                    delay,
+                )
+
+            await asyncio.sleep(delay)
+            delay *= _BACKOFF
+
+        # Unreachable: the loop either returns or raises on the last attempt.
+        raise AssertionError("retry loop exited without a result")  # pragma: no cover
+
+    async def _get(self, endpoint: str) -> httpx.Response:
+        return await self._request("GET", endpoint, idempotent=True)
+
+    async def _post(self, endpoint: str, json: dict) -> httpx.Response:
+        return await self._request("POST", endpoint, json=json, idempotent=False)
+
+    async def _put(self, endpoint: str, json: dict | None = None) -> httpx.Response:
+        return await self._request("PUT", endpoint, json=json, idempotent=True)
+
+    async def _delete(self, endpoint: str) -> httpx.Response:
+        return await self._request("DELETE", endpoint, idempotent=True)
+
     async def __aenter__(self) -> "ClientBase":
         self.logger.debug("Entering async context manager for ClientBase")
         self.__inside_context = True
@@ -77,57 +192,3 @@ class ClientBase(ABC):
             self.__inside_context = False
             await self.__client_internal.aclose()
             self.__client_internal = None
-
-    @retry(exceptions=httpx.HTTPStatusError, tries=3, delay=2, backoff=2)
-    async def _get(self, endpoint: str) -> httpx.Response:
-        async with self.semaphore:
-            self.logger.debug("GET request to %s", endpoint)
-            return await self.__client.get(
-                endpoint,
-                headers=(
-                    {"Authorization": f"Basic {self.__token.decode('utf-8')}"}
-                    if self.__token
-                    else {}
-                ),
-            )
-
-    @retry(exceptions=httpx.HTTPStatusError, tries=3, delay=2, backoff=2)
-    async def _post(self, endpoint: str, json: dict) -> httpx.Response:
-        async with self.semaphore:
-            self.logger.debug("POST request to %s with payload: %s", endpoint, json)
-            return await self.__client.post(
-                endpoint,
-                json=json,
-                headers=(
-                    {"Authorization": f"Basic {self.__token.decode('utf-8')}"}
-                    if self.__token
-                    else {}
-                ),
-            )
-
-    @retry(exceptions=httpx.HTTPStatusError, tries=3, delay=2, backoff=2)
-    async def _put(self, endpoint: str, json: dict | None = None) -> httpx.Response:
-        async with self.semaphore:
-            self.logger.debug("PUT request to %s with payload: %s", endpoint, json)
-            return await self.__client.put(
-                endpoint,
-                json=json,
-                headers=(
-                    {"Authorization": f"Basic {self.__token.decode('utf-8')}"}
-                    if self.__token
-                    else {}
-                ),
-            )
-
-    @retry(exceptions=httpx.HTTPStatusError, tries=3, delay=2, backoff=2)
-    async def _delete(self, endpoint: str) -> httpx.Response:
-        async with self.semaphore:
-            self.logger.debug("DELETE request to %s", endpoint)
-            return await self.__client.delete(
-                endpoint,
-                headers=(
-                    {"Authorization": f"Basic {self.__token.decode('utf-8')}"}
-                    if self.__token
-                    else {}
-                ),
-            )

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/dive_slate_label.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/dive_slate_label.py
@@ -7,7 +7,6 @@ from fishsense_api_sdk.models.model_base import ModelBase
 
 
 class DiveSlateLabel(ModelBase):
-    # pylint: disable=R0801
     """Model representing slate labels."""
 
     id: int | None

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/headtail_label.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/headtail_label.py
@@ -7,7 +7,6 @@ from fishsense_api_sdk.models.model_base import ModelBase
 
 
 class HeadTailLabel(ModelBase):
-    # pylint: disable=R0801
     """Model representing a head-tail label."""
 
     id: int | None

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/label_studio_sync_cursor.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/label_studio_sync_cursor.py
@@ -8,7 +8,6 @@ from fishsense_api_sdk.models.model_base import ModelBase
 
 
 class LabelStudioSyncCursor(ModelBase):
-    # pylint: disable=R0801
     """Per-(kind, project) high-water mark for Label Studio sync."""
 
     id: int | None = None

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/laser_label.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/laser_label.py
@@ -7,7 +7,6 @@ from fishsense_api_sdk.models.model_base import ModelBase
 
 
 class LaserLabel(ModelBase):
-    # pylint: disable=R0801
     """Model representing a laser label."""
 
     id: int | None

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/species_label.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/species_label.py
@@ -7,7 +7,6 @@ from fishsense_api_sdk.models.model_base import ModelBase
 
 
 class SpeciesLabel(ModelBase):
-    # pylint: disable=R0801
     """Model representing a species label."""
 
     id: int | None

--- a/libs/fishsense-api-sdk/tests/clients/test_client_base.py
+++ b/libs/fishsense-api-sdk/tests/clients/test_client_base.py
@@ -5,8 +5,10 @@ import asyncio
 import base64
 from unittest.mock import AsyncMock, Mock, patch
 
+import httpx
 import pytest
 
+from fishsense_api_sdk.clients import client_base
 from fishsense_api_sdk.clients.client_base import ClientBase
 
 
@@ -89,14 +91,14 @@ class TestClientBase:
 
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client_instance = AsyncMock()
-            mock_client_instance.get = AsyncMock(return_value=mock_response)
+            mock_client_instance.request = AsyncMock(return_value=mock_response)
             mock_client_class.return_value = mock_client_instance
 
             async with client:
                 response = await client._get("/test")
                 assert response == mock_response
-                mock_client_instance.get.assert_called_once()
-                call_kwargs = mock_client_instance.get.call_args[1]
+                mock_client_instance.request.assert_called_once()
+                call_kwargs = mock_client_instance.request.call_args[1]
                 assert "Authorization" in call_kwargs["headers"]
                 auth_header = call_kwargs["headers"]["Authorization"]
                 assert auth_header.startswith("Basic ")
@@ -122,14 +124,14 @@ class TestClientBase:
 
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client_instance = AsyncMock()
-            mock_client_instance.get = AsyncMock(return_value=mock_response)
+            mock_client_instance.request = AsyncMock(return_value=mock_response)
             mock_client_class.return_value = mock_client_instance
 
             async with client:
                 response = await client._get("/test")
                 assert response == mock_response
-                mock_client_instance.get.assert_called_once()
-                call_kwargs = mock_client_instance.get.call_args[1]
+                mock_client_instance.request.assert_called_once()
+                call_kwargs = mock_client_instance.request.call_args[1]
                 assert "Authorization" not in call_kwargs["headers"]
 
     async def test_post_request(self):
@@ -149,13 +151,13 @@ class TestClientBase:
 
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client_instance = AsyncMock()
-            mock_client_instance.post = AsyncMock(return_value=mock_response)
+            mock_client_instance.request = AsyncMock(return_value=mock_response)
             mock_client_class.return_value = mock_client_instance
 
             async with client:
                 response = await client._post("/test", json={"data": "value"})
                 assert response == mock_response
-                mock_client_instance.post.assert_called_once()
+                mock_client_instance.request.assert_called_once()
 
     async def test_put_request(self):
         """Test PUT request."""
@@ -174,13 +176,13 @@ class TestClientBase:
 
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client_instance = AsyncMock()
-            mock_client_instance.put = AsyncMock(return_value=mock_response)
+            mock_client_instance.request = AsyncMock(return_value=mock_response)
             mock_client_class.return_value = mock_client_instance
 
             async with client:
                 response = await client._put("/test", json={"data": "updated"})
                 assert response == mock_response
-                mock_client_instance.put.assert_called_once()
+                mock_client_instance.request.assert_called_once()
 
     async def test_request_outside_context_raises_error(self):
         """Test that requests outside context manager raise RuntimeError."""
@@ -202,38 +204,184 @@ class TestClientBase:
         with pytest.raises(RuntimeError, match="Client must be used within"):
             await client._put("/test", json={"data": "value"})
 
-    async def test_get_returns_4xx_5xx_responses_without_retry(self):
-        """`_get` is decorated with @retry(exceptions=HTTPStatusError, ...) but
-        never calls `raise_for_status` itself, so the decorator can never fire
-        — the response is returned as-is.
+    # ── retry contract ────────────────────────────────────────────────
+    #
+    # The old `@retry(exceptions=HTTPStatusError, tries=3)` decorators were
+    # dead twice over: `retry` is synchronous, so decorating an `async def`
+    # returned the coroutine before it could raise, and `HTTPStatusError` is
+    # only produced by `raise_for_status()`, which the callers invoke — never
+    # `_get`. Measured: one attempt, not three.
+    #
+    # That mattered beyond the SDK. `_retry_policies.SDK_FAIL_FAST_RETRY_POLICY`
+    # marks `HTTPStatusError` NON-retryable, justified by "the SDK's
+    # httpx-level @retry already absorbed any transient status". It absorbed
+    # nothing, so a single transient 5xx failed the whole activity with no
+    # retry at any layer.
 
-        This test documents the current behavior. If the retry decorator is
-        ever fixed (e.g., by raising on 5xx inside `_get`, or switching to
-        TransportError), update this test to assert the new contract.
-        """
-        semaphore = asyncio.Semaphore(10)
-        client = TestClientImpl(
+    async def _client(self):
+        return TestClientImpl(
             base_url="http://test.com",
             username="testuser",
             password="testpass",
             timeout=10,
-            semaphore=semaphore,
+            semaphore=asyncio.Semaphore(10),
         )
 
-        mock_response = Mock()
-        mock_response.status_code = 503
+    async def test_get_retries_transient_5xx_then_succeeds(self, monkeypatch):
+        monkeypatch.setattr(client_base, "_INITIAL_DELAY_S", 0)
+        client = await self._client()
+        responses = [Mock(status_code=503), Mock(status_code=200)]
 
         with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client_instance = AsyncMock()
-            mock_client_instance.get = AsyncMock(return_value=mock_response)
-            mock_client_class.return_value = mock_client_instance
+            instance = AsyncMock()
+            instance.request = AsyncMock(side_effect=responses)
+            mock_client_class.return_value = instance
 
             async with client:
                 response = await client._get("/test")
-                assert response is mock_response
-                assert response.status_code == 503
-                # Critical: called exactly once, no retry attempts.
-                assert mock_client_instance.get.call_count == 1
+
+            assert response.status_code == 200
+            assert instance.request.call_count == 2
+
+    async def test_get_gives_up_after_max_attempts_and_returns_the_response(
+        self, monkeypatch
+    ):
+        """Exhausting retries returns the failing response rather than raising:
+        callers inspect `status_code` (404-tolerance in `dive_client.get`) and
+        call `raise_for_status()` themselves."""
+        monkeypatch.setattr(client_base, "_INITIAL_DELAY_S", 0)
+        client = await self._client()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            instance = AsyncMock()
+            instance.request = AsyncMock(return_value=Mock(status_code=503))
+            mock_client_class.return_value = instance
+
+            async with client:
+                response = await client._get("/test")
+
+            assert response.status_code == 503
+            assert instance.request.call_count == client_base._MAX_ATTEMPTS
+
+    async def test_get_does_not_retry_client_errors(self, monkeypatch):
+        """A 404 is an answer, not a blip — retrying it just adds latency."""
+        monkeypatch.setattr(client_base, "_INITIAL_DELAY_S", 0)
+        client = await self._client()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            instance = AsyncMock()
+            instance.request = AsyncMock(return_value=Mock(status_code=404))
+            mock_client_class.return_value = instance
+
+            async with client:
+                response = await client._get("/test")
+
+            assert response.status_code == 404
+            assert instance.request.call_count == 1
+
+    async def test_get_retries_transport_errors(self, monkeypatch):
+        monkeypatch.setattr(client_base, "_INITIAL_DELAY_S", 0)
+        client = await self._client()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            instance = AsyncMock()
+            instance.request = AsyncMock(
+                side_effect=[httpx.ReadTimeout("slow"), Mock(status_code=200)]
+            )
+            mock_client_class.return_value = instance
+
+            async with client:
+                response = await client._get("/test")
+
+            assert response.status_code == 200
+            assert instance.request.call_count == 2
+
+    async def test_get_reraises_a_persistent_transport_error(self, monkeypatch):
+        monkeypatch.setattr(client_base, "_INITIAL_DELAY_S", 0)
+        client = await self._client()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            instance = AsyncMock()
+            instance.request = AsyncMock(side_effect=httpx.ConnectError("down"))
+            mock_client_class.return_value = instance
+
+            async with client:
+                with pytest.raises(httpx.ConnectError):
+                    await client._get("/test")
+
+            assert instance.request.call_count == client_base._MAX_ATTEMPTS
+
+    @pytest.mark.parametrize("verb", ["_put", "_delete"])
+    async def test_idempotent_verbs_retry_5xx(self, monkeypatch, verb):
+        monkeypatch.setattr(client_base, "_INITIAL_DELAY_S", 0)
+        client = await self._client()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            instance = AsyncMock()
+            instance.request = AsyncMock(
+                side_effect=[Mock(status_code=502), Mock(status_code=200)]
+            )
+            mock_client_class.return_value = instance
+
+            async with client:
+                response = await getattr(client, verb)("/test")
+
+            assert response.status_code == 200
+            assert instance.request.call_count == 2
+
+    async def test_post_does_not_retry_5xx(self, monkeypatch):
+        """POST is NOT idempotent here. `post_species` / `post_fish` create
+        rows, so a 5xx that the server had already applied would be duplicated
+        by a retry. The server may have committed before failing to respond —
+        we cannot tell from the status alone, so we do not retry."""
+        monkeypatch.setattr(client_base, "_INITIAL_DELAY_S", 0)
+        client = await self._client()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            instance = AsyncMock()
+            instance.request = AsyncMock(return_value=Mock(status_code=503))
+            mock_client_class.return_value = instance
+
+            async with client:
+                response = await client._post("/test", {"a": 1})
+
+            assert response.status_code == 503
+            assert instance.request.call_count == 1
+
+    async def test_post_retries_only_connect_errors(self, monkeypatch):
+        """A ConnectError proves the request never reached the server, so
+        replaying it cannot duplicate a write. A ReadTimeout does not — the
+        request may have been applied — so that one is left alone."""
+        monkeypatch.setattr(client_base, "_INITIAL_DELAY_S", 0)
+        client = await self._client()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            instance = AsyncMock()
+            instance.request = AsyncMock(
+                side_effect=[httpx.ConnectError("refused"), Mock(status_code=201)]
+            )
+            mock_client_class.return_value = instance
+
+            async with client:
+                response = await client._post("/test", {"a": 1})
+
+            assert response.status_code == 201
+            assert instance.request.call_count == 2
+
+    async def test_post_does_not_retry_read_timeouts(self, monkeypatch):
+        monkeypatch.setattr(client_base, "_INITIAL_DELAY_S", 0)
+        client = await self._client()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            instance = AsyncMock()
+            instance.request = AsyncMock(side_effect=httpx.ReadTimeout("slow"))
+            mock_client_class.return_value = instance
+
+            async with client:
+                with pytest.raises(httpx.ReadTimeout):
+                    await client._post("/test", {"a": 1})
+
+            assert instance.request.call_count == 1
 
     async def test_semaphore_is_used(self):
         """Test that semaphore is acquired during requests."""
@@ -251,7 +399,7 @@ class TestClientBase:
 
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client_instance = AsyncMock()
-            mock_client_instance.get = AsyncMock(return_value=mock_response)
+            mock_client_instance.request = AsyncMock(return_value=mock_response)
             mock_client_class.return_value = mock_client_instance
 
             async with client:

--- a/libs/fishsense-api-sdk/tests/clients/test_httpx_lifecycle.py
+++ b/libs/fishsense-api-sdk/tests/clients/test_httpx_lifecycle.py
@@ -37,9 +37,8 @@ async def test_one_httpx_client_constructed_per_context_entry():
 
     with patch("httpx.AsyncClient") as mock_client_class:
         mock_instance = AsyncMock()
-        mock_instance.get = AsyncMock(return_value=mock_response)
-        mock_instance.post = AsyncMock(return_value=mock_response)
-        mock_instance.put = AsyncMock(return_value=mock_response)
+        # All four verbs funnel through `AsyncClient.request` now.
+        mock_instance.request = AsyncMock(return_value=mock_response)
         mock_client_class.return_value = mock_instance
 
         async with client:
@@ -71,11 +70,11 @@ async def test_concurrent_calls_share_one_httpx_client():
 
     with patch("httpx.AsyncClient") as mock_client_class:
         mock_instance = AsyncMock()
-        mock_instance.get = AsyncMock(return_value=mock_response)
+        mock_instance.request = AsyncMock(return_value=mock_response)
         mock_client_class.return_value = mock_instance
 
         async with client:
             await asyncio.gather(*(client._get(f"/x/{i}") for i in range(40)))
 
         assert mock_client_class.call_count == 1
-        assert mock_instance.get.await_count == 40
+        assert mock_instance.request.await_count == 40

--- a/libs/fishsense-shared/pyproject.toml
+++ b/libs/fishsense-shared/pyproject.toml
@@ -11,10 +11,24 @@ dependencies = [
     "validators>=0.35.0",
 ]
 
+# boto3 is an EXTRA, not a base dependency. `fishsense_shared.object_store`
+# is imported only by the two workers that talk to Garage; fishsense-api and
+# fishsense-backup-worker also depend on this package and must not inherit
+# botocore's ~100MB into their runtime images. Both workers already declare
+# boto3 directly, so nothing needs to opt in today — the extra exists so a
+# future consumer can express the dependency honestly.
+[project.optional-dependencies]
+s3 = [
+    "boto3>=1.35.0",
+]
+
 [dependency-groups]
 dev = [
     "pytest>=8.3.0",
     "pytest-asyncio>=0.25.2",
+    # Needed to exercise `object_store` at the 100% coverage bar below.
+    "boto3>=1.35.0",
+    "moto[s3]>=5.0.0",
 ]
 
 [tool.pytest.ini_options]

--- a/libs/fishsense-shared/src/fishsense_shared/object_store.py
+++ b/libs/fishsense-shared/src/fishsense_shared/object_store.py
@@ -1,0 +1,205 @@
+"""Garage (S3-compatible) object-store contract shared by both workers.
+
+This is the **single source of truth** for the cross-worker key contract.
+It lives here, next to `preprocess_contracts`, for the same reason those
+DTOs do: it is an agreement *between* the api-worker and the data-worker,
+so neither one gets to own it.
+
+    raw/{checksum}.ORF            # scratch; api-worker PUTs, data-worker GETs
+    slate_pdf/{slate_id}.pdf      # scratch; api-worker PUTs, data-worker GETs
+    {prefix}/{folder}/{checksum}.JPG   # durable; data-worker PUTs, LS presigns
+
+`{folder}` is the per-stage JPEG prefix — `preprocess_jpeg` (0.1),
+`preprocess_groups_jpeg` (2), `preprocess_headtail_jpeg` (5.1),
+`preprocess_slate_images_jpeg` (9). `{prefix}` is the optional
+`labels_prefix` partitioning our objects inside a shared labels bucket.
+
+Each worker subclasses `BaseObjectStoreClient` and exposes only the
+method subset it is allowed to use: the api-worker stages scratch in and
+deletes it afterwards; the data-worker reads scratch and writes JPEGs.
+That asymmetry is a real safety boundary, which is why the base class
+holds the primitives and the subclasses hold the vocabulary.
+
+**NAS safety invariant**: nothing in this module can touch the NAS. The
+only deletes reachable from here target Garage scratch keys.
+
+boto3 is an optional extra of `fishsense-shared` (`[s3]`) — importing this
+module requires it, but importing the package does not.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+RAW_PREFIX = "raw"
+SLATE_PDF_PREFIX = "slate_pdf"
+
+# botocore surfaces a missing key as one of these `Error.Code` values
+# depending on whether the call was HeadObject (404/NotFound) or
+# GetObject (NoSuchKey).
+NOT_FOUND_CODES = frozenset({"404", "NoSuchKey", "NotFound"})
+
+__all__ = [
+    "NOT_FOUND_CODES",
+    "RAW_PREFIX",
+    "SLATE_PDF_PREFIX",
+    "BaseObjectStoreClient",
+    "build_s3_client",
+    "jpeg_key",
+    "open_client",
+    "raw_key",
+    "slate_pdf_key",
+]
+
+
+def raw_key(checksum: str) -> str:
+    """Physical Garage key for a staged raw `.ORF`."""
+    return f"{RAW_PREFIX}/{checksum}.ORF"
+
+
+def slate_pdf_key(slate_id: int) -> str:
+    """Physical Garage key for a staged slate-template PDF."""
+    return f"{SLATE_PDF_PREFIX}/{slate_id}.pdf"
+
+
+def jpeg_key(folder: str, checksum: str, prefix: str = "") -> str:
+    """Physical Garage key for a data-worker-written processed JPEG.
+
+    `folder` is the per-stage prefix; `prefix` is the optional
+    `labels_prefix` that partitions our JPEGs within a shared labels
+    bucket. Surrounding slashes are stripped so a caller can't produce a
+    double-slash key, which S3 treats as a different object.
+    """
+    base = f"{folder}/{checksum}.JPG"
+    prefix = (prefix or "").strip("/")
+    return f"{prefix}/{base}" if prefix else base
+
+
+def build_s3_client(
+    *, endpoint_url: str, region: str, access_key: str, secret_key: str
+):
+    """Build a boto3 S3 client pointed at Garage.
+
+    Garage requires **path-style** addressing (it has no virtual-host
+    bucket DNS) and an explicit endpoint + region; SigV4 is its default
+    signature scheme.
+    """
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint_url,
+        region_name=region,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        config=Config(
+            signature_version="s3v4",
+            s3={"addressing_style": "path"},
+        ),
+    )
+
+
+def open_client(settings, client_cls):
+    """Build `client_cls` from a worker's Dynaconf `settings`.
+
+    `client_cls` is the caller's `BaseObjectStoreClient` subclass — the
+    api-worker's staging vocabulary or the data-worker's read/write one.
+    Both read the identical `[object_store]` section, so the mapping from
+    settings to constructor lives here rather than twice.
+
+    `labels_bucket` / `labels_prefix` are optional: a single-bucket
+    deployment sets neither, and `BaseObjectStoreClient` falls back to
+    `bucket` / `""`. `or ""` guards the TOML-empty-string-as-None path,
+    which would otherwise put the literal "None" in every JPEG key.
+
+    Callers keep their own thin `open_object_store_client()` wrapper so
+    the `config` import stays function-local — importing a worker's
+    `object_store` must not eagerly trigger Dynaconf validation (see the
+    config gotcha in CLAUDE.md).
+    """
+    s3 = build_s3_client(
+        endpoint_url=settings.object_store.endpoint_url,
+        region=settings.object_store.region,
+        access_key=settings.object_store.access_key,
+        secret_key=settings.object_store.secret_key,
+    )
+    return client_cls(
+        s3,
+        settings.object_store.bucket,
+        labels_bucket=settings.object_store.get("labels_bucket", None),
+        labels_prefix=settings.object_store.get("labels_prefix", "") or "",
+    )
+
+
+class BaseObjectStoreClient:
+    """Async primitives over an injected boto3 S3 client.
+
+    Constructed per-activity-call; the boto3 client is injected so tests
+    can pass a moto-backed one. Every call is bounced through
+    `asyncio.to_thread` because boto3 is synchronous and these run inside
+    Temporal activities on the event loop.
+
+    Scratch (raw/slate) lives in `bucket`; the processed JPEGs Label
+    Studio serves live in `labels_bucket` under `labels_prefix`.
+    `labels_bucket` defaults to `bucket`, so single-bucket layouts keep
+    working unchanged.
+    """
+
+    def __init__(self, s3, bucket: str, labels_bucket=None, labels_prefix=""):
+        self._s3 = s3
+        self._bucket = bucket
+        self._labels_bucket = labels_bucket or bucket
+        self._labels_prefix = labels_prefix or ""
+
+    async def _exists(self, key: str, bucket: str | None = None) -> bool:
+        """HeadObject, mapping only *not-found* to False.
+
+        Any other error (403, 500, …) propagates: reporting them as
+        "absent" would make staging re-upload forever and make cleanup
+        believe there was nothing to delete.
+        """
+        target = bucket or self._bucket
+
+        def _do() -> bool:
+            try:
+                self._s3.head_object(Bucket=target, Key=key)
+                return True
+            except ClientError as exc:
+                code = exc.response.get("Error", {}).get("Code", "")
+                if code in NOT_FOUND_CODES:
+                    return False
+                raise
+
+        return await asyncio.to_thread(_do)
+
+    async def _get(self, key: str, bucket: str | None = None) -> bytes:
+        target = bucket or self._bucket
+
+        def _do() -> bytes:
+            response = self._s3.get_object(Bucket=target, Key=key)
+            # Close the StreamingBody so botocore returns the underlying
+            # HTTP connection to its pool; leaking it across repeated
+            # downloads can exhaust the pool and stall activities.
+            body = response["Body"]
+            try:
+                return body.read()
+            finally:
+                body.close()
+
+        return await asyncio.to_thread(_do)
+
+    async def _put(self, key: str, data: bytes, bucket: str | None = None) -> None:
+        target = bucket or self._bucket
+        await asyncio.to_thread(
+            self._s3.put_object, Bucket=target, Key=key, Body=data
+        )
+
+    async def _delete(self, key: str, bucket: str | None = None) -> None:
+        # S3 delete_object is idempotent: deleting an absent key returns
+        # success (no ClientError), so retries are naturally safe.
+        target = bucket or self._bucket
+        await asyncio.to_thread(
+            self._s3.delete_object, Bucket=target, Key=key
+        )

--- a/libs/fishsense-shared/src/fishsense_shared/taxonomy.py
+++ b/libs/fishsense-shared/src/fishsense_shared/taxonomy.py
@@ -1,0 +1,236 @@
+"""The `SpeciesLabel.content_of_image` taxonomy vocabulary.
+
+Label Studio writes the labeler's taxonomy selection into
+`SpeciesLabel.content_of_image` as a ", "-joined path:
+
+    "Fish, Hogfish (Lachnolaimus maximus)"  -> a real (wild) fish
+    "Fish Model, Weasly Fish"               -> a rigid model
+    "Calibration Targets, Ruler"            -> the ruler
+    "Slate, Laser on slate"                 -> a slate frame (stage 9)
+
+Four consumers read that string, and they used to spell the markers
+independently: `measure_fish_activity` (Python, data-worker), the stage-14
+cohort selector (SQLAlchemy, api), the `dive_pipeline_status` view (raw SQL,
+api), and the stage-9 slate cohort. Keeping them in step was a comment-only
+contract — and it had already failed. Both the controller and the view
+carried a worked example claiming `"Fish Model, …"` and
+`"Calibration Targets, Ruler"` were *skipped*, six lines above code that
+matched both as measurable; a maintainer trusting it would have deleted the
+ruler clause and silently broken ruler validation.
+
+Now the literals live here once, and every consumer derives from them.
+
+**Python vs SQL.** `is_measurable` is the definition of record: measurable
+means `measure_fish_activity` will actually bind a Measurement. The SQL and
+SQLAlchemy predicates are `LIKE`-based *approximations* of it, because the
+view has to run on Postgres in prod and SQLite under test, which rules out
+the string functions an exact port would need. `MEASURABILITY_CORPUS` is the
+shared fixture that keeps the approximation honest:
+`test_dive_pipeline_status_view.py` runs the real SQL over it and asserts
+agreement with `is_measurable`. The known ceiling is that `REAL_FISH_LIKE`
+tests the whole string for "contains `(` … ends with `)`" while
+`parse_species_names` tests only the final chunk, so a value whose only
+parens sit in an *earlier* chunk and which still ends in `)` would diverge
+("Fish (a), Hogfish)"). No taxonomy branch produces that shape; if one ever
+does, add it to the corpus and the parity test will fail rather than let the
+cohort and the activity disagree.
+"""
+
+from __future__ import annotations
+
+# --- Literals, exactly as the Label Studio labeling config emits them ------
+
+# Prefix for a physical fish model. The leaf after it is the model's identity
+# — the `name` natural key on Fish.
+FISH_MODEL_PREFIX = "Fish Model,"
+
+# The ruler is a rigid known-length target like the models, so it measures
+# through the same name-keyed path. Unlike a fish model its endpoints are
+# unambiguous — no tip-vs-fork landmark uncertainty — so it isolates
+# calibration error from labeling convention.
+RULER_CONTENT = "Calibration Targets, Ruler"
+RULER_NAME = "Ruler"
+
+# Stage-9 marker: the frame shows the slate with the laser on it. This is read
+# off `taxonomy[0]`, a separate path from the slate-*type* leaf that species
+# sync maps to `Dive.dive_slate_id`.
+SLATE_CONTENT_MARKER = "Slate, Laser on slate"
+
+# --- SQL LIKE patterns, for the SQLAlchemy + raw-SQL consumers -------------
+
+# A real fish carries a `Common Name (Scientific name)` leaf. `(` and `)` are
+# not LIKE wildcards, so this reads "contains ( and ends with )".
+REAL_FISH_LIKE = "%(%)"
+FISH_MODEL_LIKE = f"{FISH_MODEL_PREFIX}%"
+
+__all__ = [
+    "FISH_MODEL_LIKE",
+    "FISH_MODEL_PREFIX",
+    "MEASURABILITY_CORPUS",
+    "REAL_FISH_LIKE",
+    "RULER_CONTENT",
+    "RULER_NAME",
+    "SLATE_CONTENT_MARKER",
+    "SQL_BROADER_THAN_PYTHON",
+    "is_measurable",
+    "measurable_species_sql",
+    "parse_model_name",
+    "parse_species_names",
+    "rigid_target_sql",
+]
+
+
+def rigid_target_sql(col: str) -> str:
+    """SQL for "this row is a fish model or the ruler".
+
+    The `TRIM(...) <> prefix` half is not decoration. `LIKE 'Fish Model,%'`
+    matches the *empty leaf* `"Fish Model,"` — a labeler selecting the parent
+    taxonomy node without picking a model — because `%` matches the empty
+    string. `parse_model_name` returns None for it, so `measure_fish_activity`
+    skips the image. Cohort says measurable, activity says skip: no
+    Measurement is ever written, `NOT EXISTS (measurement)` stays true, and
+    the dive is re-selected every hour forever. Exactly the never-goes-false
+    wedge that blocked scheduling stage 14 before 2026-07-17, reachable by one
+    labeler mis-click.
+
+    `TRIM` also covers a space-only leaf (`"Fish Model,   "`), which
+    `parse_model_name` rejects via the matching `.strip(" ")`. Note SQL
+    `TRIM(x)` removes **spaces only**, not all whitespace — which is why
+    `parse_model_name` strips spaces only too, rather than calling bare
+    `.strip()`. Both `TRIM` and the comparison behave identically on Postgres
+    (prod) and SQLite (tests).
+    """
+    return (
+        f"(({col} LIKE '{FISH_MODEL_LIKE}' "
+        f"AND TRIM({col}) <> '{FISH_MODEL_PREFIX}') "
+        f"OR {col} = '{RULER_CONTENT}')"
+    )
+
+
+def measurable_species_sql(col: str) -> str:
+    """SQL approximation of `is_measurable` — real fish OR rigid target."""
+    return f"({col} LIKE '{REAL_FISH_LIKE}' OR {rigid_target_sql(col)})"
+
+
+
+def parse_species_names(content_of_image: str | None) -> tuple[str, str] | None:
+    """Pull `(common_name, scientific_name)` out of a real fish's taxonomy path.
+
+    Format: `"..., Common Name (Scientific name)"`. Returns None if the field
+    is empty or off-shape — we skip rather than write a malformed Species row.
+
+    The shape test is a bare `"("`, deliberately, even though the extraction
+    below splits on `" ("`. Tightening it to `" ("` looks like an improvement
+    — it would skip `"Fish, Hogfish(Lachnolaimus maximus)"` instead of
+    splitting it into nonsense — but `REAL_FISH_LIKE` cannot express
+    "space before the paren" over the whole string, so the tightening made
+    Python reject rows the SQL still matched. That direction is the
+    never-drains wedge: cohort offers, activity skips, no Measurement, dive
+    re-selected forever. Agreeing with the SQL matters more than rejecting a
+    shape the Label Studio taxonomy cannot emit, so the guard stays loose and
+    `MEASURABILITY_CORPUS` pins the agreement.
+    """
+    if not content_of_image:
+        return None
+    last_chunk = content_of_image.split(", ")[-1]
+    if "(" not in last_chunk or not last_chunk.endswith(")"):
+        return None
+    common = last_chunk.split(" (")[0].strip()
+    scientific = last_chunk.split(" (")[-1][:-1].strip()
+    if not common or not scientific:
+        return None
+    return common, scientific
+
+
+def parse_model_name(content_of_image: str | None) -> str | None:
+    """Return the target name for a rigid known-length target, else None.
+
+    Covers `"Fish Model, <name>"` and the ruler
+    (`"Calibration Targets, Ruler"` -> `"Ruler"`). Real fish and every other
+    branch return None. An empty leaf (`"Fish Model,"` with nothing after)
+    returns None — nothing to identify — matching the "skip rather than write
+    a malformed row" posture of `parse_species_names`.
+    """
+    if not content_of_image:
+        return None
+    if content_of_image.strip() == RULER_CONTENT:
+        return RULER_NAME
+    if not content_of_image.startswith(FISH_MODEL_PREFIX):
+        return None
+    # `.strip(" ")`, not `.strip()`: the SQL guard is `TRIM(col)`, which removes
+    # spaces only. Stripping all whitespace here would make Python reject
+    # "Fish Model,\t" while the SQL still matched it — the wedge again.
+    name = content_of_image[len(FISH_MODEL_PREFIX):].strip(" ")
+    return name or None
+
+
+def is_measurable(content_of_image: str | None) -> bool:
+    """True iff `measure_fish_activity` can bind this row to a Measurement.
+
+    This is the definition of record; the `LIKE` predicates approximate it.
+    Anything looser makes the stage-14 cohort offer an image the activity
+    always skips: no Measurement is written, `NOT EXISTS (measurement)` stays
+    true, and the dive is re-selected every hour forever.
+    """
+    return (
+        parse_species_names(content_of_image) is not None
+        or parse_model_name(content_of_image) is not None
+    )
+
+
+# --- Shared parity fixture -------------------------------------------------
+
+# `(content_of_image, is_measurable)` over every branch that actually occurs
+# plus the boundary cases. Used by this package's unit tests AND by the api's
+# `test_dive_pipeline_status_view.py`, which runs the real SQL predicate over
+# it — that cross-check is what stops the Python and SQL representations
+# drifting apart again.
+MEASURABILITY_CORPUS: tuple[tuple[str | None, bool], ...] = (
+    # Real fish — the `Common (Scientific)` leaf.
+    ("Fish, Hogfish (Lachnolaimus maximus)", True),
+    ("Fish, Stoplight Parrotfish (Sparisoma viride)", True),
+    ("Fish, Bar Jack (Caranx ruber)", True),
+    # Rigid known-length targets — name-keyed, no parens.
+    ("Fish Model, Weasly Fish", True),
+    ("Fish Model, Snook", True),
+    ("Fish Model, Purple Angel", True),
+    ("Calibration Targets, Ruler", True),
+    # Shapes the taxonomy cannot emit, kept because they are where the SQL
+    # approximation and the Python parser are most likely to drift apart. All
+    # of these parse into junk names — that is accepted deliberately: the two
+    # representations agreeing matters more than rejecting an unreachable
+    # value, because "SQL matches, Python skips" is the never-drains wedge
+    # while "both accept junk" is merely a junk row on input that never comes.
+    ("Fish, Hogfish(Lachnolaimus maximus)", True),  # no space before the paren
+    ("Fish, ()", True),
+    ("Fish Model,\t", True),  # tab leaf: SQL TRIM removes spaces only
+    # Not measurable.
+    ("Slate, Laser on slate", False),
+    ("Calibration Targets, Slate", False),
+    ("Fish Model,", False),  # empty leaf — parent node, no model picked
+    ("Fish Model,   ", False),  # whitespace-only leaf
+    ("", False),
+    (None, False),
+)
+
+
+# Shapes where the SQL approximation is BROADER than `is_measurable`, i.e. the
+# view/cohort would call them measurable and `measure_fish_activity` would skip
+# them. That direction is the dangerous one — it is the never-goes-false wedge
+# — so the set is pinned rather than left to chance:
+# `test_dive_pipeline_status_view.py` asserts the SQL matches exactly these and
+# nothing else, so a *new* divergence fails the build instead of reaching prod.
+#
+# The whole class comes from one thing the `LIKE` patterns cannot express: the
+# empty-name guard in `parse_species_names`. `%(%)` sees "contains ( and ends
+# with )" and has no way to check that the pieces either side of the paren are
+# non-empty. Closing it would need Postgres-only string functions, which the
+# view can't use because the tests run it on SQLite.
+#
+# None of these are producible by the Label Studio taxonomy config — every leaf
+# is a fixed choice with a non-empty common and scientific name. If one ever
+# becomes reachable, fix the guard rather than extending this tuple.
+SQL_BROADER_THAN_PYTHON: tuple[str, ...] = (
+    "Fish,  (Lachnolaimus maximus)",  # empty common name
+    "Fish, Hogfish ()",  # empty scientific name
+)

--- a/libs/fishsense-shared/tests/test_object_store.py
+++ b/libs/fishsense-shared/tests/test_object_store.py
@@ -1,0 +1,307 @@
+# pylint: disable=protected-access
+"""Unit tests for the shared Garage object-store contract.
+
+This module is the single source of truth for the cross-worker key
+contract and the S3 client shape, so the things pinned here are exactly
+the things that used to be able to drift between the api-worker's and
+data-worker's private copies:
+
+  1. Key layout — raw/{checksum}.ORF, slate_pdf/{slate_id}.pdf,
+     {prefix}/{folder}/{checksum}.JPG.
+  2. Path-style addressing (Garage has no virtual-host bucket DNS).
+  3. `BaseObjectStoreClient`'s bucket routing: scratch reads/writes go to
+     `bucket`, label-facing JPEGs to `labels_bucket` under `labels_prefix`.
+  4. `_get` closes the StreamingBody. Only the data-worker's copy did
+     this; the api-worker's leaked the connection back into botocore's
+     pool. Pinned here so one implementation can't regress alone.
+"""
+
+from __future__ import annotations
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from moto import mock_aws
+
+from fishsense_shared import object_store as sut
+
+BUCKET = "fishsense-test"
+LABELS_BUCKET = "labels-fishsense-test"
+
+
+@pytest.fixture(name="s3")
+def s3_fixture():
+    with mock_aws():
+        client = boto3.client("s3", region_name="us-east-1")
+        client.create_bucket(Bucket=BUCKET)
+        client.create_bucket(Bucket=LABELS_BUCKET)
+        yield client
+
+
+# --------------------------------------------------------------------
+# Key contract
+# --------------------------------------------------------------------
+
+
+def test_raw_and_slate_pdf_keys():
+    assert sut.raw_key("deadbeef") == "raw/deadbeef.ORF"
+    assert sut.slate_pdf_key(9) == "slate_pdf/9.pdf"
+    assert sut.RAW_PREFIX == "raw"
+    assert sut.SLATE_PDF_PREFIX == "slate_pdf"
+
+
+@pytest.mark.parametrize(
+    ("prefix", "expected"),
+    [
+        ("", "preprocess_jpeg/abc.JPG"),
+        (None, "preprocess_jpeg/abc.JPG"),
+        ("fishsense-lite", "fishsense-lite/preprocess_jpeg/abc.JPG"),
+        # Leading/trailing slashes are stripped so callers can't produce
+        # a double-slash key that reads as a different object.
+        ("/fishsense-lite/", "fishsense-lite/preprocess_jpeg/abc.JPG"),
+    ],
+)
+def test_jpeg_key_prefix_handling(prefix, expected):
+    assert sut.jpeg_key("preprocess_jpeg", "abc", prefix) == expected
+
+
+@pytest.mark.parametrize(
+    "folder",
+    [
+        "preprocess_jpeg",
+        "preprocess_groups_jpeg",
+        "preprocess_headtail_jpeg",
+        "preprocess_slate_images_jpeg",
+    ],
+)
+def test_jpeg_key_covers_every_stage_folder(folder):
+    assert sut.jpeg_key(folder, "cafef00d") == f"{folder}/cafef00d.JPG"
+
+
+def test_build_s3_client_uses_path_style_addressing_for_garage():
+    """Garage has no virtual-host bucket DNS. A regression to virtual-host
+    addressing would send every request to `bucket.garage.example.com`."""
+    client = sut.build_s3_client(
+        endpoint_url="http://garage.example.com",
+        region="garage",
+        access_key="k",
+        secret_key="s",
+    )
+    assert client.meta.config.s3["addressing_style"] == "path"
+    assert client.meta.config.signature_version == "s3v4"
+    assert client.meta.endpoint_url == "http://garage.example.com"
+
+
+# --------------------------------------------------------------------
+# Bucket routing
+# --------------------------------------------------------------------
+
+
+def test_labels_bucket_defaults_to_scratch_bucket():
+    """Single-bucket layouts keep working: an unset labels_bucket means
+    JPEGs land in the same bucket as scratch."""
+    client = sut.BaseObjectStoreClient(object(), BUCKET)
+    assert client._labels_bucket == BUCKET
+    assert client._labels_prefix == ""
+
+
+def test_labels_bucket_and_prefix_are_honored_when_set():
+    client = sut.BaseObjectStoreClient(
+        object(), BUCKET, labels_bucket=LABELS_BUCKET, labels_prefix="fishsense-lite"
+    )
+    assert client._labels_bucket == LABELS_BUCKET
+    assert client._labels_prefix == "fishsense-lite"
+
+
+def test_none_labels_prefix_normalizes_to_empty_string():
+    client = sut.BaseObjectStoreClient(object(), BUCKET, labels_prefix=None)
+    assert client._labels_prefix == ""
+
+
+# --------------------------------------------------------------------
+# _exists / _get / _put / _delete
+# --------------------------------------------------------------------
+
+
+async def test_exists_true_when_object_present(s3):
+    s3.put_object(Bucket=BUCKET, Key="raw/abc.ORF", Body=b"x")
+    client = sut.BaseObjectStoreClient(s3, BUCKET)
+    assert await client._exists("raw/abc.ORF") is True
+
+
+async def test_exists_false_when_object_missing(s3):
+    client = sut.BaseObjectStoreClient(s3, BUCKET)
+    assert await client._exists("raw/nope.ORF") is False
+
+
+async def test_exists_reraises_non_not_found_errors(s3):
+    """A 403/500 must not be silently reported as "absent" — that would
+    make the staging activity re-upload on every firing, or worse, make
+    cleanup believe it had nothing to delete."""
+
+    class _Boom:
+        def head_object(self, **_kwargs):
+            raise ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}}, "HeadObject"
+            )
+
+    client = sut.BaseObjectStoreClient(_Boom(), BUCKET)
+    with pytest.raises(ClientError) as exc_info:
+        await client._exists("raw/abc.ORF")
+    assert exc_info.value.response["Error"]["Code"] == "AccessDenied"
+    _ = s3  # bucket fixture keeps moto active for symmetry
+
+
+async def test_exists_checks_the_override_bucket(s3):
+    s3.put_object(Bucket=LABELS_BUCKET, Key="preprocess_jpeg/abc.JPG", Body=b"j")
+    client = sut.BaseObjectStoreClient(s3, BUCKET)
+    assert await client._exists("preprocess_jpeg/abc.JPG", bucket=LABELS_BUCKET) is True
+    # Same key, default (scratch) bucket -> absent.
+    assert await client._exists("preprocess_jpeg/abc.JPG") is False
+
+
+async def test_get_returns_bytes_and_closes_the_streaming_body():
+    """botocore hands back a StreamingBody that holds an HTTP connection.
+    Leaking it across repeated downloads exhausts the pool and stalls the
+    activity — the data-worker fixed this, the api-worker didn't."""
+    closed: list[bool] = []
+
+    class _Body:
+        def read(self):
+            return b"PAYLOAD"
+
+        def close(self):
+            closed.append(True)
+
+    class _S3:
+        def get_object(self, **_kwargs):
+            return {"Body": _Body()}
+
+    client = sut.BaseObjectStoreClient(_S3(), BUCKET)
+    assert await client._get("raw/abc.ORF") == b"PAYLOAD"
+    assert closed == [True], "StreamingBody was not closed"
+
+
+async def test_get_reads_from_the_override_bucket(s3):
+    s3.put_object(Bucket=LABELS_BUCKET, Key="k", Body=b"LABELS")
+    s3.put_object(Bucket=BUCKET, Key="k", Body=b"SCRATCH")
+    client = sut.BaseObjectStoreClient(s3, BUCKET)
+    assert await client._get("k") == b"SCRATCH"
+    assert await client._get("k", bucket=LABELS_BUCKET) == b"LABELS"
+
+
+async def test_get_raises_on_missing_key(s3):
+    client = sut.BaseObjectStoreClient(s3, BUCKET)
+    with pytest.raises(ClientError) as exc_info:
+        await client._get("raw/missing.ORF")
+    assert exc_info.value.response["Error"]["Code"] == "NoSuchKey"
+
+
+async def test_put_writes_to_the_default_and_override_buckets(s3):
+    client = sut.BaseObjectStoreClient(s3, BUCKET)
+    await client._put("raw/abc.ORF", b"RAW")
+    await client._put("preprocess_jpeg/abc.JPG", b"JPG", bucket=LABELS_BUCKET)
+    assert s3.get_object(Bucket=BUCKET, Key="raw/abc.ORF")["Body"].read() == b"RAW"
+    assert (
+        s3.get_object(Bucket=LABELS_BUCKET, Key="preprocess_jpeg/abc.JPG")[
+            "Body"
+        ].read()
+        == b"JPG"
+    )
+
+
+async def test_delete_removes_the_object_and_is_idempotent(s3):
+    s3.put_object(Bucket=BUCKET, Key="raw/abc.ORF", Body=b"x")
+    client = sut.BaseObjectStoreClient(s3, BUCKET)
+    await client._delete("raw/abc.ORF")
+    assert "Contents" not in s3.list_objects_v2(Bucket=BUCKET)
+    # S3 delete_object on an absent key succeeds, so retries are safe.
+    await client._delete("raw/abc.ORF")
+
+
+async def test_delete_targets_the_override_bucket(s3):
+    s3.put_object(Bucket=LABELS_BUCKET, Key="k", Body=b"x")
+    s3.put_object(Bucket=BUCKET, Key="k", Body=b"y")
+    client = sut.BaseObjectStoreClient(s3, BUCKET)
+    await client._delete("k", bucket=LABELS_BUCKET)
+    assert "Contents" not in s3.list_objects_v2(Bucket=LABELS_BUCKET)
+    assert s3.get_object(Bucket=BUCKET, Key="k")["Body"].read() == b"y"
+
+
+# --------------------------------------------------------------------
+# Settings -> client factory
+# --------------------------------------------------------------------
+
+
+class _FakeObjectStoreSettings:
+    """Stands in for Dynaconf's `settings.object_store`: attribute access
+    for required keys, `.get()` with a default for optional ones."""
+
+    def __init__(self, **values):
+        self._values = values
+        for key, value in values.items():
+            setattr(self, key, value)
+
+    def get(self, key, default=None):
+        return self._values.get(key, default)
+
+
+class _FakeSettings:
+    def __init__(self, object_store):
+        self.object_store = object_store
+
+
+def _settings(**overrides):
+    base = {
+        "endpoint_url": "http://garage.example.com",
+        "region": "garage",
+        "access_key": "k",
+        "secret_key": "s",
+        "bucket": BUCKET,
+    }
+    base.update(overrides)
+    return _FakeSettings(_FakeObjectStoreSettings(**base))
+
+
+def test_open_client_builds_the_requested_subclass():
+    """Both workers call this with their own ObjectStoreClient subclass —
+    the factory must not hardcode a class."""
+
+    class _Marker(sut.BaseObjectStoreClient):
+        pass
+
+    client = sut.open_client(_settings(), _Marker)
+    assert isinstance(client, _Marker)
+    assert client._bucket == BUCKET
+
+
+def test_open_client_defaults_optional_labels_settings():
+    """A single-bucket deployment sets neither key; both must fall back
+    without raising, since Dynaconf has no such attributes to read."""
+    client = sut.open_client(_settings(), sut.BaseObjectStoreClient)
+    assert client._labels_bucket == BUCKET
+    assert client._labels_prefix == ""
+
+
+def test_open_client_honors_split_bucket_settings():
+    client = sut.open_client(
+        _settings(labels_bucket=LABELS_BUCKET, labels_prefix="fishsense-lite"),
+        sut.BaseObjectStoreClient,
+    )
+    assert client._labels_bucket == LABELS_BUCKET
+    assert client._labels_prefix == "fishsense-lite"
+
+
+def test_open_client_normalizes_a_null_labels_prefix():
+    """`labels_prefix = ""` in TOML round-trips as None on some Dynaconf
+    paths; it must not become the string "None" in a key."""
+    client = sut.open_client(
+        _settings(labels_prefix=None), sut.BaseObjectStoreClient
+    )
+    assert client._labels_prefix == ""
+
+
+def test_open_client_passes_garage_addressing_through():
+    client = sut.open_client(_settings(), sut.BaseObjectStoreClient)
+    assert client._s3.meta.config.s3["addressing_style"] == "path"
+    assert client._s3.meta.endpoint_url == "http://garage.example.com"

--- a/libs/fishsense-shared/tests/test_taxonomy.py
+++ b/libs/fishsense-shared/tests/test_taxonomy.py
@@ -1,0 +1,194 @@
+"""Unit tests for the `content_of_image` taxonomy vocabulary.
+
+`SpeciesLabel.content_of_image` is a ", "-joined Label Studio taxonomy path,
+and four consumers read it: the stage-14 measure activity (Python), the
+stage-14 cohort selector (SQLAlchemy), the `dive_pipeline_status` view (raw
+SQL), and the stage-9 slate cohort. They used to spell the markers
+independently, and the docstrings describing them had drifted so far that the
+worked example in two files said `"Fish Model, …"` and
+`"Calibration Targets, Ruler"` were skipped while the code six lines below
+matched both as measurable.
+
+`MEASURABILITY_CORPUS` is the shared fixture: every branch that actually
+occurs, plus the boundary cases. `test_dive_pipeline_status_view.py` runs the
+*SQL* predicate over the same corpus and asserts it agrees with
+`is_measurable` here, so the two representations can't drift silently again.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fishsense_shared import taxonomy as sut
+
+
+def test_markers_match_the_label_studio_config():
+    assert sut.FISH_MODEL_PREFIX == "Fish Model,"
+    assert sut.RULER_CONTENT == "Calibration Targets, Ruler"
+    assert sut.RULER_NAME == "Ruler"
+    assert sut.SLATE_CONTENT_MARKER == "Slate, Laser on slate"
+
+
+# --------------------------------------------------------------------
+# parse_species_names — real (wild) fish
+# --------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        (
+            "Fish, Hogfish (Lachnolaimus maximus)",
+            ("Hogfish", "Lachnolaimus maximus"),
+        ),
+        (
+            "Fish, Stoplight Parrotfish (Sparisoma viride)",
+            ("Stoplight Parrotfish", "Sparisoma viride"),
+        ),
+        # Only the LAST ", "-chunk is the species; earlier chunks are the
+        # taxonomy path the labeler drilled through.
+        ("Fish, Reef, Bar Jack (Caranx ruber)", ("Bar Jack", "Caranx ruber")),
+    ],
+)
+def test_parse_species_names_reads_the_last_chunk(content, expected):
+    assert sut.parse_species_names(content) == expected
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        None,
+        "",
+        "   ",
+        "Fish Model, Weasly Fish",  # no parens
+        "Calibration Targets, Ruler",  # no parens
+        "Slate, Laser on slate",  # no parens
+        "Fish, Hogfish (",  # unbalanced
+        "Fish, Hogfish )",  # no opening paren
+        "Fish,  (Lachnolaimus maximus)",  # empty common name
+        "Fish, Hogfish ()",  # empty scientific name
+    ],
+)
+def test_parse_species_names_returns_none_off_shape(content):
+    """We skip rather than write a malformed Species row."""
+    assert sut.parse_species_names(content) is None
+
+
+# --------------------------------------------------------------------
+# parse_model_name — rigid known-length targets
+# --------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ("Fish Model, Weasly Fish", "Weasly Fish"),
+        ("Fish Model, Snook", "Snook"),
+        ("Fish Model, Purple Angel", "Purple Angel"),
+        # The ruler is a rigid known-length target like the models, so it
+        # resolves through the same name-keyed path.
+        ("Calibration Targets, Ruler", "Ruler"),
+    ],
+)
+def test_parse_model_name(content, expected):
+    assert sut.parse_model_name(content) == expected
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        None,
+        "",
+        "Fish Model,",  # empty leaf — nothing to identify
+        "Fish Model,   ",
+        "Fish, Hogfish (Lachnolaimus maximus)",  # a real fish
+        "Calibration Targets, Slate",  # not the ruler
+        "Slate, Laser on slate",
+    ],
+)
+def test_parse_model_name_returns_none_off_shape(content):
+    assert sut.parse_model_name(content) is None
+
+
+def test_a_value_is_never_both_a_species_and_a_model():
+    """`measure_fish_activity` computes both and branches on which is set, so
+    an overlap would make the binding order-dependent."""
+    for content, _ in sut.MEASURABILITY_CORPUS:
+        both = (
+            sut.parse_species_names(content) is not None
+            and sut.parse_model_name(content) is not None
+        )
+        assert not both, f"{content!r} parses as both a species and a model"
+
+
+# --------------------------------------------------------------------
+# is_measurable
+# --------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("content", "expected"), sut.MEASURABILITY_CORPUS)
+def test_is_measurable_over_the_corpus(content, expected):
+    assert sut.is_measurable(content) is expected
+
+
+def test_is_measurable_is_exactly_what_the_activity_can_bind():
+    """The definition that matters: measurable == the activity will produce a
+    Measurement. Any looser and the stage-14 cohort offers an image the
+    activity always skips, no Measurement is ever written, and the dive is
+    re-selected every hour forever — the never-goes-false shape that blocked
+    scheduling stage 14 before 2026-07-17."""
+    for content, _ in sut.MEASURABILITY_CORPUS:
+        bindable = (
+            sut.parse_species_names(content) is not None
+            or sut.parse_model_name(content) is not None
+        )
+        assert sut.is_measurable(content) is bindable
+
+
+def test_corpus_covers_both_measurable_and_unmeasurable():
+    """A corpus that drifted to all-True would make the SQL parity test
+    vacuous."""
+    outcomes = {expected for _, expected in sut.MEASURABILITY_CORPUS}
+    assert outcomes == {True, False}
+
+
+# --------------------------------------------------------------------
+# SQL fragment builders
+# --------------------------------------------------------------------
+
+
+def test_rigid_target_sql_excludes_the_empty_leaf():
+    """The guard that stops a labeler mis-click wedging the stage-14 cohort:
+    `LIKE 'Fish Model,%'` alone matches `"Fish Model,"`, which
+    `parse_model_name` rejects."""
+    sql = sut.rigid_target_sql("sl.content_of_image")
+    assert "LIKE 'Fish Model,%'" in sql
+    assert "TRIM(sl.content_of_image) <> 'Fish Model,'" in sql
+    assert "sl.content_of_image = 'Calibration Targets, Ruler'" in sql
+
+
+def test_measurable_species_sql_is_real_fish_or_rigid_target():
+    sql = sut.measurable_species_sql("sl.content_of_image")
+    assert "LIKE '%(%)'" in sql
+    assert sut.rigid_target_sql("sl.content_of_image") in sql
+
+
+def test_sql_builders_take_the_column_name():
+    """The view aliases specieslabel as `sl`; a caller with a different alias
+    must not have to string-replace."""
+    assert "x.content" in sut.measurable_species_sql("x.content")
+    assert "sl.content_of_image" not in sut.measurable_species_sql("x.content")
+
+
+def test_sql_broader_rows_are_unmeasurable_in_python():
+    """The pinned divergence set must actually be Python-unmeasurable — that
+    is the whole claim being tracked."""
+    for content in sut.SQL_BROADER_THAN_PYTHON:
+        assert sut.is_measurable(content) is False
+
+
+def test_sql_broader_rows_are_not_also_in_the_corpus():
+    """The corpus asserts exact agreement; the divergence tuple asserts a known
+    mismatch. A value in both would make one of the two tests a lie."""
+    corpus_values = {c for c, _ in sut.MEASURABILITY_CORPUS}
+    assert not corpus_values & set(sut.SQL_BROADER_THAN_PYTHON)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,6 @@ ignore-paths = ["^deploy/.*$"]
 # fail-under=10 with all checks on is unworkable for a real codebase;
 # disable the high-noise checks and require the rest to be clean.
 disable = [
-    # Famously noisy across test files where fixture boilerplate is
-    # repeated by design. Most projects disable.
-    "duplicate-code",
     # Tests document themselves by name; no need to require docstrings
     # on `def test_<thing_being_asserted>`.
     "missing-function-docstring",
@@ -86,6 +83,35 @@ disable = [
     "too-few-public-methods",
 ]
 
+# `duplicate-code` (R0801) is ENABLED on purpose — see CLAUDE.md's
+# "Never suppress duplicate-code / R0801". It was blanket-disabled here
+# for years, which made the 14 inline `# pylint: disable=duplicate-code`
+# pragmas scattered through the SDK/API models and sync workflows
+# no-ops, and let copy-pasted workflow parents drift until their
+# comments documented behavior their own code contradicted.
+#
+# The knobs below are what make it usable rather than noisy:
+#   * ignore-* strip the parts that are duplicated by design — imports,
+#     signatures, docstrings, comments — so a hit means duplicated
+#     *logic*, not duplicated boilerplate.
+#   * min-similarity-lines=12 is calibrated, not guessed: across the six
+#     package source roots it yields 6 findings, all genuine (the
+#     two-copy `object_store.py` key contract at ~92 lines, and five
+#     preprocess/predict parent-workflow clones at 20-31 lines). Dropping
+#     to 8 adds 15 more, mostly per-service `config.py`/`nas.py` pairs
+#     that are legitimately separate. Re-measure before changing it:
+#     pylint --disable=all --enable=duplicate-code --output-format=json
+#     <the six src/<pkg> roots>
+#
+# Note this only compares files within a single pylint invocation, and
+# `check.sh lint` passes only files changed since origin/main — so it
+# fires when both copies of a clone move in one PR, not on every run.
+[tool.pylint.similarities]
+min-similarity-lines = 12
+ignore-comments = true
+ignore-docstrings = true
+ignore-imports = true
+ignore-signatures = true
 [tool.pylint.basic]
 # Linear-algebra / pinhole-camera variable names + a few helper names
 # that read worse in snake_case (camera matrix `_make_K`, OpenCV's

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/backfill_slate_predictions_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/backfill_slate_predictions_activity.py
@@ -1,5 +1,18 @@
 """Attach persisted `SlatePrediction` rows to EXISTING dive-slate LS tasks.
 
+**RETIRED 2026-08-03 — registered, but nothing schedules it.** The
+ECC >= 0.80 acceptance gate does not transfer out of distribution: pool
+dives produced high-ECC (0.93-0.97) *false* fits that sailed through it
+(prod dives 65/71/77/80/83, all pool). The team declined an
+active-learning loop; `predict-slate-images-workflow-schedule` is now
+actively deleted at worker startup (`worker._RETIRED_SCHEDULE_IDS`) and
+the 130 seeded Label Studio predictions were removed.
+
+The code is kept registered so a future evaluation can start it by hand
+— it is dormant, not dead — but nothing invokes it on its own. Do not
+read it as part of the live pipeline.
+
+
 The dive-slate populate seeds model pre-annotations only at *import* time and
 runs exactly once per dive (stage-9-cohort gated: a slate frame with no
 `DiveSlateLabel` row). So a dive whose LS tasks were imported before the slate

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/cohort_selection.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/cohort_selection.py
@@ -1,0 +1,57 @@
+"""Shared body for the nine per-stage cohort selectors.
+
+Every `select_next_high_priority_dive_for_*_activity` does the same three
+things: open an SDK client, call one `dives.select_next_for_*()` endpoint, and
+log which dive came back (or that the cohort is empty). Only the endpoint and
+the stage name differ. They were nine copies of that body, and the copies
+drifted — the laser selector's docstring *and its operator-facing log line*
+described a "no LaserExtrinsics row" cohort for months after the endpoint had
+moved to "image with no non-sentinel LaserLabel". A log line that lies about
+what was queried is expensive at 3am.
+
+The activity functions themselves stay one-per-module and keep their explicit
+`@activity.defn` name. That is deliberate: Temporal resolves activities by
+string, and workflows name them as strings, so a factory that generated them
+would make `select_next_high_priority_dive_for_laser_preprocessing_activity`
+ungreppable. Each module keeps its cohort docstring too — the cohort
+*definition* is the genuinely per-stage knowledge, and it belongs next to the
+endpoint it names. What's shared here is only the plumbing.
+"""
+
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.utils import get_fs_client
+
+__all__ = ["select_next_dive"]
+
+
+async def select_next_dive(
+    stage: str,
+    select: Callable[[object], Awaitable[int | None]],
+) -> int | None:
+    """Run one cohort selector and log the outcome.
+
+    `stage` is the human-readable stage name used in both log lines, so the
+    "nothing to do" and "picked a dive" messages can't describe different
+    things. `select` receives the open SDK client and calls the one endpoint
+    for this stage — passed as a callable rather than a method name so the
+    actual `fs.dives.select_next_for_*()` call stays written out, and
+    greppable, in the calling module.
+
+    Returns the next dive_id, or None when the cohort is empty (the parent
+    workflow then ends the firing without dispatching anything).
+    """
+    async with get_fs_client() as fs:
+        dive_id = await select(fs)
+
+    if dive_id is None:
+        activity.logger.info("no HIGH-priority dives needing %s", stage)
+    else:
+        activity.logger.info(
+            "next HIGH-priority dive needing %s: dive_id=%d", stage, dive_id
+        )
+    return dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/persist_slate_predictions_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/persist_slate_predictions_activity.py
@@ -1,5 +1,18 @@
 """Activity to persist the slate-detector's per-image predictions.
 
+**RETIRED 2026-08-03 — registered, but nothing schedules it.** The
+ECC >= 0.80 acceptance gate does not transfer out of distribution: pool
+dives produced high-ECC (0.93-0.97) *false* fits that sailed through it
+(prod dives 65/71/77/80/83, all pool). The team declined an
+active-learning loop; `predict-slate-images-workflow-schedule` is now
+actively deleted at worker startup (`worker._RETIRED_SCHEDULE_IDS`) and
+the 130 seeded Label Studio predictions were removed.
+
+The code is kept registered so a future evaluation can start it by hand
+— it is dormant, not dead — but nothing invokes it on its own. Do not
+read it as part of the live pipeline.
+
+
 The data-worker `PredictSlateImagesWorkflow` returns one `SlatePredictionResult`
 per image; the api-worker parent hands them here to upsert via the SDK
 (`put_slate_prediction`, natural-key on image_id). Runs on the api side so the

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_dive_slate_label_studio_project_activity.py
@@ -248,18 +248,45 @@ async def populate_dive_slate_label_studio_project_activity(
 
         refreshed_image_ids = {image.id for image in images}
 
-        # Supersede pass: dead-letter incomplete slate rows belonging to a
-        # DIFFERENT (legacy) project so this project's rows are canonical.
-        # Rows for images this run just imported are exempt:
-        # `put_dive_slate_label` upserts on `image_id`, so the "old" row IS
-        # the one the import just refreshed —
-        # superseding it undoes this run's own work, and alternates run to run
-        # because the snapshot predates the import. Same bug hit headtail on
-        # prod dive 341 (2026-08-04); mirrors species populate's guard.
+        # Supersede pass: dead-letter incomplete rows that this project no
+        # longer owns, so its own rows are canonical. Two kinds qualify:
+        #   * rows in a DIFFERENT (legacy, pre-per-dive) project, and
+        #   * rows in THIS project whose image is no longer a target (its
+        #     laser stopped being valid), which are stale tasks to collect.
+        # Only acts on rows with an `id` (already persisted).
+        #
+        # The exemption is "same project AND refreshed this run", and needs
+        # both halves:
+        #
+        #   refreshed — superseding a row this run just re-imported undoes the
+        #     run's own work, and because the pass reads a snapshot taken
+        #     BEFORE the import and skips already-superseded rows, the outcome
+        #     ALTERNATES run to run: live -> superseded -> live... Prod dive
+        #     341 oscillated that way on every hourly firing and activity
+        #     retry, so its images never held a usable pending row and the
+        #     dive never drained from the cohort.
+        #
+        #   same project — `get_dive_slate_labels(dive_id)` returns every
+        #     non-superseded row for the dive across ALL projects, and
+        #     `put_dive_slate_label` upserts on `(image_id, label_studio_project_id)`, so
+        #     ONE IMAGE CAN HOLD TWO ROWS. Exempting by image alone let a
+        #     legacy row on a refreshed image survive forever; since
+        #     `dive_pipeline_status`'s `*_labeling_complete` needs zero
+        #     incomplete non-superseded rows, the dive read incomplete on the
+        #     dashboard permanently. (An earlier comment here claimed the
+        #     upsert keyed on `image_id` alone, "so there is only ever one row
+        #     per image". That was never true.)
+        #
+        # Species populate exempts by project only — it has no same-project GC
+        # because its cohort can't drop an image mid-flight the way a laser
+        # revalidation can.
         for old in existing_slate:
             if old.completed or old.superseded or old.id is None:
                 continue
-            if old.image_id in refreshed_image_ids:
+            if (
+                old.label_studio_project_id == project_id
+                and old.image_id in refreshed_image_ids
+            ):
                 continue
             old.superseded = True
             await fs.labels.put_dive_slate_label(old.image_id, old)

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/populate_headtail_label_studio_project_activity.py
@@ -187,24 +187,45 @@ async def populate_headtail_label_studio_project_activity(
 
         refreshed_image_ids = {image.id for image in targets}
 
-        # Supersede pass: dead-letter incomplete headtail rows that belong to
-        # a DIFFERENT (legacy, pre-per-dive) project, so this project's rows
-        # are canonical. Only acts on rows with an `id` (already persisted).
+        # Supersede pass: dead-letter incomplete rows that this project no
+        # longer owns, so its own rows are canonical. Two kinds qualify:
+        #   * rows in a DIFFERENT (legacy, pre-per-dive) project, and
+        #   * rows in THIS project whose image is no longer a target (its
+        #     laser stopped being valid), which are stale tasks to collect.
+        # Only acts on rows with an `id` (already persisted).
         #
-        # Rows for images THIS RUN just imported are exempt.
-        # `put_headtail_label` upserts on `image_id`, so there is only ever one
-        # row per image — the "old" row here IS the row the import refreshed.
-        # Superseding it undoes this run's own work, and because the pass
-        # reads a snapshot taken BEFORE the import (and skips already-
-        # superseded rows), the outcome ALTERNATES run to run: live ->
-        # superseded -> live... Prod dive 341 oscillated that way on every
-        # hourly firing and activity retry, so its images never held a usable
-        # pending row and the dive never drained from the stage-5.1 cohort.
-        # Mirrors the guard species populate already carries.
+        # The exemption is "same project AND refreshed this run", and needs
+        # both halves:
+        #
+        #   refreshed — superseding a row this run just re-imported undoes the
+        #     run's own work, and because the pass reads a snapshot taken
+        #     BEFORE the import and skips already-superseded rows, the outcome
+        #     ALTERNATES run to run: live -> superseded -> live... Prod dive
+        #     341 oscillated that way on every hourly firing and activity
+        #     retry, so its images never held a usable pending row and the
+        #     dive never drained from the cohort.
+        #
+        #   same project — `get_headtail_labels(dive_id)` returns every
+        #     non-superseded row for the dive across ALL projects, and
+        #     `put_headtail_label` upserts on `(image_id, label_studio_project_id)`, so
+        #     ONE IMAGE CAN HOLD TWO ROWS. Exempting by image alone let a
+        #     legacy row on a refreshed image survive forever; since
+        #     `dive_pipeline_status`'s `*_labeling_complete` needs zero
+        #     incomplete non-superseded rows, the dive read incomplete on the
+        #     dashboard permanently. (An earlier comment here claimed the
+        #     upsert keyed on `image_id` alone, "so there is only ever one row
+        #     per image". That was never true.)
+        #
+        # Species populate exempts by project only — it has no same-project GC
+        # because its cohort can't drop an image mid-flight the way a laser
+        # revalidation can.
         for old in existing_headtail:
             if old.completed or old.superseded or old.id is None:
                 continue
-            if old.image_id in refreshed_image_ids:
+            if (
+                old.label_studio_project_id == project_id
+                and old.image_id in refreshed_image_ids
+            ):
                 continue
             old.superseded = True
             await fs.labels.put_headtail_label(old.image_id, old)

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_slate_predict_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/resolve_slate_predict_inputs_activity.py
@@ -1,5 +1,18 @@
 """Activity to resolve the per-image inputs the slate-detector stage needs.
 
+**RETIRED 2026-08-03 — registered, but nothing schedules it.** The
+ECC >= 0.80 acceptance gate does not transfer out of distribution: pool
+dives produced high-ECC (0.93-0.97) *false* fits that sailed through it
+(prod dives 65/71/77/80/83, all pool). The team declined an
+active-learning loop; `predict-slate-images-workflow-schedule` is now
+actively deleted at worker startup (`worker._RETIRED_SCHEDULE_IDS`) and
+the 130 seeded Label Studio predictions were removed.
+
+The code is kept registered so a future evaluation can start it by hand
+— it is dormant, not dead — but nothing invokes it on its own. Do not
+read it as part of the live pipeline.
+
+
 Returns a fully-populated `PredictSlateImagesInput` for the data-worker's
 `PredictSlateImagesWorkflow`. Image set mirrors the API selector
 (`select_next_for_slate_prediction`): a slate frame

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_clustering_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_clustering_activity.py
@@ -16,19 +16,14 @@ from __future__ import annotations
 
 from temporalio import activity
 
-from fishsense_api_workflow_worker.activities.utils import get_fs_client
+from fishsense_api_workflow_worker.activities.cohort_selection import (
+    select_next_dive,
+)
 
 
 @activity.defn
 async def select_next_high_priority_dive_for_clustering_activity() -> int | None:
-    async with get_fs_client() as fs:
-        dive_id = await fs.dives.select_next_for_dive_frame_clustering()
-
-    if dive_id is None:
-        activity.logger.info("no HIGH-priority dives needing dive-frame clustering")
-    else:
-        activity.logger.info(
-            "next HIGH-priority dive needing dive-frame clustering: dive_id=%d",
-            dive_id,
-        )
-    return dive_id
+    return await select_next_dive(
+        "dive-frame clustering",
+        lambda fs: fs.dives.select_next_for_dive_frame_clustering(),
+    )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_headtail_preprocessing_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_headtail_preprocessing_activity.py
@@ -14,23 +14,14 @@ from __future__ import annotations
 
 from temporalio import activity
 
-from fishsense_api_workflow_worker.activities.utils import get_fs_client
+from fishsense_api_workflow_worker.activities.cohort_selection import (
+    select_next_dive,
+)
 
 
 @activity.defn
-async def select_next_high_priority_dive_for_headtail_preprocessing_activity() -> (
-    int | None
-):
-    async with get_fs_client() as fs:
-        dive_id = await fs.dives.select_next_for_headtail_preprocessing()
-
-    if dive_id is None:
-        activity.logger.info(
-            "no HIGH-priority dives needing headtail preprocessing"
-        )
-    else:
-        activity.logger.info(
-            "next HIGH-priority dive needing headtail preprocessing: dive_id=%d",
-            dive_id,
-        )
-    return dive_id
+async def select_next_high_priority_dive_for_headtail_preprocessing_activity() -> int | None:
+    return await select_next_dive(
+        "headtail preprocessing",
+        lambda fs: fs.dives.select_next_for_headtail_preprocessing(),
+    )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_laser_calibration_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_laser_calibration_activity.py
@@ -17,23 +17,14 @@ from __future__ import annotations
 
 from temporalio import activity
 
-from fishsense_api_workflow_worker.activities.utils import get_fs_client
+from fishsense_api_workflow_worker.activities.cohort_selection import (
+    select_next_dive,
+)
 
 
 @activity.defn
-async def select_next_high_priority_dive_for_laser_calibration_activity() -> (
-    int | None
-):
-    async with get_fs_client() as fs:
-        dive_id = await fs.dives.select_next_for_laser_calibration()
-
-    if dive_id is None:
-        activity.logger.info(
-            "no HIGH-priority dives needing laser calibration"
-        )
-    else:
-        activity.logger.info(
-            "next HIGH-priority dive needing laser calibration: dive_id=%d",
-            dive_id,
-        )
-    return dive_id
+async def select_next_high_priority_dive_for_laser_calibration_activity() -> int | None:
+    return await select_next_dive(
+        "laser calibration",
+        lambda fs: fs.dives.select_next_for_laser_calibration(),
+    )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_laser_prediction_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_laser_prediction_activity.py
@@ -13,23 +13,14 @@ from __future__ import annotations
 
 from temporalio import activity
 
-from fishsense_api_workflow_worker.activities.utils import get_fs_client
+from fishsense_api_workflow_worker.activities.cohort_selection import (
+    select_next_dive,
+)
 
 
 @activity.defn
-async def select_next_high_priority_dive_for_laser_prediction_activity() -> (
-    int | None
-):
-    async with get_fs_client() as fs:
-        dive_id = await fs.dives.select_next_for_laser_prediction()
-
-    if dive_id is None:
-        activity.logger.info(
-            "no HIGH-priority dives needing laser predictions; nothing to predict"
-        )
-    else:
-        activity.logger.info(
-            "next HIGH-priority dive needing laser predictions: dive_id=%d",
-            dive_id,
-        )
-    return dive_id
+async def select_next_high_priority_dive_for_laser_prediction_activity() -> int | None:
+    return await select_next_dive(
+        "laser predictions",
+        lambda fs: fs.dives.select_next_for_laser_prediction(),
+    )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_laser_preprocessing_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_laser_preprocessing_activity.py
@@ -1,41 +1,41 @@
 """Activity to pick the next HIGH-priority dive that needs stage 0.1
 laser preprocessing.
 
-Cohort definition: HIGH priority + no `LaserExtrinsics` row yet (same
-target the stage-13 calibration script uses, see
-`scripts/dry_run_stage13.py` in the data-worker package). Producing
-JPEGs for these dives is the work that unblocks downstream
-calibration.
+Cohort: HIGH priority + at least one *canonical* image carrying no
+non-sentinel `LaserLabel` row (i.e. none with a real
+`label_studio_project_id`). The SQL predicate lives in the api's
+`select-next/laser-preprocessing` endpoint — see
+`select_next_for_laser_preprocessing` in `dive_cohort_controller`.
 
-Lives on the api-worker so the SDK call runs on the orchestrator's
-docker network (no authentik / cross-host hop). The selector itself
-is a single SDK call that returns the cohort answer in one query —
-the prior shape was a `dives.get()` plus a sequential
-`get_laser_extrinsics(dive_id)` per HIGH-priority dive, which timed
-out the activity's schedule_to_close on backlogs of a few hundred.
+The cohort used to be "HIGH priority + no `LaserExtrinsics` row yet",
+and this module's docstring and log line still said so long after the
+code changed. That predicate tied stage 0.1 to a *downstream* gate it
+doesn't advance: a dive whose laser side was finished but whose slate
+side blocked stage-13 calibration kept getting re-selected every hour
+with no work for the resolver to return. The log line was the worse
+half — it told an operator the selector had asked about
+`laser_extrinsics` when it had asked about label rows.
+
+Lives on the api-worker so the SDK call runs on the interior docker
+network (no authentik / cross-host hop). The selector is a single SDK
+call that returns the cohort answer in one query — the prior shape was
+a `dives.get()` plus a sequential `get_laser_extrinsics(dive_id)` per
+HIGH-priority dive, which timed out the activity's schedule_to_close on
+backlogs of a few hundred.
 """
 
 from __future__ import annotations
 
 from temporalio import activity
 
-from fishsense_api_workflow_worker.activities.utils import get_fs_client
+from fishsense_api_workflow_worker.activities.cohort_selection import (
+    select_next_dive,
+)
 
 
 @activity.defn
-async def select_next_high_priority_dive_for_laser_preprocessing_activity() -> (
-    int | None
-):
-    async with get_fs_client() as fs:
-        dive_id = await fs.dives.select_next_for_laser_preprocessing()
-
-    if dive_id is None:
-        activity.logger.info(
-            "no HIGH-priority dives without laser_extrinsics; nothing to preprocess"
-        )
-    else:
-        activity.logger.info(
-            "next HIGH-priority dive needing laser preprocessing: dive_id=%d",
-            dive_id,
-        )
-    return dive_id
+async def select_next_high_priority_dive_for_laser_preprocessing_activity() -> int | None:
+    return await select_next_dive(
+        "laser preprocessing",
+        lambda fs: fs.dives.select_next_for_laser_preprocessing(),
+    )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_measure_fish_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_measure_fish_activity.py
@@ -27,19 +27,14 @@ from __future__ import annotations
 
 from temporalio import activity
 
-from fishsense_api_workflow_worker.activities.utils import get_fs_client
+from fishsense_api_workflow_worker.activities.cohort_selection import (
+    select_next_dive,
+)
 
 
 @activity.defn
 async def select_next_high_priority_dive_for_measure_fish_activity() -> int | None:
-    async with get_fs_client() as fs:
-        dive_id = await fs.dives.select_next_for_measure_fish()
-
-    if dive_id is None:
-        activity.logger.info("no HIGH-priority dives needing measurement")
-    else:
-        activity.logger.info(
-            "next HIGH-priority dive needing measurement: dive_id=%d",
-            dive_id,
-        )
-    return dive_id
+    return await select_next_dive(
+        "measurement",
+        lambda fs: fs.dives.select_next_for_measure_fish(),
+    )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_slate_prediction_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_slate_prediction_activity.py
@@ -1,5 +1,18 @@
 """Activity to pick the next HIGH-priority dive needing slate predictions.
 
+**RETIRED 2026-08-03 — registered, but nothing schedules it.** The
+ECC >= 0.80 acceptance gate does not transfer out of distribution: pool
+dives produced high-ECC (0.93-0.97) *false* fits that sailed through it
+(prod dives 65/71/77/80/83, all pool). The team declined an
+active-learning loop; `predict-slate-images-workflow-schedule` is now
+actively deleted at worker startup (`worker._RETIRED_SCHEDULE_IDS`) and
+the 130 seeded Label Studio predictions were removed.
+
+The code is kept registered so a future evaluation can start it by hand
+— it is dormant, not dead — but nothing invokes it on its own. Do not
+read it as part of the live pipeline.
+
+
 Cohort: HIGH-priority + `dive_slate_id` set + at least one slate frame
 (`SpeciesLabel.content_of_image='Slate, Laser on slate'`) with no
 `SlatePrediction` and no *completed* `DiveSlateLabel` (see
@@ -14,23 +27,14 @@ from __future__ import annotations
 
 from temporalio import activity
 
-from fishsense_api_workflow_worker.activities.utils import get_fs_client
+from fishsense_api_workflow_worker.activities.cohort_selection import (
+    select_next_dive,
+)
 
 
 @activity.defn
-async def select_next_high_priority_dive_for_slate_prediction_activity() -> (
-    int | None
-):
-    async with get_fs_client() as fs:
-        dive_id = await fs.dives.select_next_for_slate_prediction()
-
-    if dive_id is None:
-        activity.logger.info(
-            "no HIGH-priority dives needing slate predictions; nothing to predict"
-        )
-    else:
-        activity.logger.info(
-            "next HIGH-priority dive needing slate predictions: dive_id=%d",
-            dive_id,
-        )
-    return dive_id
+async def select_next_high_priority_dive_for_slate_prediction_activity() -> int | None:
+    return await select_next_dive(
+        "slate predictions",
+        lambda fs: fs.dives.select_next_for_slate_prediction(),
+    )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_slate_preprocessing_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_slate_preprocessing_activity.py
@@ -14,23 +14,14 @@ from __future__ import annotations
 
 from temporalio import activity
 
-from fishsense_api_workflow_worker.activities.utils import get_fs_client
+from fishsense_api_workflow_worker.activities.cohort_selection import (
+    select_next_dive,
+)
 
 
 @activity.defn
-async def select_next_high_priority_dive_for_slate_preprocessing_activity() -> (
-    int | None
-):
-    async with get_fs_client() as fs:
-        dive_id = await fs.dives.select_next_for_slate_preprocessing()
-
-    if dive_id is None:
-        activity.logger.info(
-            "no HIGH-priority dives needing slate preprocessing"
-        )
-    else:
-        activity.logger.info(
-            "next HIGH-priority dive needing slate preprocessing: dive_id=%d",
-            dive_id,
-        )
-    return dive_id
+async def select_next_high_priority_dive_for_slate_preprocessing_activity() -> int | None:
+    return await select_next_dive(
+        "slate preprocessing",
+        lambda fs: fs.dives.select_next_for_slate_preprocessing(),
+    )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_species_preprocessing_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_next_high_priority_dive_for_species_preprocessing_activity.py
@@ -16,23 +16,14 @@ from __future__ import annotations
 
 from temporalio import activity
 
-from fishsense_api_workflow_worker.activities.utils import get_fs_client
+from fishsense_api_workflow_worker.activities.cohort_selection import (
+    select_next_dive,
+)
 
 
 @activity.defn
-async def select_next_high_priority_dive_for_species_preprocessing_activity() -> (
-    int | None
-):
-    async with get_fs_client() as fs:
-        dive_id = await fs.dives.select_next_for_species_preprocessing()
-
-    if dive_id is None:
-        activity.logger.info(
-            "no HIGH-priority dives needing species preprocessing"
-        )
-    else:
-        activity.logger.info(
-            "next HIGH-priority dive needing species preprocessing: dive_id=%d",
-            dive_id,
-        )
-    return dive_id
+async def select_next_high_priority_dive_for_species_preprocessing_activity() -> int | None:
+    return await select_next_dive(
+        "species preprocessing",
+        lambda fs: fs.dives.select_next_for_species_preprocessing(),
+    )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/object_store.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/object_store.py
@@ -1,95 +1,42 @@
 """api-worker side of the Garage (S3-compatible) object store.
 
-Replaces the nginx ``static_file_server`` file-exchange. One bucket,
-content-type prefixes — the cross-worker key contract:
-
-    raw/{checksum}.ORF            # staged raw input (scratch)
-    slate_pdf/{slate_id}.pdf      # staged slate template (scratch)
-    {jpeg_prefix}/{checksum}.JPG  # processed output (durable), written
-                                  # by the data-worker; LS reads via presign
+The key contract and the S3 primitives live in
+`fishsense_shared.object_store` — it is an agreement *between* this
+worker and the data-worker, so neither owns it. This module is only the
+api-worker's method subset layered on top.
 
 This worker stages raw `.ORF` + slate PDFs *in* (HEAD + PUT) and cleans
-up the ``raw/`` scratch prefix afterwards (DELETE).
+up the ``raw/`` scratch prefix afterwards (DELETE). It never writes
+JPEGs — it only reads their presence, to gate the decoupled species
+populate.
 
 NAS safety invariant: the only deletes this client can issue target the
 Garage scratch prefixes. The NAS stays the read-only source of truth —
 nothing here (or anywhere on the api-worker) deletes from the NAS.
-
-Mirrors the data-worker's ``ObjectStoreClient``
-(``fishsense_data_processing_workflow_worker/object_store.py``); the key
-helpers are duplicated, like the two ``file_exchange.py`` clients were,
-because each worker uses a different method subset.
 """
 
 from __future__ import annotations
 
-import asyncio
-
-import boto3
-from botocore.config import Config
-from botocore.exceptions import ClientError
-
-RAW_PREFIX = "raw"
-SLATE_PDF_PREFIX = "slate_pdf"
-
-# botocore surfaces a missing key as one of these `Error.Code` values
-# depending on whether the call was HeadObject (404/NotFound) or
-# GetObject (NoSuchKey).
-_NOT_FOUND_CODES = {"404", "NoSuchKey", "NotFound"}
+from fishsense_shared.object_store import (
+    RAW_PREFIX,
+    SLATE_PDF_PREFIX,
+    BaseObjectStoreClient,
+    jpeg_key,
+    open_client,
+    raw_key,
+    slate_pdf_key,
+)
 
 __all__ = [
     "RAW_PREFIX",
     "SLATE_PDF_PREFIX",
     "ObjectStoreClient",
-    "build_s3_client",
+    "jpeg_key",
+    "open_client",
     "open_object_store_client",
     "raw_key",
     "slate_pdf_key",
 ]
-
-
-def raw_key(checksum: str) -> str:
-    return f"{RAW_PREFIX}/{checksum}.ORF"
-
-
-def slate_pdf_key(slate_id: int) -> str:
-    return f"{SLATE_PDF_PREFIX}/{slate_id}.pdf"
-
-
-def processed_jpeg_key(folder: str, checksum: str, prefix: str = "") -> str:
-    """Physical Garage key for a data-worker-written processed JPEG.
-
-    `folder` is the per-stage prefix (`preprocess_groups_jpeg`,
-    `preprocess_jpeg`, `preprocess_headtail_jpeg`,
-    `preprocess_slate_images_jpeg`). `prefix` is the optional
-    `labels_prefix` that partitions our JPEGs within the shared labels
-    bucket (mirrors the coral-gardeners prefix); empty → no prefix.
-    """
-    base = f"{folder}/{checksum}.JPG"
-    prefix = (prefix or "").strip("/")
-    return f"{prefix}/{base}" if prefix else base
-
-
-def build_s3_client(
-    *, endpoint_url: str, region: str, access_key: str, secret_key: str
-):
-    """Build a boto3 S3 client pointed at Garage.
-
-    Garage requires **path-style** addressing (it has no virtual-host
-    bucket DNS) and an explicit endpoint + region; SigV4 is its default
-    signature scheme.
-    """
-    return boto3.client(
-        "s3",
-        endpoint_url=endpoint_url,
-        region_name=region,
-        aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
-        config=Config(
-            signature_version="s3v4",
-            s3={"addressing_style": "path"},
-        ),
-    )
 
 
 def open_object_store_client() -> "ObjectStoreClient":
@@ -103,71 +50,17 @@ def open_object_store_client() -> "ObjectStoreClient":
     # pylint: disable=import-outside-toplevel
     from fishsense_api_workflow_worker.config import settings
 
-    s3 = build_s3_client(
-        endpoint_url=settings.object_store.endpoint_url,
-        region=settings.object_store.region,
-        access_key=settings.object_store.access_key,
-        secret_key=settings.object_store.secret_key,
-    )
-    return ObjectStoreClient(
-        s3,
-        settings.object_store.bucket,
-        labels_bucket=settings.object_store.get("labels_bucket", None),
-        labels_prefix=settings.object_store.get("labels_prefix", "") or "",
-    )
+    return open_client(settings, ObjectStoreClient)
 
 
-class ObjectStoreClient:
-    """Thin async wrapper over a boto3 S3 client for the api-worker's
-    staging + scratch-cleanup needs. Constructed per-activity-call; the
-    boto3 client is injected so tests can pass a moto-backed one.
+class ObjectStoreClient(BaseObjectStoreClient):
+    """The api-worker's staging + scratch-cleanup vocabulary.
 
     Staging (raw/slate) lives in ``bucket`` (scratch); processed JPEGs that
     Label Studio serves live in ``labels_bucket`` under ``labels_prefix``.
     ``labels_bucket`` defaults to ``bucket`` so single-bucket layouts keep
-    working unchanged."""
-
-    def __init__(self, s3, bucket: str, labels_bucket=None, labels_prefix=""):
-        self._s3 = s3
-        self._bucket = bucket
-        self._labels_bucket = labels_bucket or bucket
-        self._labels_prefix = labels_prefix or ""
-
-    async def _exists(self, key: str, bucket: str | None = None) -> bool:
-        target = bucket or self._bucket
-
-        def _do() -> bool:
-            try:
-                self._s3.head_object(Bucket=target, Key=key)
-                return True
-            except ClientError as exc:
-                code = exc.response.get("Error", {}).get("Code", "")
-                if code in _NOT_FOUND_CODES:
-                    return False
-                raise
-
-        return await asyncio.to_thread(_do)
-
-    async def _put(self, key: str, data: bytes) -> None:
-        await asyncio.to_thread(
-            self._s3.put_object, Bucket=self._bucket, Key=key, Body=data
-        )
-
-    async def _get(self, key: str, bucket: str | None = None) -> bytes:
-        target = bucket or self._bucket
-
-        def _do() -> bytes:
-            response = self._s3.get_object(Bucket=target, Key=key)
-            return response["Body"].read()
-
-        return await asyncio.to_thread(_do)
-
-    async def _delete(self, key: str) -> None:
-        # S3 delete_object is idempotent: deleting an absent key returns
-        # success (no ClientError), so retries are naturally safe.
-        await asyncio.to_thread(
-            self._s3.delete_object, Bucket=self._bucket, Key=key
-        )
+    working unchanged.
+    """
 
     # ----- staging in -----
 
@@ -183,7 +76,7 @@ class ObjectStoreClient:
         cohort with a broken image). Checks the **labels** bucket/prefix
         where the data-worker writes JPEGs."""
         return await self._exists(
-            processed_jpeg_key(folder, checksum, self._labels_prefix),
+            jpeg_key(folder, checksum, self._labels_prefix),
             bucket=self._labels_bucket,
         )
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/_dispatch.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/_dispatch.py
@@ -1,0 +1,246 @@
+"""Shared steps for the cross-worker dispatch parents.
+
+Six parent workflows (preprocess laser / species / headtail / slate,
+predict laser / slate) run the same play: pick a dive, resolve its
+inputs, wake the data-worker, stage its bytes, hand a child workflow to
+`fishsense_data_processing_queue`, then clean up. They were copy-pasted
+from each other, and the copies drifted — comments in the laser parent
+described an `ALLOW_DUPLICATE_FAILED_ONLY` policy its own code hadn't
+used for months, and referred to a populate child that had been
+decoupled. Each step lives here once so there is one place to read, and
+one place to change.
+
+**These helpers emit the same Temporal commands, in the same order, that
+the inlined code did.** That is deliberate and load-bearing: a workflow's
+command sequence is its replay contract, so a run in flight when this
+ships still replays cleanly. Timeouts and retry policies are therefore
+parameters rather than constants — each stage keeps the exact values it
+already had, even where they look arbitrary (slate-PDF staging uses
+5 min in the preprocess parent and 15 min in the predict parent).
+
+Keep these as thin, individually-callable steps rather than one
+`run_parent()` that takes a dozen flags. Each parent stays a readable
+top-to-bottom narrative of what it does — which is how workflow code
+wants to read — while the boilerplate lives in one place.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
+from temporalio.exceptions import WorkflowAlreadyStartedError
+
+with workflow.unsafe.imports_passed_through():
+    from fishsense_api_workflow_worker.workflows._retry_policies import (
+        SCALING_RETRY_POLICY,
+        SDK_FAIL_FAST_RETRY_POLICY,
+        STAGE_RAW_RETRY_POLICY,
+    )
+
+DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
+
+__all__ = [
+    "DATA_PROCESSING_TASK_QUEUE",
+    "STAGE_RAW_RETRY_POLICY",
+    "cleanup_raw",
+    "dispatch_child",
+    "dispatch_populate",
+    "run_sdk_activity",
+    "resolve_inputs",
+    "select_dive",
+    "stage_raw",
+    "stage_slate_pdf",
+    "wake_data_worker",
+]
+
+
+async def select_dive(activity_name: str) -> int | None:
+    """Run a cohort selector. Returns the next dive_id, or None when the
+    cohort is empty and this firing has nothing to do."""
+    return await workflow.execute_activity(
+        activity_name,
+        args=(),
+        schedule_to_close_timeout=timedelta(minutes=5),
+        retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+    )
+
+
+async def resolve_inputs(activity_name: str, dive_id: int, result_type: type) -> Any:
+    """Run a resolver, returning the fully-populated workflow-input DTO
+    the data-worker child consumes."""
+    return await workflow.execute_activity(
+        activity_name,
+        args=(dive_id,),
+        schedule_to_close_timeout=timedelta(minutes=5),
+        retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+        result_type=result_type,
+    )
+
+
+async def wake_data_worker() -> None:
+    """Scale the NRP data-worker up before its child lands on the queue
+    (it scales to zero when idle).
+
+    Idempotent — converges on the configured replica count, never
+    accumulates; a no-op when k8s scaling isn't configured. Returns
+    immediately, so the pod's cold start overlaps the staging steps.
+    """
+    await workflow.execute_activity(
+        "ensure_data_worker_running_activity",
+        args=(),
+        schedule_to_close_timeout=timedelta(minutes=5),
+        retry_policy=SCALING_RETRY_POLICY,
+    )
+
+
+async def stage_raw(dive_id: int) -> None:
+    """Copy the dive's raw `.ORF` bytes from NAS into Garage scratch.
+
+    Failure here is fatal on purpose — dispatching a child that would 404
+    on every `download_raw` wastes a full fan-out. The next schedule
+    firing retries; the staging activity's HEAD-check makes that cheap for
+    checksums already staged.
+    """
+    await workflow.execute_activity(
+        "stage_raw_bytes_for_dive_activity",
+        args=(dive_id,),
+        schedule_to_close_timeout=timedelta(hours=1),
+        heartbeat_timeout=timedelta(minutes=5),
+        retry_policy=STAGE_RAW_RETRY_POLICY,
+    )
+
+
+async def stage_slate_pdf(
+    slate_id: int,
+    *,
+    schedule_to_close_timeout: timedelta,
+    heartbeat_timeout: timedelta | None = None,
+    retry_policy: RetryPolicy | None = None,
+) -> None:
+    """Stage the slate template PDF (stages 9 and slate-predict).
+
+    The two callers pass different timeouts — preserved as parameters
+    rather than unified, so this refactor changes no in-flight run's
+    replay contract. Unifying them is a separate, deliberate change.
+    """
+    await workflow.execute_activity(
+        "stage_slate_pdf_activity",
+        args=(slate_id,),
+        schedule_to_close_timeout=schedule_to_close_timeout,
+        heartbeat_timeout=heartbeat_timeout,
+        retry_policy=retry_policy,
+    )
+
+
+async def dispatch_child(
+    workflow_name: str,
+    inputs: Any,
+    *,
+    child_id: str,
+    execution_timeout: timedelta,
+    result_type: type | None = None,
+) -> Any:
+    """Start the data-worker child and wait for it.
+
+    The child id is deterministic (`preprocess-laser-{dive_id}`) and the
+    reuse policy is **ALLOW_DUPLICATE**, not `ALLOW_DUPLICATE_FAILED_ONLY`.
+    FAILED_ONLY meant a *completed* id could never re-dispatch, so a dive
+    could never be reprocessed to pick up images that became processable
+    after its first successful run — a laser validated after one-shot
+    stage-1 clustering, or an orphan later assigned a cluster. Those
+    images' JPEGs were never produced and populate deferred them forever
+    (prod dives 59/439). ALLOW_DUPLICATE is safe here: resolvers return
+    only images that still need work, and the per-image activities are
+    idempotent (S3 overwrite, SDK upsert).
+
+    With ALLOW_DUPLICATE, `WorkflowAlreadyStartedError` is reachable only
+    while a prior child with this id is still *running* (a manual run
+    overlapping the schedule). That run is doing the work, so the caller
+    continues to its cleanup rather than failing the firing. Returns None
+    in that case.
+    """
+    try:
+        return await workflow.execute_child_workflow(
+            workflow_name,
+            inputs,
+            id=child_id,
+            task_queue=DATA_PROCESSING_TASK_QUEUE,
+            execution_timeout=execution_timeout,
+            id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+            result_type=result_type,
+        )
+    except WorkflowAlreadyStartedError:
+        workflow.logger.info(
+            "%s is still running; skipping duplicate dispatch and continuing",
+            child_id,
+        )
+        return None
+
+
+async def run_sdk_activity(activity_name: str, arg: Any) -> None:
+    """Run a single-argument SDK write-back step (15 min, fail-fast).
+
+    Covers the predict parents' post-child work: persisting the child's
+    returned rows (`persist_*_predictions_activity`, arg = results) and
+    attaching them to existing LS tasks
+    (`backfill_slate_predictions_for_dive_activity`, arg = dive_id).
+    Both are idempotent, so the fail-fast policy is safe — a failure just
+    means the next schedule firing redoes it.
+    """
+    await workflow.execute_activity(
+        activity_name,
+        args=(arg,),
+        schedule_to_close_timeout=timedelta(minutes=15),
+        retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+    )
+
+
+async def cleanup_raw(dive_id: int) -> None:
+    """Evict the dive's staged raw `.ORF` scratch from Garage.
+
+    The JPEGs are the durable artifact and stay (Label Studio reads them
+    via presign); only the reproducible-from-NAS scratch is dropped. The
+    NAS source is never touched — see the tripwire test asserting the
+    cleanup module imports no NAS client.
+    """
+    await workflow.execute_activity(
+        "cleanup_raw_bytes_for_dive_activity",
+        args=(dive_id,),
+        schedule_to_close_timeout=timedelta(minutes=15),
+        heartbeat_timeout=timedelta(minutes=5),
+    )
+
+
+async def dispatch_populate(workflow_name: str, dive_id: int, child_id: str) -> None:
+    """Chain into a Label-Studio populate child on this worker's queue.
+
+    Also ALLOW_DUPLICATE, and for a sharper reason than the preprocess
+    child: a *completed* populate burning the id permanently stalls any
+    dive that later gains an eligible image — it never gets an LS task,
+    never gets a label row, so it never drains from the preprocess cohort,
+    blocking every higher-id dive behind it while re-staging its raw
+    `.ORF`s from NAS every hour. Prod dive 60 held up dives 84/465/471
+    that way until 2026-08-04.
+
+    Dedup lives *inside* the child, where it also protects manual runs:
+    the populate activity selects only images with no non-sentinel label
+    row, and `import_tasks_and_record_labels` dedupes by URL against tasks
+    already in the project.
+    """
+    try:
+        await workflow.execute_child_workflow(
+            workflow_name,
+            dive_id,
+            id=child_id,
+            execution_timeout=timedelta(minutes=30),
+            id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+        )
+    except WorkflowAlreadyStartedError:
+        # Only reachable while a prior populate for this dive is still
+        # RUNNING (manual run overlapping the schedule).
+        workflow.logger.info(
+            "%s is still running; skipping duplicate dispatch", child_id
+        )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/_retry_policies.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/_retry_policies.py
@@ -9,8 +9,21 @@ for these) before surfacing.
 
 Caps attempts at 2 so a single transient blip can self-heal but a real
 bug shows up in seconds, and marks `HTTPStatusError` non-retryable
-because the SDK's `httpx`-level `@retry(tries=3)` already absorbed any
-transient status; if we still see one at this layer it's a real bug.
+because `ClientBase` already replayed any transient status underneath:
+GET/PUT/DELETE retry 5xx and transport errors up to 3 times with
+backoff, so an `HTTPStatusError` surfacing here is a 4xx or a persistent
+5xx — a real bug either way.
+
+That justification was false until 2026-08-11. `ClientBase` carried
+`@retry(exceptions=HTTPStatusError, tries=3)` decorators that never
+fired — `retry` is synchronous, so decorating an `async def` returned
+the coroutine before it could raise, and `HTTPStatusError` comes only
+from `raise_for_status()`, which the callers invoke rather than the
+decorated methods. Measured: one attempt, not three. Combined with the
+non-retryable marking below, a single transient 5xx from fishsense-api
+failed the whole activity with no retry at ANY layer. Note POST is
+deliberately still un-retried in the SDK (it creates rows), so
+write-back activities rely on `maximum_attempts` here.
 
 Used by the selector + resolver `execute_activity` calls in the parent
 workflows (preprocess 0.1/2/5.1/9, calibration 13, measure-fish 14).

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/backfill_slate_predictions_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/backfill_slate_predictions_workflow.py
@@ -1,6 +1,18 @@
 """On-demand workflow: backfill slate-detector pre-annotations onto existing
 dive-slate Label Studio tasks for one dive.
 
+**RETIRED 2026-08-03 — registered, but nothing schedules it.** The
+ECC >= 0.80 acceptance gate does not transfer out of distribution: pool
+dives produced high-ECC (0.93-0.97) *false* fits that sailed through it
+(prod dives 65/71/77/80/83, all pool). The team declined an
+active-learning loop; `predict-slate-images-workflow-schedule` is now
+actively deleted at worker startup (`worker._RETIRED_SCHEDULE_IDS`) and
+the 130 seeded Label Studio predictions were removed.
+
+The code is kept registered so a future evaluation can start it by hand
+— it is dormant, not dead — but nothing invokes it on its own. Do not
+read it as part of the live pipeline.
+
 The predict parent calls the backfill activity after every persist, so newly-
 predicted dives get their pre-annotations automatically. This standalone
 workflow is for catching up dives predicted *before* the backfill shipped (their

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/predict_laser_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/predict_laser_images_parent_workflow.py
@@ -23,17 +23,8 @@ from typing import List
 
 from fishsense_shared import LaserPredictionResult, PredictLaserImagesInput
 from temporalio import workflow
-from temporalio.common import WorkflowIDReusePolicy
-from temporalio.exceptions import WorkflowAlreadyStartedError
 
-with workflow.unsafe.imports_passed_through():
-    from fishsense_api_workflow_worker.workflows._retry_policies import (
-        SCALING_RETRY_POLICY,
-        SDK_FAIL_FAST_RETRY_POLICY,
-        STAGE_RAW_RETRY_POLICY,
-    )
-
-DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
+from fishsense_api_workflow_worker.workflows import _dispatch
 
 
 @workflow.defn
@@ -47,21 +38,16 @@ class PredictLaserImagesParentWorkflow:
 
     @workflow.run
     async def run(self) -> int | None:
-        dive_id = await workflow.execute_activity(
-            "select_next_high_priority_dive_for_laser_prediction_activity",
-            args=(),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+        dive_id = await _dispatch.select_dive(
+            "select_next_high_priority_dive_for_laser_prediction_activity"
         )
         if dive_id is None:
             return None
 
-        inputs = await workflow.execute_activity(
+        inputs = await _dispatch.resolve_inputs(
             "resolve_laser_predict_inputs_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
-            result_type=PredictLaserImagesInput,
+            dive_id,
+            PredictLaserImagesInput,
         )
 
         workflow.logger.info(
@@ -73,62 +59,21 @@ class PredictLaserImagesParentWorkflow:
         if not inputs.images:
             return inputs.dive_id
 
-        # Wake the NRP GPU data-worker before its child lands on the queue
-        # (scales to zero when idle). Idempotent; no-op when k8s scaling
-        # isn't configured.
-        await workflow.execute_activity(
-            "ensure_data_worker_running_activity",
-            args=(),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SCALING_RETRY_POLICY,
+        await _dispatch.wake_data_worker()
+        await _dispatch.stage_raw(dive_id)
+        results: List[LaserPredictionResult] = await _dispatch.dispatch_child(
+            "PredictLaserImagesWorkflow",
+            inputs,
+            child_id=f"predict-laser-{dive_id}",
+            execution_timeout=timedelta(hours=2),
+            result_type=List[LaserPredictionResult],
         )
-
-        await workflow.execute_activity(
-            "stage_raw_bytes_for_dive_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(hours=1),
-            heartbeat_timeout=timedelta(minutes=5),
-            retry_policy=STAGE_RAW_RETRY_POLICY,
-        )
-
-        results: List[LaserPredictionResult] = []
-        try:
-            results = await workflow.execute_child_workflow(
-                "PredictLaserImagesWorkflow",
-                inputs,
-                id=f"predict-laser-{dive_id}",
-                task_queue=DATA_PROCESSING_TASK_QUEUE,
-                execution_timeout=timedelta(hours=2),
-                # ALLOW_DUPLICATE so a dive can re-predict images that became
-                # eligible after a prior run; the resolver returns only
-                # still-unpredicted images and put_laser_prediction upserts.
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
-                result_type=List[LaserPredictionResult],
-            )
-        except WorkflowAlreadyStartedError:
-            # A prior child with this id is still running (manual run
-            # overlapping the schedule). It's doing the work; skip persist
-            # this firing and let cleanup run.
-            workflow.logger.info(
-                "predict-laser-%d already running; skipping duplicate dispatch",
-                dive_id,
-            )
 
         if results:
-            await workflow.execute_activity(
-                "persist_laser_predictions_activity",
-                args=(results,),
-                schedule_to_close_timeout=timedelta(minutes=15),
-                retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+            await _dispatch.run_sdk_activity(
+                "persist_laser_predictions_activity", results
             )
 
-        # Drop the staged raw `.ORF` scratch from Garage; the NAS source is
-        # never touched.
-        await workflow.execute_activity(
-            "cleanup_raw_bytes_for_dive_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(minutes=15),
-            heartbeat_timeout=timedelta(minutes=5),
-        )
+        await _dispatch.cleanup_raw(dive_id)
 
         return inputs.dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/predict_slate_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/predict_slate_images_parent_workflow.py
@@ -1,5 +1,18 @@
 """Slate-detector parent workflow (api-worker side).
 
+**RETIRED 2026-08-03 — registered, but nothing schedules it.** The
+ECC >= 0.80 acceptance gate does not transfer out of distribution: pool
+dives produced high-ECC (0.93-0.97) *false* fits that sailed through it
+(prod dives 65/71/77/80/83, all pool). The team declined an
+active-learning loop; `predict-slate-images-workflow-schedule` is now
+actively deleted at worker startup (`worker._RETIRED_SCHEDULE_IDS`) and
+the 130 seeded Label Studio predictions were removed.
+
+The code is kept registered so a future evaluation can start it by hand
+— it is dormant, not dead — but nothing invokes it on its own. Do not
+read it as part of the live pipeline.
+
+
 Model-assisted slate labeling. Picks the next HIGH-priority dive needing slate
 predictions, resolves its unpredicted slate-frame set + template + camera
 intrinsics via SDK, stages the raw `.ORF` bytes AND the slate template PDF, and
@@ -24,17 +37,8 @@ from typing import List
 
 from fishsense_shared import PredictSlateImagesInput, SlatePredictionResult
 from temporalio import workflow
-from temporalio.common import WorkflowIDReusePolicy
-from temporalio.exceptions import WorkflowAlreadyStartedError
 
-with workflow.unsafe.imports_passed_through():
-    from fishsense_api_workflow_worker.workflows._retry_policies import (
-        SCALING_RETRY_POLICY,
-        SDK_FAIL_FAST_RETRY_POLICY,
-        STAGE_RAW_RETRY_POLICY,
-    )
-
-DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
+from fishsense_api_workflow_worker.workflows import _dispatch
 
 
 @workflow.defn
@@ -48,21 +52,16 @@ class PredictSlateImagesParentWorkflow:
 
     @workflow.run
     async def run(self) -> int | None:
-        dive_id = await workflow.execute_activity(
-            "select_next_high_priority_dive_for_slate_prediction_activity",
-            args=(),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+        dive_id = await _dispatch.select_dive(
+            "select_next_high_priority_dive_for_slate_prediction_activity"
         )
         if dive_id is None:
             return None
 
-        inputs = await workflow.execute_activity(
+        inputs = await _dispatch.resolve_inputs(
             "resolve_slate_predict_inputs_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
-            result_type=PredictSlateImagesInput,
+            dive_id,
+            PredictSlateImagesInput,
         )
 
         workflow.logger.info(
@@ -74,78 +73,37 @@ class PredictSlateImagesParentWorkflow:
         if not inputs.images:
             return inputs.dive_id
 
-        # Wake the NRP data-worker before its child lands on the queue (scales
-        # to zero when idle). Idempotent; no-op when k8s scaling isn't set.
-        await workflow.execute_activity(
-            "ensure_data_worker_running_activity",
-            args=(),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SCALING_RETRY_POLICY,
-        )
-
-        # Stage the raw `.ORF` frames AND the slate template PDF — the predict
-        # activity rectifies the raw frame and renders the PDF into the template.
-        await workflow.execute_activity(
-            "stage_raw_bytes_for_dive_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(hours=1),
-            heartbeat_timeout=timedelta(minutes=5),
-            retry_policy=STAGE_RAW_RETRY_POLICY,
-        )
-        await workflow.execute_activity(
-            "stage_slate_pdf_activity",
-            args=(inputs.slate_id,),
+        await _dispatch.wake_data_worker()
+        await _dispatch.stage_raw(dive_id)
+        # The predict activity rectifies the raw frame AND renders the PDF
+        # into the template, so both must be staged first.
+        await _dispatch.stage_slate_pdf(
+            inputs.slate_id,
             schedule_to_close_timeout=timedelta(minutes=15),
             heartbeat_timeout=timedelta(minutes=5),
-            retry_policy=STAGE_RAW_RETRY_POLICY,
+            retry_policy=_dispatch.STAGE_RAW_RETRY_POLICY,
         )
-
-        results: List[SlatePredictionResult] = []
-        try:
-            results = await workflow.execute_child_workflow(
-                "PredictSlateImagesWorkflow",
-                inputs,
-                id=f"predict-slate-{dive_id}",
-                task_queue=DATA_PROCESSING_TASK_QUEUE,
-                execution_timeout=timedelta(hours=2),
-                # ALLOW_DUPLICATE so a dive can re-predict frames that became
-                # eligible after a prior run; the resolver returns only
-                # still-unpredicted frames and put_slate_prediction upserts.
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
-                result_type=List[SlatePredictionResult],
-            )
-        except WorkflowAlreadyStartedError:
-            workflow.logger.info(
-                "predict-slate-%d already running; skipping duplicate dispatch",
-                dive_id,
-            )
+        results: List[SlatePredictionResult] = await _dispatch.dispatch_child(
+            "PredictSlateImagesWorkflow",
+            inputs,
+            child_id=f"predict-slate-{dive_id}",
+            execution_timeout=timedelta(hours=2),
+            result_type=List[SlatePredictionResult],
+        )
 
         if results:
-            await workflow.execute_activity(
-                "persist_slate_predictions_activity",
-                args=(results,),
-                schedule_to_close_timeout=timedelta(minutes=15),
-                retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+            await _dispatch.run_sdk_activity(
+                "persist_slate_predictions_activity", results
             )
-            # Attach the freshly-persisted predictions to any *existing* dive-
-            # slate LS tasks. The populate seeds pre-annotations only at import
-            # time and runs once per dive, so a dive already populated before it
-            # was predicted would otherwise never surface them. Idempotent
-            # (skips tasks that already carry a slate-detector prediction).
-            await workflow.execute_activity(
-                "backfill_slate_predictions_for_dive_activity",
-                args=(dive_id,),
-                schedule_to_close_timeout=timedelta(minutes=15),
-                retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+            # Attach the freshly-persisted predictions to any *existing*
+            # dive-slate LS tasks. Populate seeds pre-annotations only at
+            # import time and runs once per dive, so a dive already populated
+            # before it was predicted would otherwise never surface them.
+            # Idempotent (skips tasks that already carry a prediction).
+            await _dispatch.run_sdk_activity(
+                "backfill_slate_predictions_for_dive_activity", dive_id
             )
 
-        # Drop the staged raw `.ORF` scratch from Garage; the NAS source is
-        # never touched.
-        await workflow.execute_activity(
-            "cleanup_raw_bytes_for_dive_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(minutes=15),
-            heartbeat_timeout=timedelta(minutes=5),
-        )
+        await _dispatch.cleanup_raw(dive_id)
 
         return inputs.dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_headtail_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_headtail_images_parent_workflow.py
@@ -1,32 +1,26 @@
 """Stage 5.1 parent workflow (api-worker side).
 
 Picks the next HIGH-priority dive needing head/tail preprocessing and
-dispatches `PreprocessHeadtailImagesWorkflow` to the data-worker.
-After archive+cleanup, chains into
-`PopulateHeadTailLabelStudioProjectWorkflow` so head/tail JPEGs land
-in their LS project in the same hourly firing that produced them.
+dispatches `PreprocessHeadtailImagesWorkflow` to the data-worker. After
+cleanup it chains into `PopulateHeadTailLabelStudioProjectWorkflow`, so
+head/tail JPEGs land in their LS project in the same hourly firing that
+produced them.
 
-Same cluster-correctness invariants as
-`PreprocessLaserImagesParentWorkflow` — see CLAUDE.md. Populate child
-uses deterministic id `populate-headtail-{dive_id}` so re-firings on
-the same cohort dive no-op via WorkflowAlreadyStarted.
+Cohort cascades from *valid laser labels* (flipped 2026-05-04), not from
+`SpeciesLabel.top_three_photos_of_group` — head/tail work starts as soon
+as the laser labelers and the validator have signed off on an image,
+in parallel with stages 1/2.
+
+Shared steps live in `_dispatch`; see `PreprocessLaserImagesParentWorkflow`
+and CLAUDE.md for the cluster-correctness invariants.
 """
 
 from datetime import timedelta
 
 from fishsense_shared import PreprocessHeadtailImagesInput
 from temporalio import workflow
-from temporalio.common import WorkflowIDReusePolicy
-from temporalio.exceptions import WorkflowAlreadyStartedError
 
-with workflow.unsafe.imports_passed_through():
-    from fishsense_api_workflow_worker.workflows._retry_policies import (
-        SCALING_RETRY_POLICY,
-        SDK_FAIL_FAST_RETRY_POLICY,
-        STAGE_RAW_RETRY_POLICY,
-    )
-
-DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
+from fishsense_api_workflow_worker.workflows import _dispatch
 
 
 @workflow.defn
@@ -40,21 +34,16 @@ class PreprocessHeadtailImagesParentWorkflow:
 
     @workflow.run
     async def run(self) -> int | None:
-        dive_id = await workflow.execute_activity(
-            "select_next_high_priority_dive_for_headtail_preprocessing_activity",
-            args=(),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+        dive_id = await _dispatch.select_dive(
+            "select_next_high_priority_dive_for_headtail_preprocessing_activity"
         )
         if dive_id is None:
             return None
 
-        inputs = await workflow.execute_activity(
+        inputs = await _dispatch.resolve_inputs(
             "resolve_headtail_preprocess_inputs_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
-            result_type=PreprocessHeadtailImagesInput,
+            dive_id,
+            PreprocessHeadtailImagesInput,
         )
 
         workflow.logger.info(
@@ -66,82 +55,19 @@ class PreprocessHeadtailImagesParentWorkflow:
         if not inputs.image_checksums:
             return inputs.dive_id
 
-        # Wake the NRP data-worker before its child workflow lands on
-        # the queue (it scales to zero when idle). Idempotent — converges
-        # on the configured replica count, never accumulates; a no-op
-        # when k8s scaling isn't configured. Returns immediately, so the
-        # pod's cold start overlaps the NAS-staging step below.
-        await workflow.execute_activity(
-            "ensure_data_worker_running_activity",
-            args=(),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SCALING_RETRY_POLICY,
+        await _dispatch.wake_data_worker()
+        await _dispatch.stage_raw(dive_id)
+        await _dispatch.dispatch_child(
+            "PreprocessHeadtailImagesWorkflow",
+            inputs,
+            child_id=f"preprocess-headtail-{dive_id}",
+            execution_timeout=timedelta(hours=1),
         )
-
-        await workflow.execute_activity(
-            "stage_raw_bytes_for_dive_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(hours=1),
-            heartbeat_timeout=timedelta(minutes=5),
-            retry_policy=STAGE_RAW_RETRY_POLICY,
+        await _dispatch.cleanup_raw(dive_id)
+        await _dispatch.dispatch_populate(
+            "PopulateHeadTailLabelStudioProjectWorkflow",
+            dive_id,
+            f"populate-headtail-{dive_id}",
         )
-
-        try:
-            await workflow.execute_child_workflow(
-                "PreprocessHeadtailImagesWorkflow",
-                inputs,
-                id=f"preprocess-headtail-{dive_id}",
-                task_queue=DATA_PROCESSING_TASK_QUEUE,
-                execution_timeout=timedelta(hours=1),
-                # ALLOW_DUPLICATE so a dive can reprocess images that became
-                # processable after its first successful run (see the species
-                # parent for the full rationale). Safe: the resolver returns only
-                # still-needed images and per-image work is idempotent. The populate
-                # child below keeps FAILED_ONLY to dedupe LS task imports.
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
-            )
-        except WorkflowAlreadyStartedError:
-            workflow.logger.info(
-                "preprocess-headtail-%d already ran successfully in a prior "
-                "firing; skipping data-worker dispatch and continuing to "
-                "cleanup + populate",
-                dive_id,
-            )
-
-        # Drop the staged raw `.ORF` scratch objects from Garage; the
-        # JPEGs stay (LS reads them via presign). NAS is never touched.
-        await workflow.execute_activity(
-            "cleanup_raw_bytes_for_dive_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(minutes=15),
-            heartbeat_timeout=timedelta(minutes=5),
-        )
-
-        try:
-            await workflow.execute_child_workflow(
-                "PopulateHeadTailLabelStudioProjectWorkflow",
-                dive_id,
-                id=f"populate-headtail-{dive_id}",
-                execution_timeout=timedelta(minutes=30),
-                # ALLOW_DUPLICATE (not FAILED_ONLY): a completed populate must
-                # not burn the id, or a dive that later gains an eligible image
-                # can never get an LS task for it -> never gets a label row ->
-                # never drains from the cohort, blocking every higher-id dive
-                # behind it while re-staging raw .ORFs every hour (prod dive 60
-                # held up 84/465/471, 2026-08-04). Safe: the child is
-                # idempotent twice over — the activity selects only images with
-                # no non-sentinel label row, and `import_tasks_and_record_labels`
-                # dedupes by URL against tasks already in the project. Matches
-                # the laser populate parent, which already runs ALLOW_DUPLICATE.
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
-            )
-        except WorkflowAlreadyStartedError:
-            # Only reachable while a prior populate for this dive is still
-            # RUNNING (manual run overlapping the schedule).
-            workflow.logger.info(
-                "populate-headtail-%d is still running; skipping duplicate "
-                "dispatch",
-                dive_id,
-            )
 
         return inputs.dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_laser_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_laser_images_parent_workflow.py
@@ -1,73 +1,44 @@
 """Stage 0.1 parent workflow (api-worker side).
 
 Picks the next HIGH-priority dive needing laser preprocessing, resolves
-its unlabeled-image-set + camera intrinsics via SDK, and dispatches
-the resolved inputs to the data-worker's `PreprocessLaserImagesWorkflow`
-on `fishsense_data_processing_queue`. After the raw-scratch cleanup,
-chains into `PopulateLaserLabelStudioProjectWorkflow` on the api-worker
-so a fresh dive lands in Label Studio in the same hourly run that
-produced its JPEGs — no operator-triggered populate needed.
+its unlabeled-image-set + camera intrinsics via SDK, and dispatches the
+resolved inputs to the data-worker's `PreprocessLaserImagesWorkflow` on
+`fishsense_data_processing_queue`.
 
-Cohort: HIGH-priority + at least one image with no completed
-`LaserLabel` in any project. Mirrors the work-state shape of the
-other three preprocess parents (dive-image / headtail / slate). The
-earlier "no `LaserExtrinsics`" cohort tied stage 0.1 to a downstream
-gate it doesn't actually advance, so dives whose laser side was done
-but slate-side blocked stage-13 calibration kept getting re-selected
-hourly with no work for the resolver to return — see
-`select_next_for_laser_preprocessing` in the api's `dive_controller`.
+Cohort: HIGH-priority + at least one canonical image with no non-sentinel
+`LaserLabel` row (any real project). The earlier "no `LaserExtrinsics`"
+cohort tied stage 0.1 to a downstream gate it doesn't advance, so dives
+whose laser side was done but whose slate side blocked stage-13
+calibration kept getting re-selected hourly with no work for the resolver
+to return — see `select_next_for_laser_preprocessing` in the api's
+`dive_cohort_controller`.
 
-Cluster-correctness invariants — relevant once the data-worker scales
-beyond a single replica:
+Laser populate is **decoupled** from this workflow (2026-07-28,
+model-assisted labeling): it runs as its own scheduled parent,
+`PopulateLaserLabelStudioProjectParentWorkflow` (+12 min), AFTER the
+laser-detector predict stage (+10). Populate seeds non-sentinel
+`LaserLabel` rows and the predict cohort excludes any image that already
+has one, so populating here (at +0) would starve the predictor before it
+ever ran.
 
-* Per-image activities (in the child workflow) PUT to Garage (S3),
-  which overwrites idempotently. Retried activities don't double-write.
-* SDK upserts on the resolver side don't mutate state — read-only.
-* The schedule that fires this workflow uses
-  `overlap_policy=ScheduleOverlapPolicy.SKIP`, so a run still in
-  flight when the next firing arrives is dropped at the schedule level.
-* The data-worker child workflow is started with a deterministic id
-  (`preprocess-laser-{dive_id}`) and
-  `id_reuse_policy=ALLOW_DUPLICATE_FAILED_ONLY`; if a parent run
-  somehow races past the schedule guard (manual + scheduled trigger
-  overlap), or if a previous parent run failed *after* the child
-  succeeded but *before* archive completed and the next firing
-  re-targets the same dive, the second child dispatch hits
-  `WorkflowAlreadyStarted` and the parent catches it. Archive +
-  cleanup + populate then still run, so a child-then-parent split
-  failure self-heals on the next firing rather than redoing
-  per-image work.
-* The populate child uses the same deterministic-id trick
-  (`populate-laser-{dive_id}`). With the work-state cohort, dives
-  drop out as labels complete, so re-firings on the same dive_id are
-  the exception (resurrected re-incomplete labels, manual triggers)
-  rather than the steady state — but the dedup still matters when
-  they happen, since populate's task-import would otherwise create
-  duplicate LS tasks for any image still flagged incomplete.
+The shared steps — and the cluster-correctness invariants behind each
+(schedule SKIP overlap, deterministic child ids, ALLOW_DUPLICATE reuse,
+idempotent per-image work) — live in `_dispatch`.
 """
 
 from datetime import timedelta
 
 from fishsense_shared import PreprocessLaserImagesInput
 from temporalio import workflow
-from temporalio.common import WorkflowIDReusePolicy
-from temporalio.exceptions import WorkflowAlreadyStartedError
 
-with workflow.unsafe.imports_passed_through():
-    from fishsense_api_workflow_worker.workflows._retry_policies import (
-        SCALING_RETRY_POLICY,
-        SDK_FAIL_FAST_RETRY_POLICY,
-        STAGE_RAW_RETRY_POLICY,
-    )
-
-DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
+from fishsense_api_workflow_worker.workflows import _dispatch
 
 
 @workflow.defn
 class PreprocessLaserImagesParentWorkflow:
     # pylint: disable=too-few-public-methods
-    """Auto-pick the next HIGH-priority dive without laser extrinsics
-    and dispatch its preprocessing to the data-worker.
+    """Auto-pick the next HIGH-priority dive needing laser preprocessing
+    and dispatch its work to the data-worker.
 
     Returns the dive_id processed (or None when the backlog is empty).
     Each invocation drains exactly one dive — an N-dive backlog clears
@@ -76,21 +47,16 @@ class PreprocessLaserImagesParentWorkflow:
 
     @workflow.run
     async def run(self) -> int | None:
-        dive_id = await workflow.execute_activity(
-            "select_next_high_priority_dive_for_laser_preprocessing_activity",
-            args=(),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+        dive_id = await _dispatch.select_dive(
+            "select_next_high_priority_dive_for_laser_preprocessing_activity"
         )
         if dive_id is None:
             return None
 
-        inputs = await workflow.execute_activity(
+        inputs = await _dispatch.resolve_inputs(
             "resolve_laser_preprocess_inputs_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
-            result_type=PreprocessLaserImagesInput,
+            dive_id,
+            PreprocessLaserImagesInput,
         )
 
         workflow.logger.info(
@@ -102,72 +68,14 @@ class PreprocessLaserImagesParentWorkflow:
         if not inputs.image_checksums:
             return inputs.dive_id
 
-        # Wake the NRP data-worker before its child workflow lands on
-        # the queue (it scales to zero when idle). Idempotent — converges
-        # on the configured replica count, never accumulates; a no-op
-        # when k8s scaling isn't configured. Returns immediately, so the
-        # pod's cold start overlaps the NAS-staging step below.
-        await workflow.execute_activity(
-            "ensure_data_worker_running_activity",
-            args=(),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SCALING_RETRY_POLICY,
+        await _dispatch.wake_data_worker()
+        await _dispatch.stage_raw(dive_id)
+        await _dispatch.dispatch_child(
+            "PreprocessLaserImagesWorkflow",
+            inputs,
+            child_id=f"preprocess-laser-{dive_id}",
+            execution_timeout=timedelta(hours=1),
         )
+        await _dispatch.cleanup_raw(dive_id)
 
-        # Phase 3a: stage raw .ORF bytes from NAS to file-exchange
-        # before the data-worker child runs. Failure here is fatal —
-        # we don't want to dispatch a child that will 404 on every
-        # download_raw. The next schedule firing retries; HEAD-check
-        # in the staging activity makes the retry cheap for already-
-        # staged checksums.
-        await workflow.execute_activity(
-            "stage_raw_bytes_for_dive_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(hours=1),
-            heartbeat_timeout=timedelta(minutes=5),
-            retry_policy=STAGE_RAW_RETRY_POLICY,
-        )
-
-        try:
-            await workflow.execute_child_workflow(
-                "PreprocessLaserImagesWorkflow",
-                inputs,
-                id=f"preprocess-laser-{dive_id}",
-                task_queue=DATA_PROCESSING_TASK_QUEUE,
-                execution_timeout=timedelta(hours=1),
-                # ALLOW_DUPLICATE so a dive can reprocess images that became
-                # processable after its first successful run (see the species
-                # parent for the full rationale). Safe: the resolver returns only
-                # still-needed images and per-image work is idempotent. The populate
-                # child below keeps FAILED_ONLY to dedupe LS task imports.
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
-            )
-        except WorkflowAlreadyStartedError:
-            workflow.logger.info(
-                "preprocess-laser-%d already ran successfully in a prior "
-                "firing; skipping data-worker dispatch and continuing to "
-                "archive + cleanup + populate",
-                dive_id,
-            )
-
-        # Drop the staged raw `.ORF` scratch objects from Garage now
-        # that the data-worker has produced the JPEGs. The JPEGs are the
-        # durable artifact and live in Garage (LS reads them via
-        # presign); only the reproducible-from-NAS raw scratch is
-        # evicted. The NAS source is never touched.
-        await workflow.execute_activity(
-            "cleanup_raw_bytes_for_dive_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(minutes=15),
-            heartbeat_timeout=timedelta(minutes=5),
-        )
-
-        # Laser populate is DECOUPLED from preprocess (2026-07-28, model-
-        # assisted labeling). It now runs as its own scheduled parent
-        # (PopulateLaserLabelStudioProjectParentWorkflow, +12 min) AFTER the
-        # laser-detector predict stage (+10), because populate seeds
-        # non-sentinel LaserLabel rows and the predict cohort excludes any
-        # image that already has a LaserLabel — populating here (at +0) would
-        # starve the predictor before it ever ran. See that parent + the
-        # `needing-laser-population` cohort.
         return inputs.dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_slate_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_slate_images_parent_workflow.py
@@ -1,33 +1,26 @@
 """Stage 9 parent workflow (api-worker side).
 
 Picks the next HIGH-priority dive needing slate preprocessing and
-dispatches `PreprocessSlateImagesWorkflow` to the data-worker. After
-archive+cleanup, chains into
-`PopulateDiveSlateLabelStudioProjectWorkflow` so slate JPEGs land in
-the dive-slate LS project in the same hourly firing that produced
-them.
+dispatches `PreprocessSlateImagesWorkflow` to the data-worker. This stage
+stages **two** inputs — the raw `.ORF` frames and the dive's slate
+template PDF — because the per-image activity composites the rendered
+template alongside the rectified frame. After cleanup it chains into
+`PopulateDiveSlateLabelStudioProjectWorkflow`.
 
-Same cluster-correctness invariants as
-`PreprocessLaserImagesParentWorkflow` — see CLAUDE.md. Populate child
-uses deterministic id `populate-dive-slate-{dive_id}` so re-firings
-on the same cohort dive no-op via WorkflowAlreadyStarted.
+Cohort: HIGH-priority + `dive_slate_id` set + at least one
+`SpeciesLabel.content_of_image = 'Slate, Laser on slate'` whose image
+carries no `DiveSlateLabel` row at all.
+
+Shared steps live in `_dispatch`; see `PreprocessLaserImagesParentWorkflow`
+and CLAUDE.md for the cluster-correctness invariants.
 """
 
 from datetime import timedelta
 
 from fishsense_shared import PreprocessSlateImagesInput
 from temporalio import workflow
-from temporalio.common import WorkflowIDReusePolicy
-from temporalio.exceptions import WorkflowAlreadyStartedError
 
-with workflow.unsafe.imports_passed_through():
-    from fishsense_api_workflow_worker.workflows._retry_policies import (
-        SCALING_RETRY_POLICY,
-        SDK_FAIL_FAST_RETRY_POLICY,
-        STAGE_RAW_RETRY_POLICY,
-    )
-
-DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
+from fishsense_api_workflow_worker.workflows import _dispatch
 
 
 @workflow.defn
@@ -41,21 +34,16 @@ class PreprocessSlateImagesParentWorkflow:
 
     @workflow.run
     async def run(self) -> int | None:
-        dive_id = await workflow.execute_activity(
-            "select_next_high_priority_dive_for_slate_preprocessing_activity",
-            args=(),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+        dive_id = await _dispatch.select_dive(
+            "select_next_high_priority_dive_for_slate_preprocessing_activity"
         )
         if dive_id is None:
             return None
 
-        inputs = await workflow.execute_activity(
+        inputs = await _dispatch.resolve_inputs(
             "resolve_slate_preprocess_inputs_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
-            result_type=PreprocessSlateImagesInput,
+            dive_id,
+            PreprocessSlateImagesInput,
         )
 
         workflow.logger.info(
@@ -68,85 +56,23 @@ class PreprocessSlateImagesParentWorkflow:
         if not inputs.image_checksums:
             return inputs.dive_id
 
-        # Wake the NRP data-worker before its child workflow lands on
-        # the queue (it scales to zero when idle). Idempotent — converges
-        # on the configured replica count, never accumulates; a no-op
-        # when k8s scaling isn't configured. Returns immediately, so the
-        # pod's cold start overlaps the NAS-staging steps below.
-        await workflow.execute_activity(
-            "ensure_data_worker_running_activity",
-            args=(),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SCALING_RETRY_POLICY,
-        )
-
-        # Slate stage needs both the raw .ORFs and the slate template
-        # PDF on the file-exchange before the data-worker child runs.
-        await workflow.execute_activity(
-            "stage_raw_bytes_for_dive_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(hours=1),
-            heartbeat_timeout=timedelta(minutes=5),
-            retry_policy=STAGE_RAW_RETRY_POLICY,
-        )
-        await workflow.execute_activity(
-            "stage_slate_pdf_activity",
-            args=(inputs.slate_id,),
+        await _dispatch.wake_data_worker()
+        await _dispatch.stage_raw(dive_id)
+        await _dispatch.stage_slate_pdf(
+            inputs.slate_id,
             schedule_to_close_timeout=timedelta(minutes=5),
         )
-
-        try:
-            await workflow.execute_child_workflow(
-                "PreprocessSlateImagesWorkflow",
-                inputs,
-                id=f"preprocess-slate-{dive_id}",
-                task_queue=DATA_PROCESSING_TASK_QUEUE,
-                execution_timeout=timedelta(hours=1),
-                # ALLOW_DUPLICATE so a dive can reprocess images that became
-                # processable after its first successful run (see the species
-                # parent for the full rationale). Safe: the resolver returns only
-                # still-needed images and per-image work is idempotent. The populate
-                # child below keeps FAILED_ONLY to dedupe LS task imports.
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
-            )
-        except WorkflowAlreadyStartedError:
-            workflow.logger.info(
-                "preprocess-slate-%d already ran successfully in a prior "
-                "firing; skipping data-worker dispatch and continuing to "
-                "cleanup + populate",
-                dive_id,
-            )
-
-        # Drop the staged raw `.ORF` scratch objects from Garage; the
-        # JPEGs stay (LS reads them via presign). NAS is never touched.
-        await workflow.execute_activity(
-            "cleanup_raw_bytes_for_dive_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(minutes=15),
-            heartbeat_timeout=timedelta(minutes=5),
+        await _dispatch.dispatch_child(
+            "PreprocessSlateImagesWorkflow",
+            inputs,
+            child_id=f"preprocess-slate-{dive_id}",
+            execution_timeout=timedelta(hours=1),
         )
-
-        try:
-            await workflow.execute_child_workflow(
-                "PopulateDiveSlateLabelStudioProjectWorkflow",
-                dive_id,
-                id=f"populate-dive-slate-{dive_id}",
-                execution_timeout=timedelta(minutes=30),
-                # ALLOW_DUPLICATE (not FAILED_ONLY) — see the headtail parent:
-                # a completed populate burning the id permanently stalls any
-                # dive that later gains an eligible image, and stalls every
-                # higher-id dive behind it. Safe: the child is idempotent twice
-                # over (activity selects only images without a completed label
-                # row; `import_tasks_and_record_labels` dedupes by URL).
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
-            )
-        except WorkflowAlreadyStartedError:
-            # Only reachable while a prior populate for this dive is still
-            # RUNNING (manual run overlapping the schedule).
-            workflow.logger.info(
-                "populate-dive-slate-%d is still running; skipping duplicate "
-                "dispatch",
-                dive_id,
-            )
+        await _dispatch.cleanup_raw(dive_id)
+        await _dispatch.dispatch_populate(
+            "PopulateDiveSlateLabelStudioProjectWorkflow",
+            dive_id,
+            f"populate-dive-slate-{dive_id}",
+        )
 
         return inputs.dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_species_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/preprocess_species_images_parent_workflow.py
@@ -1,40 +1,29 @@
 """Stage 2 parent workflow (api-worker side).
 
-Picks the next HIGH-priority dive needing species preprocessing,
-resolves its PREDICTION clusters + camera intrinsics + laser/species
-labels via SDK, and dispatches `PreprocessSpeciesImagesWorkflow` as a
-child on the data-worker (`fishsense_data_processing_queue`). After the
-child writes the group-preprocessed JPEGs to Garage, it cleans up the
-staged raw scratch and stops there.
+Picks the next HIGH-priority dive needing species preprocessing, resolves
+its PREDICTION clusters + camera intrinsics + laser/species labels via
+SDK, and dispatches `PreprocessSpeciesImagesWorkflow` to the data-worker.
+The child writes the group-preprocessed JPEGs to Garage; this parent then
+evicts the staged raw scratch and stops.
 
-Species LS-task population is **decoupled** from this workflow — it no
-longer chains into `PopulateSpeciesLabelStudioProjectWorkflow`. The
-hourly `PopulateSpeciesLabelStudioProjectParentWorkflow` (+20 min)
-selects the superseded-aware "needs species population" cohort and fans
-out the idempotent, JPEG-gated populate per dive. Decoupling lets dives
-whose old-project species rows were superseded (post hosted-LS
-migration) get (re)populated without re-preprocessing.
+Species LS-task population is **decoupled** from this workflow — it does
+not chain into `PopulateSpeciesLabelStudioProjectWorkflow`. The hourly
+`PopulateSpeciesLabelStudioProjectParentWorkflow` (+20 min) selects the
+superseded-aware "needs species population" cohort and fans out the
+idempotent, JPEG-gated populate per dive. Decoupling lets dives whose
+old-project species rows were superseded (post hosted-LS migration) get
+(re)populated without re-preprocessing.
 
-Same cluster-correctness invariants as
-`PreprocessLaserImagesParentWorkflow` — see CLAUDE.md's "Cross-worker
-orchestration pattern" section.
+Shared steps live in `_dispatch`; see `PreprocessLaserImagesParentWorkflow`
+and CLAUDE.md's "Cross-worker orchestration pattern" for the invariants.
 """
 
 from datetime import timedelta
 
 from fishsense_shared import PreprocessSpeciesImagesInput
 from temporalio import workflow
-from temporalio.common import WorkflowIDReusePolicy
-from temporalio.exceptions import WorkflowAlreadyStartedError
 
-with workflow.unsafe.imports_passed_through():
-    from fishsense_api_workflow_worker.workflows._retry_policies import (
-        SCALING_RETRY_POLICY,
-        SDK_FAIL_FAST_RETRY_POLICY,
-        STAGE_RAW_RETRY_POLICY,
-    )
-
-DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
+from fishsense_api_workflow_worker.workflows import _dispatch
 
 
 @workflow.defn
@@ -44,27 +33,20 @@ class PreprocessSpeciesImagesParentWorkflow:
     preprocessing and dispatch its work to the data-worker.
 
     Returns the dive_id processed (or None when the backlog is empty).
-    Each invocation drains exactly one dive — an N-dive backlog clears
-    in N hourly schedule firings.
     """
 
     @workflow.run
     async def run(self) -> int | None:
-        dive_id = await workflow.execute_activity(
-            "select_next_high_priority_dive_for_species_preprocessing_activity",
-            args=(),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
+        dive_id = await _dispatch.select_dive(
+            "select_next_high_priority_dive_for_species_preprocessing_activity"
         )
         if dive_id is None:
             return None
 
-        inputs = await workflow.execute_activity(
+        inputs = await _dispatch.resolve_inputs(
             "resolve_species_preprocess_inputs_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SDK_FAIL_FAST_RETRY_POLICY,
-            result_type=PreprocessSpeciesImagesInput,
+            dive_id,
+            PreprocessSpeciesImagesInput,
         )
 
         total_images = sum(len(cluster) for cluster in inputs.clusters)
@@ -79,70 +61,14 @@ class PreprocessSpeciesImagesParentWorkflow:
         if not inputs.clusters or total_images == 0:
             return inputs.dive_id
 
-        # Wake the NRP data-worker before its child workflow lands on
-        # the queue (it scales to zero when idle). Idempotent — converges
-        # on the configured replica count, never accumulates; a no-op
-        # when k8s scaling isn't configured. Returns immediately, so the
-        # pod's cold start overlaps the NAS-staging step below.
-        await workflow.execute_activity(
-            "ensure_data_worker_running_activity",
-            args=(),
-            schedule_to_close_timeout=timedelta(minutes=5),
-            retry_policy=SCALING_RETRY_POLICY,
+        await _dispatch.wake_data_worker()
+        await _dispatch.stage_raw(dive_id)
+        await _dispatch.dispatch_child(
+            "PreprocessSpeciesImagesWorkflow",
+            inputs,
+            child_id=f"preprocess-species-{dive_id}",
+            execution_timeout=timedelta(hours=2),
         )
+        await _dispatch.cleanup_raw(dive_id)
 
-        await workflow.execute_activity(
-            "stage_raw_bytes_for_dive_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(hours=1),
-            heartbeat_timeout=timedelta(minutes=5),
-            retry_policy=STAGE_RAW_RETRY_POLICY,
-        )
-
-        try:
-            await workflow.execute_child_workflow(
-                "PreprocessSpeciesImagesWorkflow",
-                inputs,
-                id=f"preprocess-species-{dive_id}",
-                task_queue=DATA_PROCESSING_TASK_QUEUE,
-                execution_timeout=timedelta(hours=2),
-                # ALLOW_DUPLICATE, not ALLOW_DUPLICATE_FAILED_ONLY: the child
-                # must be able to re-run on a dive it already processed, to
-                # pick up images that became processable AFTER that run — a
-                # laser validated after one-shot stage-1 clustering, or an
-                # orphan later assigned a cluster. FAILED_ONLY permanently
-                # blocked that (a completed id can never re-dispatch), so such
-                # images' JPEGs were never produced and populate deferred them
-                # forever. Safe: the resolver returns only images that still
-                # need work (finished images aren't redone) and the per-image
-                # activities are idempotent (S3 overwrite). (Species populate
-                # is decoupled — the scheduled populate parent owns dedup of
-                # LS imports — so there is no populate child here to worry
-                # about; laser/headtail/slate keep FAILED_ONLY on theirs.)
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
-            )
-        except WorkflowAlreadyStartedError:
-            # Only reachable now if a prior child with this id is still
-            # RUNNING (e.g. a manual run overlapping the schedule). The
-            # in-flight run is doing the work; continue to cleanup.
-            workflow.logger.info(
-                "preprocess-species-%d already running; skipping duplicate "
-                "dispatch and continuing to cleanup",
-                dive_id,
-            )
-
-        # Drop the staged raw `.ORF` scratch objects from Garage; the
-        # JPEGs stay (LS reads them via presign). NAS is never touched.
-        await workflow.execute_activity(
-            "cleanup_raw_bytes_for_dive_activity",
-            args=(dive_id,),
-            schedule_to_close_timeout=timedelta(minutes=15),
-            heartbeat_timeout=timedelta(minutes=5),
-        )
-
-        # NOTE: species LS-task population is decoupled from preprocess as
-        # of the scheduled-populate parent — this workflow only writes the
-        # JPEGs. `PopulateSpeciesLabelStudioProjectParentWorkflow`
-        # (hourly, +20 min) selects the superseded-aware cohort and fans
-        # out the idempotent, JPEG-gated populate per dive.
         return inputs.dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/sync_label_studio_dive_slate_labels_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/sync_label_studio_dive_slate_labels_workflow.py
@@ -18,7 +18,6 @@ class SyncLabelStudioDiveSlateLabelsWorkflow:
     @workflow.run
     async def run(self):
         """Run the workflow to sync dive-slate labels from Label Studio."""
-        # pylint: disable=duplicate-code
         await workflow.execute_activity(
             "sync_users_label_studio_activity",
             args=(),

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/sync_label_studio_headtail_labels_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/sync_label_studio_headtail_labels_workflow.py
@@ -18,7 +18,6 @@ class SyncLabelStudioHeadTailLabelsWorkflow:
     @workflow.run
     async def run(self):
         """Run the workflow to sync laser head tail from Label Studio."""
-        # pylint: disable=duplicate-code
         await workflow.execute_activity(
             "sync_users_label_studio_activity",
             args=(),

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/sync_label_studio_laser_labels_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/sync_label_studio_laser_labels_workflow.py
@@ -32,7 +32,6 @@ class SyncLabelStudioLaserLabelsWorkflow:
     @workflow.run
     async def run(self):
         """Run the workflow to sync laser labels from Label Studio."""
-        # pylint: disable=duplicate-code
         await workflow.execute_activity(
             "sync_users_label_studio_activity",
             args=(),

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/sync_label_studio_species_labels_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/sync_label_studio_species_labels_workflow.py
@@ -18,7 +18,6 @@ class SyncLabelStudioSpeciesLabelsWorkflow:
     @workflow.run
     async def run(self):
         """Run the workflow to sync species labels from Label Studio."""
-        # pylint: disable=duplicate-code
         await workflow.execute_activity(
             "sync_users_label_studio_activity",
             args=(),

--- a/services/fishsense-api-workflow-worker/tests/test_backfill_slate_predictions_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_backfill_slate_predictions_workflow.py
@@ -24,11 +24,13 @@ from fishsense_shared import (
     PredictSlateImagesInput,
     SlatePredictionResult,
 )
+from fishsense_api_workflow_worker.workflows._dispatch import (
+    DATA_PROCESSING_TASK_QUEUE,
+)
 from fishsense_api_workflow_worker.workflows.backfill_slate_predictions_workflow import (  # noqa: E501  pylint: disable=line-too-long
     BackfillSlatePredictionsWorkflow,
 )
 from fishsense_api_workflow_worker.workflows.predict_slate_images_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
-    DATA_PROCESSING_TASK_QUEUE,
     PredictSlateImagesParentWorkflow,
 )
 

--- a/services/fishsense-api-workflow-worker/tests/test_object_store.py
+++ b/services/fishsense-api-workflow-worker/tests/test_object_store.py
@@ -38,29 +38,12 @@ def _keys(s3) -> set[str]:
     return {o["Key"] for o in resp.get("Contents", [])}
 
 
-def test_key_helpers():
-    assert sut.raw_key("abc123") == "raw/abc123.ORF"
-    assert sut.slate_pdf_key(7) == "slate_pdf/7.pdf"
-    assert sut.processed_jpeg_key("preprocess_jpeg", "abc") == (
-        "preprocess_jpeg/abc.JPG"
-    )
-    assert sut.processed_jpeg_key("preprocess_jpeg", "abc", "fishsense-lite") == (
-        "fishsense-lite/preprocess_jpeg/abc.JPG"
-    )
-
-
-def test_build_s3_client_uses_path_style_addressing_for_garage():
-    """Garage has no virtual-host bucket DNS, so the client MUST use
-    path-style addressing. A regression to virtual-host addressing
-    would make every request hit `bucket.garage.example.com` and fail."""
-    client = sut.build_s3_client(
-        endpoint_url="http://garage.example.com",
-        region="garage",
-        access_key="k",
-        secret_key="s",
-    )
-    assert client.meta.config.s3["addressing_style"] == "path"
-    assert client.meta.endpoint_url == "http://garage.example.com"
+# The key contract (`raw_key` / `slate_pdf_key` / `jpeg_key`) and
+# `build_s3_client`'s path-style addressing now live in
+# `fishsense_shared.object_store` and are pinned by
+# `libs/fishsense-shared/tests/test_object_store.py`. Asserting them again
+# here would be the same duplication this module was just refactored out of.
+# What stays below is what is genuinely this worker's: its method subset.
 
 
 async def test_upload_raw_writes_expected_key_and_bytes(s3):

--- a/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
@@ -73,11 +73,12 @@ def _headtail_label(
     completed: bool,
     superseded: bool = False,
     has_id: bool = True,
+    project_id: int = 71,
 ) -> HeadTailLabel:
     return HeadTailLabel(
         id=image_id * 1000 if has_id else None,
         label_studio_task_id=image_id * 11,
-        label_studio_project_id=71,
+        label_studio_project_id=project_id,
         head_x=None,
         head_y=None,
         tail_x=None,
@@ -407,3 +408,47 @@ async def test_defers_images_whose_jpeg_is_not_in_garage(monkeypatch):
     assert n == 1, "only the image with a rendered JPEG is seeded"
     written = [c.args[1] for c in fs.labels.put_headtail_label.await_args_list]
     assert {w.image_id for w in written} == {1}
+
+
+@pytest.mark.asyncio
+async def test_legacy_other_project_rows_are_superseded_even_when_refreshed(monkeypatch):
+    """A legacy-project row must be dead-lettered even if this run re-imported
+    its image.
+
+    `get_headtail_labels(dive_id)` returns every non-superseded row for the
+    dive across ALL projects, and `put_headtail_label` upserts on
+    `(image_id, label_studio_project_id)` — so one image really can hold both a
+    legacy row and this project's row. The exemption used to be image-based
+    ("this run refreshed image 1, so skip everything for image 1"), which let
+    the legacy row survive forever. Since `dive_pipeline_status`
+    `headtail_labeling_complete` requires ZERO incomplete non-superseded rows,
+    that dive read incomplete on the dashboard permanently, even after
+    labelers finished the per-dive project.
+
+    The exemption is now (same project AND refreshed), so this run's own row
+    stays live while the legacy one retires.
+    """
+    laser = [_laser(1)]
+    images_by_id = {1: _image(1, "a")}
+    existing = [
+        # This project's live row for image 1 — must stay live (dive 341).
+        _headtail_label(1, completed=False, has_id=True, project_id=71),
+        # A legacy shared-project row for the SAME image — must be superseded.
+        _headtail_label(1, completed=False, has_id=True, project_id=66),
+    ]
+
+    fs = _make_fs_client(laser, existing, images_by_id)
+    ls = _make_ls_client(returned_task_ids=[4003])
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(sut_utils, "_get_ls_client", lambda: ls)
+
+    await ActivityEnvironment().run(
+        sut.populate_headtail_label_studio_project_activity, 42, 71
+    )
+
+    written = [c.args[1] for c in fs.labels.put_headtail_label.await_args_list]
+    superseded = [w for w in written if w.superseded]
+    assert [w.label_studio_project_id for w in superseded] == [66], (
+        "only the legacy-project row should be dead-lettered"
+    )

--- a/services/fishsense-api-workflow-worker/tests/test_predict_laser_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_predict_laser_images_parent_workflow.py
@@ -28,8 +28,10 @@ from fishsense_shared import (
     PredictLaserImage,
     PredictLaserImagesInput,
 )
-from fishsense_api_workflow_worker.workflows.predict_laser_images_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
+from fishsense_api_workflow_worker.workflows._dispatch import (
     DATA_PROCESSING_TASK_QUEUE,
+)
+from fishsense_api_workflow_worker.workflows.predict_laser_images_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
     PredictLaserImagesParentWorkflow,
 )
 

--- a/services/fishsense-api-workflow-worker/tests/test_preprocess_headtail_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preprocess_headtail_images_parent_workflow.py
@@ -12,8 +12,10 @@ from temporalio import activity, workflow
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
-from fishsense_api_workflow_worker.workflows.preprocess_headtail_images_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
+from fishsense_api_workflow_worker.workflows._dispatch import (
     DATA_PROCESSING_TASK_QUEUE,
+)
+from fishsense_api_workflow_worker.workflows.preprocess_headtail_images_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
     PreprocessHeadtailImagesParentWorkflow,
 )
 from fishsense_shared import PreprocessHeadtailImagesInput

--- a/services/fishsense-api-workflow-worker/tests/test_preprocess_laser_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preprocess_laser_images_parent_workflow.py
@@ -32,8 +32,10 @@ from temporalio import activity, workflow
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
-from fishsense_api_workflow_worker.workflows.preprocess_laser_images_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
+from fishsense_api_workflow_worker.workflows._dispatch import (
     DATA_PROCESSING_TASK_QUEUE,
+)
+from fishsense_api_workflow_worker.workflows.preprocess_laser_images_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
     PreprocessLaserImagesParentWorkflow,
 )
 from fishsense_shared import PreprocessLaserImagesInput

--- a/services/fishsense-api-workflow-worker/tests/test_preprocess_slate_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preprocess_slate_images_parent_workflow.py
@@ -12,8 +12,10 @@ from temporalio import activity, workflow
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
-from fishsense_api_workflow_worker.workflows.preprocess_slate_images_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
+from fishsense_api_workflow_worker.workflows._dispatch import (
     DATA_PROCESSING_TASK_QUEUE,
+)
+from fishsense_api_workflow_worker.workflows.preprocess_slate_images_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
     PreprocessSlateImagesParentWorkflow,
 )
 from fishsense_shared import PreprocessSlateImagesInput

--- a/services/fishsense-api-workflow-worker/tests/test_preprocess_species_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preprocess_species_images_parent_workflow.py
@@ -12,8 +12,10 @@ from temporalio import activity, workflow
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
-from fishsense_api_workflow_worker.workflows.preprocess_species_images_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
+from fishsense_api_workflow_worker.workflows._dispatch import (
     DATA_PROCESSING_TASK_QUEUE,
+)
+from fishsense_api_workflow_worker.workflows.preprocess_species_images_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
     PreprocessSpeciesImagesParentWorkflow,
 )
 from fishsense_shared import PreprocessSpeciesImagesInput

--- a/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_clustering_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_clustering_activity.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from temporalio.testing import ActivityEnvironment
 
+from fishsense_api_workflow_worker.activities import cohort_selection
 from fishsense_api_workflow_worker.activities import (
     select_next_high_priority_dive_for_clustering_activity as sut,
 )
@@ -30,7 +31,7 @@ def _make_fs(*, dive_id: int | None):
 @pytest.mark.asyncio
 async def test_passes_through_dive_id_from_sdk(monkeypatch):
     fs = _make_fs(dive_id=42)
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(cohort_selection, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_clustering_activity
@@ -43,7 +44,7 @@ async def test_passes_through_dive_id_from_sdk(monkeypatch):
 @pytest.mark.asyncio
 async def test_returns_none_when_sdk_returns_none(monkeypatch):
     fs = _make_fs(dive_id=None)
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(cohort_selection, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_clustering_activity

--- a/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_headtail_preprocessing_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_headtail_preprocessing_activity.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from temporalio.testing import ActivityEnvironment
 
+from fishsense_api_workflow_worker.activities import cohort_selection
 from fishsense_api_workflow_worker.activities import (
     select_next_high_priority_dive_for_headtail_preprocessing_activity as sut,
 )
@@ -30,7 +31,7 @@ def _make_fs(*, dive_id: int | None):
 @pytest.mark.asyncio
 async def test_passes_through_dive_id_from_sdk(monkeypatch):
     fs = _make_fs(dive_id=42)
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(cohort_selection, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_headtail_preprocessing_activity
@@ -43,7 +44,7 @@ async def test_passes_through_dive_id_from_sdk(monkeypatch):
 @pytest.mark.asyncio
 async def test_returns_none_when_sdk_returns_none(monkeypatch):
     fs = _make_fs(dive_id=None)
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(cohort_selection, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_headtail_preprocessing_activity

--- a/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_laser_calibration_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_laser_calibration_activity.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from temporalio.testing import ActivityEnvironment
 
+from fishsense_api_workflow_worker.activities import cohort_selection
 from fishsense_api_workflow_worker.activities import (
     select_next_high_priority_dive_for_laser_calibration_activity as sut,
 )
@@ -30,7 +31,7 @@ def _make_fs(*, dive_id: int | None):
 @pytest.mark.asyncio
 async def test_passes_through_dive_id_from_sdk(monkeypatch):
     fs = _make_fs(dive_id=42)
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(cohort_selection, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_laser_calibration_activity
@@ -43,7 +44,7 @@ async def test_passes_through_dive_id_from_sdk(monkeypatch):
 @pytest.mark.asyncio
 async def test_returns_none_when_sdk_returns_none(monkeypatch):
     fs = _make_fs(dive_id=None)
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(cohort_selection, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_laser_calibration_activity

--- a/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_laser_preprocessing_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_laser_preprocessing_activity.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from temporalio.testing import ActivityEnvironment
 
+from fishsense_api_workflow_worker.activities import cohort_selection
 from fishsense_api_workflow_worker.activities import (
     select_next_high_priority_dive_for_laser_preprocessing_activity as sut,
 )
@@ -31,7 +32,7 @@ def _make_fs(*, dive_id: int | None):
 @pytest.mark.asyncio
 async def test_passes_through_dive_id_from_sdk(monkeypatch):
     fs = _make_fs(dive_id=42)
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(cohort_selection, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_laser_preprocessing_activity
@@ -44,7 +45,7 @@ async def test_passes_through_dive_id_from_sdk(monkeypatch):
 @pytest.mark.asyncio
 async def test_returns_none_when_sdk_returns_none(monkeypatch):
     fs = _make_fs(dive_id=None)
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(cohort_selection, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_laser_preprocessing_activity

--- a/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_measure_fish_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_measure_fish_activity.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from temporalio.testing import ActivityEnvironment
 
+from fishsense_api_workflow_worker.activities import cohort_selection
 from fishsense_api_workflow_worker.activities import (
     select_next_high_priority_dive_for_measure_fish_activity as sut,
 )
@@ -30,7 +31,7 @@ def _make_fs(*, dive_id: int | None):
 @pytest.mark.asyncio
 async def test_passes_through_dive_id_from_sdk(monkeypatch):
     fs = _make_fs(dive_id=42)
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(cohort_selection, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_measure_fish_activity
@@ -43,7 +44,7 @@ async def test_passes_through_dive_id_from_sdk(monkeypatch):
 @pytest.mark.asyncio
 async def test_returns_none_when_sdk_returns_none(monkeypatch):
     fs = _make_fs(dive_id=None)
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(cohort_selection, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_measure_fish_activity

--- a/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_slate_preprocessing_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_slate_preprocessing_activity.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from temporalio.testing import ActivityEnvironment
 
+from fishsense_api_workflow_worker.activities import cohort_selection
 from fishsense_api_workflow_worker.activities import (
     select_next_high_priority_dive_for_slate_preprocessing_activity as sut,
 )
@@ -30,7 +31,7 @@ def _make_fs(*, dive_id: int | None):
 @pytest.mark.asyncio
 async def test_passes_through_dive_id_from_sdk(monkeypatch):
     fs = _make_fs(dive_id=42)
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(cohort_selection, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_slate_preprocessing_activity
@@ -43,7 +44,7 @@ async def test_passes_through_dive_id_from_sdk(monkeypatch):
 @pytest.mark.asyncio
 async def test_returns_none_when_sdk_returns_none(monkeypatch):
     fs = _make_fs(dive_id=None)
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(cohort_selection, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_slate_preprocessing_activity

--- a/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_species_preprocessing_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_select_next_high_priority_dive_for_species_preprocessing_activity.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from temporalio.testing import ActivityEnvironment
 
+from fishsense_api_workflow_worker.activities import cohort_selection
 from fishsense_api_workflow_worker.activities import (
     select_next_high_priority_dive_for_species_preprocessing_activity as sut,
 )
@@ -30,7 +31,7 @@ def _make_fs(*, dive_id: int | None):
 @pytest.mark.asyncio
 async def test_passes_through_dive_id_from_sdk(monkeypatch):
     fs = _make_fs(dive_id=42)
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(cohort_selection, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_species_preprocessing_activity
@@ -43,7 +44,7 @@ async def test_passes_through_dive_id_from_sdk(monkeypatch):
 @pytest.mark.asyncio
 async def test_returns_none_when_sdk_returns_none(monkeypatch):
     fs = _make_fs(dive_id=None)
-    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    monkeypatch.setattr(cohort_selection, "get_fs_client", lambda: fs)
 
     result = await ActivityEnvironment().run(
         sut.select_next_high_priority_dive_for_species_preprocessing_activity

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/a2f7c31d9e64_measurable_excludes_empty_fish_model_leaf.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/a2f7c31d9e64_measurable_excludes_empty_fish_model_leaf.py
@@ -1,0 +1,74 @@
+"""dive_pipeline_status: measurable excludes the empty "Fish Model," leaf
+
+Revision ID: a2f7c31d9e64
+Revises: c3e8b1d47a52
+Create Date: 2026-08-11 00:00:00.000000
+
+The measurable-species predicate matched `content_of_image = "Fish Model,"` —
+the parent taxonomy node with no model leaf, which a labeler produces by
+selecting "Fish Model" and not picking one. `LIKE 'Fish Model,%'` matches it
+because `%` matches the empty string.
+
+`measure_fish_activity` does NOT accept it: `parse_model_name` returns None for
+an empty (or whitespace-only) leaf, so the activity skips the image rather than
+writing a Fish with an empty `name`. Cohort says measurable, activity says
+skip — no Measurement is ever written, `NOT EXISTS (measurement)` stays true,
+and the dive is re-selected every hour forever. That is the identical
+never-goes-false shape that blocked scheduling stage 14 before 2026-07-17,
+reachable from a single labeler mis-click.
+
+The predicate now adds `AND TRIM(content_of_image) <> 'Fish Model,'`, which
+also covers a whitespace-only leaf (matching `parse_model_name`'s `.strip()`).
+`TRIM` behaves identically on Postgres (prod) and SQLite (tests).
+
+Found by `test_measurable_species_sql_agrees_with_taxonomy_is_measurable`,
+which runs this SQL and `fishsense_shared.taxonomy.is_measurable` over the
+shared `MEASURABILITY_CORPUS` and asserts they select the same rows. Before
+this revision the three copies of the predicate were kept in step by comments
+only — comments that had themselves drifted into claiming fish models and the
+ruler were unmeasurable.
+
+Drop + recreate rather than CREATE OR REPLACE: Postgres is restrictive about
+column-shape changes on replace, and the view has no dependents (see the
+`dive_pipeline_status` section of CLAUDE.md).
+
+No data is touched, and the column shape is unchanged. On prod the effect is
+confined to dives holding at least one empty-leaf `"Fish Model,"` species row:
+those stop counting toward `measured`'s denominator, so a dive wedged on one
+can finally read `measured = true` and drain from the stage-14 cohort. Every
+other dive's flags are byte-identical.
+"""
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from fishsense_api.views import (
+    DIVE_PIPELINE_STATUS_VIEW_SQL,
+    DROP_DIVE_PIPELINE_STATUS_VIEW_SQL,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "a2f7c31d9e64"
+down_revision: Union[str, Sequence[str], None] = "c3e8b1d47a52"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Recreate the view with the empty-leaf guard."""
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)
+
+
+def downgrade() -> None:
+    """Recreate from whatever `views.py` currently holds.
+
+    Not a true inverse: the SQL is imported from `views.py`, the single source
+    of truth, so downgrading after reverting the code restores the old
+    predicate while downgrading without reverting is a no-op. Same trade-off
+    every view migration in this tree makes.
+    """
+    op.execute(DROP_DIVE_PIPELINE_STATUS_VIEW_SQL)
+    op.execute(DIVE_PIPELINE_STATUS_VIEW_SQL)

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_cohort_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_cohort_controller.py
@@ -27,9 +27,11 @@ import logging
 from typing import List
 
 from fastapi import Depends
-from sqlalchemy import func, or_
+from sqlalchemy import and_, func, or_
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
+
+from fishsense_shared import taxonomy
 
 from fishsense_api.database import get_async_session
 from fishsense_api.models.data_source import DataSource
@@ -81,6 +83,7 @@ def _valid_laser_conditions():
 
     Mirrors `views._VALID_LASER_SQL` — the view and these selectors are
     two representations of the same predicate and must stay in step.
+    `test_dive_pipeline_status_view.py` pins that agreement.
     """
     return (
         LaserLabel.completed == True,
@@ -93,47 +96,55 @@ def _valid_laser_conditions():
 def _measurable_species_conditions():
     """A species row stage 14 can actually turn into a Measurement.
 
-    `measure_fish_activity._parse_species_names` reads the species name from
-    the LAST ", "-separated chunk of `content_of_image` and requires the
-    `Common Name (Scientific name)` shape, returning None otherwise — the
-    activity then skips the image rather than writing a malformed Species
-    row. Only the `Fish` taxonomy branch carries that shape:
+    Three measurable branches, matching `taxonomy.is_measurable`:
 
-        "Fish, Hogfish (Lachnolaimus maximus)"  -> measurable
-        "Fish Model, Weasly Fish"               -> skipped (no parens)
-        "Calibration Targets, Ruler"            -> skipped (no parens)
+        "Fish, Hogfish (Lachnolaimus maximus)"  -> real fish, `Common
+                                                   (Scientific)` leaf
+        "Fish Model, Weasly Fish"               -> rigid model, name-keyed
+        "Calibration Targets, Ruler"            -> the ruler, name-keyed
 
-    Without this, the cohort and the activity disagree in a way that cannot
-    resolve: the selector keeps offering an image the activity always skips,
-    so no Measurement is written, `~is_measured` stays true, and the dive is
-    re-selected every hour forever. That is the same never-goes-false shape
-    that blocked scheduling stage 14 before 2026-07-17.
+    Everything else — `"Slate, Laser on slate"`, other Calibration Targets —
+    is not measurable. (An earlier version of this docstring listed the
+    bottom two branches as *skipped*, six lines above the code matching them.
+    It was written when only the first branch existed and never updated when
+    models and the ruler were added; the ruler clause in particular looks
+    like dead code if you believe the comment.)
 
-    Two measurable branches: real fish carry the `Common (Scientific)` shape
-    (parens); physical fish models carry a `Fish Model, <name>` prefix (no
-    parens) — `measure_fish_activity` resolves those to a name-keyed Fish.
-    Calibration Targets stay unmeasurable.
+    Without this condition the cohort and the activity disagree in a way that
+    cannot resolve: the selector keeps offering an image the activity always
+    skips, so no Measurement is written, `~is_measured` stays true, and the
+    dive is re-selected every hour forever. That is the same never-goes-false
+    shape that blocked scheduling stage 14 before 2026-07-17.
 
-    Mirrors `views._MEASURABLE_SPECIES_SQL` — keep the two in step.
+    These `LIKE` patterns approximate `taxonomy.is_measurable`, which is the
+    definition of record. `test_dive_pipeline_status_view.py` runs the SQL
+    over `taxonomy.MEASURABILITY_CORPUS` and asserts the two agree.
     """
     return (  # pylint: disable=no-member
         or_(
-            SpeciesLabel.content_of_image.like("%(%)"),
-            SpeciesLabel.content_of_image.like("Fish Model,%"),
-            SpeciesLabel.content_of_image == "Calibration Targets, Ruler",
+            SpeciesLabel.content_of_image.like(taxonomy.REAL_FISH_LIKE),
+            _is_fish_model_condition(),
         ),
     )
 
 
 def _is_fish_model_condition():
-    """A physical fish-model species row. Models carry no grouping labels and
-    thus no LABEL_STUDIO cluster, so the stage-14 cohort waives the cluster
-    requirement for them (identity is the model name; length uses only
-    laser/head-tail/calibration). Mirrors `views._IS_FISH_MODEL_SQL`."""
+    """A rigid known-length target (fish model or the ruler).
+
+    These carry no grouping labels and thus no LABEL_STUDIO cluster, so the
+    stage-14 cohort waives the cluster requirement for them: identity is the
+    target name, and length uses only laser/head-tail/calibration.
+    Mirrors `views._IS_FISH_MODEL_SQL`.
+    """
     # pylint: disable=no-member
     return or_(
-        SpeciesLabel.content_of_image.like("Fish Model,%"),
-        SpeciesLabel.content_of_image == "Calibration Targets, Ruler",
+        and_(
+            SpeciesLabel.content_of_image.like(taxonomy.FISH_MODEL_LIKE),
+            # Excludes the empty leaf "Fish Model," — see
+            # `taxonomy.rigid_target_sql` for why that one matters.
+            func.trim(SpeciesLabel.content_of_image) != taxonomy.FISH_MODEL_PREFIX,
+        ),
+        SpeciesLabel.content_of_image == taxonomy.RULER_CONTENT,
     )
 
 
@@ -161,8 +172,9 @@ def _valid_headtail_conditions():
 # raises and re-fires every hour.
 MIN_COMPLETED_SLATE_LABELS = 2
 
-# Stage-9 species_label.content_of_image marker.
-SLATE_CONTENT_MARKER = "Slate, Laser on slate"
+# Stage-9 species_label.content_of_image marker (re-exported from the
+# shared taxonomy vocabulary so the view and the worker read the same one).
+SLATE_CONTENT_MARKER = taxonomy.SLATE_CONTENT_MARKER
 
 
 # Cohort selectors used by the api-workflow-worker hourly schedules.

--- a/services/fishsense-api/src/fishsense_api/controllers/label_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/label_controller.py
@@ -23,6 +23,39 @@ from fishsense_api.server import app
 logger = logging.getLogger(__name__)
 
 
+async def _resolve_label_natural_key(
+    session: AsyncSession, model, image_id: int, project_id: int | None
+) -> int | None:
+    """Existing row id for `(image_id, project_id)`, or None.
+
+    `session.merge` keys on the PRIMARY key alone, so a body with `id=None`
+    always INSERTs. Every label model carries a `uq_<kind>_image_project`
+    constraint on `(image_id, label_studio_project_id)`, so that second INSERT
+    is a duplicate-key 500 — exactly what a populate retry produced (prod
+    headtail dive 347). Resolving the natural key first turns the merge into an
+    UPDATE. Same shape as `post_measurement` / `uq_measurement_image_fish`.
+
+    The NULL-project branch is the one that is easy to miss. Sentinel rows
+    carry `label_studio_project_id = NULL`, and SQL treats NULLs as DISTINCT in
+    a unique constraint — `(11, NULL)` never conflicts with `(11, NULL)`. So
+    the constraint cannot protect those rows, and skipping resolution for them
+    (which the four handlers used to do) meant every write appended another
+    row, unbounded. `IS NULL` has to be spelled explicitly because `== None`
+    renders as `= NULL`, which is never true.
+
+    Spelled once rather than four times: the handlers were four textual copies
+    that `duplicate-code` cannot see, because the differing model name makes
+    every line differ.
+    """
+    query = select(model).where(model.image_id == image_id)
+    if project_id is None:
+        query = query.where(model.label_studio_project_id.is_(None))
+    else:
+        query = query.where(model.label_studio_project_id == project_id)
+    existing = (await session.exec(query)).first()
+    return existing.id if existing is not None else None
+
+
 @app.get("/api/v1/labels/dive-slate/label-studio-project-ids")
 async def get_dive_slate_label_studio_project_ids(
     incomplete: bool = False,
@@ -106,22 +139,12 @@ async def put_dive_slate_label(
     label = DiveSlateLabel.model_validate(jsonable_encoder(label))
     label.image_id = image_id
 
-    # Natural-key upsert: merge on id=None always INSERTs, violating
-    # uq_dive_slate_image_project on a populate retry. Resolve to the
-    # existing (image_id, project) row first (see put_headtail_label).
-    if label.id is None and label.label_studio_project_id is not None:
-        existing = (
-            await session.exec(
-                select(DiveSlateLabel)
-                .where(DiveSlateLabel.image_id == image_id)
-                .where(
-                    DiveSlateLabel.label_studio_project_id
-                    == label.label_studio_project_id
-                )
-            )
-        ).first()
-        if existing is not None:
-            label.id = existing.id
+    # Natural-key upsert — see `_resolve_label_natural_key` for why
+    # merge alone duplicates, including the NULL-project case.
+    if label.id is None:
+        label.id = await _resolve_label_natural_key(
+            session, DiveSlateLabel, image_id, label.label_studio_project_id
+        )
 
     label = await session.merge(label)
     await session.flush()
@@ -245,25 +268,12 @@ async def put_headtail_label(
     label = HeadTailLabel.model_validate(jsonable_encoder(label))
     label.image_id = image_id
 
-    # session.merge keys on the primary key alone, so a body with id=None
-    # always INSERTs — which violates uq_headtail_image_project when the
-    # populate activity retries and re-writes a sentinel row that already
-    # exists for this (image_id, project). Resolve the natural key to the
-    # existing row id first so the merge becomes an UPDATE (see
-    # post_measurement / uq_measurement_image_fish for the precedent).
-    if label.id is None and label.label_studio_project_id is not None:
-        existing = (
-            await session.exec(
-                select(HeadTailLabel)
-                .where(HeadTailLabel.image_id == image_id)
-                .where(
-                    HeadTailLabel.label_studio_project_id
-                    == label.label_studio_project_id
-                )
-            )
-        ).first()
-        if existing is not None:
-            label.id = existing.id
+    # Natural-key upsert — see `_resolve_label_natural_key` for why
+    # merge alone duplicates, including the NULL-project case.
+    if label.id is None:
+        label.id = await _resolve_label_natural_key(
+            session, HeadTailLabel, image_id, label.label_studio_project_id
+        )
 
     label = await session.merge(label)
     await session.flush()
@@ -466,22 +476,12 @@ async def put_laser_label(
     label = LaserLabel.model_validate(jsonable_encoder(label))
     label.image_id = image_id
 
-    # Natural-key upsert: merge on id=None always INSERTs, violating
-    # uq_laser_image_project on a populate retry. Resolve to the existing
-    # (image_id, project) row first (see put_headtail_label).
-    if label.id is None and label.label_studio_project_id is not None:
-        existing = (
-            await session.exec(
-                select(LaserLabel)
-                .where(LaserLabel.image_id == image_id)
-                .where(
-                    LaserLabel.label_studio_project_id
-                    == label.label_studio_project_id
-                )
-            )
-        ).first()
-        if existing is not None:
-            label.id = existing.id
+    # Natural-key upsert — see `_resolve_label_natural_key` for why
+    # merge alone duplicates, including the NULL-project case.
+    if label.id is None:
+        label.id = await _resolve_label_natural_key(
+            session, LaserLabel, image_id, label.label_studio_project_id
+        )
 
     label = await session.merge(label)
     await session.flush()
@@ -577,22 +577,12 @@ async def put_species_label(
     label = SpeciesLabel.model_validate(jsonable_encoder(label))
     label.image_id = image_id
 
-    # Natural-key upsert: merge on id=None always INSERTs, violating
-    # uq_species_image_project on a populate retry. Resolve to the existing
-    # (image_id, project) row first (see put_headtail_label).
-    if label.id is None and label.label_studio_project_id is not None:
-        existing = (
-            await session.exec(
-                select(SpeciesLabel)
-                .where(SpeciesLabel.image_id == image_id)
-                .where(
-                    SpeciesLabel.label_studio_project_id
-                    == label.label_studio_project_id
-                )
-            )
-        ).first()
-        if existing is not None:
-            label.id = existing.id
+    # Natural-key upsert — see `_resolve_label_natural_key` for why
+    # merge alone duplicates, including the NULL-project case.
+    if label.id is None:
+        label.id = await _resolve_label_natural_key(
+            session, SpeciesLabel, image_id, label.label_studio_project_id
+        )
 
     label = await session.merge(label)
     await session.flush()

--- a/services/fishsense-api/src/fishsense_api/models/dive_slate_label.py
+++ b/services/fishsense-api/src/fishsense_api/models/dive_slate_label.py
@@ -9,7 +9,6 @@ from fishsense_api.models.model_base import ModelBase
 
 
 class DiveSlateLabel(ModelBase, table=True):
-    # pylint: disable=R0801
     """Model representing slate labels."""
 
     __table_args__ = (

--- a/services/fishsense-api/src/fishsense_api/models/head_tail_label.py
+++ b/services/fishsense-api/src/fishsense_api/models/head_tail_label.py
@@ -12,7 +12,6 @@ from fishsense_api.models.model_base import ModelBase
 
 
 class HeadTailLabel(ModelBase, table=True):
-    # pylint: disable=R0801
     """Model representing a head-tail label."""
 
     __table_args__ = (

--- a/services/fishsense-api/src/fishsense_api/models/label_studio_sync_cursor.py
+++ b/services/fishsense-api/src/fishsense_api/models/label_studio_sync_cursor.py
@@ -21,7 +21,6 @@ from fishsense_api.models.model_base import ModelBase
 
 
 class LabelStudioSyncCursor(ModelBase, table=True):
-    # pylint: disable=R0801
     """Per-(kind, project) high-water mark for Label Studio sync."""
 
     __table_args__ = (

--- a/services/fishsense-api/src/fishsense_api/models/laser_label.py
+++ b/services/fishsense-api/src/fishsense_api/models/laser_label.py
@@ -11,7 +11,6 @@ from fishsense_api.models.model_base import ModelBase
 
 
 class LaserLabel(ModelBase, table=True):
-    # pylint: disable=R0801
     """Model representing a laser label."""
 
     __table_args__ = (

--- a/services/fishsense-api/src/fishsense_api/models/species_label.py
+++ b/services/fishsense-api/src/fishsense_api/models/species_label.py
@@ -9,7 +9,6 @@ from fishsense_api.models.model_base import ModelBase
 
 
 class SpeciesLabel(ModelBase, table=True):
-    # pylint: disable=R0801
     """Model representing a species label."""
 
     __table_args__ = (

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -17,13 +17,16 @@ test suite to spin up a real Postgres.
 
 from __future__ import annotations
 
+from fishsense_shared import taxonomy
+
 DIVE_PIPELINE_STATUS_VIEW_NAME = "dive_pipeline_status"
 
-# Slate-content marker mirrors `dive_controller.SLATE_CONTENT_MARKER`.
-# Kept inline rather than imported to avoid `views.py` pulling controller
-# imports during alembic migration runs (alembic env loads `views` to
-# get this string before the FastAPI app is initialized).
-_SLATE_CONTENT_MARKER = "Slate, Laser on slate"
+# Stage-9 slate marker. Sourced from `fishsense_shared.taxonomy` rather than
+# from `dive_cohort_controller`, which keeps the old constraint satisfied —
+# `views.py` must not pull controller imports, because alembic's env loads
+# this module during migrations, before the FastAPI app exists — while still
+# giving the view, the cohort selector and the data-worker one definition.
+_SLATE_CONTENT_MARKER = taxonomy.SLATE_CONTENT_MARKER
 
 # A *valid* laser label: the labeler placed a point, the validator signed
 # off, and `ValidateLaserLabelsForDiveWorkflow`'s RANSAC fit hasn't
@@ -48,44 +51,39 @@ _VALID_HEADTAIL_SQL = """htl.completed = TRUE
 
 # An image stage 14 can actually turn into a Measurement.
 #
-# `measure_fish_activity._parse_species_names` reads the species name out of
-# the LAST ", "-separated chunk of `content_of_image` and requires the
-# `Common Name (Scientific name)` shape — it returns None otherwise and the
-# activity skips the image rather than writing a malformed Species row. Only
-# the `Fish` branch of the taxonomy carries that shape:
+# Three measurable branches, matching `taxonomy.is_measurable`:
 #
-#     "Fish, Hogfish (Lachnolaimus maximus)"  -> measurable
-#     "Fish Model, Weasly Fish"               -> skipped (no parens)
-#     "Calibration Targets, Ruler"            -> skipped (no parens)
+#     "Fish, Hogfish (Lachnolaimus maximus)"  -> real fish (parens leaf)
+#     "Fish Model, Weasly Fish"               -> rigid model, name-keyed
+#     "Calibration Targets, Ruler"            -> the ruler, name-keyed
+#
+# Everything else — "Slate, Laser on slate", other Calibration Targets — is
+# not measurable. (An earlier version of this comment listed the bottom two
+# as *skipped* and asserted "Calibration Targets stays unmeasurable", while
+# the SQL below matched both. It predated fish models and the ruler and was
+# never updated.)
 #
 # Without this condition the cohort and the activity disagree, and that
 # disagreement cannot resolve: the selector keeps offering an image the
 # activity always skips, no Measurement is ever written, so `NOT EXISTS
 # (measurement)` stays true and the dive is re-selected every hour forever.
 # That is the same never-goes-false shape that blocked scheduling stage 14
-# before 2026-07-17, so it is spelled once and mirrored in
-# `dive_controller._measurable_species_conditions`.
+# before 2026-07-17.
+#
+# These LIKE patterns approximate `fishsense_shared.taxonomy.is_measurable`,
+# which is the definition of record (it is what `measure_fish_activity`
+# actually binds on). `test_dive_pipeline_status_view.py` runs this SQL over
+# `taxonomy.MEASURABILITY_CORPUS` and asserts the two agree, so the Python
+# and SQL representations cannot drift apart silently again.
 #
 # Assumes the enclosing subquery aliases specieslabel as `sl`.
-#
-# Two measurable branches: real fish carry a `Common (Scientific)` name
-# (parens); physical fish models carry a `Fish Model, <name>` prefix (no
-# parens) — measure_fish_activity resolves those to a name-keyed Fish. Any
-# other branch (Calibration Targets) stays unmeasurable. Mirrors
-# `dive_controller._measurable_species_conditions` and
-# `measure_fish_activity` (`_parse_species_names` / `_parse_model_name`).
-_MEASURABLE_SPECIES_SQL = (
-    "(sl.content_of_image LIKE '%(%)' "
-    "OR sl.content_of_image LIKE 'Fish Model,%' "
-    "OR sl.content_of_image = 'Calibration Targets, Ruler')"
-)
+_MEASURABLE_SPECIES_SQL = taxonomy.measurable_species_sql("sl.content_of_image")
 
-# A fish-model row (no cluster required — models carry no grouping labels).
+# A rigid known-length target — fish model or ruler. No cluster required:
+# these carry no grouping labels. Mirrors
+# `dive_cohort_controller._is_fish_model_condition`.
 # Assumes the enclosing subquery aliases specieslabel as `sl`.
-_IS_FISH_MODEL_SQL = (
-    "(sl.content_of_image LIKE 'Fish Model,%' "
-    "OR sl.content_of_image = 'Calibration Targets, Ruler')"
-)
+_IS_FISH_MODEL_SQL = taxonomy.rigid_target_sql("sl.content_of_image")
 
 # "Complete" everywhere = ≥1 completed-non-superseded row AND zero
 # incomplete-non-superseded rows. Mirrors
@@ -96,8 +94,8 @@ _IS_FISH_MODEL_SQL = (
 # The same physical frames live under several dive rows (half of prod's image
 # table is duplicate content; 207 of 479 dives are duplicates end to end), and
 # `is_canonical` marks which copy is real. The cohort selectors in
-# `dive_controller` gate on it so a duplicate dive can never become pipeline
-# work, and this view has to use the identical predicate or the two drift:
+# `dive_cohort_controller` gate on it so a duplicate dive can never become
+# pipeline work, and this view has to use the identical predicate or the two drift:
 # the dashboard would report a dive as perpetually incomplete while the worker
 # correctly does nothing with it. `test_dive_pipeline_status_view.py` pins that
 # agreement explicitly.

--- a/services/fishsense-api/tests/test_canonical_only_pipeline_work.py
+++ b/services/fishsense-api/tests/test_canonical_only_pipeline_work.py
@@ -142,7 +142,7 @@ def test_every_cohort_selector_filters_on_is_canonical():
     )
 
     # Both modules, deliberately: the selectors live in `dive_cohort_controller`
-    # but `dive_controller` still correlates Image to Dive (canonical dives), and
+    # but `dive_cohort_controller` still correlates Image to Dive (canonical dives), and
     # a future selector could land in either. Checking only where they happen to
     # live today is how this guard would quietly stop guarding.
     source = "\n".join(

--- a/services/fishsense-api/tests/test_dive_pipeline_status_view.py
+++ b/services/fishsense-api/tests/test_dive_pipeline_status_view.py
@@ -1337,3 +1337,171 @@ async def test_calibration_source_none_when_uncalibrated(session):
     row = await _row(session, 1)
     assert row["calibration_source"] == "none"
     assert row["calibrated"] is False
+
+
+# ---------------------------------------------------------------------------
+# SQL <-> Python parity for the measurable-species predicate
+# ---------------------------------------------------------------------------
+
+
+async def test_measurable_species_sql_agrees_with_taxonomy_is_measurable(session):
+    """The one predicate that exists in three languages must mean one thing.
+
+    `taxonomy.is_measurable` is the definition of record — it is literally
+    "can `measure_fish_activity` bind this row to a Measurement". The SQL here
+    and the SQLAlchemy conditions in `dive_cohort_controller` are `LIKE`-based
+    approximations, because the view runs on Postgres in prod and SQLite under
+    test and can't use either one's string functions.
+
+    Approximations are fine; *unverified* approximations are how the cohort
+    starts offering images the activity always skips, which never resolves and
+    re-selects the dive every hour forever. So both representations are run
+    over the same corpus and compared row by row.
+    """
+    from fishsense_shared import taxonomy  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.views import (  # pylint: disable=import-outside-toplevel
+        _MEASURABLE_SPECIES_SQL,
+    )
+
+    corpus = taxonomy.MEASURABILITY_CORPUS
+    session.add_all(
+        [
+            SpeciesLabel(
+                image_id=1000 + i,
+                label_studio_project_id=70,
+                content_of_image=content,
+            )
+            for i, (content, _) in enumerate(corpus)
+        ]
+    )
+    await session.flush()
+
+    result = await session.execute(
+        text(
+            "SELECT sl.image_id FROM specieslabel sl "
+            f"WHERE {_MEASURABLE_SPECIES_SQL}"
+        )
+    )
+    matched_by_sql = {row[0] for row in result}
+
+    expected = {
+        1000 + i for i, (_, measurable) in enumerate(corpus) if measurable
+    }
+    assert matched_by_sql == expected, (
+        "SQL and taxonomy.is_measurable disagree on: "
+        + repr(
+            sorted(
+                corpus[i - 1000][0]
+                for i in matched_by_sql.symmetric_difference(expected)
+            )
+        )
+    )
+
+
+async def test_measurable_species_sql_agrees_with_the_sqlalchemy_conditions(session):
+    """The view's raw SQL and the cohort selector's SQLAlchemy build the same
+    predicate from the same constants; assert they select the same rows."""
+    from sqlmodel import select  # pylint: disable=import-outside-toplevel
+
+    from fishsense_shared import taxonomy  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+        _measurable_species_conditions,
+    )
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.views import (  # pylint: disable=import-outside-toplevel
+        _MEASURABLE_SPECIES_SQL,
+    )
+
+    corpus = taxonomy.MEASURABILITY_CORPUS
+    session.add_all(
+        [
+            SpeciesLabel(
+                image_id=2000 + i,
+                label_studio_project_id=70,
+                content_of_image=content,
+            )
+            for i, (content, _) in enumerate(corpus)
+        ]
+    )
+    await session.flush()
+
+    via_sql = {
+        row[0]
+        for row in await session.execute(
+            text(
+                "SELECT sl.image_id FROM specieslabel sl "
+                f"WHERE {_MEASURABLE_SPECIES_SQL} AND sl.image_id >= 2000"
+            )
+        )
+    }
+    via_orm = set(
+        (
+            await session.exec(
+                select(SpeciesLabel.image_id)
+                .where(*_measurable_species_conditions())
+                .where(SpeciesLabel.image_id >= 2000)
+            )
+        ).all()
+    )
+    assert via_sql == via_orm
+
+
+async def test_sql_is_broader_than_python_only_where_pinned(session):
+    """A *new* SQL/Python divergence must fail the build.
+
+    The dangerous direction is SQL-broader: the cohort offers an image the
+    activity skips, no Measurement is written, and the dive is re-selected
+    every hour forever. `taxonomy.SQL_BROADER_THAN_PYTHON` is the pinned,
+    known-unreachable set (the empty-name guard the LIKE patterns can't
+    express). This asserts the real SQL matches exactly those and no others,
+    so widening the predicate — or tightening the Python parser, which is how
+    this regressed once already — is caught here rather than in prod.
+    """
+    from fishsense_shared import taxonomy  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.views import (  # pylint: disable=import-outside-toplevel
+        _MEASURABLE_SPECIES_SQL,
+    )
+
+    probes = [c for c, _ in taxonomy.MEASURABILITY_CORPUS if c is not None]
+    probes += list(taxonomy.SQL_BROADER_THAN_PYTHON)
+    session.add_all(
+        [
+            SpeciesLabel(
+                image_id=3000 + i,
+                label_studio_project_id=70,
+                content_of_image=content,
+            )
+            for i, content in enumerate(probes)
+        ]
+    )
+    await session.flush()
+
+    matched_by_sql = {
+        row[0]
+        for row in await session.execute(
+            text(
+                "SELECT sl.image_id FROM specieslabel sl "
+                f"WHERE {_MEASURABLE_SPECIES_SQL} AND sl.image_id >= 3000"
+            )
+        )
+    }
+    sql_broader = {
+        probes[i - 3000]
+        for i in matched_by_sql
+        if not taxonomy.is_measurable(probes[i - 3000])
+    }
+    assert sql_broader == set(taxonomy.SQL_BROADER_THAN_PYTHON)
+
+    # And the reverse direction — Python measurable, SQL not — must be empty:
+    # that would silently under-measure a dive while reporting it complete.
+    python_broader = {
+        c
+        for i, c in enumerate(probes)
+        if taxonomy.is_measurable(c) and (3000 + i) not in matched_by_sql
+    }
+    assert python_broader == set()

--- a/services/fishsense-api/tests/test_label_upsert_endpoint.py
+++ b/services/fishsense-api/tests/test_label_upsert_endpoint.py
@@ -111,3 +111,57 @@ async def test_put_label_distinct_projects_same_image_both_persist(
 
     rows = (await session.exec(select(model))).all()
     assert len(rows) == 2
+
+
+@pytest.mark.parametrize("put_fn,model", _cases())
+async def test_put_label_with_null_project_upserts_rather_than_accumulating(
+    session, put_fn, model
+):
+    """A NULL-project sentinel row must upsert too, not append a row per call.
+
+    `uq_<kind>_image_project` cannot protect this case: the constraint spans
+    `(image_id, label_studio_project_id)`, and SQL treats NULLs as DISTINCT, so
+    `(11, NULL)` never conflicts with `(11, NULL)`. The handlers also skipped
+    natural-key resolution entirely when the project was NULL, so every write
+    inserted another row — unbounded, with nothing to stop it.
+
+    That is a live candidate for the ~2000 unexplained sentinel rows in prod
+    (one per HIGH-priority canonical image, "source unclear"): they are exactly
+    the rows a repeated NULL-project PUT would leave behind. It also matters to
+    the cohort selectors, which count "non-sentinel" rows by testing
+    `label_studio_project_id IS NOT NULL` — duplicates on the NULL side skew
+    nothing today but grow forever.
+    """
+    await put_fn(
+        11, _label(model, task_id=None, project_id=None, completed=False), session=session
+    )
+    await session.flush()
+    await put_fn(
+        11, _label(model, task_id=None, project_id=None, completed=True), session=session
+    )
+    await session.flush()
+
+    rows = (await session.exec(select(model))).all()
+    assert len(rows) == 1, "a repeated NULL-project PUT must upsert, not accumulate"
+    assert rows[0].completed is True, "latest write wins"
+
+
+@pytest.mark.parametrize("put_fn,model", _cases())
+async def test_null_project_row_is_distinct_from_a_real_project_row(
+    session, put_fn, model
+):
+    """Resolving the NULL-project row must not hijack a real-project row for
+    the same image, or populate would overwrite the sentinel it meant to
+    replace and lose the task binding."""
+    await put_fn(
+        11, _label(model, task_id=None, project_id=None, completed=False), session=session
+    )
+    await session.flush()
+    await put_fn(
+        11, _label(model, task_id=700, project_id=73, completed=False), session=session
+    )
+    await session.flush()
+
+    rows = (await session.exec(select(model))).all()
+    assert len(rows) == 2
+    assert sorted(r.label_studio_project_id or 0 for r in rows) == [0, 73]

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/measure_fish_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/measure_fish_activity.py
@@ -38,6 +38,7 @@ from fishsense_api_sdk.models.measurement import Measurement
 from fishsense_api_sdk.models.species import Species
 from fishsense_api_sdk.models.species_label import SpeciesLabel
 from fishsense_core.world_point import WorldPointHandler
+from fishsense_shared import taxonomy
 from temporalio import activity
 
 from fishsense_data_processing_workflow_worker.activities.utils import get_fs_client
@@ -73,60 +74,16 @@ class MeasureFishResult:
 __all__ = ["MeasureFishResult", "measure_fish_activity"]
 
 
-# Taxonomy prefix for physical fish models. The leaf after it (e.g. "Grouper")
-# is the model's identity — the `name` natural key on Fish. Mirrors the
-# `LIKE 'Fish Model,%'` clause in `views._MEASURABLE_SPECIES_SQL` and
-# `dive_controller._measurable_species_conditions`; keep the three in step.
-_FISH_MODEL_PREFIX = "Fish Model,"
-
-# The ruler is a rigid known-length target like the models, so it measures
-# through the same name-keyed path. Its span is currently always the 14-inch
-# one (0.3556 m, seeded in `fishmodelreference`) — see the caveat there if
-# labelers ever start marking a different span.
-_RULER_CONTENT = "Calibration Targets, Ruler"
-_RULER_NAME = "Ruler"
-
-
-def _parse_model_name(content_of_image: str | None) -> str | None:
-    """Return the target name for a known-length rigid target, else None.
-
-    Covers `Fish Model, <name>` and the ruler (`Calibration Targets, Ruler` ->
-    "Ruler"). Real fish (`..., Common (Scientific)`) and every other branch
-    return None. An empty leaf ("Fish Model," with nothing after) returns None
-    — nothing to identify — matching the "skip rather than write a malformed
-    row" posture of `_parse_species_names`.
-
-    The ruler earns its place here because, unlike a fish model, its endpoints
-    are unambiguous: it carries no tail-landmark (fork vs tip) uncertainty, so
-    it isolates calibration error from labeling convention.
-    """
-    if not content_of_image:
-        return None
-    if content_of_image.strip() == _RULER_CONTENT:
-        return _RULER_NAME
-    if not content_of_image.startswith(_FISH_MODEL_PREFIX):
-        return None
-    name = content_of_image[len(_FISH_MODEL_PREFIX):].strip()
-    return name or None
-
-
-def _parse_species_names(content_of_image: str | None) -> tuple[str, str] | None:
-    """Pull (common_name, scientific_name) out of the species label's
-    `content_of_image` field. Format: "..., Common Name (Scientific name)".
-
-    Returns None if the field is empty or doesn't match the expected
-    shape (we'd rather skip than write a malformed Species row).
-    """
-    if not content_of_image:
-        return None
-    last_chunk = content_of_image.split(", ")[-1]
-    if "(" not in last_chunk or not last_chunk.endswith(")"):
-        return None
-    common = last_chunk.split(" (")[0].strip()
-    scientific = last_chunk.split(" (")[-1][:-1].strip()
-    if not common or not scientific:
-        return None
-    return common, scientific
+# The `content_of_image` taxonomy vocabulary — markers and parsers — lives in
+# `fishsense_shared.taxonomy`, imported above. It used to be spelled here and
+# again in the api's cohort selector and `dive_pipeline_status` view, kept in
+# step by comments that had already drifted: both api copies documented
+# "Fish Model, ..." and "Calibration Targets, Ruler" as *skipped* while their
+# code matched both as measurable. One definition now, cross-checked against
+# the SQL by `test_dive_pipeline_status_view.py` over
+# `taxonomy.MEASURABILITY_CORPUS`.
+_parse_model_name = taxonomy.parse_model_name
+_parse_species_names = taxonomy.parse_species_names
 
 
 async def _ensure_species(fs: Client, common: str, scientific: str) -> Species:

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_laser_image.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_laser_image.py
@@ -15,6 +15,7 @@ the unit tests mock the detector.
 import asyncio
 import logging
 import os
+import threading
 from typing import Any
 
 from temporalio import activity
@@ -33,7 +34,14 @@ DEFAULT_CHECKPOINT_PATH = os.environ.get(
 
 # Module-level cache: the detector loads its weights once per worker process
 # (loading is expensive and every per-image activity in the fan-out reuses it).
+#
+# The lock is load-bearing, not defensive. Activities run in a real
+# ThreadPoolExecutor (`worker.py`'s `activity_executor` +
+# `max_concurrent_activities`), so on a cold pod the whole first batch of
+# per-image activities enters this together. Unguarded, each thread sees
+# `_DETECTOR is None` and loads its own copy of the checkpoint onto the GPU.
 _DETECTOR: Any = None
+_DETECTOR_LOCK = threading.Lock()
 
 
 def _load_detector(checkpoint_path: str) -> Any:
@@ -49,11 +57,20 @@ def _load_detector(checkpoint_path: str) -> Any:
 
 
 def _get_detector(checkpoint_path: str = DEFAULT_CHECKPOINT_PATH) -> Any:
-    """Return the process-wide detector, loading it on first use."""
+    """Return the process-wide detector, loading it on first use.
+
+    Double-checked locking: the fast path is a bare read for the common case
+    (already loaded), and only the cold path pays for the lock. Safe under
+    CPython because `_DETECTOR` is published by a single atomic assignment —
+    a thread that sees a non-None value sees a fully-constructed detector.
+    """
     global _DETECTOR  # pylint: disable=global-statement
-    if _DETECTOR is None:
-        _log.info("loading LaserDetector checkpoint=%s", checkpoint_path)
-        _DETECTOR = _load_detector(checkpoint_path)
+    if _DETECTOR is not None:
+        return _DETECTOR
+    with _DETECTOR_LOCK:
+        if _DETECTOR is None:
+            _log.info("loading LaserDetector checkpoint=%s", checkpoint_path)
+            _DETECTOR = _load_detector(checkpoint_path)
     return _DETECTOR
 
 

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_slate_image.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_slate_image.py
@@ -1,5 +1,18 @@
 """Model-assisted slate labeling (data-worker, CPU).
 
+**RETIRED 2026-08-03 — registered, but nothing schedules it.** The
+ECC >= 0.80 acceptance gate does not transfer out of distribution: pool
+dives produced high-ECC (0.93-0.97) *false* fits that sailed through it
+(prod dives 65/71/77/80/83, all pool). The team declined an
+active-learning loop; `predict-slate-images-workflow-schedule` is now
+actively deleted at worker startup (`worker._RETIRED_SCHEDULE_IDS`) and
+the 130 seeded Label Studio predictions were removed.
+
+The code is kept registered so a future evaluation can start it by hand
+— it is dormant, not dead — but nothing invokes it on its own. Do not
+read it as part of the live pipeline.
+
+
 Runs the fishsense-core dive-slate estimator (`fishsense_core.slate`, v2.4.0+)
 on one rectified frame and returns the board's reference points in
 rectified-photo pixels — the same space the sync activity stores
@@ -20,6 +33,7 @@ corpus), so every rejection returns a *reason* and the default is to decline.
 import asyncio
 import logging
 import os
+import threading
 from typing import Any, Sequence
 
 from temporalio import activity
@@ -37,6 +51,9 @@ _log = logging.getLogger(__name__)
 DEFAULT_SLATE_CHECKPOINT_PATH = os.environ.get("E4EFS_SLATE_DETECTOR__CHECKPOINT", "")
 _MASKER: Any = None
 _MASKER_LOADED = False
+# See `_get_masker` — the flag must only ever be published *after* `_MASKER`,
+# and the lock is what stops a concurrent caller reading the pair mid-load.
+_MASKER_LOCK = threading.Lock()
 
 
 def _get_masker() -> Any:
@@ -45,32 +62,45 @@ def _get_masker() -> Any:
     Caches the outcome (including failure) so a missing mask doesn't retry the
     load on every frame. Loads from a local checkpoint when
     `E4EFS_SLATE_DETECTOR__CHECKPOINT` points at one, else from HuggingFace.
+
+    `_MASKER_LOADED` is set in a `finally`, *after* `_MASKER` is assigned, and
+    the whole cold path is serialized. Setting the flag first was a real bug:
+    `from_pretrained()` reaches HuggingFace and takes seconds, and activities
+    run in a real thread pool, so every frame arriving during that window read
+    the flag as True, got a still-unset `_MASKER`, and silently fell back to
+    the classical path. Silently, because nothing raised — the degradation
+    warning below only fires for an actual load failure.
     """
     global _MASKER, _MASKER_LOADED  # pylint: disable=global-statement
     if _MASKER_LOADED:
         return _MASKER
-    _MASKER_LOADED = True
-    try:
-        # no-name-in-module: BoardMasker ships in fishsense-core[slate] >= 2.4.0
-        from fishsense_core.slate import (  # pylint: disable=import-outside-toplevel,import-error,no-name-in-module
-            BoardMasker,
-        )
+    with _MASKER_LOCK:
+        if _MASKER_LOADED:
+            return _MASKER
+        try:
+            # no-name-in-module: BoardMasker ships in fishsense_core[slate] >= 2.4.0
+            from fishsense_core.slate import (  # pylint: disable=import-outside-toplevel,import-error,no-name-in-module
+                BoardMasker,
+            )
 
-        if DEFAULT_SLATE_CHECKPOINT_PATH and os.path.exists(
-            DEFAULT_SLATE_CHECKPOINT_PATH
-        ):
-            _MASKER = BoardMasker.from_checkpoint(DEFAULT_SLATE_CHECKPOINT_PATH)
-        else:
-            _MASKER = BoardMasker.from_pretrained()
-        _log.info("loaded BoardMasker (learned board mask)")
-    except Exception as exc:  # pylint: disable=broad-except
-        # torch/hf missing, no network, or bad checkpoint — fall back to the
-        # classical estimator. The mask only adds coverage; it's never required.
-        _log.warning(
-            "BoardMasker unavailable (%s); using classical slate path", exc
-        )
-        _MASKER = None
+            if DEFAULT_SLATE_CHECKPOINT_PATH and os.path.exists(
+                DEFAULT_SLATE_CHECKPOINT_PATH
+            ):
+                _MASKER = BoardMasker.from_checkpoint(DEFAULT_SLATE_CHECKPOINT_PATH)
+            else:
+                _MASKER = BoardMasker.from_pretrained()
+            _log.info("loaded BoardMasker (learned board mask)")
+        except Exception as exc:  # pylint: disable=broad-except
+            # torch/hf missing, no network, or bad checkpoint — fall back to the
+            # classical estimator. The mask only adds coverage; it's never required.
+            _log.warning(
+                "BoardMasker unavailable (%s); using classical slate path", exc
+            )
+            _MASKER = None
+        finally:
+            _MASKER_LOADED = True
     return _MASKER
+
 
 # ECC >= 0.80 keeps ~58% of frames at median ~6 px (measured on the corpus in
 # slate_training/docs/design.md). Coverage matters more than the last few px for

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/object_store.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/object_store.py
@@ -1,15 +1,13 @@
 """data-worker side of the Garage (S3-compatible) object store.
 
-Mirror of the api-worker's ``ObjectStoreClient``
-(``fishsense_api_workflow_worker/object_store.py``). The data-worker
-reads staged raw inputs + slate PDFs and writes processed JPEGs; it has
-**no NAS access** by design.
+The key contract and the S3 primitives live in
+`fishsense_shared.object_store` — it is an agreement *between* this
+worker and the api-worker, so neither owns it. This module is only the
+data-worker's method subset layered on top.
 
-Key contract (shared with the api-worker):
-
-    raw/{checksum}.ORF            # read
-    slate_pdf/{slate_id}.pdf      # read (stage 9)
-    {jpeg_prefix}/{checksum}.JPG  # write (durable; LS reads via presign)
+This worker reads staged raw inputs + slate PDFs from the scratch bucket
+and writes processed JPEGs to the labels bucket. It has **no NAS access**
+by design, and no way to delete anything.
 
 The ``{jpeg_prefix}`` values are the same folder names the workflows
 already pass as ``output_folder`` — ``preprocess_jpeg`` (0.1),
@@ -19,59 +17,26 @@ already pass as ``output_folder`` — ``preprocess_jpeg`` (0.1),
 
 from __future__ import annotations
 
-import asyncio
-
-import boto3
-from botocore.config import Config
-
-RAW_PREFIX = "raw"
-SLATE_PDF_PREFIX = "slate_pdf"
+from fishsense_shared.object_store import (
+    RAW_PREFIX,
+    SLATE_PDF_PREFIX,
+    BaseObjectStoreClient,
+    jpeg_key,
+    open_client,
+    raw_key,
+    slate_pdf_key,
+)
 
 __all__ = [
     "RAW_PREFIX",
     "SLATE_PDF_PREFIX",
     "ObjectStoreClient",
-    "build_s3_client",
     "jpeg_key",
+    "open_client",
     "open_object_store_client",
     "raw_key",
     "slate_pdf_key",
 ]
-
-
-def raw_key(checksum: str) -> str:
-    return f"{RAW_PREFIX}/{checksum}.ORF"
-
-
-def slate_pdf_key(slate_id: int) -> str:
-    return f"{SLATE_PDF_PREFIX}/{slate_id}.pdf"
-
-
-def jpeg_key(folder: str, checksum: str, prefix: str = "") -> str:
-    base = f"{folder}/{checksum}.JPG"
-    prefix = (prefix or "").strip("/")
-    return f"{prefix}/{base}" if prefix else base
-
-
-def build_s3_client(
-    *, endpoint_url: str, region: str, access_key: str, secret_key: str
-):
-    """Build a boto3 S3 client pointed at Garage.
-
-    Garage requires **path-style** addressing (no virtual-host bucket
-    DNS) and an explicit endpoint + region; SigV4 is its default.
-    """
-    return boto3.client(
-        "s3",
-        endpoint_url=endpoint_url,
-        region_name=region,
-        aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
-        config=Config(
-            signature_version="s3v4",
-            s3={"addressing_style": "path"},
-        ),
-    )
 
 
 def open_object_store_client() -> "ObjectStoreClient":
@@ -84,49 +49,17 @@ def open_object_store_client() -> "ObjectStoreClient":
     # pylint: disable=import-outside-toplevel
     from fishsense_data_processing_workflow_worker.config import settings
 
-    s3 = build_s3_client(
-        endpoint_url=settings.object_store.endpoint_url,
-        region=settings.object_store.region,
-        access_key=settings.object_store.access_key,
-        secret_key=settings.object_store.secret_key,
-    )
-    return ObjectStoreClient(
-        s3,
-        settings.object_store.bucket,
-        labels_bucket=settings.object_store.get("labels_bucket", None),
-        labels_prefix=settings.object_store.get("labels_prefix", "") or "",
-    )
+    return open_client(settings, ObjectStoreClient)
 
 
-class ObjectStoreClient:
-    """Thin async wrapper over a boto3 S3 client for the data-worker's
-    read + JPEG-write needs. Constructed per-activity-call; the boto3
-    client is injected so tests can pass a moto-backed one.
+class ObjectStoreClient(BaseObjectStoreClient):
+    """The data-worker's read + JPEG-write vocabulary.
 
     Reads raw/slate **scratch** from ``bucket``; writes processed JPEGs to
     ``labels_bucket`` (the LS-facing bucket) under ``labels_prefix``.
     ``labels_bucket`` defaults to ``bucket`` so single-bucket layouts keep
-    working unchanged."""
-
-    def __init__(self, s3, bucket: str, labels_bucket=None, labels_prefix=""):
-        self._s3 = s3
-        self._bucket = bucket
-        self._labels_bucket = labels_bucket or bucket
-        self._labels_prefix = labels_prefix or ""
-
-    async def _get(self, key: str) -> bytes:
-        def _do() -> bytes:
-            response = self._s3.get_object(Bucket=self._bucket, Key=key)
-            # Close the StreamingBody so botocore returns the underlying
-            # HTTP connection to its pool; leaking it across repeated
-            # downloads can exhaust the pool and stall activities.
-            body = response["Body"]
-            try:
-                return body.read()
-            finally:
-                body.close()
-
-        return await asyncio.to_thread(_do)
+    working unchanged.
+    """
 
     async def download_raw(self, checksum: str) -> bytes:
         return await self._get(raw_key(checksum))
@@ -137,9 +70,8 @@ class ObjectStoreClient:
     async def upload_processed_jpeg(
         self, folder: str, checksum: str, data: bytes
     ) -> None:
-        await asyncio.to_thread(
-            self._s3.put_object,
-            Bucket=self._labels_bucket,
-            Key=jpeg_key(folder, checksum, self._labels_prefix),
-            Body=data,
+        await self._put(
+            jpeg_key(folder, checksum, self._labels_prefix),
+            data,
+            bucket=self._labels_bucket,
         )

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/predict_slate_images_workflow.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/workflows/predict_slate_images_workflow.py
@@ -1,5 +1,17 @@
-"""Model-assisted slate labeling: fan out `predict_slate_image` across a dive's
-slate frames and return one gated prediction per image.
+"""Model-assisted slate labeling: fan out `predict_slate_image` across a
+dive's slate frames and return one gated prediction per image.
+
+**RETIRED 2026-08-03 — registered, but nothing schedules it.** The
+ECC >= 0.80 acceptance gate does not transfer out of distribution: pool
+dives produced high-ECC (0.93-0.97) *false* fits that sailed through it
+(prod dives 65/71/77/80/83, all pool). The team declined an
+active-learning loop; `predict-slate-images-workflow-schedule` is now
+actively deleted at worker startup (`worker._RETIRED_SCHEDULE_IDS`) and
+the 130 seeded Label Studio predictions were removed.
+
+The code is kept registered so a future evaluation can start it by hand
+— it is dormant, not dead — but nothing invokes it on its own. Do not
+read it as part of the live pipeline.
 
 Runs the fishsense-core dive-slate estimator (`fishsense_core.slate`, v2.4.0+)
 on the CPU data-worker. Predictions seed the dive-slate Label Studio tasks as

--- a/services/fishsense-data-processing-workflow-worker/tests/test_object_store.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_object_store.py
@@ -29,30 +29,12 @@ def s3():
         yield client
 
 
-def test_key_helpers():
-    assert sut.raw_key("deadbeef") == "raw/deadbeef.ORF"
-    assert sut.slate_pdf_key(9) == "slate_pdf/9.pdf"
-    assert sut.jpeg_key("preprocess_groups_jpeg", "cafef00d") == (
-        "preprocess_groups_jpeg/cafef00d.JPG"
-    )
-    # labels_prefix partitions our JPEGs within the shared labels bucket.
-    assert sut.jpeg_key("preprocess_groups_jpeg", "cafef00d", "fishsense-lite") == (
-        "fishsense-lite/preprocess_groups_jpeg/cafef00d.JPG"
-    )
-    assert sut.jpeg_key("preprocess_jpeg", "x", "/fishsense-lite/") == (
-        "fishsense-lite/preprocess_jpeg/x.JPG"
-    )
-
-
-def test_build_s3_client_uses_path_style_addressing_for_garage():
-    client = sut.build_s3_client(
-        endpoint_url="http://garage.example.com",
-        region="garage",
-        access_key="k",
-        secret_key="s",
-    )
-    assert client.meta.config.s3["addressing_style"] == "path"
-    assert client.meta.endpoint_url == "http://garage.example.com"
+# The key contract (`raw_key` / `slate_pdf_key` / `jpeg_key`) and
+# `build_s3_client`'s path-style addressing now live in
+# `fishsense_shared.object_store` and are pinned by
+# `libs/fishsense-shared/tests/test_object_store.py`. Asserting them again
+# here would be the same duplication this module was just refactored out of.
+# What stays below is what is genuinely this worker's: its method subset.
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-data-processing-workflow-worker/tests/test_predict_laser_image.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_predict_laser_image.py
@@ -16,7 +16,10 @@ and never need the `[laser-detector]` extra installed:
 from __future__ import annotations
 
 import sys
+import threading
+import time
 import types
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -112,6 +115,41 @@ def test_get_detector_loads_once_and_caches(monkeypatch):
 
     assert first is second
     assert loads == ["/models/run3.pt"]  # loaded exactly once
+
+
+def test_get_detector_loads_once_under_concurrency(monkeypatch):
+    """Activities run in a real ThreadPoolExecutor (see `worker.py`'s
+    `activity_executor` + `max_concurrent_activities`), so N threads can enter
+    the lazy init together on a cold pod. Unguarded, each one sees
+    `_DETECTOR is None` and loads its own copy of a GPU checkpoint — N times
+    the VRAM, on the machine least able to spare it.
+
+    The second caller is released only once the first is *inside* the load, so
+    this pins the overlap rather than hoping for it.
+    """
+    monkeypatch.setattr(sut, "_DETECTOR", None)
+    loads: list[str] = []
+    loading_started = threading.Event()
+
+    def _slow_load(checkpoint_path):
+        loading_started.set()
+        time.sleep(0.2)
+        loads.append(checkpoint_path)
+        return SimpleNamespace(name="detector")
+
+    monkeypatch.setattr(sut, "_load_detector", _slow_load)
+
+    def _late_caller():
+        assert loading_started.wait(timeout=5)
+        return sut._get_detector("/models/run3.pt")
+
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        first = pool.submit(sut._get_detector, "/models/run3.pt")
+        late = [pool.submit(_late_caller) for _ in range(2)]
+        results = [first.result(timeout=10)] + [f.result(timeout=10) for f in late]
+
+    assert loads == ["/models/run3.pt"], f"checkpoint loaded {len(loads)}x, want 1"
+    assert all(r is results[0] for r in results)
 
 
 # --------------------------------- activity ----------------------------------

--- a/services/fishsense-data-processing-workflow-worker/tests/test_predict_slate_image.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_predict_slate_image.py
@@ -11,6 +11,10 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 
 from fishsense_data_processing_workflow_worker.activities import (
@@ -71,6 +75,46 @@ def test_gate_confidence_boundary_is_inclusive():
     est = _estimate(sut.DEFAULT_MIN_CONFIDENCE, [[1.0, 1.0]])
     pts, _conf, reason = sut.gate_estimate(est, "V-Slate 1", 4000, 3000)
     assert reason is None and pts == [[1.0, 1.0]]
+
+
+def test_get_masker_returns_the_masker_to_a_concurrent_caller(monkeypatch):
+    # pylint: disable=protected-access
+    """The "cache the outcome" flag must not be set before the outcome exists.
+
+    Activities run in a real thread pool, and `BoardMasker.from_pretrained()`
+    reaches HuggingFace — seconds, not microseconds. A caller arriving during
+    that window used to see `_MASKER_LOADED = True`, read a still-unset
+    `_MASKER`, and silently take the classical path. Silently, because the
+    degradation warning only fires in the `except` branch and nothing raised.
+    So the whole first concurrent batch of frames lost the learned mask, with
+    nothing in the logs to say so.
+    """
+    import fishsense_core.slate as slate_mod  # pylint: disable=import-outside-toplevel
+
+    sentinel = object()
+    loading_started = threading.Event()
+
+    def _slow_from_pretrained(*_a, **_k):
+        loading_started.set()
+        time.sleep(0.2)
+        return sentinel
+
+    monkeypatch.setattr(slate_mod.BoardMasker, "from_pretrained", _slow_from_pretrained)
+    monkeypatch.setattr(sut, "DEFAULT_SLATE_CHECKPOINT_PATH", "")
+    monkeypatch.setattr(sut, "_MASKER", None)
+    monkeypatch.setattr(sut, "_MASKER_LOADED", False)
+
+    def _late_caller():
+        assert loading_started.wait(timeout=5)
+        return sut._get_masker()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(sut._get_masker)
+        late = pool.submit(_late_caller)
+        assert first.result(timeout=10) is sentinel
+        assert late.result(timeout=10) is sentinel, (
+            "concurrent caller got the classical fallback while the mask was loading"
+        )
 
 
 def test_get_masker_falls_back_to_none_and_caches(monkeypatch):

--- a/tools/apply_image_path_patch.py
+++ b/tools/apply_image_path_patch.py
@@ -37,14 +37,14 @@ Dry-run (default — no writes):
     uv run --package fishsense-api python tools/apply_image_path_patch.py \\
         --patch-file rollover_scan_with_orphans.json \\
         --db-host fabricant-prod.ucsd.edu \\
-        --db-name fishsense --db-user postgres --db-pass "$PG_PASS"
+        --db-name fishsense --db-user postgres    # PGPASSWORD in env
 
 Apply for real:
 
     uv run --package fishsense-api python tools/apply_image_path_patch.py \\
         --patch-file rollover_scan_with_orphans.json \\
         --db-host fabricant-prod.ucsd.edu \\
-        --db-name fishsense --db-user postgres --db-pass "$PG_PASS" \\
+        --db-name fishsense --db-user postgres    # PGPASSWORD in env \\
         --apply
 
 Per-cohort rollout (recommended): `--dive-id 237` first, eyeball the
@@ -56,6 +56,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from collections import Counter
 from dataclasses import dataclass
@@ -261,6 +262,15 @@ def _run(args: argparse.Namespace) -> int:
         print("no patch rows to process — exiting.")
         return 0
 
+    db_pass = args.db_pass or os.environ.get("PGPASSWORD")
+    if not db_pass:
+        print(
+            "No password supplied. Set PGPASSWORD (preferred) or pass "
+            "--db-pass.",
+            file=sys.stderr,
+        )
+        return 2
+
     print(
         f"connecting to {args.db_user}@{args.db_host}:{args.db_port}/"
         f"{args.db_name}"
@@ -268,7 +278,7 @@ def _run(args: argparse.Namespace) -> int:
     conninfo = (
         f"host={args.db_host} port={args.db_port} "
         f"dbname={args.db_name} user={args.db_user} "
-        f"password={args.db_pass}"
+        f"password={db_pass}"
     )
 
     # Single transaction: either every row commits or none. psycopg
@@ -324,7 +334,16 @@ def _parse_args(argv: Iterable[str]) -> argparse.Namespace:
     p.add_argument("--db-port", type=int, default=5432)
     p.add_argument("--db-name", required=True)
     p.add_argument("--db-user", required=True)
-    p.add_argument("--db-pass", required=True)
+    # NOT required, and prefer the env var: an argv password is visible to
+    # every user on the box via `ps aux` and lands in shell history. libpq's
+    # own convention is PGPASSWORD, so scripted callers already expect it.
+    p.add_argument(
+        "--db-pass",
+        default=None,
+        help="Prod Postgres password. Prefer setting PGPASSWORD instead — "
+             "a password passed here is exposed in `ps` output and shell "
+             "history.",
+    )
     p.add_argument(
         "--dive-id",
         type=int,

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
@@ -463,43 +463,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -718,7 +718,6 @@ dependencies = [
     { name = "httpx" },
     { name = "numpy" },
     { name = "pydantic" },
-    { name = "retry" },
 ]
 
 [package.metadata]
@@ -726,7 +725,6 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "numpy", specifier = ">=2" },
     { name = "pydantic", specifier = ">=2.12.2" },
-    { name = "retry", specifier = ">=0.9.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -1010,23 +1008,34 @@ dependencies = [
     { name = "validators" },
 ]
 
+[package.optional-dependencies]
+s3 = [
+    { name = "boto3" },
+]
+
 [package.dev-dependencies]
 dev = [
+    { name = "boto3" },
+    { name = "moto", extra = ["s3"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", marker = "extra == 's3'", specifier = ">=1.35.0" },
     { name = "dynaconf", specifier = ">=3.2.11" },
     { name = "platformdirs", specifier = ">=4.3.8" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "temporalio", specifier = ">=1.15.0" },
     { name = "validators", specifier = ">=0.35.0" },
 ]
+provides-extras = ["s3"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "boto3", specifier = ">=1.35.0" },
+    { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
     { name = "pytest", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", specifier = ">=0.25.2" },
 ]
@@ -1866,7 +1875,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1905,7 +1914,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1917,7 +1926,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1947,9 +1956,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1961,7 +1970,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2138,7 +2147,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2326,15 +2335,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
-]
-
-[[package]]
-name = "py"
-version = "1.11.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719", size = 207796, upload-time = "2021-11-04T17:17:01.377Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/f0/10642828a8dfb741e5f3fbaac830550a518a775c7fff6f04a007259b0548/py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378", size = 98708, upload-time = "2021-11-04T17:17:00.152Z" },
 ]
 
 [[package]]
@@ -2737,19 +2737,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f0/1a/4af3e6d659394b809838490b144e4ab8d7ed3b9fecc7ca78f5d2f79b1a3d/responses-0.26.2.tar.gz", hash = "sha256:9c9259b46a8349197edebf43cfa68a87e1a2802ef503ff8b2fecbabc0b45afd8", size = 84030, upload-time = "2026-07-03T16:44:50.325Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/28/693e1d9ebf72baa062ded80d837a035b86ce75eda5a269379e9e2b1008a8/responses-0.26.2-py3-none-any.whl", hash = "sha256:6fdfeabd58e5ec473b98dfe02e6d46d3173bd8dd573eff2ccccf1a05a5135364", size = 35609, upload-time = "2026-07-03T16:44:49.1Z" },
-]
-
-[[package]]
-name = "retry"
-version = "0.9.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "decorator" },
-    { name = "py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/72/75d0b85443fbc8d9f38d08d2b1b67cc184ce35280e4a3813cda2f445f3a4/retry-0.9.2.tar.gz", hash = "sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4", size = 6448, upload-time = "2016-05-11T13:58:51.541Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/0d/53aea75710af4528a25ed6837d71d117602b01946b307a3912cb3cfcbcba/retry-0.9.2-py2.py3-none-any.whl", hash = "sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606", size = 7986, upload-time = "2016-05-11T13:58:39.925Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
A code-review sweep that started as de-duplication and turned up five real
bugs on the way. Every commit is independently reviewable; the messages carry
the evidence (what was measured, what reproduced under test).

## Bugs fixed

**`fix(sdk)` — the SDK's retry has never worked.** `ClientBase` carried
`@retry(exceptions=HTTPStatusError, tries=3)` on all four verbs, dead twice
over: `retry` is synchronous, so decorating an `async def` returns the
coroutine before it can raise (measured: **1 attempt, not 3**), and
`HTTPStatusError` only comes from `raise_for_status()`, which the subclasses
call. This mattered beyond the SDK — `SDK_FAIL_FAST_RETRY_POLICY` marks
`HTTPStatusError` non-retryable *because* "the SDK's httpx-level @retry
already absorbed any transient status". It absorbed nothing, so a single
transient 5xx failed the whole activity with **no retry at any layer**, for
every selector and resolver in the preprocess/calibration/measure parents.

**`fix(data-worker)` — two racy lazy model caches.** `_get_masker` set
`_MASKER_LOADED = True` *before* the load, so any frame arriving during the
HuggingFace fetch read the flag as True, got a still-unset `_MASKER`, and
silently took the classical path — silently, because nothing raised.
`_get_detector` let N threads each load a GPU checkpoint. Both reproduced
under test before the fix (3 loads instead of 1; the concurrent caller got
`None`).

**`fix(api)` — the empty `"Fish Model,"` leaf wedged the stage-14 cohort.**
`LIKE 'Fish Model,%'` matches the parent taxonomy node with no leaf, which
`parse_model_name` rejects. Cohort says measurable, activity says skip, no
Measurement is written, dive re-selected every hour forever — the same
never-goes-false shape that blocked scheduling stage 14 before 2026-07-17,
reachable from one labeler mis-click. Found by the new SQL↔Python parity test.

**`fix(api-worker)` — legacy label rows never retired.** The headtail/slate
supersede passes exempted by *image*, justified by a comment claiming the
upsert keys on `image_id` alone. It keys on `(image_id, project_id)`, and the
fetch spans all projects, so one image can hold two rows — and a legacy row on
a refreshed image survived forever, keeping `*_labeling_complete` false on the
dashboard permanently.

**`fix(api)` — NULL-project label rows accumulated without bound.**
`uq_<kind>_image_project` can't protect them (SQL treats NULLs as distinct)
and the handlers skipped resolution for them entirely. A live candidate for
the ~2000 unexplained sentinel rows in prod.

Plus `fix(web)`: `/portal` checked authentication but never authorization —
any Authentik realm account could rewrite `calibration_dive_id`, a live
pipeline input. `groups` was plumbed end-to-end and only ever *displayed*; the
`groups` OIDC scope was never even requested. Also removes `debug: true` and
two `console.log`s that dumped the full OIDC profile on every SSR call.

## Refactors

`duplicate-code` was disabled workspace-wide, making all 14 inline pragmas
no-ops. Now enabled and tuned (`min-similarity-lines = 12`, calibrated not
guessed); removing the 14 pragmas added zero findings. The clones it found are
collapsed into `fishsense_shared.object_store`, `fishsense_shared.taxonomy`,
`workflows/_dispatch.py` and `activities/cohort_selection.py`.

**Temporal replay:** the `_dispatch` helpers emit the same commands, in the
same order, that the inlined code did — runs in flight at deploy still replay.
Per-stage timeouts are parameters, not constants, keeping their existing values
even where they look arbitrary.

## Review focus

- **`a2f7c31d9e64` is the only migration and `dacd212` the only prod behaviour
  change.** Drop/recreate of `dive_pipeline_status`; no data touched, column
  shape unchanged, other three view DDLs verified byte-identical. Effect is
  confined to dives holding an empty-leaf row — they stop counting toward
  `measured`'s denominator and can finally drain.
- **Do not merge `f5c4306` ahead of the Authentik work.** `lib/authz.ts` fails
  closed by design, so the portal denies everyone until (1) the
  `fishsense-portal-admin` group exists and holds the team, and (2) the
  FishSense OIDC app has the `groups` scope + property mapping. Change the
  group name in `compose.yml` first if the real one differs.
- The verb split in the SDK retry is a judgement call: GET/PUT/DELETE replay
  5xx and transport errors; POST replays only `ConnectError`, because
  `post_species`/`post_fish`/`post_cluster` create rows and a 5xx can come from
  a server that already committed.

## Verification

`./check.sh lint` 10.00/10 · `duplicate-code` 0 findings · 1,210 Python tests
and 89 web tests pass · web typecheck clean · `uv lock --check` clean ·
fishsense-shared holds its 100% coverage ratchet.

The `-m integration` and `-m k8s` suites were run locally by the author (they
need the devcontainer stack and a cluster, which I can't reach); everything
above is what I verified directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
