### PR TITLE
feat(ingest): folder listing, preflight, and a checksum-verification workflow

### DIFF
--- a/libs/fishsense-shared/src/fishsense_shared/ingest_contracts.py
+++ b/libs/fishsense-shared/src/fishsense_shared/ingest_contracts.py
@@ -21,6 +21,7 @@ from typing import List
 from pydantic import BaseModel
 
 __all__ = [
+    "ChecksumMismatch",
     "IngestDiveRequest",
     "IngestPreflight",
     "IngestProgress",
@@ -28,6 +29,7 @@ __all__ = [
     "PreflightImage",
     "RejectedImage",
     "SubfolderReport",
+    "VerifyChecksumsReport",
 ]
 
 
@@ -133,6 +135,51 @@ class RejectedImage(BaseModel):
 
     path: str
     reason: str
+
+
+class ChecksumMismatch(BaseModel):
+    """One row whose stored value disagrees with the file on the NAS.
+
+    Both values are carried because "some rows disagree" is not actionable —
+    the useful finding is *how* they disagree, which is what says whether the
+    migration used a different algorithm or the file itself changed.
+    """
+
+    image_id: int | None = None
+    path: str
+    stored: str | None = None
+    computed: str | None = None
+
+
+class VerifyChecksumsReport(BaseModel):
+    """Result of re-hashing a migrated dive against the NAS.
+
+    Read-only. Every ingest convention was recovered by reading the retired
+    spider crawler's source, which proves what *spider* wrote but not that all
+    ~131k rows came from spider — and no stored value had ever been compared
+    against the bytes still on the NAS.
+
+    The gap is worth closing because of how it fails: if existing checksums
+    were computed differently, duplicate detection does not error, it silently
+    reports zero overlap. A re-ingest of an already-present dive would look
+    entirely new and every frame would land canonical.
+    """
+
+    dive_id: int
+    #: Rows in the dive, before any sampling limit.
+    total_in_dive: int = 0
+    checked: int = 0
+    checksum_matched: int = 0
+    mismatches: List[ChecksumMismatch] = []
+    #: Stored `taken_datetime` disagreeing with EXIF 0x0132 stamped UTC.
+    #: Tracked apart from checksums: a wrong checksum breaks duplicate
+    #: detection, a wrong timestamp breaks stage-1 clustering.
+    timestamp_mismatches: List[ChecksumMismatch] = []
+    #: The row exists but its file does not — itself one of the answers.
+    missing_on_nas: List[ChecksumMismatch] = []
+    #: NULL `checksum` on a migrated row; the column duplicate detection joins
+    #: on, so a blank one is a finding rather than a skip.
+    no_stored_checksum: List[ChecksumMismatch] = []
 
 
 class IngestProgress(BaseModel):

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/list_dive_folder_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/list_dive_folder_activity.py
@@ -1,0 +1,144 @@
+"""Activity: enumerate the `.ORF` frames in one dive folder on the NAS.
+
+The first step of ingest, and the one that fixes the shape of everything after
+it: **one request means one dive, and a dive is exactly one directory.**
+
+That is precedent, not preference. The retired spider crawler walked the tree
+recursively but assigned `dive = image.parent.relative_to(data_root)`
+(`discovery.py:238`), so a nested folder always became its own dive row and
+never extra frames on its parent. Every one of the ~479 dive rows in prod
+follows that convention. Recursing here and attaching a subdirectory's frames
+to the named dive would merge dives that are distinct rows today — silently,
+and with nothing in the data afterwards to say which frames came from where.
+
+So a subdirectory holding `.ORF`s is *reported*, not ingested. That is the
+Olympus rollover case: the TG-6 wraps its frame counter at `PA199999` and
+starts a child folder mid-dive, which reads as "more frames of this dive" to a
+person and as "a second dive" to every convention in the database. Surfacing it
+as "here is another dive to submit" keeps the operator deciding.
+
+NAS access here is read-only, in line with the rest of the api-worker: this
+activity lists, and nothing else.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import List
+
+from synology_filestation import DSMError
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.nas_errors import (
+    raise_if_permanent_dsm_error,
+)
+from fishsense_api_workflow_worker.config import settings
+from fishsense_api_workflow_worker.nas import NasDownloadClient, NasEntry
+from fishsense_shared.ingest_contracts import IngestDiveRequest, SubfolderReport
+
+# Case-insensitive: Olympus writes `.ORF`, but operators and copy tools produce
+# `.orf` and occasionally `.Orf`. A case-sensitive match would ingest a partial
+# dive that no later step can detect as partial, because the missing frames
+# were never listed in the first place.
+_RAW_SUFFIX = ".orf"
+
+__all__ = [
+    "DiveFolderListing",
+    "list_dive_folder_activity",
+    "resolve_nas_folder",
+]
+
+
+@dataclass
+class DiveFolderListing:
+    """What is in the folder, before anything has been read or written."""
+
+    #: The absolute NAS path actually listed, after root resolution.
+    folder_path: str
+    #: `.ORF` files directly inside `folder_path`, name-sorted.
+    files: List[NasEntry] = field(default_factory=list)
+    #: Immediate subdirectories that hold `.ORF`s — separate dives, reported
+    #: for the operator to submit themselves.
+    subfolders: List[SubfolderReport] = field(default_factory=list)
+
+
+def _build_nas_client() -> NasDownloadClient:
+    return NasDownloadClient(
+        nas_url=settings.e4e_nas.url,
+        username=settings.e4e_nas.username,
+        password=settings.e4e_nas.password,
+    )
+
+
+def resolve_nas_folder(relative_path: str) -> str:
+    """Join `e4e_nas.raw_root_path` with a share-relative request path.
+
+    The DB stores paths share-relative while FileStation needs them absolute —
+    the same asymmetry `stage_raw_bytes_for_dive_activity` handles, and worth
+    getting right because FileStation surfaces an unresolved path as a 502
+    rather than a 404. An already-absolute path passes through, so an operator
+    pasting a full NAS path isn't double-prefixed.
+    """
+    if relative_path.startswith("/"):
+        return relative_path.rstrip("/")
+    root = settings.e4e_nas.raw_root_path.rstrip("/")
+    return f"{root}/{relative_path.strip('/')}"
+
+
+def _is_raw(entry: NasEntry) -> bool:
+    return not entry.is_dir and entry.name.lower().endswith(_RAW_SUFFIX)
+
+
+async def _list(client, folder_path: str) -> List[NasEntry]:
+    """One `list_dir`, with permanent errors classified.
+
+    No inner retry loop: the bounded jittered Temporal policy owns backoff, and
+    an inner loop underneath it is what produced the download storm that
+    tripped the NAS auto-block.
+    """
+    try:
+        return await asyncio.to_thread(client.list_dir, folder_path=folder_path)
+    except DSMError as exc:
+        raise_if_permanent_dsm_error(exc, context=folder_path)
+        raise
+
+
+@activity.defn
+async def list_dive_folder_activity(
+    request: IngestDiveRequest,
+) -> DiveFolderListing:
+    client = _build_nas_client()
+    folder_path = resolve_nas_folder(request.dive_path)
+
+    entries = await _list(client, folder_path)
+
+    # Name-sorted, because batching and heartbeat-resume both index into this
+    # list. DSM promises no order, so a retry that saw a different one would
+    # re-download frames it had already registered and skip ones it hadn't.
+    files = sorted((e for e in entries if _is_raw(e)), key=lambda e: e.name)
+
+    subfolders: List[SubfolderReport] = []
+    for entry in sorted(
+        (e for e in entries if e.is_dir), key=lambda e: e.name
+    ):
+        # Exactly one level down: enough to count a rollover folder's frames,
+        # and no more. A full walk would turn a path mistyped near the share
+        # root into an enumeration of the entire NAS, over a download backend
+        # that already falls over under load.
+        children = await _list(client, entry.path)
+        orf_count = sum(1 for child in children if _is_raw(child))
+        if orf_count:
+            subfolders.append(
+                SubfolderReport(path=entry.path, orf_count=orf_count)
+            )
+
+    activity.logger.info(
+        "listed dive folder path=%s frames=%d subfolders=%d",
+        folder_path,
+        len(files),
+        len(subfolders),
+    )
+    return DiveFolderListing(
+        folder_path=folder_path, files=files, subfolders=subfolders
+    )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/nas_errors.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/nas_errors.py
@@ -1,0 +1,73 @@
+"""Shared classification of Synology FileStation errors into retryable and
+permanent.
+
+Extracted from `stage_raw_bytes_for_dive_activity` when ingest needed the same
+judgement. The rule it encodes is worth stating once: **retry/backoff belongs to
+the Temporal retry policy on the activity call, never to an inner loop.** An
+inner loop underneath Temporal's outer retry is what produced the
+200×-per-file download storm that tripped the NAS auto-block (krg-infra#501).
+
+So these helpers only *classify*. A permanent error becomes a non-retryable
+`ApplicationError` so Temporal stops rescheduling something doomed; everything
+else propagates untouched so the bounded jittered policy backs off and tries
+again.
+
+The code is recovered by string-parsing `DSMError`'s message because the
+`synology-filestation` client doesn't expose it structurally yet (feedback
+filed upstream). Delete `dsm_error_code` when it does.
+"""
+
+from __future__ import annotations
+
+import re
+
+from temporalio.exceptions import ApplicationError
+
+# `type` on the non-retryable ApplicationError raised for a missing file. Must
+# stay in step with `non_retryable_error_types` in `STAGE_RAW_RETRY_POLICY`
+# (workflows/_retry_policies.py) — Temporal matches on this string, so a rename
+# here silently restores retrying on doomed work.
+NAS_FILE_NOT_FOUND_TYPE = "NasFileNotFound"
+
+# FileStation codes that are *permanent*: retrying cannot help, so fail fast
+# rather than burning the retry budget. 408 = "No such file or directory".
+#
+# Transient codes are deliberately absent and must stay that way — 502
+# (shared download backend falling over), 407 (backend fail-closed) and 402
+# (busy) are all routine and self-healing under backoff.
+PERMANENT_DSM_CODES = frozenset({408})
+
+__all__ = [
+    "NAS_FILE_NOT_FOUND_TYPE",
+    "PERMANENT_DSM_CODES",
+    "dsm_error_code",
+    "raise_if_permanent_dsm_error",
+]
+
+
+def dsm_error_code(exc: BaseException) -> int | None:
+    """Best-effort extract the FileStation error code from a `DSMError`, whose
+    message is `"Synology API error <code>"`. Returns None when the message
+    doesn't carry one — an unrecognised error is treated as transient, which
+    errs toward retrying rather than toward declaring a dive dead."""
+    match = re.search(r"error\s+(\d+)", str(exc))
+    return int(match.group(1)) if match else None
+
+
+def raise_if_permanent_dsm_error(exc: BaseException, *, context: str) -> None:
+    """Convert a permanent `DSMError` into a non-retryable `ApplicationError`.
+
+    Returns normally when the error is transient (or unrecognised), leaving the
+    caller to re-raise so Temporal's policy owns the backoff.
+
+    `context` names what was being reached for — a path, a folder — because the
+    resulting failure is what an operator reads in the Temporal UI, and
+    "Synology 408" on its own doesn't say which file was missing.
+    """
+    code = dsm_error_code(exc)
+    if code in PERMANENT_DSM_CODES:
+        raise ApplicationError(
+            f"NAS path not found (Synology {code}): {context}",
+            type=NAS_FILE_NOT_FOUND_TYPE,
+            non_retryable=True,
+        ) from exc

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/preflight_ingest_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/preflight_ingest_activity.py
@@ -1,0 +1,325 @@
+"""Activity: decide whether a dive folder can be ingested, and write nothing.
+
+Preflight is the gate. It reads each frame's EXIF header, resolves the camera,
+runs every validation, and returns an `IngestPreflight`. A non-empty `errors`
+list means the workflow refuses to proceed; `dry_run` returns this and stops.
+
+**Every problem at once, never first-wins.** An operator submitting a folder
+has one round trip worth of attention, and "fix this, resubmit, discover the
+next thing" spends it badly. So the checks accumulate into a list rather than
+raising at the first failure.
+
+What it refuses, and why each is unrecoverable later:
+
+  * **Unresolvable camera, and no `Artist` fallback.** `Artist` is a free-text
+    rig label; matching on it would bind intrinsics belonging to different
+    glass, and stage 14 would report confident wrong lengths. Refusing forces
+    someone to add the `Camera` row, which is a minute's work and correct.
+  * **A folder spanning two serials.** One folder is one rig; the schema has no
+    way to say otherwise. Spider only wrote a report file and carried on, which
+    is how such dives got in unnoticed.
+  * **A camera with no intrinsics.** Discovered later, it means a dive that
+    sits in the stage-14 cohort forever without ever producing a measurement.
+  * **Unstated calibration intent.** A fish-only dive with no slate frames can
+    never self-calibrate, so stage 14 can never measure it — and nothing in the
+    files reveals that. Exactly one of `self_calibrates` / `calibration_dive_id`
+    is required.
+  * **A frame with no readable timestamp.** Stage-1 clustering is pure
+    timestamp maths, so a defaulted value corrupts it silently.
+  * **A path over 255 characters.** `Image.path` is varchar(255); without the
+    check the dive half-ingests and fails on one row with a 422 that doesn't
+    say which file.
+
+Reads are ranged — the first megabyte holds the EXIF — which is what makes a
+dry run affordable: ~1 MB per frame instead of ~15 MB across FileStation's
+fragile shared download backend. They are also serial, matching the default
+`e4e_nas.stage_concurrency` of 1: that backend 502s under concurrent transfers,
+and a preflight is not worth risking it for.
+
+Duplicate detection here is **layer 1 only** — a leaf-name collision against
+existing dives, free because the dive list is already fetched. Content-based
+containment (layer 2) needs every frame's checksum, which needs the full files,
+so it runs after the scan and lands in the final report.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import List
+
+from synology_filestation import DSMError
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.list_dive_folder_activity import (
+    DiveFolderListing,
+)
+from fishsense_api_workflow_worker.activities.nas_errors import (
+    raise_if_permanent_dsm_error,
+)
+from fishsense_api_workflow_worker.activities.utils import get_fs_client
+from fishsense_api_workflow_worker.config import settings
+from fishsense_api_workflow_worker.exif import read_exif
+from fishsense_api_workflow_worker.nas import NasDownloadClient
+from fishsense_shared.ingest_contracts import (
+    IngestDiveRequest,
+    IngestPreflight,
+    PreflightImage,
+)
+
+# EXIF lives in the first megabyte of an ORF. Sized generously rather than
+# tightly — the MakerNote's Equipment IFD sits well past the main IFD, and a
+# short read costs a whole re-listing to discover.
+EXIF_HEADER_BYTES = 1024 * 1024
+
+# `Image.path` / `Dive.path` are varchar(255) (MAX_PATH_LENGTH in the API's
+# image_controller / dive_controller). Checked here against the *stored*,
+# share-relative form, not the absolute NAS path.
+MAX_PATH_LENGTH = 255
+
+__all__ = ["EXIF_HEADER_BYTES", "MAX_PATH_LENGTH", "preflight_ingest_activity"]
+
+
+def _build_nas_client() -> NasDownloadClient:
+    return NasDownloadClient(
+        nas_url=settings.e4e_nas.url,
+        username=settings.e4e_nas.username,
+        password=settings.e4e_nas.password,
+    )
+
+
+def _relative_path(absolute_path: str) -> str:
+    """Strip `e4e_nas.raw_root_path` back off, giving the form the DB stores.
+
+    Every existing `Image.path` is share-relative, and the staging activity
+    re-prepends the root. Storing an absolute path would work until someone
+    moved the share.
+    """
+    root = settings.e4e_nas.raw_root_path.rstrip("/") + "/"
+    if absolute_path.startswith(root):
+        return absolute_path[len(root):]
+    return absolute_path.lstrip("/")
+
+
+def _parse_taken_datetime(raw: str | None) -> datetime | None:
+    """`"YYYY:MM:DD HH:MM:SS"` → an aware UTC datetime.
+
+    The value is the camera's wall clock, and the recorded UTC offset is
+    deliberately **not** applied — that is the convention ~111k existing rows
+    follow. Matching it matters more than being right: a consistent offset is
+    recoverable later, two conventions mixed inside one column is not.
+    """
+    if not raw:
+        return None
+    try:
+        naive = datetime.strptime(raw, "%Y:%m:%d %H:%M:%S")
+    except ValueError:
+        return None
+    return naive.replace(tzinfo=timezone.utc)
+
+
+async def _read_header(nas, file_path: str) -> bytes:
+    """One ranged read. No inner retry — Temporal's bounded policy owns
+    backoff, and an inner loop under it is what tripped the NAS auto-block."""
+    try:
+        return await asyncio.to_thread(
+            nas.download_range,
+            file_path=file_path,
+            offset=0,
+            length=EXIF_HEADER_BYTES,
+        )
+    except DSMError as exc:
+        raise_if_permanent_dsm_error(exc, context=file_path)
+        raise
+
+
+def _check_calibration_intent(request: IngestDiveRequest) -> List[str]:
+    """Exactly one of the two must be given.
+
+    Both is contradictory: `get_laser_extrinsics_for_dive` resolves own-wins,
+    so the link the operator took trouble to specify would be silently ignored.
+    Neither leaves a dive that can never be measured and never says why.
+    """
+    borrows = request.calibration_dive_id is not None
+    if request.self_calibrates and borrows:
+        return [
+            "Contradictory calibration intent: self_calibrates=True and "
+            f"calibration_dive_id={request.calibration_dive_id}. A dive with "
+            "its own slate always self-calibrates, so the link would be "
+            "ignored — pass exactly one."
+        ]
+    if not request.self_calibrates and not borrows:
+        return [
+            "No calibration intent given. Pass self_calibrates=True if this "
+            "dive has its own slate frames, or calibration_dive_id=<dive> to "
+            "borrow a sibling's calibration. Without one, stage 14 can never "
+            "measure this dive."
+        ]
+    return []
+
+
+async def _resolve_camera(fs, request, serials, artists, errors, warnings):
+    """Resolve to a `(camera_id, camera_name)` pair, or `(None, None)`."""
+    if len(serials) > 1:
+        errors.append(
+            "Frames span more than one camera serial "
+            f"({', '.join(sorted(serials))}). One folder is one rig — split "
+            "the folder and submit each dive separately."
+        )
+        return None, None
+
+    cameras = await fs.cameras.get() or []
+
+    if request.camera_id is not None:
+        match = next((c for c in cameras if c.id == request.camera_id), None)
+        if match is None:
+            errors.append(f"No Camera row with id {request.camera_id}.")
+            return None, None
+        return match.id, match.name
+
+    if not serials:
+        errors.append(
+            "No camera serial found in any frame's Olympus MakerNote, and no "
+            "camera_id override was given."
+        )
+        return None, None
+
+    serial = next(iter(serials))
+    match = next((c for c in cameras if c.serial_number == serial), None)
+    if match is None:
+        errors.append(
+            f"Camera serial {serial} matches no Camera row. Add the camera "
+            "(with its intrinsics) before ingesting. Deliberately not falling "
+            "back to the EXIF Artist tag — a free-text rig label would bind "
+            "the wrong intrinsics and stage 14 would report confident wrong "
+            "lengths."
+        )
+        return None, None
+
+    # The serial is authoritative; a disagreeing Artist means a mislabelled
+    # Camera.name or a re-housed body. Nothing else in the pipeline would ever
+    # notice, so say it here.
+    for artist in sorted(a for a in artists if a and a != match.name):
+        warnings.append(
+            f"EXIF Artist {artist!r} disagrees with the resolved camera's "
+            f"name {match.name!r} (serial {serial})."
+        )
+    return match.id, match.name
+
+
+@activity.defn
+async def preflight_ingest_activity(
+    request: IngestDiveRequest, listing: DiveFolderListing
+) -> IngestPreflight:
+    # pylint: disable=too-many-locals,too-many-branches
+    # Preflight is a checklist: the branch count IS the feature. Splitting it
+    # into per-check helpers would scatter the "collect, never raise" contract
+    # that makes the all-at-once report work.
+    errors: List[str] = []
+    warnings: List[str] = []
+
+    errors.extend(_check_calibration_intent(request))
+
+    if not listing.files:
+        errors.append(
+            f"No .ORF frames directly inside {listing.folder_path}. Ingest is "
+            "non-recursive — a dive is exactly one directory."
+        )
+
+    for subfolder in listing.subfolders:
+        warnings.append(
+            f"{subfolder.path} contains {subfolder.orf_count} .ORF files. "
+            "Under the existing convention that is a separate dive — submit it "
+            "as its own request; it is not included here."
+        )
+
+    nas = _build_nas_client()
+    images: List[PreflightImage] = []
+    serials: set[str] = set()
+    artists: set[str] = set()
+
+    for entry in listing.files:
+        activity.heartbeat(entry.path)
+        stored_path = _relative_path(entry.path)
+        if len(stored_path) > MAX_PATH_LENGTH:
+            errors.append(
+                f"Path exceeds {MAX_PATH_LENGTH} characters "
+                f"({len(stored_path)}): {stored_path}"
+            )
+            continue
+
+        exif = read_exif(await _read_header(nas, entry.path))
+        taken = _parse_taken_datetime(exif.date_time)
+        if taken is None:
+            errors.append(
+                f"No readable EXIF timestamp in {stored_path}. Stage-1 "
+                "clustering is pure timestamp maths, so the frame cannot be "
+                "ingested with a defaulted value."
+            )
+            continue
+        if exif.date_time_is_fallback:
+            warnings.append(
+                f"{stored_path} has no DateTime (0x0132); fell back to "
+                "DateTimeOriginal (0x9003)."
+            )
+
+        if exif.serial_number:
+            serials.add(exif.serial_number)
+        if exif.artist:
+            artists.add(exif.artist)
+
+        images.append(
+            PreflightImage(
+                path=stored_path,
+                size=entry.size,
+                taken_datetime=taken,
+                exif_offset=exif.offset_time,
+                serial_number=exif.serial_number,
+                artist=exif.artist,
+            )
+        )
+
+    async with get_fs_client() as fs:
+        camera_id, camera_name = await _resolve_camera(
+            fs, request, serials, artists, errors, warnings
+        )
+
+        if camera_id is not None:
+            if await fs.cameras.get_intrinsics(camera_id) is None:
+                errors.append(
+                    f"Camera {camera_id} ({camera_name}) has no intrinsics. "
+                    "Stage 14 cannot measure this dive until they exist."
+                )
+
+        # Layer 1 duplicate detection: leaf-name collision. Free, since the
+        # dive list is already here. Catches the real prod case — dives 64 and
+        # 66 are both `082929_FishModels_FSL07`. Content-based containment
+        # needs checksums, so it runs after the scan.
+        leaf = listing.folder_path.rstrip("/").rsplit("/", 1)[-1]
+        for dive in await fs.dives.get() or []:
+            if not dive.path:
+                continue
+            if dive.path.rstrip("/").rsplit("/", 1)[-1] == leaf:
+                warnings.append(
+                    f"Dive {dive.id} has the same folder name ({leaf!r}) at "
+                    f"{dive.path}. Dive names are not unique in prod; this may "
+                    "be a re-ingest."
+                )
+
+    activity.logger.info(
+        "preflight path=%s frames=%d errors=%d warnings=%d",
+        listing.folder_path,
+        len(images),
+        len(errors),
+        len(warnings),
+    )
+    return IngestPreflight(
+        dive_path=listing.folder_path,
+        images=images,
+        subfolders=list(listing.subfolders),
+        resolved_camera_id=camera_id,
+        resolved_camera_name=camera_name,
+        total_bytes=sum(e.size for e in listing.files),
+        errors=errors,
+        warnings=warnings,
+    )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/stage_raw_bytes_for_dive_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/stage_raw_bytes_for_dive_activity.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import re
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -45,6 +44,10 @@ from synology_filestation import DSMError
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
+from fishsense_api_workflow_worker.activities.nas_errors import (
+    NAS_FILE_NOT_FOUND_TYPE,
+    raise_if_permanent_dsm_error,
+)
 from fishsense_api_workflow_worker.activities.utils import get_fs_client
 from fishsense_api_workflow_worker.config import settings
 from fishsense_api_workflow_worker.object_store import open_object_store_client
@@ -69,19 +72,9 @@ def _stage_concurrency() -> int:
         value = DEFAULT_STAGE_CONCURRENCY
     return max(1, value)
 
-# `type` on the non-retryable ApplicationError we raise for a missing
-# file; must match `non_retryable_error_types` in STAGE_RAW_RETRY_POLICY.
-NAS_FILE_NOT_FOUND_TYPE = "NasFileNotFound"
-
-# Synology FileStation error codes that are *permanent* — retrying can't
-# help, so we fail the dive fast (non-retryable) instead of burning the
-# Temporal retry budget. 408 = "No such file or directory". Transient
-# codes (502 TransportError, 407 backend-fail-closed, 402 busy) are left
-# to propagate so the bounded Temporal retry policy backs off and retries.
-# NOTE: this string-parses the DSM code because the client doesn't expose
-# it structurally yet — remove once `synology-filestation` classifies
-# errors upstream (feedback filed).
-_PERMANENT_DSM_CODES = frozenset({408})
+# `NAS_FILE_NOT_FOUND_TYPE` and the permanent/transient split now live in
+# `activities/nas_errors.py`, shared with the ingest activities. Re-exported
+# here because this module's `__all__` is part of its existing surface.
 
 __all__ = [
     "DEFAULT_STAGE_CONCURRENCY",
@@ -121,14 +114,6 @@ def _iter_leaf_exceptions(exc: BaseException):
         yield exc
 
 
-def _dsm_error_code(exc: BaseException) -> int | None:
-    """Best-effort extract the Synology FileStation error code from a
-    `DSMError` (whose message is `"Synology API error <code>"`). Interim
-    until the client exposes the code structurally."""
-    match = re.search(r"error\s+(\d+)", str(exc))
-    return int(match.group(1)) if match else None
-
-
 async def _download_one(nas, *, src_path: str, dest_dir: str) -> None:
     """Download a single file. Retry/backoff is intentionally NOT here —
     the bounded, jittered Temporal `retry_policy` on the activity owns
@@ -146,13 +131,7 @@ async def _download_one(nas, *, src_path: str, dest_dir: str) -> None:
             nas.download_to, src_path=src_path, dest_dir=dest_dir
         )
     except DSMError as exc:
-        code = _dsm_error_code(exc)
-        if code in _PERMANENT_DSM_CODES:
-            raise ApplicationError(
-                f"NAS file not found (Synology {code}): {src_path}",
-                type=NAS_FILE_NOT_FOUND_TYPE,
-                non_retryable=True,
-            ) from exc
+        raise_if_permanent_dsm_error(exc, context=src_path)
         raise
 
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/verify_dive_checksums_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/verify_dive_checksums_activity.py
@@ -1,0 +1,212 @@
+"""Activity: re-hash a migrated dive's frames against the NAS and report.
+
+Answers "do we trust the existing data?" with a measurement instead of an
+argument.
+
+Every ingest convention was recovered by reading the retired spider crawler:
+`Image.checksum` is `md5` of the whole file (`backend.py:67`) and
+`taken_datetime` is naive EXIF tag 0x0132 stamped UTC (`backend.py:20`). That
+derivation is solid and the migration chain is traced end to end — but it
+proves what *spider* wrote. It does not prove all ~131k rows came from spider,
+and no stored value had ever been compared against the bytes on the NAS.
+
+The gap matters because of its failure mode. If existing checksums were
+computed even slightly differently, duplicate detection does not error — it
+silently reports **zero overlap**. A re-ingest of an already-present dive would
+look entirely new, every frame would land `is_canonical=True`, and the
+canonical-only gating would have nothing to gate on.
+
+**Read-only, by construction.** No NAS writes, no SDK writes; a test tripwire
+asserts this module's source contains no write call. It runs against prod data
+to answer a question and must not be able to change the answer.
+
+**Findings, not failures.** A mismatch — or a row whose file is gone — is one
+of the answers being looked for, so the run records it and carries on. Only an
+infrastructure error (a NAS that is down rather than a file that is absent)
+propagates for Temporal to retry. That is the opposite of
+`stage_raw_bytes_for_dive_activity`, where a missing file is a non-retryable
+failure, and the difference is deliberate: staging is trying to *do* something.
+
+Whole files are downloaded, unlike preflight's ranged 1 MB read — an MD5 of the
+whole file needs the whole file. So a dive is ~500 × ~15 MB, and `limit` exists
+to sample: answering "does the convention hold" does not need every frame.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from synology_filestation import DSMError
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.nas_errors import dsm_error_code
+from fishsense_api_workflow_worker.activities.utils import get_fs_client
+from fishsense_api_workflow_worker.config import settings
+from fishsense_api_workflow_worker.exif import read_exif
+from fishsense_api_workflow_worker.nas import NasDownloadClient
+from fishsense_shared.ingest_contracts import (
+    ChecksumMismatch,
+    VerifyChecksumsReport,
+)
+
+# Matches `spider/backend.py:67` exactly. The chunking is not scoping — it is
+# byte-identical to hashing the whole buffer — but it keeps a 15 MB buffer per
+# frame off the heap, which is why spider did it and why we do.
+_HASH_CHUNK_BYTES = 8192
+
+# EXIF sits at the front of the file; no need to re-read 15 MB to compare a
+# timestamp we already have on disk.
+_EXIF_HEADER_BYTES = 1024 * 1024
+
+# "No such file or directory". Here it is a *finding* (the row outlived its
+# file), not the permanent failure it is when staging.
+_DSM_NOT_FOUND = 408
+
+__all__ = ["verify_dive_checksums_activity"]
+
+
+def _build_nas_client() -> NasDownloadClient:
+    return NasDownloadClient(
+        nas_url=settings.e4e_nas.url,
+        username=settings.e4e_nas.username,
+        password=settings.e4e_nas.password,
+    )
+
+
+def _resolve_nas_path(relative_path: str) -> str:
+    """Prepend the share root, as the staging activity does. Absolute paths
+    pass through so a hand-corrected row isn't double-prefixed."""
+    if relative_path.startswith("/"):
+        return relative_path
+    root = settings.e4e_nas.raw_root_path.rstrip("/")
+    return f"{root}/{relative_path.lstrip('/')}"
+
+
+def _file_checksum(path: Path) -> str:
+    """`md5` of the whole file, streamed. The convention of record."""
+    digest = hashlib.md5()
+    with open(path, "rb") as handle:
+        for blob in iter(lambda: handle.read(_HASH_CHUNK_BYTES), b""):
+            digest.update(blob)
+    return digest.hexdigest()
+
+
+def _exif_taken_datetime(path: Path) -> datetime | None:
+    """Naive EXIF 0x0132 stamped UTC — agreement with the migrated rows, not
+    correctness. The camera's recorded offset is deliberately not applied."""
+    with open(path, "rb") as handle:
+        header = handle.read(_EXIF_HEADER_BYTES)
+    raw = read_exif(header).date_time
+    if not raw:
+        return None
+    try:
+        return datetime.strptime(raw, "%Y:%m:%d %H:%M:%S").replace(
+            tzinfo=timezone.utc
+        )
+    except ValueError:
+        return None
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    """Compare like with like: a row read back without tzinfo is still UTC by
+    the migration's construction, so an aware/naive mix must not read as a
+    mismatch."""
+    if value is None or value.tzinfo is not None:
+        return value
+    return value.replace(tzinfo=timezone.utc)
+
+
+def _verify_one(nas, image, report: VerifyChecksumsReport) -> None:
+    """Download one frame, compare, and record. Never raises on a finding."""
+    src_path = _resolve_nas_path(image.path)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        try:
+            nas.download_to(src_path=src_path, dest_dir=tmpdir)
+        except DSMError as exc:
+            if dsm_error_code(exc) == _DSM_NOT_FOUND:
+                report.missing_on_nas.append(
+                    ChecksumMismatch(
+                        image_id=image.id, path=image.path, stored=image.checksum
+                    )
+                )
+                return
+            # A NAS that is down, rather than a file that is absent. Propagate
+            # so Temporal's bounded policy retries rather than recording a
+            # finding that is really an outage.
+            raise
+
+        local = Path(tmpdir) / os.path.basename(src_path)
+        computed = _file_checksum(local)
+        exif_taken = _exif_taken_datetime(local)
+
+    if not image.checksum:
+        report.no_stored_checksum.append(
+            ChecksumMismatch(
+                image_id=image.id, path=image.path, computed=computed
+            )
+        )
+    elif image.checksum == computed:
+        report.checksum_matched += 1
+    else:
+        report.mismatches.append(
+            ChecksumMismatch(
+                image_id=image.id,
+                path=image.path,
+                stored=image.checksum,
+                computed=computed,
+            )
+        )
+
+    stored_taken = _as_utc(image.taken_datetime)
+    if stored_taken != exif_taken:
+        report.timestamp_mismatches.append(
+            ChecksumMismatch(
+                image_id=image.id,
+                path=image.path,
+                stored=stored_taken.isoformat() if stored_taken else None,
+                computed=exif_taken.isoformat() if exif_taken else None,
+            )
+        )
+
+
+@activity.defn
+async def verify_dive_checksums_activity(
+    dive_id: int, limit: int | None = None
+) -> VerifyChecksumsReport:
+    async with get_fs_client() as fs:
+        images = await fs.images.get(dive_id=dive_id) or []
+
+    # Deliberately NOT filtered to canonical rows. The duplicates are half the
+    # table and are exactly the population whose provenance is least certain,
+    # so excluding them would skip the rows most worth checking.
+    ordered = sorted(images, key=lambda i: i.path or "")
+    report = VerifyChecksumsReport(dive_id=dive_id, total_in_dive=len(ordered))
+    selected = ordered if limit is None else ordered[:limit]
+
+    nas = _build_nas_client()
+    for index, image in enumerate(selected):
+        if not image.path:
+            continue
+        # Details carry the index so a retry resumes rather than re-downloading
+        # everything already checked — whole files, so that is real bandwidth.
+        activity.heartbeat(index)
+        await asyncio.to_thread(_verify_one, nas, image, report)
+        report.checked += 1
+
+    activity.logger.info(
+        "verified dive_id=%d checked=%d matched=%d mismatched=%d "
+        "timestamp_mismatched=%d missing=%d no_checksum=%d",
+        dive_id,
+        report.checked,
+        report.checksum_matched,
+        len(report.mismatches),
+        len(report.timestamp_mismatches),
+        len(report.missing_on_nas),
+        len(report.no_stored_checksum),
+    )
+    return report

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -166,6 +166,9 @@ from fishsense_api_workflow_worker.activities.sync_users_label_studio_activity i
 from fishsense_api_workflow_worker.activities.update_dive_image_groups_activity import (
     update_dive_image_groups_activity,
 )
+from fishsense_api_workflow_worker.activities.verify_dive_checksums_activity import (
+    verify_dive_checksums_activity,
+)
 from fishsense_api_workflow_worker.config import configure_logging, settings
 from fishsense_api_workflow_worker.workflows.create_dive_slate_label_studio_project_workflow import (  # pylint: disable=line-too-long
     CreateDiveSlateLabelStudioProjectWorkflow,
@@ -244,6 +247,9 @@ from fishsense_api_workflow_worker.workflows.sync_label_studio_species_labels_wo
 )
 from fishsense_api_workflow_worker.workflows.update_dive_image_groups_workflow import (
     UpdateDiveImageGroupsWorkflow,
+)
+from fishsense_api_workflow_worker.workflows.verify_dive_checksums_workflow import (
+    VerifyDiveChecksumsWorkflow,
 )
 from fishsense_api_workflow_worker.workflows.scale_down_idle_data_worker_workflow import (  # pylint: disable=line-too-long
     ScaleDownIdleDataWorkerWorkflow,
@@ -625,6 +631,7 @@ async def main():
                 ReconcileLabelingConfigsWorkflow,
                 PopulateDiveSlateLabelStudioProjectWorkflow,
                 UpdateDiveImageGroupsWorkflow,
+                VerifyDiveChecksumsWorkflow,
                 ClusterDiveFramesParentWorkflow,
                 PredictLaserImagesParentWorkflow,
                 PredictSlateImagesParentWorkflow,
@@ -659,6 +666,7 @@ async def main():
                 populate_headtail_label_studio_project_activity,
                 populate_dive_slate_label_studio_project_activity,
                 update_dive_image_groups_activity,
+                verify_dive_checksums_activity,
                 resolve_dive_frame_clustering_inputs_activity,
                 resolve_laser_preprocess_inputs_activity,
                 resolve_laser_predict_inputs_activity,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/verify_dive_checksums_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/verify_dive_checksums_workflow.py
@@ -1,0 +1,64 @@
+"""Workflow to re-hash one migrated dive against the NAS.
+
+On-demand, no schedule, read-only. Exists so "do we trust the migrated data?"
+can be answered by an operator on demand rather than by a one-off script:
+
+  * it runs inside the slot, where the NAS credentials already live, so nobody
+    has to copy them anywhere to ask the question;
+  * whole-file downloads over FileStation's fragile backend get Temporal's
+    bounded jittered retry and a heartbeat that resumes mid-dive instead of
+    re-pulling gigabytes;
+  * the report is durable and visible in the Temporal UI, so a finding can be
+    pointed at later rather than living in someone's terminal scrollback.
+
+```
+temporal workflow start \
+    --task-queue fishsense_api_queue \
+    --type VerifyDiveChecksumsWorkflow \
+    --workflow-id verify-checksums-<dive_id> \
+    --input <dive_id> --input 25
+```
+
+The second argument samples: verification pulls whole files (~15 MB each, the
+one thing preflight's ranged read avoids), and answering "does the convention
+hold" does not need all ~500 frames of a dive. Pass `null` to check every one.
+"""
+
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from fishsense_shared.ingest_contracts import VerifyChecksumsReport
+
+
+@workflow.defn
+class VerifyDiveChecksumsWorkflow:
+    # pylint: disable=too-few-public-methods
+    """Compare stored `checksum` / `taken_datetime` against the files on NAS."""
+
+    @workflow.run
+    async def run(
+        self, dive_id: int, limit: int | None = None
+    ) -> VerifyChecksumsReport:
+        """Verify `dive_id`, optionally sampling the first `limit` frames."""
+        return await workflow.execute_activity(
+            "verify_dive_checksums_activity",
+            args=(dive_id, limit),
+            # Generous: a full dive is ~500 whole-file downloads over a backend
+            # that is deliberately driven serially.
+            schedule_to_close_timeout=timedelta(hours=6),
+            # One frame at a time, so a gap this long means the transfer is
+            # wedged rather than slow.
+            heartbeat_timeout=timedelta(minutes=10),
+            retry_policy=RetryPolicy(
+                initial_interval=timedelta(seconds=30),
+                backoff_coefficient=2.0,
+                maximum_interval=timedelta(minutes=5),
+                # Bounded: this is diagnostic, not load-bearing. If the NAS is
+                # having a bad day the answer is to ask again later, not to
+                # keep hammering a fragile shared download backend.
+                maximum_attempts=5,
+            ),
+        )

--- a/services/fishsense-api-workflow-worker/tests/conftest.py
+++ b/services/fishsense-api-workflow-worker/tests/conftest.py
@@ -44,6 +44,14 @@ def configure_worker_settings(
     monkeypatch.setenv("E4EFS_E4E_NAS__URL", "http://nas.example.com")
     monkeypatch.setenv("E4EFS_E4E_NAS__USERNAME", "unused")
     monkeypatch.setenv("E4EFS_E4E_NAS__PASSWORD", "unused")
+    # Same reason as temporal.port/.tls above: `raw_root_path` has a validator
+    # default, but a `settings.reload()` elsewhere in the session doesn't
+    # re-apply defaults, so any test reading it becomes order-dependent —
+    # passing alone, AccessError in the full suite. Tests that care about the
+    # prefix still set their own value and override this.
+    monkeypatch.setenv(
+        "E4EFS_E4E_NAS__RAW_ROOT_PATH", "/fishsense_data/REEF/data"
+    )
     monkeypatch.setenv("E4EFS_FISHSENSE_API__URL", "http://fishsense-api.example.com")
 
     if _is_integration_test(request):

--- a/services/fishsense-api-workflow-worker/tests/test_list_dive_folder_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_list_dive_folder_activity.py
@@ -1,0 +1,283 @@
+"""Unit tests for `list_dive_folder_activity` — the first step of ingest.
+
+The behaviour under test is almost entirely about what ingest *refuses* to do.
+
+**One request means one dive, and a dive is exactly one directory.** That is
+not a simplification: spider walked the tree recursively but then assigned
+`dive = image.parent.relative_to(data_root)` (`discovery.py:238`), so a nested
+folder always became its own separate dive row, never extra frames on the
+parent. Attaching a subdirectory's frames to the named dive would merge dives
+that are distinct rows in prod today — silently, and with no way to tell
+afterwards which frames came from where.
+
+So subdirectories holding `.ORF`s are *reported* and not ingested. That is the
+Olympus rollover case: the TG-6 wraps its frame counter at `PA199999` and
+starts a child folder mid-dive, which reads as "more frames of this dive" to a
+human and as "a second dive" to every convention in the database.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from temporalio.exceptions import ApplicationError
+
+
+def _entry(path: str, *, is_dir: bool = False, size: int = 1024):
+    from fishsense_api_workflow_worker.nas import (  # pylint: disable=import-outside-toplevel
+        NasEntry,
+    )
+
+    return NasEntry(
+        path=path,
+        name=path.rstrip("/").rsplit("/", 1)[-1],
+        is_dir=is_dir,
+        size=size,
+    )
+
+
+def _listing_client(tree: dict[str, list]):
+    """A fake NasClient whose `list_dir` serves a canned folder tree.
+
+    Keyed by the folder path so a test can assert *which* folders were listed —
+    the non-recursion property is about the calls made, not just the result.
+    """
+    client = MagicMock()
+    client.listed = []
+
+    def _list_dir(*, folder_path: str):
+        client.listed.append(folder_path)
+        if folder_path not in tree:
+            raise AssertionError(f"unexpected list_dir({folder_path!r})")
+        return tree[folder_path]
+
+    client.list_dir.side_effect = _list_dir
+    return client
+
+
+async def _run(request, client, monkeypatch):
+    from fishsense_api_workflow_worker.activities import (  # pylint: disable=import-outside-toplevel
+        list_dive_folder_activity as sut,
+    )
+
+    monkeypatch.setattr(sut, "_build_nas_client", lambda: client)
+    return await sut.list_dive_folder_activity(request)
+
+
+def _request(**kwargs):
+    from fishsense_shared.ingest_contracts import (  # pylint: disable=import-outside-toplevel
+        IngestDiveRequest,
+    )
+
+    kwargs.setdefault("dive_path", "2024.06.20.REEF/082929_FishModels_FSL07")
+    kwargs.setdefault("self_calibrates", True)
+    return IngestDiveRequest(**kwargs)
+
+
+ROOT = "/fishsense_data/REEF/data"
+FOLDER = f"{ROOT}/2024.06.20.REEF/082929_FishModels_FSL07"
+
+
+# ── what counts as a frame ────────────────────────────────────────────
+
+
+async def test_matches_orf_case_insensitively(monkeypatch):
+    """Olympus writes `.ORF`; operators and copy tools produce `.orf`. A
+    case-sensitive match would silently ingest a partial dive, which
+    `finalize` cannot detect because the missing frames were never listed."""
+    client = _listing_client(
+        {
+            FOLDER: [
+                _entry(f"{FOLDER}/PA010001.ORF"),
+                _entry(f"{FOLDER}/PA010002.orf"),
+                _entry(f"{FOLDER}/PA010003.Orf"),
+            ]
+        }
+    )
+
+    listing = await _run(_request(), client, monkeypatch)
+
+    assert [f.name for f in listing.files] == [
+        "PA010001.ORF",
+        "PA010002.orf",
+        "PA010003.Orf",
+    ]
+
+
+async def test_ignores_files_that_are_not_orf(monkeypatch):
+    """Dive folders routinely carry JPEGs, `.MOV` clips and Finder debris.
+    Only raws are frames."""
+    client = _listing_client(
+        {
+            FOLDER: [
+                _entry(f"{FOLDER}/PA010001.ORF"),
+                _entry(f"{FOLDER}/PA010001.JPG"),
+                _entry(f"{FOLDER}/notes.txt"),
+                _entry(f"{FOLDER}/.DS_Store"),
+            ]
+        }
+    )
+
+    listing = await _run(_request(), client, monkeypatch)
+
+    assert [f.name for f in listing.files] == ["PA010001.ORF"]
+
+
+async def test_files_are_returned_in_a_deterministic_order(monkeypatch):
+    """Batching and heartbeat-resume both index into this list, so a retry
+    that saw a different order would re-download frames it had already
+    registered and skip ones it hadn't. DSM does not promise an order."""
+    client = _listing_client(
+        {
+            FOLDER: [
+                _entry(f"{FOLDER}/PA010003.ORF"),
+                _entry(f"{FOLDER}/PA010001.ORF"),
+                _entry(f"{FOLDER}/PA010002.ORF"),
+            ]
+        }
+    )
+
+    listing = await _run(_request(), client, monkeypatch)
+
+    assert [f.name for f in listing.files] == [
+        "PA010001.ORF",
+        "PA010002.ORF",
+        "PA010003.ORF",
+    ]
+
+
+# ── the non-recursion rule ────────────────────────────────────────────
+
+
+async def test_a_subfolder_of_orfs_is_reported_not_ingested(monkeypatch):
+    """The rollover case. Its frames must NOT join this dive — under the
+    convention every existing row follows, that folder is its own dive."""
+    sub = f"{FOLDER}/101923_Alligator1_FSL06"
+    client = _listing_client(
+        {
+            FOLDER: [
+                _entry(f"{FOLDER}/PA010001.ORF"),
+                _entry(sub, is_dir=True),
+            ],
+            sub: [
+                _entry(f"{sub}/PA199998.ORF"),
+                _entry(f"{sub}/PA199999.ORF"),
+            ],
+        }
+    )
+
+    listing = await _run(_request(), client, monkeypatch)
+
+    assert [f.name for f in listing.files] == ["PA010001.ORF"]
+    assert len(listing.subfolders) == 1
+    assert listing.subfolders[0].path == sub
+    assert listing.subfolders[0].orf_count == 2
+
+
+async def test_a_subfolder_without_orfs_is_not_reported(monkeypatch):
+    """`.thumbnails`, `__MACOSX` and the like are noise, not a missed dive.
+    Reporting them would train operators to ignore the warning."""
+    sub = f"{FOLDER}/.thumbnails"
+    client = _listing_client(
+        {
+            FOLDER: [
+                _entry(f"{FOLDER}/PA010001.ORF"),
+                _entry(sub, is_dir=True),
+            ],
+            sub: [_entry(f"{sub}/PA010001_thumb.jpg")],
+        }
+    )
+
+    listing = await _run(_request(), client, monkeypatch)
+
+    assert listing.subfolders == []
+
+
+async def test_does_not_descend_past_the_immediate_children(monkeypatch):
+    """Counting a subfolder's frames needs one level. Going deeper would
+    turn a mis-typed path near the share root into a walk of the entire NAS,
+    over a download backend that falls over under load."""
+    sub = f"{FOLDER}/rollover"
+    deeper = f"{sub}/deeper"
+    client = _listing_client(
+        {
+            FOLDER: [_entry(sub, is_dir=True)],
+            sub: [
+                _entry(f"{sub}/PA199999.ORF"),
+                _entry(deeper, is_dir=True),
+            ],
+        }
+    )
+
+    listing = await _run(_request(), client, monkeypatch)
+
+    assert client.listed == [FOLDER, sub]
+    assert listing.subfolders[0].orf_count == 1
+
+
+# ── path resolution ───────────────────────────────────────────────────
+
+
+async def test_the_request_path_is_resolved_against_the_nas_raw_root(monkeypatch):
+    """`Image.path` is stored share-relative but FileStation needs absolute —
+    the same asymmetry `stage_raw_bytes_for_dive_activity` handles. Getting it
+    wrong surfaces as a 502, not a 404."""
+    client = _listing_client({FOLDER: []})
+
+    await _run(_request(), client, monkeypatch)
+
+    assert client.listed == [FOLDER]
+
+
+async def test_an_absolute_request_path_is_not_double_prefixed(monkeypatch):
+    """An operator pasting a full NAS path is the obvious mistake to absorb."""
+    client = _listing_client({FOLDER: []})
+
+    await _run(_request(dive_path=FOLDER), client, monkeypatch)
+
+    assert client.listed == [FOLDER]
+
+
+# ── failure ───────────────────────────────────────────────────────────
+
+
+async def test_a_missing_folder_fails_non_retryably(monkeypatch):
+    """Synology 408 is "no such file". A mistyped path cannot be fixed by
+    waiting, so Temporal must not burn its retry budget on it — the same
+    classification the staging activity makes."""
+    from synology_filestation import DSMError  # pylint: disable=import-outside-toplevel
+
+    client = MagicMock()
+    client.list_dir.side_effect = DSMError("Synology API error 408")
+
+    with pytest.raises(ApplicationError) as excinfo:
+        await _run(_request(), client, monkeypatch)
+
+    assert excinfo.value.non_retryable
+    assert "408" in str(excinfo.value)
+
+
+async def test_a_transient_nas_error_propagates_for_temporal_to_retry(monkeypatch):
+    """502 is FileStation's shared download backend falling over — routine and
+    self-healing. It must reach Temporal's bounded jittered policy rather than
+    being converted into a permanent failure."""
+    from synology_filestation import DSMError  # pylint: disable=import-outside-toplevel
+
+    client = MagicMock()
+    client.list_dir.side_effect = DSMError("Synology API error 502")
+
+    with pytest.raises(DSMError):
+        await _run(_request(), client, monkeypatch)
+
+
+async def test_an_empty_folder_lists_cleanly_rather_than_failing(monkeypatch):
+    """Preflight is what reports "no frames here", with the rest of its
+    findings. Failing at listing would hand the operator one error at a time —
+    the opposite of the all-at-once contract."""
+    client = _listing_client({FOLDER: []})
+
+    listing = await _run(_request(), client, monkeypatch)
+
+    assert listing.files == []
+    assert listing.subfolders == []

--- a/services/fishsense-api-workflow-worker/tests/test_preflight_ingest_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preflight_ingest_activity.py
@@ -1,0 +1,415 @@
+"""Unit tests for `preflight_ingest_activity` — the gate ingest has to pass.
+
+Preflight writes nothing. Its whole job is to decide whether the folder can
+become a dive, and to say so completely: **every problem at once, never
+first-wins.** An operator submitting a folder from a boat has one round trip
+worth of attention, and "fix this, resubmit, discover the next thing" spends it
+badly.
+
+The checks it makes are the ones nothing downstream can recover from:
+
+  * A camera that can't be resolved, or has no intrinsics, silently gives
+    stage 14 the wrong geometry — measurements come out plausible and wrong.
+  * A folder spanning two serials is two rigs in one dive, which the schema
+    has no way to express (spider only wrote a report file and carried on).
+  * Unstated calibration intent produces a dive that can never be measured and
+    never says why.
+  * A frame with no readable timestamp corrupts stage-1 clustering, which is
+    pure timestamp maths.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from temporalio.testing import ActivityEnvironment
+
+from ._tiff_builder import build_orf
+
+SERIAL = "BJ6C67989"
+ROOT = "/fishsense_data/REEF/data"
+FOLDER = f"{ROOT}/2024.06.20.REEF/082929_FishModels_FSL07"
+
+
+def _camera(camera_id=7, serial=SERIAL, name="FSL-07"):
+    from fishsense_api_sdk.models.camera import (  # pylint: disable=import-outside-toplevel
+        Camera,
+    )
+
+    return Camera(id=camera_id, serial_number=serial, name=name)
+
+
+def _entry(name: str, size: int = 15_000_000):
+    from fishsense_api_workflow_worker.nas import (  # pylint: disable=import-outside-toplevel
+        NasEntry,
+    )
+
+    return NasEntry(
+        path=f"{FOLDER}/{name}", name=name, is_dir=False, size=size
+    )
+
+
+def _listing(names=("PA010001.ORF", "PA010002.ORF"), subfolders=()):
+    from fishsense_api_workflow_worker.activities.list_dive_folder_activity import (  # pylint: disable=import-outside-toplevel
+        DiveFolderListing,
+    )
+
+    return DiveFolderListing(
+        folder_path=FOLDER,
+        files=[_entry(n) for n in names],
+        subfolders=list(subfolders),
+    )
+
+
+def _request(**kwargs):
+    from fishsense_shared.ingest_contracts import (  # pylint: disable=import-outside-toplevel
+        IngestDiveRequest,
+    )
+
+    kwargs.setdefault("dive_path", "2024.06.20.REEF/082929_FishModels_FSL07")
+    kwargs.setdefault("self_calibrates", True)
+    return IngestDiveRequest(**kwargs)
+
+
+def _fs(cameras=None, intrinsics=object(), dives=None):
+    """Fake SDK client: cameras to resolve against, intrinsics presence, and
+    the existing dives that layer-1 duplicate detection compares leaf names to.
+    """
+    fs = MagicMock()
+    fs.cameras.get = AsyncMock(
+        return_value=[_camera()] if cameras is None else cameras
+    )
+    fs.cameras.get_intrinsics = AsyncMock(return_value=intrinsics)
+    fs.dives.get = AsyncMock(return_value=dives or [])
+    fs.__aenter__ = AsyncMock(return_value=fs)
+    fs.__aexit__ = AsyncMock(return_value=False)
+    return fs
+
+
+async def _run(request, listing, monkeypatch, *, fs=None, headers=None):
+    """Drive the activity with canned NAS header bytes, one per listed file.
+
+    `headers` maps a file name to the bytes its ranged read returns; anything
+    unlisted gets a well-formed default header.
+    """
+    from fishsense_api_workflow_worker.activities import (  # pylint: disable=import-outside-toplevel
+        preflight_ingest_activity as sut,
+    )
+
+    default = build_orf(
+        date_time="2024:08:21 08:56:51", serial_number=SERIAL, artist="FSL-07"
+    )
+    headers = headers or {}
+
+    nas = MagicMock()
+    nas.download_range.side_effect = lambda *, file_path, offset=0, length=0: (
+        headers.get(file_path.rsplit("/", 1)[-1], default)
+    )
+
+    monkeypatch.setattr(sut, "_build_nas_client", lambda: nas)
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs or _fs())
+    # Preflight heartbeats per frame — a 500-frame dive is a long activity —
+    # so it needs a real activity context.
+    return await ActivityEnvironment().run(
+        sut.preflight_ingest_activity, request, listing
+    )
+
+
+# ── the all-at-once contract ──────────────────────────────────────────
+
+
+async def test_reports_every_error_at_once_rather_than_the_first(monkeypatch):
+    """The property the whole activity exists for. A folder with three
+    *independent* problems must come back with three errors, not one.
+
+    Independence is the point of the fixture: the frames carry a good serial so
+    the camera still resolves, which is what lets the missing-intrinsics check
+    run at all. Faults that mask each other (an unreadable serial makes
+    "has intrinsics?" unanswerable) would prove nothing about accumulation.
+    """
+    long_name = "P" + "A" * 300 + ".ORF"
+    listing = _listing(names=("PA010001.ORF", long_name))
+
+    preflight = await _run(
+        _request(self_calibrates=False),  # no calibration intent
+        listing,
+        monkeypatch,
+        fs=_fs(intrinsics=None),  # resolvable camera, but no intrinsics
+    )
+
+    joined = " | ".join(preflight.errors)
+    assert "intrinsics" in joined
+    assert "calibration" in joined
+    assert "255" in joined
+    assert len(preflight.errors) == 3
+
+
+# ── camera resolution ─────────────────────────────────────────────────
+
+
+async def test_resolves_the_camera_from_the_makernote_serial(monkeypatch):
+    preflight = await _run(_request(), _listing(), monkeypatch)
+
+    assert preflight.errors == []
+    assert preflight.resolved_camera_id == 7
+    assert preflight.resolved_camera_name == "FSL-07"
+
+
+async def test_an_unknown_serial_fails_and_does_not_fall_back_to_artist(
+    monkeypatch,
+):
+    """The anti-regression test for the camera decision. `Artist` is a free-text
+    rig label; matching on it would resolve a camera whose intrinsics belong to
+    different glass, and stage 14 would report confident wrong lengths. Better
+    to refuse and make someone add the Camera row."""
+    fs = _fs(cameras=[_camera(camera_id=3, serial="OTHER123", name="FSL-07")])
+
+    preflight = await _run(_request(), _listing(), monkeypatch, fs=fs)
+
+    assert preflight.resolved_camera_id is None
+    assert any(SERIAL in e for e in preflight.errors)
+
+
+async def test_an_explicit_camera_id_overrides_serial_resolution(monkeypatch):
+    """The escape hatch for a body whose MakerNote is unreadable, or frames
+    copied through a tool that stripped it."""
+    fs = _fs(cameras=[_camera(camera_id=3, serial="OTHER123", name="FSL-03")])
+
+    preflight = await _run(
+        _request(camera_id=3), _listing(), monkeypatch, fs=fs
+    )
+
+    assert preflight.errors == []
+    assert preflight.resolved_camera_id == 3
+
+
+async def test_a_dive_spanning_two_serials_fails(monkeypatch):
+    """One folder is one rig. Mixed intrinsics inside a single dive can't be
+    expressed in the schema, and spider's response — write a report file and
+    carry on — is how such dives got in unnoticed."""
+    other = build_orf(
+        date_time="2024:08:21 08:56:51",
+        serial_number="XX9Z11111",
+        artist="FSL-03",
+    )
+
+    preflight = await _run(
+        _request(),
+        _listing(),
+        monkeypatch,
+        headers={"PA010002.ORF": other},
+    )
+
+    assert any("serial" in e.lower() for e in preflight.errors)
+    assert SERIAL in " ".join(preflight.errors)
+    assert "XX9Z11111" in " ".join(preflight.errors)
+
+
+async def test_a_camera_without_intrinsics_fails(monkeypatch):
+    """Stage 14 needs intrinsics to exist before the dive is worth ingesting;
+    discovering it later means a dive that sits in the cohort forever."""
+    preflight = await _run(
+        _request(), _listing(), monkeypatch, fs=_fs(intrinsics=None)
+    )
+
+    assert any("intrinsics" in e for e in preflight.errors)
+
+
+async def test_artist_disagreeing_with_the_resolved_camera_is_a_warning(
+    monkeypatch,
+):
+    """Not fatal — the serial is authoritative — but it means a mislabelled
+    `Camera.name` or a re-housed body, and nothing else in the pipeline would
+    ever notice."""
+    fs = _fs(cameras=[_camera(camera_id=7, serial=SERIAL, name="FSL-99")])
+
+    preflight = await _run(_request(), _listing(), monkeypatch, fs=fs)
+
+    assert preflight.errors == []
+    assert any("FSL-07" in w and "FSL-99" in w for w in preflight.warnings)
+
+
+# ── calibration intent ────────────────────────────────────────────────
+
+
+async def test_neither_calibration_intent_given_fails(monkeypatch):
+    """A fish-only dive with no slate frames can never self-calibrate, so
+    stage 14 can never measure it — and that is invisible in the files. The
+    intent has to be stated at ingest or the dive quietly never completes."""
+    preflight = await _run(
+        _request(self_calibrates=False), _listing(), monkeypatch
+    )
+
+    assert any("calibration" in e for e in preflight.errors)
+
+
+async def test_both_calibration_intents_given_fails(monkeypatch):
+    """Contradictory intent. `own wins` would silently ignore the link the
+    operator went to the trouble of specifying."""
+    preflight = await _run(
+        _request(self_calibrates=True, calibration_dive_id=61),
+        _listing(),
+        monkeypatch,
+    )
+
+    assert any("calibration" in e for e in preflight.errors)
+
+
+async def test_borrowing_calibration_alone_is_valid(monkeypatch):
+    preflight = await _run(
+        _request(self_calibrates=False, calibration_dive_id=61),
+        _listing(),
+        monkeypatch,
+    )
+
+    assert preflight.errors == []
+
+
+# ── per-frame validation ──────────────────────────────────────────────
+
+
+async def test_a_frame_without_a_readable_timestamp_fails(monkeypatch):
+    """Stage-1 clustering is pure timestamp maths, so a defaulted timestamp
+    corrupts it silently. Rejecting the frame is the only safe answer."""
+    blind = build_orf(
+        date_time=None, date_time_original=None, serial_number=SERIAL
+    )
+
+    preflight = await _run(
+        _request(), _listing(), monkeypatch, headers={"PA010002.ORF": blind}
+    )
+
+    assert any("PA010002.ORF" in e for e in preflight.errors)
+
+
+async def test_the_timestamp_is_the_naive_exif_value_stamped_utc(monkeypatch):
+    """The convention ~111k existing rows follow: the camera's wall clock,
+    labelled UTC, with the recorded offset deliberately NOT applied. Matching
+    it matters more than being right — mixing conventions inside one table is
+    worse than a consistent offset."""
+    preflight = await _run(_request(), _listing(), monkeypatch)
+
+    assert preflight.images[0].taken_datetime == datetime(
+        2024, 8, 21, 8, 56, 51, tzinfo=timezone.utc
+    )
+
+
+async def test_the_camera_offset_is_surfaced_but_not_applied(monkeypatch):
+    with_offset = build_orf(
+        date_time="2024:08:21 08:56:51",
+        offset_time="-08:00",
+        serial_number=SERIAL,
+    )
+
+    preflight = await _run(
+        _request(),
+        _listing(names=("PA010001.ORF",)),
+        monkeypatch,
+        headers={"PA010001.ORF": with_offset},
+    )
+
+    assert preflight.images[0].exif_offset == "-08:00"
+    assert preflight.images[0].taken_datetime.hour == 8
+
+
+async def test_a_fallback_timestamp_tag_is_warned_about(monkeypatch):
+    """0x0132 missing means this body isn't the one the convention was derived
+    from. The frame is still usable; the divergence should be visible."""
+    fallback = build_orf(
+        date_time=None,
+        date_time_original="2024:08:21 08:56:51",
+        serial_number=SERIAL,
+    )
+
+    preflight = await _run(
+        _request(),
+        _listing(names=("PA010001.ORF",)),
+        monkeypatch,
+        headers={"PA010001.ORF": fallback},
+    )
+
+    assert preflight.errors == []
+    assert any("PA010001.ORF" in w for w in preflight.warnings)
+
+
+async def test_a_path_over_255_characters_fails_and_names_the_offender(
+    monkeypatch,
+):
+    """`Image.path` is varchar(255). Without this the dive half-ingests and
+    fails on one row with a 422 that doesn't say which file."""
+    long_name = "P" + "A" * 300 + ".ORF"
+
+    preflight = await _run(
+        _request(), _listing(names=("PA010001.ORF", long_name)), monkeypatch
+    )
+
+    assert any(long_name in e for e in preflight.errors)
+
+
+async def test_an_empty_folder_fails(monkeypatch):
+    """Almost always a mistyped path. Creating an empty dive would leave a row
+    that no stage can ever act on."""
+    preflight = await _run(_request(), _listing(names=()), monkeypatch)
+
+    assert any("No .ORF frames" in e for e in preflight.errors)
+
+
+# ── reporting ─────────────────────────────────────────────────────────
+
+
+async def test_reads_only_the_first_megabyte_of_each_frame(monkeypatch):
+    """What makes a dry run affordable: ~1 MB per file instead of ~15 MB
+    across FileStation's fragile shared download backend. A 500-frame dive is
+    0.5 GB rather than 7.5 GB."""
+    from fishsense_api_workflow_worker.activities import (  # pylint: disable=import-outside-toplevel
+        preflight_ingest_activity as sut,
+    )
+
+    nas = MagicMock()
+    nas.download_range.return_value = build_orf(
+        date_time="2024:08:21 08:56:51", serial_number=SERIAL
+    )
+    monkeypatch.setattr(sut, "_build_nas_client", lambda: nas)
+    monkeypatch.setattr(sut, "get_fs_client", _fs)
+
+    await ActivityEnvironment().run(
+        sut.preflight_ingest_activity, _request(), _listing()
+    )
+
+    for call in nas.download_range.call_args_list:
+        assert call.kwargs["offset"] == 0
+        assert call.kwargs["length"] == sut.EXIF_HEADER_BYTES
+
+
+async def test_totals_and_subfolders_are_carried_into_the_report(monkeypatch):
+    from fishsense_shared.ingest_contracts import (  # pylint: disable=import-outside-toplevel
+        SubfolderReport,
+    )
+
+    listing = _listing(
+        subfolders=[SubfolderReport(path=f"{FOLDER}/rollover", orf_count=47)]
+    )
+
+    preflight = await _run(_request(), listing, monkeypatch)
+
+    assert preflight.total_bytes == 30_000_000
+    assert preflight.subfolders[0].orf_count == 47
+    assert any("rollover" in w for w in preflight.warnings)
+
+
+async def test_a_leaf_name_collision_with_an_existing_dive_warns(monkeypatch):
+    """Layer 1 of duplicate detection — free, since preflight already has the
+    dive list. Catches the real prod case: dives 64 and 66 are both
+    `082929_FishModels_FSL07`. Content-based containment needs checksums, so it
+    can only run after the scan."""
+    existing = MagicMock()
+    existing.id = 64
+    existing.path = "2023.01.01.REEF/082929_FishModels_FSL07"
+
+    preflight = await _run(
+        _request(), _listing(), monkeypatch, fs=_fs(dives=[existing])
+    )
+
+    assert preflight.errors == []
+    assert any("64" in w for w in preflight.warnings)

--- a/services/fishsense-api-workflow-worker/tests/test_verify_dive_checksums_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_verify_dive_checksums_activity.py
@@ -1,0 +1,289 @@
+"""Unit tests for `verify_dive_checksums_activity` — does the migrated data
+mean what we think it means?
+
+Every ingest convention was recovered by reading the retired spider crawler's
+source: checksum is `md5` of the whole file (`backend.py:67`), and
+`taken_datetime` is naive EXIF tag 0x0132 stamped UTC (`backend.py:20`). That
+derivation is solid, but it proves what *spider wrote*. It does not prove that
+all ~131k rows came from spider, and no stored value has ever been compared
+against the bytes still sitting on the NAS.
+
+The gap matters because of how it fails. If existing checksums were computed
+even slightly differently, duplicate detection does not error — it silently
+reports **zero overlap**. A re-ingest of an already-present dive would look
+entirely new, every frame would land `is_canonical=True`, and the canonical-only
+gating would have nothing to gate on.
+
+So this activity re-hashes real files and reports. It is **read-only**: no
+writes to the NAS, no writes through the SDK. A mismatch is a *finding*, not a
+failure — the run completes and reports everything it saw, because "which rows
+disagree, and how" is the question being asked.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from temporalio.testing import ActivityEnvironment
+
+from ._tiff_builder import build_orf
+
+ROOT = "/fishsense_data/REEF/data"
+DIVE_FOLDER = "2024.06.20.REEF/082929_FishModels_FSL07"
+
+
+def _orf(date_time="2024:08:21 08:56:51") -> bytes:
+    """A synthetic ORF, padded past one hash chunk so the streaming read is
+    exercised rather than incidentally fitting in a single buffer."""
+    return build_orf(date_time=date_time, serial_number="BJ6C67989") + b"\0" * 40_000
+
+
+def _image(image_id, name, data, *, checksum=None, taken=None):
+    """An `Image` row as the SDK returns it, defaulting to values that agree
+    with `data` so a test only has to state the disagreement it cares about."""
+    image = MagicMock()
+    image.id = image_id
+    image.path = f"{DIVE_FOLDER}/{name}"
+    image.checksum = (
+        checksum if checksum is not None else hashlib.md5(data).hexdigest()
+    )
+    image.taken_datetime = (
+        taken
+        if taken is not None
+        else datetime(2024, 8, 21, 8, 56, 51, tzinfo=timezone.utc)
+    )
+    image.is_canonical = True
+    return image
+
+
+def _fs(images):
+    fs = MagicMock()
+    fs.images.get = AsyncMock(return_value=images)
+    fs.__aenter__ = AsyncMock(return_value=fs)
+    fs.__aexit__ = AsyncMock(return_value=False)
+    return fs
+
+
+def _nas(contents: dict[str, bytes]):
+    """A fake NAS that materialises real files, keyed by basename.
+
+    Real files rather than in-memory bytes because the activity must hash from
+    disk in chunks — a 15 MB buffer per frame times a dive is real memory for
+    no benefit, and that is exactly what spider avoided.
+    """
+    nas = MagicMock()
+
+    def _download_to(*, src_path: str, dest_dir: str):
+        name = src_path.rsplit("/", 1)[-1]
+        if name not in contents:
+            from synology_filestation import (  # pylint: disable=import-outside-toplevel
+                DSMError,
+            )
+
+            raise DSMError("Synology API error 408")
+        Path(dest_dir, name).write_bytes(contents[name])
+
+    nas.download_to.side_effect = _download_to
+    return nas
+
+
+async def _run(images, contents, monkeypatch, **kwargs):
+    from fishsense_api_workflow_worker.activities import (  # pylint: disable=import-outside-toplevel
+        verify_dive_checksums_activity as sut,
+    )
+
+    monkeypatch.setattr(sut, "_build_nas_client", lambda: _nas(contents))
+    monkeypatch.setattr(sut, "get_fs_client", lambda: _fs(images))
+    return await ActivityEnvironment().run(
+        sut.verify_dive_checksums_activity, 412, kwargs.get("limit")
+    )
+
+
+# ── the question being asked ──────────────────────────────────────────
+
+
+async def test_a_row_whose_stored_checksum_matches_the_file_is_counted_matched(
+    monkeypatch,
+):
+    data = _orf()
+    report = await _run(
+        [_image(1, "PA010001.ORF", data)], {"PA010001.ORF": data}, monkeypatch
+    )
+
+    assert report.checked == 1
+    assert report.checksum_matched == 1
+    assert report.mismatches == []
+
+
+async def test_a_checksum_mismatch_reports_both_values_and_the_path(monkeypatch):
+    """The finding has to be actionable. "Some rows disagree" would send
+    someone back to the NAS to work out which."""
+    data = _orf()
+    stored = "0" * 32
+    report = await _run(
+        [_image(1, "PA010001.ORF", data, checksum=stored)],
+        {"PA010001.ORF": data},
+        monkeypatch,
+    )
+
+    assert report.checksum_matched == 0
+    assert len(report.mismatches) == 1
+    finding = report.mismatches[0]
+    assert finding.path.endswith("PA010001.ORF")
+    assert finding.stored == stored
+    assert finding.computed == hashlib.md5(data).hexdigest()
+
+
+async def test_the_checksum_is_md5_of_the_whole_file(monkeypatch):
+    """Pins the convention recovered from `spider/backend.py:67`. A reader that
+    hashed only the header, or canonicalised anything, would agree with itself
+    forever and disagree with every migrated row."""
+    data = _orf()
+    report = await _run(
+        [_image(1, "PA010001.ORF", data, checksum=hashlib.md5(data).hexdigest())],
+        {"PA010001.ORF": data},
+        monkeypatch,
+    )
+
+    assert report.checksum_matched == 1
+
+
+async def test_a_timestamp_mismatch_is_reported_separately(monkeypatch):
+    """The second migrated assumption, free once the bytes are local. Tracked
+    apart from checksums because the two have different consequences — a wrong
+    checksum breaks duplicate detection, a wrong timestamp breaks stage-1
+    clustering."""
+    data = _orf()
+    wrong = datetime(1999, 1, 1, tzinfo=timezone.utc)
+    report = await _run(
+        [_image(1, "PA010001.ORF", data, taken=wrong)],
+        {"PA010001.ORF": data},
+        monkeypatch,
+    )
+
+    assert report.checksum_matched == 1
+    assert len(report.timestamp_mismatches) == 1
+    assert report.timestamp_mismatches[0].stored == wrong.isoformat()
+
+
+async def test_the_stored_timestamp_convention_is_naive_0x0132_stamped_utc(
+    monkeypatch,
+):
+    """Agreement, not correctness. The camera's offset is deliberately not
+    applied — matching the ~111k existing rows matters more than being right,
+    because one consistent offset is recoverable and two mixed conventions in
+    one column are not."""
+    data = _orf(date_time="2024:08:21 08:56:51")
+    report = await _run(
+        [
+            _image(
+                1,
+                "PA010001.ORF",
+                data,
+                taken=datetime(2024, 8, 21, 8, 56, 51, tzinfo=timezone.utc),
+            )
+        ],
+        {"PA010001.ORF": data},
+        monkeypatch,
+    )
+
+    assert report.timestamp_mismatches == []
+
+
+# ── findings, not failures ────────────────────────────────────────────
+
+
+async def test_a_file_missing_from_the_nas_is_a_finding_not_a_crash(monkeypatch):
+    """The difference from the staging activity, which treats a missing file as
+    a non-retryable failure. Here "the row exists but the file is gone" is one
+    of the answers being looked for, so the run reports it and carries on."""
+    data = _orf()
+    report = await _run(
+        [
+            _image(1, "PA010001.ORF", data),
+            _image(2, "GONE.ORF", data),
+        ],
+        {"PA010001.ORF": data},
+        monkeypatch,
+    )
+
+    assert report.checked == 2
+    assert report.checksum_matched == 1
+    assert [m.path.rsplit("/", 1)[-1] for m in report.missing_on_nas] == [
+        "GONE.ORF"
+    ]
+
+
+async def test_a_row_with_no_stored_checksum_is_reported_not_silently_skipped(
+    monkeypatch,
+):
+    """A NULL checksum is itself a migration finding — the column is what
+    duplicate detection joins on, so a blank one silently excludes the row from
+    every overlap calculation."""
+    data = _orf()
+    image = _image(1, "PA010001.ORF", data)
+    image.checksum = None  # `_image` derives one by default; this is the point
+
+    report = await _run([image], {"PA010001.ORF": data}, monkeypatch)
+
+    assert report.checked == 1
+    assert report.checksum_matched == 0
+    assert report.mismatches == []
+    assert len(report.no_stored_checksum) == 1
+    assert report.no_stored_checksum[0].computed == hashlib.md5(data).hexdigest()
+
+
+async def test_one_bad_row_does_not_stop_the_rest_being_checked(monkeypatch):
+    data = _orf()
+    report = await _run(
+        [
+            _image(1, "A.ORF", data, checksum="0" * 32),
+            _image(2, "B.ORF", data),
+            _image(3, "C.ORF", data),
+        ],
+        {"A.ORF": data, "B.ORF": data, "C.ORF": data},
+        monkeypatch,
+    )
+
+    assert report.checked == 3
+    assert report.checksum_matched == 2
+    assert len(report.mismatches) == 1
+
+
+# ── cost control ──────────────────────────────────────────────────────
+
+
+async def test_a_limit_caps_how_many_frames_are_downloaded(monkeypatch):
+    """A dive is ~500 frames at ~15 MB. Verification pulls whole files — the
+    one thing preflight's ranged read avoids — so a sample has to be possible.
+    Answering "does the convention hold" does not need every frame."""
+    data = _orf()
+    images = [_image(i, f"P{i:04d}.ORF", data) for i in range(10)]
+    contents = {f"P{i:04d}.ORF": data for i in range(10)}
+
+    report = await _run(images, contents, monkeypatch, limit=3)
+
+    assert report.checked == 3
+    assert report.total_in_dive == 10
+
+
+# ── read-only ─────────────────────────────────────────────────────────
+
+
+def test_the_module_imports_no_write_capable_client():
+    """Tripwire, mirroring the cleanup activity's. This runs against prod data
+    to answer a question; it must not be able to change the answer. Catches a
+    future edit that reaches for `upload`, `delete` or an SDK write.
+    """
+    import inspect  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api_workflow_worker.activities import (  # pylint: disable=import-outside-toplevel
+        verify_dive_checksums_activity as sut,
+    )
+
+    source = inspect.getsource(sut)
+    for forbidden in (".upload(", ".delete(", ".post(", ".put(", "upload_bytes"):
+        assert forbidden not in source, f"verification must stay read-only: {forbidden}"

--- a/services/fishsense-api-workflow-worker/tests/test_verify_dive_checksums_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_verify_dive_checksums_workflow.py
@@ -1,0 +1,80 @@
+"""Workflow contract test for VerifyDiveChecksumsWorkflow.
+
+In-process Temporal worker with the activity stubbed. Pins the two things an
+operator depends on when they run this by hand: both arguments reach the
+activity, and the sampling limit is genuinely optional — a dive is ~500 frames
+at ~15 MB, so `--input <dive_id>` alone must mean "check everything", not
+"crash because the second argument is missing".
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from temporalio import activity
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from fishsense_api_workflow_worker.workflows.verify_dive_checksums_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    VerifyDiveChecksumsWorkflow,
+)
+from fishsense_shared.ingest_contracts import VerifyChecksumsReport
+
+TASK_QUEUE = "test-verify-checksums"
+
+
+def _stub(seen: list):
+    @activity.defn(name="verify_dive_checksums_activity")
+    async def stub_activity(
+        dive_id: int, limit: int | None
+    ) -> VerifyChecksumsReport:
+        seen.append((dive_id, limit))
+        return VerifyChecksumsReport(
+            dive_id=dive_id,
+            total_in_dive=55,
+            checked=limit or 55,
+            checksum_matched=limit or 55,
+        )
+
+    return stub_activity
+
+
+async def _run(*args):
+    """Execute the workflow against a stubbed activity, returning
+    `(report, calls)` so a test can assert on both."""
+    seen: list[tuple[int, int | None]] = []
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=TASK_QUEUE,
+            workflows=[VerifyDiveChecksumsWorkflow],
+            activities=[_stub(seen)],
+        ):
+            report = await env.client.execute_workflow(
+                VerifyDiveChecksumsWorkflow.run,
+                args=args,
+                id=f"{TASK_QUEUE}-{uuid.uuid4()}",
+                task_queue=TASK_QUEUE,
+            )
+    return report, seen
+
+
+@pytest.mark.asyncio
+async def test_forwards_dive_id_and_limit_and_returns_the_report():
+    report, seen = await _run(412, 25)
+
+    assert seen == [(412, 25)]
+    assert report.dive_id == 412
+    assert report.checked == 25
+    assert report.total_in_dive == 55
+
+
+@pytest.mark.asyncio
+async def test_the_limit_is_optional_and_defaults_to_the_whole_dive():
+    """`temporal workflow start --input 412` with no second argument is the
+    obvious way to run this, and it must mean "check every frame"."""
+    report, seen = await _run(412)
+
+    assert seen == [(412, None)]
+    assert report.checked == 55


### PR DESCRIPTION
PR 2, part 2 of dive ingestion — three of the five activities, plus one
workflow that is runnable on its own. Design: `docs/plans/dive-image-ingestion.md`.

**Ingest still does not work after this.** `IngestDiveWorkflow` and the
`scan_and_register` / `create_dive` / `finalize_dive` activities are not here,
so the two ingest activities below have no caller yet. The verification
workflow *is* complete and runnable.

## What you can actually run

`VerifyDiveChecksumsWorkflow(dive_id, limit=None)` — re-hashes a migrated
dive's frames against the NAS and reports.

```
temporal workflow start \
    --task-queue fishsense_api_queue \
    --type VerifyDiveChecksumsWorkflow \
    --workflow-id verify-checksums-412 \
    --input 412 --input 25
```

This exists because of a gap worth naming. Every ingest convention was
recovered by reading the retired spider crawler — checksum is `md5` of the
whole file (`backend.py:67`), `taken_datetime` is naive EXIF 0x0132 stamped UTC
(`backend.py:20`). The derivation is solid and the migration chain is traced end
to end, but it proves what *spider* wrote. It does not prove all ~131k rows came
from spider, and no stored value had ever been compared against the bytes still
on the NAS.

The failure mode is what makes it worth measuring: if existing checksums were
computed even slightly differently, duplicate detection does not error — it
silently reports **zero overlap**. A re-ingest of an already-present dive would
look entirely new, every frame would land `is_canonical=True`, and #555's
canonical-only gating would have nothing to gate on.

A workflow rather than a script so it runs inside the slot where the NAS
credentials already live, gets bounded retry plus a heartbeat that resumes
mid-dive instead of re-pulling gigabytes, and leaves a durable report.

Two inversions from `stage_raw_bytes_for_dive_activity`, both deliberate:

* **A missing file is a finding, not a failure.** Staging treats Synology 408 as
  non-retryable because it is trying to *do* something. Here "the row outlived
  its file" is one of the answers being looked for. Only a NAS that is genuinely
  down propagates for retry.
* **Non-canonical rows are checked too** — half the table, and the population
  whose provenance is least certain, so skipping them would skip the rows most
  worth checking.

Read-only by construction, with a tripwire test asserting the module's source
contains no `upload` / `delete` / `post` / `put`. It runs against prod data to
answer a question and must not be able to change the answer.

## The two ingest activities

**`list_dive_folder`** — non-recursive, `.ORF` matched case-insensitively,
name-sorted (batching and heartbeat-resume index into that list, and DSM
promises no order).

Non-recursion is precedent, not preference: spider walked the tree but assigned
`dive = image.parent.relative_to(data_root)`, so a nested folder always became
its own dive row. Attaching a subdirectory's frames to the named dive would
silently merge dives that are distinct rows in prod, with nothing left in the
data to say which frames came from where. So a subdirectory holding `.ORF`s is
*reported*, covering the Olympus rollover case (the TG-6 wraps its counter at
`PA199999` and starts a child folder mid-dive).

**`preflight_ingest`** — reads a ranged 1 MB per frame instead of ~15 MB, so a
500-frame dry run moves ~0.5 GB rather than 7.5 GB across FileStation's fragile
backend. Writes nothing.

Faults accumulate rather than raising at the first one — an operator has one
round trip worth of attention. It refuses on:

* an unresolvable camera serial, with **no fallback to the EXIF `Artist` tag** —
  a free-text rig label would bind intrinsics belonging to different glass and
  stage 14 would report confident wrong lengths;
* a folder spanning two serials (one folder is one rig; spider only wrote a
  report file and carried on, which is how such dives got in unnoticed);
* a camera with no intrinsics;
* unstated *or* contradictory calibration intent — exactly one of
  `self_calibrates` / `calibration_dive_id`;
* a frame with no readable timestamp, since stage-1 clustering is pure timestamp
  maths and a defaulted value corrupts it silently;
* a stored path over 255 characters, named.

Timestamps reproduce the existing convention exactly: naive 0x0132 stamped UTC,
camera offset surfaced but **not** applied. Agreement with the ~111k existing
rows matters more than correctness — one consistent offset is recoverable, two
conventions in one column are not.

Duplicate detection here is layer 1 only (leaf-name collision, free from the
already-fetched dive list). Content containment needs checksums, so it runs
after the scan.

## Two things this PR also fixes

* **Extracted rather than copied.** The Synology permanent/transient
  classification lived only in `stage_raw_bytes_for_dive_activity`; ingest needs
  the same judgement, so it moved to `activities/nas_errors.py` and `stage_raw`
  imports it. Keeps the "no inner retry loop" rule stated once — that rule is
  what tripped the NAS auto-block (krg-infra#501).
* **A latent order-dependent test bug.** `e4e_nas.raw_root_path` has a validator
  default, but a `settings.reload()` elsewhere in the session does not re-apply
  defaults, so reading it was green alone and `AccessError` in the full suite.
  Now seeded in the conftest placeholder block beside `temporal.port` / `.tls`,
  which carry a comment describing this exact failure.

## Tests

42 new (11 listing, 19 preflight, 10 verification activity, 2 verification
workflow contract). 410 pass in the worker, 159 in fishsense-shared, pylint
10.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)