### PR TITLE
fix(scaling): forward the rotated Temporal leaf to NRP and reclaim a wedged data-worker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -302,12 +302,87 @@ jobs:
           printf '%s' "$NRP_KUBECONFIG" > "$RUNNER_TEMP/.kube/config"
           echo "KUBECONFIG=$RUNNER_TEMP/.kube/config" >> "$GITHUB_ENV"
 
+      - name: Preflight - Temporal client cert must be valid
+        # THE most common way this deploy fails, and the least obvious from the
+        # logs. The data-worker's krg-prod mTLS leaf lives in a Secret created
+        # out-of-band, so `kubectl apply -k` neither manages nor validates it.
+        # When it expires, pods crash 10s after start with
+        # `received fatal alert: CertificateExpired`, and the only symptom the job
+        # surfaces is `rollout status` timing out five minutes later — which is
+        # indistinguishable from a bad image, a quota denial, or NRP GC. That cost
+        # a real investigation on 2026-08-18. Fail in seconds, by name, instead.
+        #
+        # deploy/incus/nrp_cert_sync/ now forwards the rotated leaf automatically,
+        # so a failure here means that forwarder is not running or not reaching NRP.
+        run: |
+          set -euo pipefail
+          ns=e4e-fishsense
+          secret=fishsense-data-worker-temporal-certs
+          if ! kubectl -n "$ns" get secret "$secret" >/dev/null 2>&1; then
+            echo "::error::Secret $ns/$secret is missing - the data-worker cannot authenticate to krg-prod Temporal. See deploy/k8s/data-worker/README.md."
+            exit 1
+          fi
+          kubectl -n "$ns" get secret "$secret" -o jsonpath='{.data.client\.pem}' \
+            | base64 -d > "$RUNNER_TEMP/client.pem"
+          notafter=$(openssl x509 -in "$RUNNER_TEMP/client.pem" -noout -enddate | cut -d= -f2)
+          if ! openssl x509 -in "$RUNNER_TEMP/client.pem" -noout -checkend 0 >/dev/null; then
+            echo "::error::The data-worker's Temporal client cert EXPIRED on $notafter. Every pod will CrashLoopBackOff on 'CertificateExpired' and this rollout cannot converge. Re-run the slot's nrp-temporal-cert-sync service, or re-mint per deploy/k8s/data-worker/README.md."
+            exit 1
+          fi
+          # 48h: the leaf is a 7-day cert forwarded from the slot roughly every 5
+          # days, so this only fires when the forwarder has actually stopped.
+          if ! openssl x509 -in "$RUNNER_TEMP/client.pem" -noout -checkend 172800 >/dev/null; then
+            echo "::warning::The data-worker's Temporal client cert expires $notafter (< 48h). Check that nrp-temporal-cert-sync is running on the slot."
+          fi
+          echo "Temporal client cert valid until $notafter"
+          rm -f "$RUNNER_TEMP/client.pem"
+
       - name: Apply data-worker manifests (kubectl is preinstalled on ubuntu-latest)
         run: |
           kubectl version --client
+          # NRP garbage-collects Deployments older than two weeks unless the
+          # namespace holds a permanent-service exception, and ours has been
+          # collected at least once (the object was recreated 2026-08-17 while its
+          # ConfigMaps still dated to July — those are not time-GC'd). `apply`
+          # recreates it correctly, so GC is survivable; it is worth saying out
+          # loud, because a recreated Deployment starts at replicas=1 rather than
+          # whatever the api-worker had scaled it to, and because a namespace
+          # collecting repeatedly is the signal to chase the exception with NRP.
+          if kubectl get deployment/fishsense-data-processing-workflow-worker -n e4e-fishsense >/dev/null 2>&1; then
+            echo "Deployment exists - this is an in-place rollout."
+          else
+            echo "::warning::Deployment is absent and will be recreated - NRP's 2-week GC has collected it. Request a permanent-service exception for the e4e-fishsense namespace (Matrix, https://nrp.ai/contact); see deploy/k8s/data-worker/README.md."
+          fi
           kubectl apply -k deploy/k8s/data-worker
           kubectl rollout status deployment/fishsense-data-processing-workflow-worker --timeout=5m
 
+      - name: Diagnose a failed rollout
+        if: failure()
+        # `rollout status` reports only "timed out waiting for the condition",
+        # which names no cause. Everything needed to tell an expired cert from an
+        # OOMKill from an unschedulable GPU request is one API call away — collect
+        # it here so the job log is self-sufficient and nobody has to reproduce
+        # cluster access to read it.
+        run: |
+          ns=e4e-fishsense
+          echo "::group::Pods"
+          kubectl -n "$ns" get pods -o wide || true
+          echo "::endgroup::"
+          echo "::group::Container state (exit codes, restart counts)"
+          kubectl -n "$ns" get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}  waiting: {.status.containerStatuses[*].state.waiting.reason}{"\n"}  lastTerminated: {.status.containerStatuses[*].lastState.terminated.reason}{" exit="}{.status.containerStatuses[*].lastState.terminated.exitCode}{"\n"}  restarts: {.status.containerStatuses[*].restartCount}{"\n"}{end}' || true
+          echo "::endgroup::"
+          echo "::group::Recent events"
+          kubectl -n "$ns" get events --sort-by=.lastTimestamp | tail -30 || true
+          echo "::endgroup::"
+          echo "::group::Pod logs"
+          for p in $(kubectl -n "$ns" get pods -l app.kubernetes.io/name=fishsense-data-processing-workflow-worker -o name 2>/dev/null); do
+            echo "--- $p (previous container) ---"
+            kubectl -n "$ns" logs "$p" --tail=40 --previous 2>/dev/null \
+              || kubectl -n "$ns" logs "$p" --tail=40 2>/dev/null \
+              || echo "(no logs)"
+          done
+          echo "::endgroup::"
+
       - name: Clean up kubeconfig
         if: always()
-        run: rm -f "$RUNNER_TEMP/.kube/config"
+        run: rm -f "$RUNNER_TEMP/.kube/config" "$RUNNER_TEMP/client.pem"

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -16,6 +16,8 @@ on:
     branches: [main]
     paths:
       - 'deploy/k8s/**'
+      # The slot-side cert forwarder is exercised against the same kind cluster.
+      - 'deploy/incus/nrp_cert_sync/**'
       - 'services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/k8s_scaling.py'
       - 'services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/ensure_data_worker_running_activity.py'
       - 'services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/scale_down_data_worker_if_idle_activity.py'
@@ -28,6 +30,8 @@ on:
   pull_request:
     paths:
       - 'deploy/k8s/**'
+      # The slot-side cert forwarder is exercised against the same kind cluster.
+      - 'deploy/incus/nrp_cert_sync/**'
       - 'services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/k8s_scaling.py'
       - 'services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/ensure_data_worker_running_activity.py'
       - 'services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/scale_down_data_worker_if_idle_activity.py'
@@ -78,6 +82,18 @@ jobs:
         run: |
           kubectl apply -k deploy/k8s/data-worker
           kubectl get deployment fishsense-data-processing-workflow-worker -n e4e-fishsense -o yaml
+
+      - name: Test the slot-side Temporal cert forwarder
+        # deploy/incus/nrp_cert_sync/sync.sh runs on the Incus slot and pushes the
+        # rotated krg-prod leaf into this namespace's Secret — the gap that expired
+        # on 2026-08-14 and crash-looped every data-worker pod. Nothing else in CI
+        # covers it, and the kind cluster + Secrets + Deployment this job already
+        # built are exactly what it needs. Asserts the upsert, the sha256
+        # short-circuit that keeps a converge from rolling the Deployment for
+        # nothing, and that a rotation does roll it.
+        env:
+          NRP_NAMESPACE: e4e-fishsense
+        run: deploy/incus/nrp_cert_sync/test_sync.sh
 
       - uses: actions/setup-python@v5
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -767,6 +767,47 @@ from `deploy/temporal_volumes/certs` — the same `TLSConfig` is built
 from `settings.temporal.{client_cert,client_private_key,server_root_ca_cert,domain}`
 across every service that talks to Temporal.
 
+## Temporal mTLS rotation — two consumers, two mechanisms
+
+The krg-prod leaf is a **7-day** cert, and re-rendering it is only half a
+fix: a process builds its TLS config once at `Client.connect` and holds
+the old leaf for its whole life. Both halves have to be arranged, and the
+two consumers are arranged differently.
+
+* **In the slot** — vault-agent renders
+  `/run/tenant/temporal/{tls.crt,tls.key,ca.crt}` and re-renders before
+  expiry (`krg.vaultAgent.renewal`, krg-infra #534). `temporal.reload` in
+  the root `flake.nix` names the compose services to restart on rotation;
+  the hook is `docker compose ... restart <svc>...`. **Add a service there
+  when it gains a `/run/tenant/temporal` mount** — that mount is the tell.
+  `fishsense-api` is the pending one (the ingest controller,
+  `docs/plans/dive-image-ingestion.md` §2.7).
+* **On NRP** — the data-worker holds the *same* identity
+  (`CN=fishsense-worker`; krg issues `common_name=<tenant>-worker`) in the
+  k8s Secret `fishsense-data-worker-temporal-certs`. vault-agent cannot
+  reach the cluster, so the slot forwards it:
+  `deploy/incus/nrp_cert_sync/` is a one-shot compose service, also listed
+  in `temporal.reload`, that upserts the Secret and `rollout restart`s the
+  Deployment. It short-circuits on an unchanged leaf via a
+  `fishsense.e4e.ucsd.edu/leaf-sha256` annotation, so running it on every
+  converge costs nothing.
+
+**This is the shape of the 2026-08-14 outage.** The NRP copy was minted by
+hand at `ttl=720h` and renewed by nobody. It expired, every data-worker pod
+crash-looped on `received fatal alert: CertificateExpired`, and the
+consequence surfaced four days later as a v2.15.2 `kubectl rollout status`
+timeout with no stated cause — read at first as NRP having killed the
+deploy. NRP *had* separately GC'd the Deployment (2-week rule; `apply`
+recreates it), which made the misattribution easy. Two guards now exist so
+this can't be silent again: `deploy.yml` preflights the leaf's expiry and
+fails by name in seconds, and dumps pod state, events and previous-container
+logs on any rollout failure.
+
+Corollary: **`kubectl rollout status` timing out is not a diagnosis.** It
+reports "timed out waiting for the condition" for an expired cert, an
+OOMKill, an unschedulable GPU request and a quota denial alike. Read the
+`Diagnose a failed rollout` group in the job log before forming a theory.
+
 ## Worker config validation gotcha
 
 Dynaconf eagerly validates **every** `Validator` on first attribute
@@ -1111,6 +1152,45 @@ devcontainer, pre-NRP). `active_replicas` is clamped to `[1, 4]`; >1
 is a deliberate operator choice (giant single dive, or active-window
 resilience on a preemption-prone cluster), never automatic. See
 `deploy/k8s/data-worker/README.md`.
+
+**The sweeper also reclaims a *wedged* worker, not just an idle one.**
+"Queue is busy" and "worker is doing work" are the same thing only while
+the worker can actually start. A data-worker that can't — expired
+Temporal cert, bad image tag, unschedulable GPU request, exhausted
+quota — never drains its queue, so every dispatched child sits `Running`
+until it times out, the queue never *looks* idle, and the Deployment
+stays pinned at `active_replicas` holding NRP GPUs around the clock
+while accomplishing nothing. **The failure suppresses the cleanup that
+would have bounded its cost.** Prod sat exactly there from 2026-08-14
+(expired Temporal leaf → CrashLoopBackOff → replicas stuck at 2). So
+`scale_down_data_worker_if_idle_activity` scales to 0 when the queue is
+busy but `k8s_scaling.deployment_is_wedged` reports the Deployment wants
+pods and has none Ready, and logs a WARNING — reclaiming the pods bounds
+the waste but fixes nothing, and the backlog left behind is real work
+that isn't happening.
+
+The wedge check is deliberately shallow — `spec.replicas` vs
+`status.readyReplicas` from one Deployment read, which is all the deploy
+identity is allowed (`deployments: get`; it has no `pods` access).
+Richer signals were measured against the live wedge and rejected:
+`Progressing` read `True`/`NewReplicaSetAvailable` throughout (the
+ReplicaSet *had* progressed, months earlier), and `Available`'s
+`lastTransitionTime` is useless as a "wedged since" clock because the
+pod has no readinessProbe, so every crash cycle flips it Ready then
+not-Ready and resets the timestamp. Note `readyReplicas` is **absent**
+rather than 0 when nothing is Ready — reading `None` as "unknown, assume
+healthy" is exactly what kept the GPUs pinned.
+
+Being time-free leaves one false positive: a sweep landing inside a
+genuine cold start scales down a worker that was about to be ready. That
+costs an hour, not correctness — the next parent with work scales it
+back up, and per-image activities are idempotent, so interrupted
+children re-run.
+
+**`ensure_data_worker_running_activity` never refuses to scale up**, even
+into a known wedge. That is what makes recovery automatic once the
+underlying fault is fixed; the cost is a Deployment that oscillates 0↔N
+while broken, which is a far louder signal than silently holding GPUs.
 
 NRP GCs Deployments older than 2 weeks unless the namespace is on its
 exceptions list — the bootstrap requests a permanent-service

--- a/deploy/incus/compose.yml
+++ b/deploy/incus/compose.yml
@@ -226,7 +226,7 @@ services:
 
   # ── api-side Temporal worker (hourly schedules, LS sync, preprocess parents) ───────────
   fishsense-api-workflow-worker:
-    image: ghcr.io/ucsd-e4e/fishsense-api-workflow-worker:v1.50.1
+    image: ghcr.io/ucsd-e4e/fishsense-api-workflow-worker:v1.50.0
     restart: unless-stopped
     # Secrets as dynaconf E4EFS_* env overrides from the vault-agent render
     # (API basic-auth, Garage keys, LS key, NAS creds — see secrets.nix).
@@ -257,6 +257,37 @@ services:
       - ./worker_volumes/backup_worker/logs:/e4efs/logs:rw
       - /run/tenant/temporal:/run/tenant/temporal:ro
     networks: [interior]
+
+  # ── push the rotated Temporal leaf out to the NRP data-worker ──────────────────────────
+  # One-shot, and the ONLY thing in this stack that talks to Kubernetes.
+  #
+  # The krg-prod Temporal leaf is a 7-day cert. vault-agent re-renders it before
+  # expiry and flake.nix's `temporal.reload` restarts the two workers above so they
+  # pick it up. The data-worker is on NRP, out of vault-agent's reach, and its copy
+  # of the SAME identity (CN=fishsense-worker) sat in a hand-minted `ttl=720h` k8s
+  # Secret that nothing renewed — it expired 2026-08-14 and crash-looped every pod
+  # on `CertificateExpired`, which is what timed out the v2.15.2 rollout. The slot is
+  # where the renewed leaf lands, so the slot is what forwards it.
+  #
+  # `restart: "no"` + listed in `temporal.reload`: the hook is
+  # `docker compose ... restart <svc>`, which starts an exited container again, so
+  # every rotation re-runs this. It also runs on each converge — a no-op when the
+  # leaf is unchanged (sync.sh compares a sha256 annotation before touching anything).
+  #
+  # Not on the `interior` network: it needs egress to the NRP API server, not to the
+  # other containers. Go's crypto/x509 is also why kubectl works here at all — the
+  # api-worker's Python client can't reach the same endpoint, because OpenSSL 3.5
+  # rejects NRP's CA for carrying no Authority Key Identifier.
+  nrp-temporal-cert-sync:
+    image: alpine/kubectl:1.34.1
+    restart: "no"
+    entrypoint: ["/bin/sh", "/sync/sync.sh"]
+    volumes:
+      - ./nrp_cert_sync:/sync:ro
+      # The leaf to forward — same vault-agent render the two workers mount.
+      - /run/tenant/temporal:/run/tenant/temporal:ro
+      # NRP kubeconfig (vault-agent SOFT render). sync.sh exits 0 when it's absent.
+      - /run/tenant/nrp:/run/tenant/nrp:ro
 
   # ── in-slot Postgres: `fishsense` + `superset` DBs only (temporal_db moved to krg-prod) ─
   postgres:

--- a/deploy/incus/nrp_cert_sync/sync.sh
+++ b/deploy/incus/nrp_cert_sync/sync.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+# Mirror the slot's rotated Temporal leaf into the NRP data-worker's Secret.
+#
+# WHY THIS EXISTS. The krg-prod Temporal mTLS leaf is a 7-day cert. On the slot,
+# vault-agent re-renders it before expiry (krg.vaultAgent.renewal, krg-infra #534)
+# and `temporal.reload` in flake.nix restarts the compose services that hold it —
+# a process builds its TLS config once at `Client.connect`, so a fresh file on
+# /run recovers nothing on its own.
+#
+# The data-worker runs on NRP, outside the slot, and vault-agent cannot reach it.
+# Its copy of the SAME identity lived in a hand-minted `ttl=720h` k8s Secret that
+# nothing renewed. It expired 2026-08-14 05:46:26 UTC and every pod went
+# CrashLoopBackOff on `received fatal alert: CertificateExpired`, which is what
+# made the v2.15.2 rollout time out. The 2026-08-17 rotation fix covered the two
+# slot services and missed this one. This script closes that gap: the slot is
+# where the renewed cert lands, so the slot is what pushes it onward.
+#
+# Same identity, not a second one: krg-infra's tenant module issues
+# `pki_int/issue/temporal-client common_name=<tenant>-worker` -> CN=fishsense-worker,
+# which is exactly the CN the expired k8s cert carried. `ca.crt` is the render of
+# `.Data.issuing_ca` (CN=KRG Lab Internal Intermediate CA), matching root-ca.pem.
+#
+# Run as a one-shot compose service (`restart: "no"`), listed in flake.nix's
+# `temporal.reload`. That hook is `docker compose ... restart <svc>...`, which
+# starts an exited container again — so each rotation re-runs this. It also runs
+# on every converge, which is harmless: it is a no-op when the leaf is unchanged.
+#
+# Paths are overridable so CI can exercise this against a kind cluster
+# (.github/workflows/k8s-tests.yml).
+set -eu
+
+TEMPORAL_CERT_DIR="${TEMPORAL_CERT_DIR:-/run/tenant/temporal}"
+KUBECONFIG="${KUBECONFIG:-/run/tenant/nrp/kubeconfig}"
+NRP_NAMESPACE="${NRP_NAMESPACE:-e4e-fishsense}"
+SECRET_NAME="${SECRET_NAME:-fishsense-data-worker-temporal-certs}"
+DEPLOY_NAME="${DEPLOY_NAME:-fishsense-data-processing-workflow-worker}"
+# Records which leaf the Secret currently holds, so a converge that changed
+# nothing does not roll the data-worker.
+FP_ANNOTATION="fishsense.e4e.ucsd.edu/leaf-sha256"
+export KUBECONFIG
+
+log() { echo "[nrp-temporal-cert-sync] $*"; }
+
+# The NRP kubeconfig is a SOFT vault-agent render — it can legitimately be
+# absent (not yet seeded, or a slot brought up without NRP). That is not a
+# failure of the interior stack, so exit clean and say why.
+if [ ! -r "$KUBECONFIG" ]; then
+    log "no kubeconfig at $KUBECONFIG - nothing to sync (soft render absent)"
+    exit 0
+fi
+
+for f in tls.crt tls.key ca.crt; do
+    if [ ! -r "$TEMPORAL_CERT_DIR/$f" ]; then
+        log "ERROR: missing $TEMPORAL_CERT_DIR/$f - is the temporal render enabled?"
+        exit 1
+    fi
+done
+
+fingerprint="$(sha256sum "$TEMPORAL_CERT_DIR/tls.crt" | cut -d' ' -f1)"
+
+# `|| true`: a missing Secret (first run, or one wiped alongside the namespace)
+# must fall through to the create below, not abort under `set -e`.
+#
+# The key is spelled out again here rather than interpolating $FP_ANNOTATION:
+# kubectl's jsonpath needs every dot in an annotation KEY backslash-escaped, so
+# the two spellings genuinely differ. Keep them in step.
+current="$(kubectl -n "$NRP_NAMESPACE" get secret "$SECRET_NAME" \
+    -o "jsonpath={.metadata.annotations['fishsense\\.e4e\\.ucsd\\.edu/leaf-sha256']}" \
+    2>/dev/null || true)"
+
+if [ -n "$current" ] && [ "$current" = "$fingerprint" ]; then
+    log "leaf unchanged ($fingerprint) - no update, no rollout"
+    exit 0
+fi
+
+log "pushing rotated leaf to $NRP_NAMESPACE/$SECRET_NAME"
+# create --dry-run | apply is the idempotent upsert: it creates the Secret when
+# absent and replaces the three keys when present, without a delete window.
+kubectl -n "$NRP_NAMESPACE" create secret generic "$SECRET_NAME" \
+    --from-file=client.pem="$TEMPORAL_CERT_DIR/tls.crt" \
+    --from-file=client.key="$TEMPORAL_CERT_DIR/tls.key" \
+    --from-file=root-ca.pem="$TEMPORAL_CERT_DIR/ca.crt" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n "$NRP_NAMESPACE" annotate secret "$SECRET_NAME" \
+    "$FP_ANNOTATION=$fingerprint" --overwrite
+
+# kubelet refreshes a mounted Secret in place, but the worker reads /certs once
+# at Client.connect - so running pods keep the old leaf until they are replaced.
+# A no-op when the api-worker has it scaled to 0: the annotation lands on the
+# pod template and the next scale-up starts on the new cert.
+log "rolling $DEPLOY_NAME onto the new leaf"
+# kubectl refuses a second `rollout restart` inside the same second ("if restart
+# has already been triggered within the past second"). That guard firing means a
+# restart just landed, which is the outcome we wanted - take it rather than
+# failing the sync under `set -e`. Any other failure is real and propagates.
+if restart_out="$(kubectl -n "$NRP_NAMESPACE" rollout restart "deployment/$DEPLOY_NAME" 2>&1)"; then
+    log "$restart_out"
+else
+    case "$restart_out" in
+        *"within the past second"*)
+            log "a rollout was already triggered this second - taking it" ;;
+        *)
+            log "ERROR: $restart_out"
+            exit 1 ;;
+    esac
+fi
+
+log "done ($fingerprint)"

--- a/deploy/incus/nrp_cert_sync/test_sync.sh
+++ b/deploy/incus/nrp_cert_sync/test_sync.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Exercises sync.sh against a real cluster (kind in CI, see
+# .github/workflows/k8s-tests.yml). Needs a working KUBECONFIG, the
+# `e4e-fishsense` namespace, and the data-worker Deployment applied.
+#
+# sync.sh never parses the cert bodies — it hashes tls.crt and uploads all
+# three files — so plain text fixtures cover the real behaviour and the test
+# needs no PKI tooling.
+set -euo pipefail
+
+NS="${NRP_NAMESPACE:-e4e-fishsense}"
+SECRET=fishsense-data-worker-temporal-certs
+DEPLOY=fishsense-data-processing-workflow-worker
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+CERTS="$WORK/temporal"
+mkdir -p "$CERTS"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "  ok - $*"; }
+
+restarted_at() {
+    kubectl -n "$NS" get "deployment/$DEPLOY" \
+        -o 'jsonpath={.spec.template.metadata.annotations.kubectl\.kubernetes\.io/restartedAt}' 2>/dev/null || true
+}
+leaf_annotation() {
+    kubectl -n "$NS" get secret "$SECRET" \
+        -o "jsonpath={.metadata.annotations['fishsense\\.e4e\\.ucsd\\.edu/leaf-sha256']}" 2>/dev/null || true
+}
+run_sync() { TEMPORAL_CERT_DIR="$CERTS" NRP_NAMESPACE="$NS" "$HERE/sync.sh"; }
+
+echo "1. absent kubeconfig is a clean no-op, not a stack failure"
+out="$(TEMPORAL_CERT_DIR="$CERTS" KUBECONFIG="$WORK/nope" "$HERE/sync.sh")" \
+    || fail "expected exit 0 when the soft render is absent"
+grep -q "nothing to sync" <<<"$out" || fail "expected a 'nothing to sync' message, got: $out"
+pass "exits 0 and explains itself"
+
+echo "2. a missing cert render is a hard error"
+if TEMPORAL_CERT_DIR="$CERTS" NRP_NAMESPACE="$NS" "$HERE/sync.sh" >/dev/null 2>&1; then
+    fail "expected non-zero exit when tls.crt is missing"
+fi
+pass "exits non-zero"
+
+printf 'leaf-v1\n' > "$CERTS/tls.crt"
+printf 'key-v1\n'  > "$CERTS/tls.key"
+printf 'ca-v1\n'   > "$CERTS/ca.crt"
+
+echo "3. first run pushes the leaf and rolls the deployment"
+before_roll="$(restarted_at)"
+run_sync >/dev/null
+[[ "$(kubectl -n "$NS" get secret "$SECRET" -o jsonpath='{.data.client\.pem}' | base64 -d)" == "leaf-v1" ]] \
+    || fail "client.pem was not updated from tls.crt"
+[[ "$(kubectl -n "$NS" get secret "$SECRET" -o jsonpath='{.data.client\.key}' | base64 -d)" == "key-v1" ]] \
+    || fail "client.key was not updated from tls.key"
+[[ "$(kubectl -n "$NS" get secret "$SECRET" -o jsonpath='{.data.root-ca\.pem}' | base64 -d)" == "ca-v1" ]] \
+    || fail "root-ca.pem was not updated from ca.crt"
+expected="$(sha256sum "$CERTS/tls.crt" | cut -d' ' -f1)"
+[[ "$(leaf_annotation)" == "$expected" ]] || fail "leaf-sha256 annotation not recorded"
+after_roll="$(restarted_at)"
+[[ -n "$after_roll" && "$after_roll" != "$before_roll" ]] || fail "deployment was not rolled"
+pass "secret upserted, annotated, deployment rolled"
+
+echo "4. an unchanged leaf does not roll the deployment again"
+sleep 1   # restartedAt is second-resolution; without this a real roll could alias
+before_roll="$(restarted_at)"
+out="$(run_sync)"
+grep -q "leaf unchanged" <<<"$out" || fail "expected the unchanged short-circuit, got: $out"
+[[ "$(restarted_at)" == "$before_roll" ]] || fail "deployment was rolled on an unchanged leaf"
+pass "no-op on a converge that rotated nothing"
+
+echo "5. a rotated leaf is pushed and rolls the deployment"
+printf 'leaf-v2\n' > "$CERTS/tls.crt"
+printf 'key-v2\n'  > "$CERTS/tls.key"
+sleep 1
+before_roll="$(restarted_at)"
+run_sync >/dev/null
+[[ "$(kubectl -n "$NS" get secret "$SECRET" -o jsonpath='{.data.client\.pem}' | base64 -d)" == "leaf-v2" ]] \
+    || fail "rotated client.pem was not pushed"
+[[ "$(leaf_annotation)" == "$(sha256sum "$CERTS/tls.crt" | cut -d' ' -f1)" ]] \
+    || fail "leaf-sha256 annotation not updated on rotation"
+[[ "$(restarted_at)" != "$before_roll" ]] || fail "deployment was not rolled on rotation"
+pass "rotation propagates and rolls"
+
+echo "6. it recreates the Secret if it is missing entirely"
+kubectl -n "$NS" delete secret "$SECRET" >/dev/null
+run_sync >/dev/null
+[[ "$(kubectl -n "$NS" get secret "$SECRET" -o jsonpath='{.data.client\.pem}' | base64 -d)" == "leaf-v2" ]] \
+    || fail "Secret was not recreated from scratch"
+pass "recreates a deleted Secret"
+
+echo "ALL PASS"

--- a/deploy/k8s/data-worker/README.md
+++ b/deploy/k8s/data-worker/README.md
@@ -116,12 +116,17 @@ what CI uses to `kubectl apply` (repo secret `NRP_KUBECONFIG`).
      --from-literal=object_store_access_key='<garage-access-key>' \
      --from-literal=object_store_secret_key='<garage-secret-key>'
 
-   # 2. Temporal mTLS material — the data-worker's OWN krg-prod client
-   #    identity, distinct from the api-worker's. Mint on krg-deploy:
+   # 2. Temporal mTLS material — the krg-prod client identity. This is the
+   #    SAME identity the slot's workers use, CN=fishsense-worker, not a
+   #    second one: krg-infra's tenant module issues
+   #    `pki_int/issue/temporal-client common_name=<tenant>-worker`.
+   #    Bootstrap only — see "Cert rotation" below; after the first apply
+   #    the slot re-pushes this Secret on every rotation. Mint on krg-deploy:
    #      bao write pki_int/issue/temporal-client \
    #        common_name=fishsense-worker ttl=720h
    #    (CN authorized for the fishsense tenant now that krg-infra #435's
-   #    grant is live). Renew ~30d. root-ca.pem is krg-prod's Temporal CA.
+   #    grant is live). root-ca.pem is krg-prod's Temporal CA (the KRG Lab
+   #    Internal Intermediate, good to 2031) — only the leaf turns over.
    kubectl create secret generic fishsense-data-worker-temporal-certs -n e4e-fishsense \
      --from-file=client.pem=/path/to/fishsense-data-processing-workflow-worker.pem \
      --from-file=client.key=/path/to/fishsense-data-processing-workflow-worker.key \
@@ -140,6 +145,62 @@ what CI uses to `kubectl apply` (repo secret `NRP_KUBECONFIG`).
    bumps the image tag in `kustomization.yaml` and opens an
    `auto-deploy/fishsense-data-processing-workflow-worker-*` PR;
    merging it triggers `deploy.yml` to `kubectl apply -k` again.
+
+## Cert rotation — the slot pushes it, nothing here pulls it
+
+The krg-prod Temporal leaf is a **7-day** cert. On the Incus slot,
+vault-agent re-renders it before expiry (`krg.vaultAgent.renewal`,
+krg-infra #534) and the root `flake.nix`'s `temporal.reload` restarts the
+services holding it — re-rendering alone recovers nothing, because a
+worker builds its TLS config once at `Client.connect` and keeps the old
+leaf for the life of the process.
+
+vault-agent cannot reach into NRP, so this Secret was originally minted by
+hand at `ttl=720h` and renewed by nobody. **It expired 2026-08-14 05:46:26
+UTC**, every pod went `CrashLoopBackOff` on `received fatal alert:
+CertificateExpired`, and the v2.15.2 rollout on 2026-08-18 timed out with
+no stated cause — which read as NRP having killed the deploy. (NRP had in
+fact GC'd the Deployment separately; `apply` recreated it fine. The cert is
+what kept it down.)
+
+That gap is closed by
+[`deploy/incus/nrp_cert_sync/`](../../incus/nrp_cert_sync/): a one-shot
+compose service on the slot, listed in `flake.nix`'s `temporal.reload`,
+that pushes the rotated leaf into this Secret and `rollout restart`s the
+Deployment. It is a no-op when the leaf is unchanged (it compares a
+`fishsense.e4e.ucsd.edu/leaf-sha256` annotation), so it is safe on every
+converge. `deploy.yml` also refuses to deploy on an expired leaf, naming
+it in seconds rather than timing out after five minutes.
+
+Consequences worth knowing:
+
+* **The Secret is no longer hand-managed.** Editing it by hand is fine for
+  an emergency, but the next rotation overwrites it. Fix the forwarder,
+  not the Secret.
+* **Do not `kubectl delete` this Secret casually.** The forwarder recreates
+  it on the next rotation, which can be days away; until then every pod
+  crash-loops. Re-run the forwarder explicitly instead:
+  `docker compose ... restart nrp-temporal-cert-sync` on the slot.
+* The leaf the data-worker now carries is a 7-day cert refreshed roughly
+  every 5 days, not the old 30-day one. That is strictly better — but it
+  means a forwarder that silently stops shows up within a week.
+
+## NRP's 2-week Deployment GC
+
+The bootstrap above asks NRP for a permanent-service exception. **As of
+2026-08-20 the namespace does not appear to hold one** — the Deployment's
+`creationTimestamp` was 2026-08-17 while its ConfigMaps still dated to
+July, i.e. the object had been collected and recreated by a deploy.
+ConfigMaps and Secrets are not time-GC'd, and our pods are ReplicaSet-owned
+so the 6-hour bare-pod rule never applies; the Deployment is the only thing
+at risk.
+
+This is survivable — `kubectl apply -k` recreates it, and `deploy.yml`
+logs a `::warning::` when it has to, so repeated collection is visible in
+the job log rather than silent. Two caveats: a recreated Deployment starts
+at `replicas: 1` instead of whatever the api-worker had scaled it to, and
+any work queued while it was absent simply waits. Still worth chasing the
+exception with NRP support (Matrix, <https://nrp.ai/contact>).
 
 ## Prerequisite on the Incus slot side
 

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,17 @@
         reload = [
           "fishsense-api-workflow-worker"
           "fishsense-backup-worker"
+          # Not a consumer of the cert — a FORWARDER of it. The data-worker runs on
+          # NRP, outside vault-agent's reach, and holds the same CN=fishsense-worker
+          # identity in a k8s Secret. Nothing renewed that copy: it was hand-minted
+          # `ttl=720h` on 2026-07-15, expired 2026-08-14 05:46:26 UTC, and every pod
+          # has crash-looped on `CertificateExpired` since — which is what timed out
+          # the v2.15.2 rollout and read as "NRP killed the deploy".
+          #
+          # This one-shot service re-pushes the rotated leaf and rolls the Deployment.
+          # `restart` starts an exited container again, so it re-runs each rotation;
+          # it no-ops when the leaf is unchanged. See deploy/incus/nrp_cert_sync/.
+          "nrp-temporal-cert-sync"
         ];
       };
     };

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/k8s_scaling.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/k8s_scaling.py
@@ -154,6 +154,49 @@ def _relax_x509_strict_verification(api_client, configuration) -> None:
         pool_kw.pop(key, None)
 
 
+def deployment_is_wedged(api, namespace: str, name: str) -> bool:
+    """True iff the Deployment wants pods but has no Ready one.
+
+    This is the escape hatch on the sweeper's "is the queue busy?" check, and
+    it exists because those two signals can disagree in exactly one direction
+    that matters. A data-worker that cannot start — expired Temporal cert, bad
+    image tag, unschedulable GPU request, exhausted quota — never drains its
+    task queue, so every dispatched child sits ``Running`` until it times out
+    and the queue never *looks* idle. The sweeper then declines to scale down,
+    the Deployment stays pinned at ``active_replicas``, and it holds NRP GPUs
+    around the clock while getting no work done. Prod sat exactly there from
+    2026-08-14 (see the Temporal-cert notes in CLAUDE.md): the failure
+    suppressed the very cleanup that would have bounded its cost.
+
+    "Busy" is only a reason to keep pods alive when the pods can make progress.
+
+    Deliberately shallow — ``spec.replicas`` versus ``status.readyReplicas``,
+    both from the one Deployment read the deploy identity is already allowed
+    (``deployments: get``; it has no ``pods`` access). Richer signals were
+    measured against the live wedge and rejected:
+
+    * ``Progressing`` read ``True``/``NewReplicaSetAvailable`` throughout — the
+      ReplicaSet *had* progressed, back when a pod first came up.
+    * ``Available``'s ``lastTransitionTime`` is useless as a "wedged since"
+      clock. The pod has no readinessProbe, so each crash cycle flips it Ready
+      then not-Ready and the timestamp resets every few seconds.
+
+    Nothing here is time-based, which leaves one false positive: a sweep that
+    lands inside a genuine cold start (image pull) sees no Ready pod and scales
+    down. That costs an hour, not correctness — the next parent with real work
+    scales it straight back up, and per-image activities are idempotent by
+    design, so the children it interrupts simply re-run.
+    """
+    deployment = api.read_namespaced_deployment(name=name, namespace=namespace)
+    desired = (deployment.spec.replicas if deployment.spec else None) or 0
+    status = deployment.status
+    # k8s OMITS readyReplicas rather than sending 0, so this is None in exactly
+    # the wedged case. Reading None as "unknown, assume healthy" is what would
+    # keep the GPUs pinned.
+    ready = (status.ready_replicas if status else None) or 0
+    return desired > 0 and ready == 0
+
+
 def set_deployment_replicas(api, namespace: str, name: str, replicas: int) -> None:
     """Set a Deployment's replica count via the scale subresource.
 

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/scale_down_data_worker_if_idle_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/scale_down_data_worker_if_idle_activity.py
@@ -29,6 +29,7 @@ from temporalio.client import Client
 
 from fishsense_api_workflow_worker.activities.k8s_scaling import (
     apps_v1_api,
+    deployment_is_wedged,
     resolve_scaling_config,
     set_deployment_replicas,
 )
@@ -83,21 +84,49 @@ async def scale_down_data_worker_if_idle_activity() -> bool:
         )
         return False
 
-    if await _data_worker_task_queue_busy(config.idle_cooldown_minutes):
+    busy = await _data_worker_task_queue_busy(config.idle_cooldown_minutes)
+
+    def _sweep() -> str:
+        """Return the outcome: ``idle``, ``wedged`` or ``busy``.
+
+        One thread hop and one k8s client for the whole decision — the wedge
+        check and the scale call share both.
+        """
+        api = apps_v1_api(config.kubeconfig_path)
+        if busy and not deployment_is_wedged(
+            api, config.namespace, config.deployment_name
+        ):
+            return "busy"
+        outcome = "wedged" if busy else "idle"
+        set_deployment_replicas(api, config.namespace, config.deployment_name, 0)
+        return outcome
+
+    outcome = await asyncio.to_thread(_sweep)
+
+    if outcome == "busy":
         activity.logger.info(
-            "data-worker task queue still busy or within %d-minute cooldown; "
-            "leaving %s/%s replicas as-is",
+            "data-worker task queue still busy or within %d-minute cooldown "
+            "and the worker is healthy; leaving %s/%s replicas as-is",
             config.idle_cooldown_minutes,
             config.namespace,
             config.deployment_name,
         )
         return False
 
-    def _scale_to_zero() -> None:
-        api = apps_v1_api(config.kubeconfig_path)
-        set_deployment_replicas(api, config.namespace, config.deployment_name, 0)
+    if outcome == "wedged":
+        # WARNING, not info: reclaiming the pods bounds the cost but fixes
+        # nothing. Something is stopping the data-worker from starting, and the
+        # queue backlog this leaves behind is real work that is not happening.
+        activity.logger.warning(
+            "data-worker %s/%s has no Ready pod but its task queue is busy - "
+            "it cannot drain and was holding replicas for nothing; scaled to 0. "
+            "Check pod status (CrashLoopBackOff? expired Temporal cert? "
+            "unschedulable?) - the next parent with work will scale it back up.",
+            config.namespace,
+            config.deployment_name,
+        )
+        return True
 
-    await asyncio.to_thread(_scale_to_zero)
     activity.logger.info(
         "data-worker task queue idle; scaled %s/%s to 0",
         config.namespace,

--- a/services/fishsense-api-workflow-worker/tests/test_k8s_scaling.py
+++ b/services/fishsense-api-workflow-worker/tests/test_k8s_scaling.py
@@ -7,6 +7,7 @@ count, defaults) and the declarative replica-set call shape.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -88,3 +89,54 @@ def test_set_deployment_replicas_patches_scale_subresource():
     api.patch_namespaced_deployment_scale.assert_called_once_with(
         name="my-dep", namespace="my-ns", body={"spec": {"replicas": 0}}
     )
+
+
+class _Deployment:
+    """Minimal stand-in for V1Deployment's spec.replicas / status.ready_replicas."""
+
+    def __init__(self, desired, ready):
+        self.spec = SimpleNamespace(replicas=desired)
+        self.status = SimpleNamespace(ready_replicas=ready)
+
+
+def _api_returning(deployment):
+    api = MagicMock()
+    api.read_namespaced_deployment.return_value = deployment
+    return api
+
+
+@pytest.mark.parametrize(
+    "desired,ready,expected",
+    [
+        # The prod wedge, 2026-08-14 onward: two pods asked for, none ever Ready
+        # (CrashLoopBackOff on an expired Temporal cert). `ready_replicas` comes
+        # back as None, not 0 — k8s omits the field rather than zeroing it, and
+        # treating None as "unknown, assume healthy" is what would keep the
+        # GPUs pinned.
+        (2, None, True),
+        (2, 0, True),
+        (1, None, True),
+        # A worker that has Ready pods is doing its job, however busy.
+        (2, 1, False),
+        (2, 2, False),
+        (1, 1, False),
+        # Already scaled to zero: nothing is held, so there is nothing to
+        # reclaim and this must not read as a wedge (it would make the sweeper
+        # claim a scale-down it never performed).
+        (0, None, False),
+        (0, 0, False),
+        (None, None, False),
+    ],
+)
+def test_deployment_is_wedged(desired, ready, expected):
+    api = _api_returning(_Deployment(desired, ready))
+    assert (
+        k8s_scaling.deployment_is_wedged(api, "fishsense", "data-worker") is expected
+    )
+
+
+def test_deployment_is_wedged_tolerates_a_status_less_deployment():
+    """A freshly-created Deployment can come back with `status` unset."""
+    deployment = SimpleNamespace(spec=SimpleNamespace(replicas=2), status=None)
+    api = _api_returning(deployment)
+    assert k8s_scaling.deployment_is_wedged(api, "fishsense", "data-worker") is True

--- a/services/fishsense-api-workflow-worker/tests/test_k8s_scaling_integration.py
+++ b/services/fishsense-api-workflow-worker/tests/test_k8s_scaling_integration.py
@@ -129,16 +129,67 @@ async def test_scale_down_when_idle_zeroes_the_real_deployment(
     assert _replicas(kubeconfig, namespace) == 0
 
 
-async def test_scale_down_leaves_a_busy_deployment_alone(
+async def test_scale_down_leaves_a_busy_healthy_deployment_alone(
     configure_scaling, kubeconfig, namespace, monkeypatch
 ):
+    """Busy + able to make progress = leave it running.
+
+    `deployment_is_wedged` is stubbed False here because this cluster cannot
+    produce the honest version of "healthy": the Deployment requests
+    `nvidia.com/gpu: 1` with a compute-capability node affinity, and kind has
+    no GPU nodes, so its pods are permanently Unschedulable and never Ready.
+    That same fact is what makes the wedge test below real rather than
+    simulated.
+    """
     async def _busy(_cooldown: int) -> bool:
         return True
 
     monkeypatch.setattr(scale_down_mod, "_data_worker_task_queue_busy", _busy)
+    monkeypatch.setattr(scale_down_mod, "deployment_is_wedged", lambda *_a, **_k: False)
     _set_replicas(kubeconfig, namespace, 1)
     result = await ActivityEnvironment().run(
         scale_down_mod.scale_down_data_worker_if_idle_activity
     )
     assert result is False
     assert _replicas(kubeconfig, namespace) == 1
+
+
+async def test_deployment_is_wedged_against_a_real_apiserver(
+    configure_scaling, kubeconfig, namespace
+):
+    """Pins the field semantics the wedge check depends on.
+
+    The predicate hinges on `status.readyReplicas` being ABSENT (deserialized
+    as None) rather than 0 when nothing is Ready — a real apiserver is the only
+    thing that can confirm that, and reading None as "unknown, assume healthy"
+    is precisely what pinned prod's GPUs from 2026-08-14.
+    """
+    _set_replicas(kubeconfig, namespace, 1)
+    assert k8s_scaling.deployment_is_wedged(_api(kubeconfig), namespace, DEPLOYMENT)
+
+    # Scaled to zero, nothing is held, so there is nothing to reclaim.
+    _set_replicas(kubeconfig, namespace, 0)
+    assert not k8s_scaling.deployment_is_wedged(_api(kubeconfig), namespace, DEPLOYMENT)
+
+
+async def test_scale_down_reclaims_a_wedged_busy_deployment(
+    configure_scaling, kubeconfig, namespace, monkeypatch
+):
+    """End-to-end reproduction of the prod feedback loop, unmocked.
+
+    The queue reports busy AND the Deployment cannot produce a Ready pod — in
+    kind because the GPU request is unschedulable, in prod from 2026-08-14
+    because the Temporal client cert had expired and every pod crash-looped.
+    Before this behaviour existed the sweeper read "busy" and left the replicas
+    up, so the Deployment held NRP GPUs indefinitely while draining nothing.
+    """
+    async def _busy(_cooldown: int) -> bool:
+        return True
+
+    monkeypatch.setattr(scale_down_mod, "_data_worker_task_queue_busy", _busy)
+    _set_replicas(kubeconfig, namespace, 2)
+    result = await ActivityEnvironment().run(
+        scale_down_mod.scale_down_data_worker_if_idle_activity
+    )
+    assert result is True
+    assert _replicas(kubeconfig, namespace) == 0

--- a/services/fishsense-api-workflow-worker/tests/test_scale_down_data_worker_if_idle_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_scale_down_data_worker_if_idle_activity.py
@@ -53,18 +53,51 @@ async def test_noop_when_scaling_disabled(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_does_not_scale_down_when_busy(monkeypatch):
+async def test_does_not_scale_down_when_busy_and_worker_is_healthy(monkeypatch):
+    """Busy + a Ready pod = real work in flight. Leave it alone."""
     monkeypatch.setattr(sut, "resolve_scaling_config", lambda: _config())
     _stub_busy(monkeypatch, True)
+    monkeypatch.setattr(sut, "apps_v1_api", lambda path: MagicMock())
+    monkeypatch.setattr(sut, "deployment_is_wedged", lambda *_a, **_k: False)
     monkeypatch.setattr(
         sut,
         "set_deployment_replicas",
-        lambda *_a, **_k: pytest.fail("must not scale a busy data-worker"),
+        lambda *_a, **_k: pytest.fail("must not scale a busy, healthy data-worker"),
     )
     result = await ActivityEnvironment().run(
         sut.scale_down_data_worker_if_idle_activity
     )
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_scales_down_a_wedged_worker_even_though_the_queue_looks_busy(
+    monkeypatch,
+):
+    """The feedback loop this exists to break.
+
+    A data-worker that cannot produce a Ready pod (expired Temporal cert, bad
+    image, unschedulable) never drains its queue — so every dispatched child
+    sits Running, the queue never looks idle, and the Deployment stays pinned at
+    `active_replicas` holding GPUs around the clock. Exactly the state prod was
+    in from 2026-08-14. "Busy" is only a reason to keep the pods when the pods
+    can actually make progress.
+    """
+    monkeypatch.setattr(sut, "resolve_scaling_config", lambda: _config())
+    _stub_busy(monkeypatch, True)
+    monkeypatch.setattr(sut, "apps_v1_api", lambda path: MagicMock())
+    monkeypatch.setattr(sut, "deployment_is_wedged", lambda *_a, **_k: True)
+    calls: list = []
+    monkeypatch.setattr(
+        sut,
+        "set_deployment_replicas",
+        lambda a, ns, name, n: calls.append((ns, name, n)),
+    )
+    result = await ActivityEnvironment().run(
+        sut.scale_down_data_worker_if_idle_activity
+    )
+    assert result is True
+    assert calls == [("fishsense", "fishsense-data-processing-workflow-worker", 0)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The data-worker has been down since **2026-08-14** and its Deployment pinned at 2 replicas, holding NRP GPUs around the clock. Two independent gaps, one visible symptom: the v2.15.2 Deploy job timing out on `kubectl rollout status`.

## 1. The cert expired and nothing renewed it

The krg-prod Temporal leaf is a 7-day cert. #570 automated rotation **for the slot** — vault-agent re-renders it, `temporal.reload` restarts the two compose services that hold it. The data-worker runs on NRP, out of vault-agent's reach, holding the **same** identity in a k8s Secret hand-minted at `ttl=720h` and renewed by nobody:

```
subject=CN=fishsense-worker
notAfter=Aug 14 05:46:26 2026 GMT     <-- expired
```

Every pod has crash-looped on `received fatal alert: CertificateExpired` since (~565 restarts each), which is why the rollout could never converge.

(The README's claim that this was "the data-worker's OWN identity, distinct from the api-worker's" was wrong — krg issues `common_name=<tenant>-worker`, so both are `CN=fishsense-worker`. Corrected here.)

`deploy/incus/nrp_cert_sync/` closes the gap: a one-shot `alpine/kubectl` compose service, listed in `temporal.reload`, that upserts the Secret from `/run/tenant/temporal/*` and rolls the Deployment. The hook is `docker compose ... restart <svc>`, which starts an exited container again, so each rotation re-runs it; it no-ops on an unchanged leaf via a sha256 annotation, so it's free on every converge.

kubectl works here where our Python client can't: Go's `crypto/x509` doesn't require an Authority Key Identifier, and NRP's CA has none.

## 2. Scale-to-zero — the TLS diagnosis was wrong

Scale-to-zero was **not** broken by TLS. #273's `_relax_x509_strict_verification` works; verified in prod, where both activities log real 200s against NRP every hour. The earlier diagnosis used a raw `kubernetes` client, which tests the library's defaults rather than our code — differing by exactly the thing under investigation.

The real defect: the sweeper can't tell **busy** from **wedged**. A data-worker that can't start never drains its queue, so dispatched children sit `Running` until they time out, the queue never looks idle, and the Deployment stays pinned at `active_replicas` getting nothing done. *The failure suppressed the cleanup that would have bounded its cost.*

`k8s_scaling.deployment_is_wedged` — `spec.replicas > 0` and no Ready replica — now lets the sweeper reclaim those pods, logging a WARNING since this bounds waste without fixing anything.

The signal was chosen by **measuring the live wedge**, not assumed:

| Signal | Verdict |
|---|---|
| `readyReplicas` | **absent**, not `0`, when nothing is Ready — reading `None` as "assume healthy" is what pinned the GPUs |
| `Progressing` | `True`/`NewReplicaSetAvailable` throughout — the ReplicaSet *had* progressed, months earlier |
| `Available.lastTransitionTime` | flaps every few seconds — no readinessProbe, so each crash cycle briefly goes Ready |
| pod-level (restartCount) | richer, but the deploy identity has **no `pods` RBAC** |

Being time-free leaves one false positive — a sweep inside a genuine cold start — which costs an hour, not correctness: scale-up is parent-driven and the activities are idempotent. `ensure_data_worker_running_activity` deliberately still never refuses to scale up, so recovery stays automatic.

## 3. CI stops being opaque

`deploy.yml` now preflights the leaf's expiry and fails **by name in seconds**:

```
::error::The data-worker's Temporal client cert EXPIRED on Aug 14 05:46:26 2026 GMT.
```

plus a `::warning::` when it has to recreate a Deployment NRP's 2-week GC collected (it had — `creationTimestamp` 2026-08-17 against July ConfigMaps), and a pod state / events / previous-container-logs dump on any rollout failure. `rollout status` timing out is not a diagnosis; it reads identically for an expired cert, an OOMKill, an unschedulable GPU request and a quota denial.

## Testing

Against real clusters, not mocks. The forwarder's 6 cases and the 5 k8s integration tests run against kind, where the wedge case is **genuine rather than simulated** — the GPU request makes pods `Unschedulable`, so `readyReplicas` really is absent. 429 api-worker unit tests pass, pylint 10.00/10, shellcheck and yamllint clean.

Testing found two real bugs, both now covered:
- `kubectl rollout restart` errors if triggered twice inside one second, which aborted the sync under `set -e`.
- `bitnami/kubectl` no longer exists on Docker Hub (2025 policy change).

## Deploying

The two halves ship by **different routes**:
- The api-worker change (wedge reclaim) rides the normal release → promote → auto-deploy chain.
- `flake.nix` + `compose.yml` (cert forwarding) cut no release and open no `auto-deploy/*` PR — they need a manual `deploy.yml` dispatch with `target: incus`, or the nightly `autoUpgrade`.

**No cert needs minting.** The slot already holds a valid auto-renewing leaf, so converging the forwarder recovers the data-worker on its own.

Still worth chasing separately: the NRP permanent-service exception for the `e4e-fishsense` namespace (Matrix, https://nrp.ai/contact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)