### PR TITLE
fix(web): configure the portal allowlist in the local stack

### DIFF
--- a/apps/fishsense-lite-web/tests/integration/portal.integration.test.ts
+++ b/apps/fishsense-lite-web/tests/integration/portal.integration.test.ts
@@ -14,6 +14,37 @@ const AUTH_SECRET = "fishsense_local_test_auth_secret_only_for_ci_v1";
 // prefix. JWE encryption salt defaults to the cookie name in Auth.js v5.
 const SESSION_COOKIE_NAME = "authjs.session-token";
 
+// Must match `PORTAL_ALLOWED_GROUPS` on the fishsense-lite-web service in
+// deploy/compose.local.yml. `isPortalAuthorized` fails closed, so an unset
+// allowlist denies everyone — a drift here renders the not-authorized dead
+// end instead of the portal, which is exactly how this test first failed.
+const ALLOWED_GROUP = "test-group";
+
+/** Mint a session JWE the way next-auth does on a real OIDC callback. */
+async function sessionCookie(groups: string[]) {
+  return encode({
+    token: {
+      sub: "test-user-id",
+      name: "Integration Test User",
+      email: "integration-test@fishsense.local",
+      groups,
+    },
+    secret: AUTH_SECRET,
+    salt: SESSION_COOKIE_NAME,
+    maxAge: 60 * 60,
+  });
+}
+
+async function getPortal(cookie?: string) {
+  return fetch(`${WEB_URL}/portal`, {
+    cache: "no-store",
+    redirect: "manual",
+    ...(cookie
+      ? { headers: { cookie: `${SESSION_COOKIE_NAME}=${cookie}` } }
+      : {}),
+  });
+}
+
 describe("/portal SSR auth gate (against the local stack)", () => {
   it("redirects signed-out GET /portal to the next-auth sign-in route", async () => {
     // Pins the workaround for the Next.js 15.5 middleware-loader bug —
@@ -39,27 +70,42 @@ describe("/portal SSR auth gate (against the local stack)", () => {
     // → session, app/portal/page.tsx renders session.user). A change
     // that drops a field from the dl, breaks the cookie name, or
     // mis-salts the JWE would surface here.
-    const sessionToken = await encode({
-      token: {
-        sub: "test-user-id",
-        name: "Integration Test User",
-        email: "integration-test@fishsense.local",
-        groups: ["test-group"],
-      },
-      secret: AUTH_SECRET,
-      salt: SESSION_COOKIE_NAME,
-      maxAge: 60 * 60,
-    });
+    const res = await getPortal(await sessionCookie([ALLOWED_GROUP]));
 
-    const res = await fetch(`${WEB_URL}/portal`, {
-      cache: "no-store",
-      redirect: "manual",
-      headers: { cookie: `${SESSION_COOKIE_NAME}=${sessionToken}` },
-    });
     expect(res.status).toBe(200);
     const body = await res.text();
     expect(body).toContain("Integration Test User");
     expect(body).toContain("integration-test@fishsense.local");
-    expect(body).toContain("test-group");
+    expect(body).toContain(ALLOWED_GROUP);
+  });
+
+  it("renders a dead end, not the portal, for a signed-in user in no allowed group", async () => {
+    // The authorization half of the gate, which nothing covered end to end.
+    // Signing in only proves an account in the Authentik realm — the whole
+    // university SSO population, not the FishSense team. Before the gate
+    // existed, any realm account could rewrite `calibration_dive_id`, which
+    // is a live pipeline input: a dive measured off a borrowed calibration
+    // runs -8..+2% error against ~1% for its own.
+    //
+    // Asserted as an absence as well as a presence, because the failure that
+    // matters is the gate silently disappearing — a test that only checked
+    // for the denial text would still pass if the page rendered BOTH.
+    const res = await getPortal(await sessionCookie(["some-other-group"]));
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("not in a group permitted");
+    expect(body).not.toContain("Dive calibration links");
+  });
+
+  it("does not redirect an authorized-but-signed-in user into a sign-in loop", async () => {
+    // A denied user is already signed in, so redirecting them to sign-in
+    // would loop forever. The dead end has to be a 200 with a sign-out
+    // affordance instead — pinned here because "redirect on failure" is the
+    // reflexive fix someone will reach for.
+    const res = await getPortal(await sessionCookie([]));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("location")).toBeNull();
   });
 });

--- a/deploy/compose.local.yml
+++ b/deploy/compose.local.yml
@@ -292,6 +292,12 @@ services:
       # stack the container's published port on the host is the right
       # value.
       AUTH_URL: http://localhost:3000
+      # `isPortalAuthorized` fails CLOSED: an unset or empty allowlist denies
+      # everyone, because a check that defaults to open is not a check. So the
+      # local stack has to configure it like a real deployment or every /portal
+      # request renders the not-authorized dead end. Must match the `groups`
+      # claim the integration test mints into its session cookie.
+      PORTAL_ALLOWED_GROUPS: test-group
     ports:
       - "3000:3000"
     networks:


### PR DESCRIPTION
Unblocks the release PR (#556), whose `integration` job is red.

## What broke

`/portal` rendered the not-authorized dead end instead of the user page:

```
AssertionError: expected '<!DOCTYPE html>…' to contain 'Integration Test User'
```

Not a bad test. #558 gated `/portal` on group membership, and
`isPortalAuthorized` **fails closed** — an unset or empty
`PORTAL_ALLOWED_GROUPS` denies everyone, deliberately, because a check that
defaults to open is not a check. The local stack never set it, so every
`/portal` request in CI was correctly denied.

The production posture is right and unchanged. The test stack just needed
configuring like a real deployment.

## Why #558 went green

`integration` is **skipped on ordinary PR runs** — the release PR is the first
place it executed. Worth remembering the next time a web change lands green and
the release goes red.

## Also: the gate had no end-to-end coverage

`lib/authz.test.ts` unit-tests the predicate, but nothing exercised the
authorization half through a real SSR request. Three tests now do:

* an allowed user renders the portal;
* a signed-in user in no allowed group gets the dead end — asserted as an
  **absence** as well as a presence, because the failure that matters is the
  gate silently disappearing, and a test that only looked for the denial text
  would still pass if the page rendered both;
* a denied user gets a **200 dead end, not a redirect**. Redirecting is the
  reflexive fix someone will reach for, and it loops forever for a user who is
  already signed in and simply lacks the group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)