### PR TITLE
fix(incus): symlink nrp_cert_sync into the compose project dir

### DIFF
--- a/deploy/incus/compose.yml
+++ b/deploy/incus/compose.yml
@@ -274,10 +274,16 @@ services:
   # every rotation re-runs this. It also runs on each converge — a no-op when the
   # leaf is unchanged (sync.sh compares a sha256 annotation before touching anything).
   #
-  # Not on the `interior` network: it needs egress to the NRP API server, not to the
-  # other containers. Go's crypto/x509 is also why kubectl works here at all — the
-  # api-worker's Python client can't reach the same endpoint, because OpenSSL 3.5
-  # rejects NRP's CA for carrying no Authority Key Identifier.
+  # On `interior` for its egress, same as the api-worker — which reaches this exact
+  # NRP endpoint from it today, so the path is proven. (It needs nothing FROM the
+  # other containers.) Go's crypto/x509 is why kubectl works here at all: it does
+  # not require an Authority Key Identifier and NRP's cluster CA has none, which is
+  # what a default-context Python client trips over.
+  #
+  # `./nrp_cert_sync` resolves against the compose PROJECT DIRECTORY
+  # (/var/lib/krg/fishsense), not this file's store path — workdir.nix symlinks it
+  # there. Miss that and docker silently creates an empty dir and the container
+  # exits on a missing script.
   nrp-temporal-cert-sync:
     image: alpine/kubectl:1.34.1
     restart: "no"
@@ -288,6 +294,7 @@ services:
       - /run/tenant/temporal:/run/tenant/temporal:ro
       # NRP kubeconfig (vault-agent SOFT render). sync.sh exits 0 when it's absent.
       - /run/tenant/nrp:/run/tenant/nrp:ro
+    networks: [interior]
 
   # ── in-slot Postgres: `fishsense` + `superset` DBs only (temporal_db moved to krg-prod) ─
   postgres:

--- a/deploy/incus/workdir.nix
+++ b/deploy/incus/workdir.nix
@@ -22,6 +22,11 @@
     "L+ /var/lib/krg/fishsense/superset_volumes       - - - - ${./superset_volumes}"
     "L+ /var/lib/krg/fishsense/pg_volumes             - - - - ${./pg_volumes}"
     "L+ /var/lib/krg/fishsense/fishsense_api_volumes  - - - - ${./fishsense_api_volumes}"
+    # nrp-temporal-cert-sync's script, mounted :ro at /sync. Easy to forget and
+    # SILENT when you do: docker creates a missing bind source as an empty dir,
+    # so the container would come up with no /sync/sync.sh and exit non-zero
+    # rather than failing the converge.
+    "L+ /var/lib/krg/fishsense/nrp_cert_sync          - - - - ${./nrp_cert_sync}"
     # worker: config is read-only (symlink), logs are read-write (real dir)
     "d  /var/lib/krg/fishsense/worker_volumes                       0755 root root -"
     "d  /var/lib/krg/fishsense/worker_volumes/api_worker            0755 root root -"


### PR DESCRIPTION
Follow-up to #575, which merged with only its first commit — this fix was pushed to the branch moments after the merge and never landed. **Without it the cert forwarder from #575 is a no-op that looks deployed**, so this should go in before the next `deploy.yml` converge.

## The bug

The krg composeStack runner invokes compose with `--project-directory /var/lib/krg/fishsense`, so the `./nrp_cert_sync` bind in `compose.yml` resolves **there** — not against the compose file's Nix store path. That directory is populated by `deploy/incus/workdir.nix`, which symlinks every other relative bind (`traefik-dynamic.yml`, `pg_volumes`, `worker_volumes/*/config`, …) into place. I added the compose service in #575 but not the corresponding `workdir.nix` entry.

The failure mode is silent, which is what makes it worth a dedicated PR: docker creates a missing bind source as an **empty directory** rather than erroring. The container would have started with no `/sync/sync.sh`, exited non-zero, and left the Temporal leaf un-forwarded — while `fishsense-selfupdate` reported success and the data-worker stayed in `CrashLoopBackOff`. That is precisely the "green deploy, nothing deployed" shape CLAUDE.md warns about.

## Verification

By evaluating the flake, not by assuming:

```
$ nix eval .#nixosConfigurations.fishsense.config.systemd.tmpfiles.rules
"L+ /var/lib/krg/fishsense/nrp_cert_sync - - - - /nix/store/1sk9...-nrp_cert_sync"

$ ls /nix/store/1sk9...-nrp_cert_sync/
sync.sh  test_sync.sh
```

Evaluated on top of current `main` (i.e. after #577), so it composes with what's there now.

## Also

Moves the service onto the `interior` network instead of relying on an auto-created default. The api-worker reaches this same NRP endpoint from `interior` today, so the path is proven; the isolation argument for a separate network was marginal for a service that only ever makes outbound calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)