### PR TITLE
feat(ingest): sweep every canonical dive's checksums, in Temporal

### DIFF
--- a/libs/fishsense-shared/src/fishsense_shared/ingest_contracts.py
+++ b/libs/fishsense-shared/src/fishsense_shared/ingest_contracts.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel
 
 __all__ = [
     "ChecksumMismatch",
+    "DiveVerificationSummary",
     "IngestDiveRequest",
     "IngestPreflight",
     "IngestProgress",
@@ -29,6 +30,8 @@ __all__ = [
     "PreflightImage",
     "RejectedImage",
     "SubfolderReport",
+    "VerifyAllDivesProgress",
+    "VerifyAllDivesReport",
     "VerifyChecksumsReport",
 ]
 
@@ -180,6 +183,69 @@ class VerifyChecksumsReport(BaseModel):
     #: NULL `checksum` on a migrated row; the column duplicate detection joins
     #: on, so a blank one is a finding rather than a skip.
     no_stored_checksum: List[ChecksumMismatch] = []
+
+
+class DiveVerificationSummary(BaseModel):
+    """One dive's verification result, compressed.
+
+    Counts rather than per-image rows, because a sweep over every canonical
+    dive would otherwise return tens of thousands of records. The individual
+    mismatches are carried — those are the findings — but agreement is just a
+    number.
+    """
+
+    dive_id: int
+    checked: int = 0
+    total_in_dive: int = 0
+    checksum_matched: int = 0
+    mismatches: List[ChecksumMismatch] = []
+    timestamp_mismatches: List[ChecksumMismatch] = []
+    missing_on_nas: List[ChecksumMismatch] = []
+    no_stored_checksum: List[ChecksumMismatch] = []
+    #: Set when the dive could not be verified at all (NAS down, activity
+    #: exhausted its retries). Distinct from "verified, found nothing wrong" —
+    #: conflating the two would let an unreachable dive read as clean.
+    error: str | None = None
+
+    @property
+    def is_clean(self) -> bool:
+        return self.error is None and not (
+            self.mismatches
+            or self.timestamp_mismatches
+            or self.missing_on_nas
+            or self.no_stored_checksum
+        )
+
+
+class VerifyAllDivesProgress(BaseModel):
+    """Shape of the sweep's `progress` query. A full sweep is ~930 GB off the
+    NAS, so it runs for a long time and has to be observable while running."""
+
+    state: str = "starting"
+    total_dives: int = 0
+    dives_done: int = 0
+    current_dive_id: int | None = None
+    images_checked: int = 0
+    checksum_matched: int = 0
+    dives_with_findings: int = 0
+    dives_errored: int = 0
+
+
+class VerifyAllDivesReport(BaseModel):
+    """Aggregate across every dive the sweep visited."""
+
+    dives_requested: int = 0
+    dives_verified: int = 0
+    images_checked: int = 0
+    checksum_matched: int = 0
+    #: Every dive visited, clean ones included — absence of a finding is itself
+    #: the result being sought, and dropping the clean rows would make it
+    #: impossible to tell "verified, fine" from "never reached".
+    dives: List[DiveVerificationSummary] = []
+
+    @property
+    def dives_with_findings(self) -> List[DiveVerificationSummary]:
+        return [d for d in self.dives if not d.is_clean]
 
 
 class IngestProgress(BaseModel):

--- a/libs/fishsense-shared/tests/test_ingest_contracts.py
+++ b/libs/fishsense-shared/tests/test_ingest_contracts.py
@@ -22,6 +22,12 @@ from fishsense_shared import (
     RejectedImage,
     SubfolderReport,
 )
+from fishsense_shared.ingest_contracts import (
+    ChecksumMismatch,
+    DiveVerificationSummary,
+    VerifyAllDivesProgress,
+    VerifyAllDivesReport,
+)
 
 
 def test_a_request_needs_only_a_dive_path():
@@ -158,7 +164,6 @@ def test_the_contract_round_trips_through_json():
 
 
 def test_a_dive_with_nothing_wrong_is_clean():
-    from fishsense_shared.ingest_contracts import DiveVerificationSummary
 
     summary = DiveVerificationSummary(
         dive_id=412, checked=5, total_in_dive=55, checksum_matched=5
@@ -181,10 +186,6 @@ def test_any_kind_of_finding_makes_a_dive_not_clean(field):
     different things — a wrong checksum breaks duplicate detection, a wrong
     timestamp breaks stage-1 clustering — but any of them means this dive did
     not come through the migration the way we think it did."""
-    from fishsense_shared.ingest_contracts import (
-        ChecksumMismatch,
-        DiveVerificationSummary,
-    )
 
     summary = DiveVerificationSummary(
         dive_id=412,
@@ -200,7 +201,6 @@ def test_a_dive_that_errored_is_not_clean_even_with_no_findings():
     """The distinction the whole audit rests on. An unreachable dive has no
     findings *because it was never read* — letting that read as clean would
     quietly shrink the corpus the audit claims to cover."""
-    from fishsense_shared.ingest_contracts import DiveVerificationSummary
 
     summary = DiveVerificationSummary(dive_id=412, error="NAS unreachable")
 
@@ -211,11 +211,6 @@ def test_the_sweep_report_singles_out_the_dives_with_findings():
     """Clean dives stay in `dives` — absence of a finding is the result being
     sought, so dropping them would make "verified, fine" indistinguishable from
     "never reached"."""
-    from fishsense_shared.ingest_contracts import (
-        ChecksumMismatch,
-        DiveVerificationSummary,
-        VerifyAllDivesReport,
-    )
 
     report = VerifyAllDivesReport(
         dives_requested=3,
@@ -239,12 +234,6 @@ def test_the_sweep_report_singles_out_the_dives_with_findings():
 def test_the_audit_contract_round_trips_through_json():
     """Temporal serializes the sweep's return value, and a ~479-dive report is
     the largest payload in this contract."""
-    from fishsense_shared.ingest_contracts import (
-        ChecksumMismatch,
-        DiveVerificationSummary,
-        VerifyAllDivesProgress,
-        VerifyAllDivesReport,
-    )
 
     report = VerifyAllDivesReport(
         dives_requested=1,

--- a/libs/fishsense-shared/tests/test_ingest_contracts.py
+++ b/libs/fishsense-shared/tests/test_ingest_contracts.py
@@ -152,3 +152,125 @@ def test_the_contract_round_trips_through_json():
     restored = IngestReport.model_validate_json(report.model_dump_json())
 
     assert restored == report
+
+
+# ── the migration audit ───────────────────────────────────────────────
+
+
+def test_a_dive_with_nothing_wrong_is_clean():
+    from fishsense_shared.ingest_contracts import DiveVerificationSummary
+
+    summary = DiveVerificationSummary(
+        dive_id=412, checked=5, total_in_dive=55, checksum_matched=5
+    )
+
+    assert summary.is_clean is True
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "mismatches",
+        "timestamp_mismatches",
+        "missing_on_nas",
+        "no_stored_checksum",
+    ],
+)
+def test_any_kind_of_finding_makes_a_dive_not_clean(field):
+    """All four are findings. They are separate fields because they mean
+    different things — a wrong checksum breaks duplicate detection, a wrong
+    timestamp breaks stage-1 clustering — but any of them means this dive did
+    not come through the migration the way we think it did."""
+    from fishsense_shared.ingest_contracts import (
+        ChecksumMismatch,
+        DiveVerificationSummary,
+    )
+
+    summary = DiveVerificationSummary(
+        dive_id=412,
+        checked=5,
+        checksum_matched=4,
+        **{field: [ChecksumMismatch(path="a/b.ORF")]},
+    )
+
+    assert summary.is_clean is False
+
+
+def test_a_dive_that_errored_is_not_clean_even_with_no_findings():
+    """The distinction the whole audit rests on. An unreachable dive has no
+    findings *because it was never read* — letting that read as clean would
+    quietly shrink the corpus the audit claims to cover."""
+    from fishsense_shared.ingest_contracts import DiveVerificationSummary
+
+    summary = DiveVerificationSummary(dive_id=412, error="NAS unreachable")
+
+    assert summary.is_clean is False
+
+
+def test_the_sweep_report_singles_out_the_dives_with_findings():
+    """Clean dives stay in `dives` — absence of a finding is the result being
+    sought, so dropping them would make "verified, fine" indistinguishable from
+    "never reached"."""
+    from fishsense_shared.ingest_contracts import (
+        ChecksumMismatch,
+        DiveVerificationSummary,
+        VerifyAllDivesReport,
+    )
+
+    report = VerifyAllDivesReport(
+        dives_requested=3,
+        dives_verified=3,
+        dives=[
+            DiveVerificationSummary(dive_id=11, checked=5, checksum_matched=5),
+            DiveVerificationSummary(
+                dive_id=22,
+                checked=5,
+                checksum_matched=4,
+                mismatches=[ChecksumMismatch(path="a/b.ORF")],
+            ),
+            DiveVerificationSummary(dive_id=33, error="NAS unreachable"),
+        ],
+    )
+
+    assert [d.dive_id for d in report.dives_with_findings] == [22, 33]
+    assert len(report.dives) == 3
+
+
+def test_the_audit_contract_round_trips_through_json():
+    """Temporal serializes the sweep's return value, and a ~479-dive report is
+    the largest payload in this contract."""
+    from fishsense_shared.ingest_contracts import (
+        ChecksumMismatch,
+        DiveVerificationSummary,
+        VerifyAllDivesProgress,
+        VerifyAllDivesReport,
+    )
+
+    report = VerifyAllDivesReport(
+        dives_requested=1,
+        dives_verified=1,
+        images_checked=5,
+        checksum_matched=4,
+        dives=[
+            DiveVerificationSummary(
+                dive_id=22,
+                checked=5,
+                checksum_matched=4,
+                mismatches=[
+                    ChecksumMismatch(
+                        image_id=9,
+                        path="a/b.ORF",
+                        stored="0" * 32,
+                        computed="1" * 32,
+                    )
+                ],
+            )
+        ],
+    )
+    progress = VerifyAllDivesProgress(state="verifying", total_dives=479)
+
+    assert VerifyAllDivesReport.model_validate_json(report.model_dump_json()) == report
+    assert (
+        VerifyAllDivesProgress.model_validate_json(progress.model_dump_json())
+        == progress
+    )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/preflight_ingest_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/preflight_ingest_activity.py
@@ -31,10 +31,15 @@ What it refuses, and why each is unrecoverable later:
     say which file.
 
 Reads are ranged — the first megabyte holds the EXIF — which is what makes a
-dry run affordable: ~1 MB per frame instead of ~15 MB across FileStation's
-fragile shared download backend. They are also serial, matching the default
-`e4e_nas.stage_concurrency` of 1: that backend 502s under concurrent transfers,
-and a preflight is not worth risking it for.
+dry run affordable: ~1 MB per frame instead of ~15 MB. That saving is about
+bytes moved, so it holds regardless of transport: `synology-filestation` >=0.2.0
+prefers SMB and falls back to FileStation, and paces either way (`throttle=True`,
+`max_concurrency=4`, `min_interval_ms=150`).
+
+Reads are also serial here. Not because the transport can't cope — the client
+handles its own pacing — but because a preflight shares the NAS with the hourly
+staging activities doing real pipeline work, and a dry run should never be the
+reason one of those is slow.
 
 Duplicate detection here is **layer 1 only** — a leaf-name collision against
 existing dives, free because the dive list is already fetched. Content-based

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_canonical_dive_ids_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/select_canonical_dive_ids_activity.py
@@ -1,0 +1,29 @@
+"""Activity: list the canonical dives, for the migration audit sweep.
+
+Thin wrapper over `dives.get_canonical()` so the sweep workflow stays a pure
+orchestrator with no SDK import of its own. Returns ids rather than `Dive`
+rows: the sweep only iterates them, and a list of ints keeps the workflow's
+event history small over a run that visits several hundred dives.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.utils import get_fs_client
+
+__all__ = ["select_canonical_dive_ids_activity"]
+
+
+@activity.defn
+async def select_canonical_dive_ids_activity() -> List[int]:
+    async with get_fs_client() as fs:
+        dives = await fs.dives.get_canonical() or []
+
+    # Ascending so a sweep's progress is legible against dive ids, and so an
+    # interrupted run can be resumed with an explicit tail of the list.
+    dive_ids = sorted(d.id for d in dives if d.id is not None)
+    activity.logger.info("canonical dives selected count=%d", len(dive_ids))
+    return dive_ids

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -166,6 +166,9 @@ from fishsense_api_workflow_worker.activities.sync_users_label_studio_activity i
 from fishsense_api_workflow_worker.activities.update_dive_image_groups_activity import (
     update_dive_image_groups_activity,
 )
+from fishsense_api_workflow_worker.activities.select_canonical_dive_ids_activity import (  # pylint: disable=line-too-long
+    select_canonical_dive_ids_activity,
+)
 from fishsense_api_workflow_worker.activities.verify_dive_checksums_activity import (
     verify_dive_checksums_activity,
 )
@@ -247,6 +250,9 @@ from fishsense_api_workflow_worker.workflows.sync_label_studio_species_labels_wo
 )
 from fishsense_api_workflow_worker.workflows.update_dive_image_groups_workflow import (
     UpdateDiveImageGroupsWorkflow,
+)
+from fishsense_api_workflow_worker.workflows.verify_all_dives_checksums_workflow import (  # pylint: disable=line-too-long
+    VerifyAllDivesChecksumsWorkflow,
 )
 from fishsense_api_workflow_worker.workflows.verify_dive_checksums_workflow import (
     VerifyDiveChecksumsWorkflow,
@@ -632,6 +638,7 @@ async def main():
                 PopulateDiveSlateLabelStudioProjectWorkflow,
                 UpdateDiveImageGroupsWorkflow,
                 VerifyDiveChecksumsWorkflow,
+                VerifyAllDivesChecksumsWorkflow,
                 ClusterDiveFramesParentWorkflow,
                 PredictLaserImagesParentWorkflow,
                 PredictSlateImagesParentWorkflow,
@@ -667,6 +674,7 @@ async def main():
                 populate_dive_slate_label_studio_project_activity,
                 update_dive_image_groups_activity,
                 verify_dive_checksums_activity,
+                select_canonical_dive_ids_activity,
                 resolve_dive_frame_clustering_inputs_activity,
                 resolve_laser_preprocess_inputs_activity,
                 resolve_laser_predict_inputs_activity,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/verify_all_dives_checksums_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/verify_all_dives_checksums_workflow.py
@@ -1,0 +1,177 @@
+"""Sweep: re-hash every canonical dive against the NAS and report.
+
+Every dive in the database arrived through the migration, so "does the
+recovered convention actually hold?" is a question about the whole corpus.
+`VerifyDiveChecksumsWorkflow` answers it for one dive; this answers it for all
+of them.
+
+**This runs on the api-worker, inside the slot, on the NAS's own network.** It
+is never driven from a workstation: ~930 GB does not belong on a WAN link, and
+the NAS credentials live in the slot, not on anyone's laptop. Temporal is what
+makes that possible — start the workflow from anywhere, the bytes never leave
+the LAN.
+
+**Cost is what shapes the rest.** 65,981 canonical images at ~14.5 MB each is
+**~930 GB**. Transport is `synology-filestation` >=0.2.0, which prefers SMB and
+falls back to FileStation, and paces itself either way (`throttle=True`,
+`max_concurrency=4`, `min_interval_ms=150`, internal retry capped at 60s
+backoff) — that release is what fixed the FileStation download 502s. So the
+constraint is no longer "the transport will fall over"; it is that ~930 GB
+shares one NAS with the hourly staging activities doing real pipeline work.
+Three consequences, all deliberate:
+
+* **`limit_per_dive` is a runtime argument.** Whether a dive came through a
+  *different ingest path* is a per-dive property, so ~5 frames per dive settles
+  it for ~20 GB — about 2% of the cost. Checking every frame answers the
+  different question "is any individual row corrupt". One workflow serves both;
+  pick at start time.
+* **Dives are verified one at a time.** The client already paces individual
+  transfers; this is the layer above it, and it exists so a multi-day audit
+  never outranks the pipeline for the NAS. There is no concurrency knob,
+  because the correct value is 1 and a knob invites raising it.
+* **One dive's failure does not abandon the sweep.** A full run is days of
+  transfer; losing it because dive 300 of 479 was briefly unreachable would be
+  its own outage. The dive is recorded with an `error` — deliberately a
+  separate field, so an unreachable dive can never read as clean.
+
+Read-only throughout; see `verify_dive_checksums_activity` for the tripwire.
+
+```
+# sample: ~5 frames/dive, ~20 GB, answers the migration question
+temporal workflow start --task-queue fishsense_api_queue \
+    --type VerifyAllDivesChecksumsWorkflow \
+    --workflow-id verify-sweep-sample --input 5
+
+# full: every canonical frame, ~930 GB, days
+temporal workflow start --task-queue fishsense_api_queue \
+    --type VerifyAllDivesChecksumsWorkflow \
+    --workflow-id verify-sweep-full --input null
+
+# just the dives a sample flagged
+... --input null --input '[64, 66, 412]'
+```
+
+Progress is queryable while it runs (`temporal workflow query --type progress`),
+which matters when the run lasts days.
+"""
+
+from datetime import timedelta
+from typing import List
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from fishsense_shared.ingest_contracts import (
+        DiveVerificationSummary,
+        VerifyAllDivesProgress,
+        VerifyAllDivesReport,
+        VerifyChecksumsReport,
+    )
+
+# One dive can be ~500 whole-file downloads driven serially. The per-dive
+# activity has its own bounded policy; this is the outer ceiling.
+_PER_DIVE_TIMEOUT = timedelta(hours=6)
+
+
+@workflow.defn
+class VerifyAllDivesChecksumsWorkflow:
+    """Verify the migrated checksums of every canonical dive."""
+
+    def __init__(self) -> None:
+        self._progress = VerifyAllDivesProgress()
+
+    @workflow.query
+    def progress(self) -> VerifyAllDivesProgress:
+        """Live counts. A full sweep runs for days, so "is it still going, and
+        how far?" must be answerable without waiting for the return value."""
+        return self._progress
+
+    @workflow.run
+    async def run(
+        self,
+        limit_per_dive: int | None = None,
+        dive_ids: List[int] | None = None,
+    ) -> VerifyAllDivesReport:
+        if dive_ids is None:
+            self._progress.state = "selecting"
+            dive_ids = await workflow.execute_activity(
+                "select_canonical_dive_ids_activity",
+                schedule_to_close_timeout=timedelta(minutes=5),
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+
+        report = VerifyAllDivesReport(dives_requested=len(dive_ids))
+        self._progress.state = "verifying"
+        self._progress.total_dives = len(dive_ids)
+
+        for dive_id in dive_ids:
+            self._progress.current_dive_id = dive_id
+            # The WHOLE per-dive body sits inside the try, not just the
+            # activity call. An exception escaping a workflow body fails the
+            # workflow *task*, which Temporal reschedules indefinitely — so a
+            # bug here manifests as a sweep that hangs forever rather than one
+            # that fails. Catching wide keeps a multi-day run recoverable.
+            try:
+                result = await workflow.execute_activity(
+                    "verify_dive_checksums_activity",
+                    args=(dive_id, limit_per_dive),
+                    # Required: without it the payload decodes to a plain dict
+                    # and every attribute access below raises.
+                    result_type=VerifyChecksumsReport,
+                    schedule_to_close_timeout=_PER_DIVE_TIMEOUT,
+                    heartbeat_timeout=timedelta(minutes=10),
+                    retry_policy=RetryPolicy(
+                        initial_interval=timedelta(seconds=30),
+                        backoff_coefficient=2.0,
+                        maximum_interval=timedelta(minutes=5),
+                        maximum_attempts=5,
+                    ),
+                )
+                summary = DiveVerificationSummary(
+                    dive_id=result.dive_id,
+                    checked=result.checked,
+                    total_in_dive=result.total_in_dive,
+                    checksum_matched=result.checksum_matched,
+                    mismatches=result.mismatches,
+                    timestamp_mismatches=result.timestamp_mismatches,
+                    missing_on_nas=result.missing_on_nas,
+                    no_stored_checksum=result.no_stored_checksum,
+                )
+            except Exception as exc:  # pylint: disable=broad-except
+                # Any per-dive failure is data about the corpus, not a reason to
+                # discard the sweep — and `error` keeps it distinguishable from
+                # a clean result, so an unreachable dive never reads as verified.
+                workflow.logger.warning(
+                    "verification failed dive_id=%d: %s", dive_id, exc
+                )
+                report.dives.append(
+                    DiveVerificationSummary(dive_id=dive_id, error=str(exc))
+                )
+                self._progress.dives_errored += 1
+                self._progress.dives_with_findings += 1
+                self._progress.dives_done += 1
+                continue
+
+            report.dives.append(summary)
+            report.dives_verified += 1
+            report.images_checked += summary.checked
+            report.checksum_matched += summary.checksum_matched
+
+            self._progress.dives_done += 1
+            self._progress.images_checked += summary.checked
+            self._progress.checksum_matched += summary.checksum_matched
+            if not summary.is_clean:
+                self._progress.dives_with_findings += 1
+
+        self._progress.state = "done"
+        self._progress.current_dive_id = None
+        workflow.logger.info(
+            "sweep complete dives=%d verified=%d images=%d matched=%d findings=%d",
+            report.dives_requested,
+            report.dives_verified,
+            report.images_checked,
+            report.checksum_matched,
+            len(report.dives_with_findings),
+        )
+        return report

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/verify_dive_checksums_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/verify_dive_checksums_workflow.py
@@ -5,9 +5,8 @@ can be answered by an operator on demand rather than by a one-off script:
 
   * it runs inside the slot, where the NAS credentials already live, so nobody
     has to copy them anywhere to ask the question;
-  * whole-file downloads over FileStation's fragile backend get Temporal's
-    bounded jittered retry and a heartbeat that resumes mid-dive instead of
-    re-pulling gigabytes;
+  * whole-file downloads get Temporal's bounded jittered retry and a heartbeat
+    that resumes mid-dive instead of re-pulling gigabytes;
   * the report is durable and visible in the Temporal UI, so a finding can be
     pointed at later rather than living in someone's terminal scrollback.
 
@@ -19,7 +18,7 @@ temporal workflow start \
     --input <dive_id> --input 25
 ```
 
-The second argument samples: verification pulls whole files (~15 MB each, the
+The second argument samples: verification pulls whole files (~14.5 MB each, the
 one thing preflight's ranged read avoids), and answering "does the convention
 hold" does not need all ~500 frames of a dive. Pass `null` to check every one.
 """
@@ -46,8 +45,8 @@ class VerifyDiveChecksumsWorkflow:
         return await workflow.execute_activity(
             "verify_dive_checksums_activity",
             args=(dive_id, limit),
-            # Generous: a full dive is ~500 whole-file downloads over a backend
-            # that is deliberately driven serially.
+            # Generous: a full dive is ~500 whole-file downloads, driven
+            # serially so a diagnostic run never outranks pipeline staging.
             schedule_to_close_timeout=timedelta(hours=6),
             # One frame at a time, so a gap this long means the transfer is
             # wedged rather than slow.
@@ -57,8 +56,9 @@ class VerifyDiveChecksumsWorkflow:
                 backoff_coefficient=2.0,
                 maximum_interval=timedelta(minutes=5),
                 # Bounded: this is diagnostic, not load-bearing. If the NAS is
-                # having a bad day the answer is to ask again later, not to
-                # keep hammering a fragile shared download backend.
+                # having a bad day the answer is to ask again later. Note the
+                # client retries internally too (max_attempts=5, backoff capped
+                # at 60s), so this sits on top of that.
                 maximum_attempts=5,
             ),
         )

--- a/services/fishsense-api-workflow-worker/tests/test_exif.py
+++ b/services/fishsense-api-workflow-worker/tests/test_exif.py
@@ -31,6 +31,13 @@ from pathlib import Path
 
 import pytest
 
+# pylint: disable=import-error  # noqa: E501
+# `tests` is not a unique package name in this workspace — both
+# services/fishsense-api-workflow-worker/tests and libs/*/tests are called
+# `tests`, and pylint binds the name to whichever it parses FIRST. CI lints
+# `git diff --name-only` output, which is alphabetical, so a changed
+# libs/*/tests file wins and this relative import stops resolving. The
+# import itself is correct — pytest resolves it fine.
 from ._tiff_builder import build_orf
 
 _REAL_ORF = (

--- a/services/fishsense-api-workflow-worker/tests/test_preflight_ingest_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preflight_ingest_activity.py
@@ -359,9 +359,10 @@ async def test_an_empty_folder_fails(monkeypatch):
 
 
 async def test_reads_only_the_first_megabyte_of_each_frame(monkeypatch):
-    """What makes a dry run affordable: ~1 MB per file instead of ~15 MB
-    across FileStation's fragile shared download backend. A 500-frame dive is
-    0.5 GB rather than 7.5 GB."""
+    """What makes a dry run affordable: ~1 MB per file instead of ~15 MB — a
+    500-frame dive previews for 0.5 GB rather than 7.5 GB. The saving is in
+    bytes moved, so it holds whether the client resolves the read over SMB or
+    falls back to FileStation."""
     from fishsense_api_workflow_worker.activities import (  # pylint: disable=import-outside-toplevel
         preflight_ingest_activity as sut,
     )

--- a/services/fishsense-api-workflow-worker/tests/test_preflight_ingest_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preflight_ingest_activity.py
@@ -25,6 +25,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 from temporalio.testing import ActivityEnvironment
 
+# pylint: disable=import-error  # noqa: E501
+# `tests` is not a unique package name in this workspace — both
+# services/fishsense-api-workflow-worker/tests and libs/*/tests are called
+# `tests`, and pylint binds the name to whichever it parses FIRST. CI lints
+# `git diff --name-only` output, which is alphabetical, so a changed
+# libs/*/tests file wins and this relative import stops resolving. The
+# import itself is correct — pytest resolves it fine.
 from ._tiff_builder import build_orf
 
 SERIAL = "BJ6C67989"

--- a/services/fishsense-api-workflow-worker/tests/test_verify_all_dives_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_verify_all_dives_workflow.py
@@ -1,0 +1,220 @@
+"""Contract tests for VerifyAllDivesChecksumsWorkflow — the migration audit sweep.
+
+All ~479 dives came through the migration, so the question "does the recovered
+convention actually hold?" is asked of the whole corpus, not one dive.
+
+It runs on the api-worker inside the slot, on the NAS's own network — never
+driven from a workstation, because ~930 GB does not belong on a WAN link and
+the NAS credentials live in the slot. Temporal is what lets the run be started
+from anywhere while the bytes stay on the LAN.
+
+Cost shapes the rest: 65,981 canonical images at ~14.5 MB each is **~930 GB**.
+Individual transfers are already paced by the client (SMB-preferred, throttled,
+FileStation fallback), so the constraint is contention — that ~930 GB shares one
+NAS with the hourly staging activities doing real pipeline work. So:
+
+  * `limit_per_dive` is a runtime argument. Whether a dive came through a
+    *different ingest path* is a per-dive property, so ~5 frames answers it at
+    ~2% of the cost; every frame answers the different question "is any single
+    row corrupt". Same workflow serves both.
+  * Dives are verified **one at a time**. The sweep is diagnostic and must
+    never outrank real pipeline work for NAS bandwidth.
+  * One dive's failure must not abandon the sweep — losing hours of transfer
+    because dive 300 of 479 was unreachable would be its own outage.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from temporalio import activity
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from fishsense_api_workflow_worker.workflows.verify_all_dives_checksums_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    VerifyAllDivesChecksumsWorkflow,
+)
+from fishsense_shared.ingest_contracts import (
+    ChecksumMismatch,
+    VerifyChecksumsReport,
+)
+
+TASK_QUEUE = "test-verify-sweep"
+
+
+def _activities(dive_ids, *, per_dive=None, fail_on=()):
+    """Stub the selector and the per-dive verifier.
+
+    `per_dive` maps dive_id -> report; `fail_on` names dives whose activity
+    raises, standing in for a dive whose NAS reads exhausted their retries.
+    """
+    calls: list[tuple[int, int | None]] = []
+
+    @activity.defn(name="select_canonical_dive_ids_activity")
+    async def select() -> list[int]:
+        return list(dive_ids)
+
+    @activity.defn(name="verify_dive_checksums_activity")
+    async def verify(dive_id: int, limit: int | None) -> VerifyChecksumsReport:
+        calls.append((dive_id, limit))
+        if dive_id in fail_on:
+            raise RuntimeError(f"NAS unreachable for dive {dive_id}")
+        if per_dive and dive_id in per_dive:
+            return per_dive[dive_id]
+        return VerifyChecksumsReport(
+            dive_id=dive_id, total_in_dive=55, checked=5, checksum_matched=5
+        )
+
+    return [select, verify], calls
+
+
+async def _run(dive_ids, *args, per_dive=None, fail_on=(), **kwargs):
+    acts, calls = _activities(dive_ids, per_dive=per_dive, fail_on=fail_on)
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=TASK_QUEUE,
+            workflows=[VerifyAllDivesChecksumsWorkflow],
+            activities=acts,
+        ):
+            report = await env.client.execute_workflow(
+                VerifyAllDivesChecksumsWorkflow.run,
+                args=args or (None,),
+                id=f"{TASK_QUEUE}-{uuid.uuid4()}",
+                task_queue=TASK_QUEUE,
+                **kwargs,
+            )
+    return report, calls
+
+
+# ── the sweep ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_visits_every_canonical_dive_the_selector_returns():
+    report, calls = await _run([11, 22, 33], 5)
+
+    assert [c[0] for c in calls] == [11, 22, 33]
+    assert report.dives_requested == 3
+    assert report.dives_verified == 3
+    assert report.images_checked == 15
+
+
+@pytest.mark.asyncio
+async def test_the_per_dive_limit_is_forwarded_to_each_dive():
+    """The knob that decides whether this is a 20 GB sample or a 930 GB full
+    sweep. Nothing else about the workflow changes between the two."""
+    _, calls = await _run([11, 22], 5)
+
+    assert calls == [(11, 5), (22, 5)]
+
+
+@pytest.mark.asyncio
+async def test_no_limit_means_every_frame_of_every_dive():
+    _, calls = await _run([11], None)
+
+    assert calls == [(11, None)]
+
+
+@pytest.mark.asyncio
+async def test_dives_are_verified_one_at_a_time():
+    """Serial by design. The client already paces individual transfers; this is
+    the layer above it. Verification is diagnostic and shares one NAS with the
+    hourly staging activities doing real pipeline work, so a parallel sweep
+    would starve them for days."""
+    report, calls = await _run([11, 22, 33, 44], 5)
+
+    # A concurrent fan-out could interleave; strict input order proves serial.
+    assert [c[0] for c in calls] == [11, 22, 33, 44]
+    assert report.dives_verified == 4
+
+
+# ── findings ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_findings_are_carried_per_dive_and_clean_dives_are_kept():
+    """Clean rows are the result too. Dropping them would make "verified, fine"
+    indistinguishable from "never reached", which is the whole point of an
+    audit."""
+    dirty = VerifyChecksumsReport(
+        dive_id=22,
+        total_in_dive=55,
+        checked=5,
+        checksum_matched=4,
+        mismatches=[
+            ChecksumMismatch(
+                image_id=9, path="a/b.ORF", stored="0" * 32, computed="1" * 32
+            )
+        ],
+    )
+    report, _ = await _run([11, 22], 5, per_dive={22: dirty})
+
+    assert len(report.dives) == 2
+    assert [d.dive_id for d in report.dives_with_findings] == [22]
+    assert report.dives_with_findings[0].mismatches[0].stored == "0" * 32
+    assert report.checksum_matched == 9
+
+
+@pytest.mark.asyncio
+async def test_a_dive_that_cannot_be_verified_is_recorded_and_the_sweep_goes_on():
+    """A full sweep is days of transfer. Abandoning it because one dive was
+    unreachable would be its own outage — and an unreachable dive must not read
+    as clean, which is why `error` is a separate field rather than an absence
+    of findings."""
+    report, calls = await _run([11, 22, 33], 5, fail_on=(22,))
+
+    # Distinct ids, in order: dive 22 appears several times because the retry
+    # policy legitimately re-attempts it, and the point of the test is that 33
+    # was still reached afterwards — not how many attempts 22 got.
+    attempted = list(dict.fromkeys(c[0] for c in calls))
+    assert attempted == [11, 22, 33]
+    assert report.dives_verified == 2
+    errored = [d for d in report.dives if d.error]
+    assert [d.dive_id for d in errored] == [22]
+    assert errored[0].is_clean is False
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_dive_list_overrides_the_selector():
+    """For re-running just the dives a sample flagged, without re-walking the
+    whole corpus."""
+    _, calls = await _run([11, 22, 33], 5, [33])
+
+    assert [c[0] for c in calls] == [33]
+
+
+# ── observability ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_progress_is_queryable_while_the_sweep_runs():
+    """A 930 GB sweep runs for days. "Is it still going, and how far?" has to be
+    answerable without waiting for the return value."""
+    acts, _ = _activities([11, 22])
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=TASK_QUEUE,
+            workflows=[VerifyAllDivesChecksumsWorkflow],
+            activities=acts,
+        ):
+            handle = await env.client.start_workflow(
+                VerifyAllDivesChecksumsWorkflow.run,
+                args=(5,),
+                id=f"{TASK_QUEUE}-{uuid.uuid4()}",
+                task_queue=TASK_QUEUE,
+            )
+            await handle.result()
+            # Query by method reference, not by name string: the reference
+            # carries the return type, so the payload decodes to the model.
+            # `handle.query("progress")` hands back a bare dict.
+            progress = await handle.query(
+                VerifyAllDivesChecksumsWorkflow.progress
+            )
+
+    assert progress.state == "done"
+    assert progress.total_dives == 2
+    assert progress.dives_done == 2
+    assert progress.images_checked == 10

--- a/services/fishsense-api-workflow-worker/tests/test_verify_dive_checksums_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_verify_dive_checksums_activity.py
@@ -29,6 +29,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 from temporalio.testing import ActivityEnvironment
 
+# pylint: disable=import-error  # noqa: E501
+# `tests` is not a unique package name in this workspace — both
+# services/fishsense-api-workflow-worker/tests and libs/*/tests are called
+# `tests`, and pylint binds the name to whichever it parses FIRST. CI lints
+# `git diff --name-only` output, which is alphabetical, so a changed
+# libs/*/tests file wins and this relative import stops resolving. The
+# import itself is correct — pytest resolves it fine.
 from ._tiff_builder import build_orf
 
 ROOT = "/fishsense_data/REEF/data"

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "fishsense-api"
-version = "1.45.1"
+version = "1.46.0"
 source = { editable = "services/fishsense-api" }
 dependencies = [
     { name = "alembic" },
@@ -712,7 +712,7 @@ dev = [
 
 [[package]]
 name = "fishsense-api-sdk"
-version = "1.45.0"
+version = "1.45.1"
 source = { editable = "libs/fishsense-api-sdk" }
 dependencies = [
     { name = "httpx" },
@@ -739,7 +739,7 @@ dev = [
 
 [[package]]
 name = "fishsense-api-workflow-worker"
-version = "1.48.5"
+version = "1.49.0"
 source = { editable = "services/fishsense-api-workflow-worker" }
 dependencies = [
     { name = "boto3" },
@@ -879,7 +879,7 @@ provides-extras = ["laser-detector", "rectified", "slate"]
 
 [[package]]
 name = "fishsense-data-processing-workflow-worker"
-version = "2.15.0"
+version = "2.15.1"
 source = { editable = "services/fishsense-data-processing-workflow-worker" }
 dependencies = [
     { name = "boto3" },
@@ -998,7 +998,7 @@ dev = [
 
 [[package]]
 name = "fishsense-shared"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "libs/fishsense-shared" }
 dependencies = [
     { name = "dynaconf" },


### PR DESCRIPTION
All ~479 dives came through the migration, so "does the recovered convention
actually hold?" is a question about the whole corpus.
`VerifyAllDivesChecksumsWorkflow` walks the canonical dives and runs the
per-dive verifier from #559 over each.

**It runs on the api-worker inside the slot, on the NAS's own network.** Never
driven from a workstation — ~930 GB does not belong on a WAN link, and the NAS
credentials live in the slot. Temporal is what lets the run be started from
anywhere while the bytes stay on the LAN.

## Cost shapes everything else

65,981 canonical images × ~14.5 MB ≈ **930 GB**. So:

* **`limit_per_dive` is a runtime argument.** Whether a dive came through a
  *different ingest path* is a per-dive property, so ~5 frames per dive settles
  it for ~20 GB — about 2% of the cost. Checking every frame answers the
  different question, "is any individual row corrupt". One workflow serves both;
  pick at start time.
* **Dives run one at a time.** The client already paces individual transfers;
  this is the layer above it, so a multi-day audit never outranks pipeline
  staging for the NAS. There is no concurrency knob — the right value is 1, and
  a knob invites raising it.
* **One dive's failure records an `error` and the sweep continues.** A full run
  is days of transfer; losing it to one briefly-unreachable dive would be its own
  outage. `error` is a separate field from "no findings", so an unreachable dive
  can never read as clean.

Progress is queryable while it runs, which matters over days.

```
# sample: ~5 frames/dive, ~20 GB — answers the migration question
temporal workflow start --task-queue fishsense_api_queue \
    --type VerifyAllDivesChecksumsWorkflow \
    --workflow-id verify-sweep-sample --input 5

# full: every canonical frame, ~930 GB
... --workflow-id verify-sweep-full --input null

# just the dives a sample flagged
... --input null --input '[64, 66, 412]'

temporal workflow query --workflow-id verify-sweep-full --type progress
```

## Corrects stale reasoning in the #559 docstrings

They justified serial reads with *"FileStation's fragile shared download backend
502s under concurrent transfers"*. That is precisely what
`synology-filestation` >=0.2.0 fixed — it prefers **SMB**, falls back to
FileStation, and paces itself (`throttle=True`, `max_concurrency=4`,
`min_interval_ms=150`, internal retry capped at 60 s backoff).

The real constraint is **contention** with hourly pipeline staging, not
transport fragility. The ranged-read saving in preflight still holds, because
that one is about bytes moved and is transport-independent.

Worth noting: the client now retries internally, so Temporal's per-activity
policy sits on top of a bounded inner retry. That is the library's designed
behaviour (it is what fixed the 502s), but it is a change from the "no inner
retry loop" rule CLAUDE.md states, and worth knowing when reading a retry storm.

## Two bugs found writing this, same root cause

`execute_activity` without `result_type` decodes to a plain **dict**, so
`result.dive_id` raised `AttributeError`. That line sat *outside* the `try`, so
it failed the workflow **task** — which Temporal reschedules indefinitely. The
symptom is a sweep that **hangs forever** rather than one that fails; the test
run had to be killed and diagnosed from workflow history.

Both fixed: `result_type=VerifyChecksumsReport`, and the whole per-dive body is
now inside the `try`. Same trap on the query side — query by method reference,
not by name string, or you get a bare dict back.

## Tests

8 new workflow contract tests. 418 pass in the worker, 159 in fishsense-shared,
pylint 10.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)