### PR TITLE
fix(flake): name the services to restart when the Temporal cert rotates

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,9 +20,10 @@
     # the nightly `system.autoUpgrade` (#460) rolls it out. Skip it and the slot freezes
     # on old, unpatched packages. A new kernel needs a manual `incus restart` (allowReboot=false).
     #
-    # The lock currently carries krg-infra @ 309364df (incl. #435–#440/#443/#453,
+    # The lock currently carries krg-infra @ 62e83d64 (incl. #435–#440/#443/#453,
     # #459 compose force-recreate, #460 nightly auto-upgrade, #496 runner
-    # registration-token churn gate + `Restart = "on-failure"` on the runner).
+    # registration-token churn gate + `Restart = "on-failure"` on the runner,
+    # #534 vault-agent cert renewal + the `temporal.reload` rotation hook).
     # `git log -p flake.lock` is the real history of what shipped.
     #
     # #496 is why this axis being ours is not academic: krg fixed the runner
@@ -62,7 +63,32 @@
       # In-VM vault-agent renders a `fishsense-worker` Temporal client cert to
       # /run/tenant/temporal/{tls.crt,tls.key,ca.crt} (ADR 0023 / krg-infra #435).
       # Required — without it no cert renders and the workers can't reach krg-prod Temporal.
-      temporal = {namespace = "fishsense";};
+      #
+      # `reload` is the tenant half of ROTATION, and it is load-bearing: the leaf is a
+      # 7-day cert, and the platform now re-renders it before expiry
+      # (krg.vaultAgent.renewal, krg-infra #534) — but a process that builds its TLS
+      # config once at `Client.connect` keeps the OLD cert for its whole life, so a
+      # fresh file on /run recovers nothing on its own. That is exactly how the
+      # 2026-08-17 outage worked: the cert expired at 11:09 UTC and the api-worker
+      # spent ~7h retrying task-queue polls with `CertificateExpired` while every
+      # hourly schedule sat idle.
+      #
+      # These are the only two compose services that mount /run/tenant/temporal.
+      # Leaving the list empty would restart the ENTIRE interior stack on every
+      # rotation — postgres, superset and the public web path included — roughly every
+      # 5 days, for a cert two workers use.
+      #
+      # ADD `fishsense-api` HERE when its Temporal client lands (the ingest controller,
+      # docs/plans/dive-image-ingestion.md §2.7). The tell is the service gaining a
+      # /run/tenant/temporal mount in deploy/incus/compose.yml; miss it and ingest
+      # silently holds an expired cert until something else restarts the container.
+      temporal = {
+        namespace = "fishsense";
+        reload = [
+          "fishsense-api-workflow-worker"
+          "fishsense-backup-worker"
+        ];
+      };
     };
   in {
     # The Incus slot (booted at 10.100.0.10) converges to THIS config via our runner.


### PR DESCRIPTION
The tenant half of [krg-infra #534](https://github.com/KastnerRG/krg-infra/pull/534).

## Context: the 2026-08-17 outage

The 7-day Temporal client leaf expired at **11:09:38 UTC** — seven days to the
second after the one-shot `openbao-agent` render on Aug 10 — and the api-worker
spent ~7h retrying task-queue polls with `received fatal alert:
CertificateExpired`. Every hourly schedule sat idle.

krg-infra #534 fixes the platform half (`krg.vaultAgent.renewal` re-renders the
leaf at 33% of remaining lifetime). This PR supplies the half only we can:
**which services to restart when it rotates.**

That half is load-bearing. Re-rendering alone recovers nothing — a process that
builds its TLS config once at `Client.connect` holds the old cert for its whole
life. Fresh bytes on `/run` don't reach it.

## The change

```nix
temporal = {
  namespace = "fishsense";
  reload = [ "fishsense-api-workflow-worker" "fishsense-backup-worker" ];
};
```

These are the only two compose services that mount `/run/tenant/temporal`.

Leaving `reload` empty is *valid* — it restarts the whole interior stack — but
blunt: postgres, superset and the public web path would bounce roughly every
5 days for a cert two workers use.

Also advances the pin-history comment to `62e83d64` (the merge of #534). The
lock itself was bumped separately by `update-flake.yml` (2915322), dispatched
out-of-cycle so the `reload` option exists before this references it.

## Note for later

`fishsense-api` is deliberately **not** in the list — it has no Temporal client
yet. When the ingest controller lands
(`docs/plans/dive-image-ingestion.md` §2.7) it must be added. The tell is that
service gaining a `/run/tenant/temporal` mount in `deploy/incus/compose.yml`;
miss it and ingest silently holds an expired cert until something else restarts
the container. There's a comment in the flake saying so.

## Still needed to end the current outage

This is prevention, not recovery — the cert on disk is already expired and a
converge alone won't fix that. Recovery is still:

```
systemctl restart openbao-agent.service
docker restart fishsense-fishsense-api-workflow-worker-1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)