### PR TITLE
fix(k8s): let the deploy identity write the Temporal cert Secret

### DIFF
--- a/deploy/k8s/data-worker/deployer-rbac.yaml
+++ b/deploy/k8s/data-worker/deployer-rbac.yaml
@@ -2,11 +2,15 @@
 #
 # This is OPERATOR bootstrap, applied out-of-band with an interactive
 # (kubelogin/OIDC) kubeconfig — NOT part of `kustomization.yaml`. It is
-# deliberately excluded because the ServiceAccount it defines can only
-# touch deployments/scale/configmaps (see the Role below); it cannot
-# create serviceaccounts, roles, or secrets, so CI (which authenticates
-# AS this SA) could never apply this file. Chicken-and-egg: a human with
-# cluster-admin applies this once, then everything else is non-interactive.
+# deliberately excluded because the ServiceAccount it defines cannot
+# create serviceaccounts or roles (see the Role below), so CI (which
+# authenticates AS this SA) could never apply this file. Chicken-and-egg:
+# a human with cluster-admin applies this once, then everything else is
+# non-interactive.
+#
+# RE-APPLY THIS when the Role below changes — it is the one file here that
+# `kubectl apply -k` does NOT pick up, so a rule added in git is inert until
+# an operator runs the command below by hand.
 #
 #   kubectl apply -f deploy/k8s/data-worker/deployer-rbac.yaml
 #
@@ -32,7 +36,10 @@ metadata:
 #    succeeds but `rollout status` fails "cannot watch resource deployments".
 #  - api-worker scaling: get/patch on deployments/scale (ensure_data_worker_
 #    running_activity scales up; ScaleDownIdleDataWorkerWorkflow to 0).
-# No secrets, no serviceaccounts, no cluster-scoped verbs — least privilege.
+#  - the slot's nrp-temporal-cert-sync (deploy/incus/nrp_cert_sync/): upserts
+#    the Temporal client cert Secret. See the secrets rules for why they are
+#    split in two.
+# No serviceaccounts, no roles, no cluster-scoped verbs — least privilege.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -48,6 +55,26 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "create", "update", "patch"]
+  # Secrets are split across two rules on purpose, and the split is the whole
+  # point: this identity must be able to WRITE the Temporal leaf without being
+  # able to READ `fishsense-data-worker-secrets`, which holds the fishsense-api
+  # password and the Garage S3 key/secret.
+  #
+  # RBAC cannot scope `create` by name (there is no object to name yet), so it
+  # stays unrestricted — that permits creating some new Secret, but still never
+  # reading an existing one.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  # Everything that can read or overwrite an EXISTING Secret is pinned to the
+  # one name the forwarder owns. `kubectl apply` needs get (to diff) + patch;
+  # `kubectl annotate` needs get + patch; update covers the replace path.
+  # No `list` — list cannot be name-scoped, so granting it would hand over
+  # every Secret in the namespace and undo the split above.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["fishsense-data-worker-temporal-certs"]
+    verbs: ["get", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Found by converging: the cert forwarder from #575 upserts `fishsense-data-worker-temporal-certs` as the `fishsense-deployer` ServiceAccount, which had **no `secrets` access at all**. The first converge failed with:

```
secrets "fishsense-data-worker-temporal-certs" is forbidden:
User "system:serviceaccount:e4e-fishsense:fishsense-deployer"
cannot get resource "secrets" in API group "" in the namespace "e4e-fishsense"
```

My miss — I audited this Role for `pods` access while designing `deployment_is_wedged` and didn't notice the forwarder needs `secrets`. It failed loudly and before doing damage, and `restart: "no"` meant nothing else in the stack was affected.

## The grant is split in two on purpose

This identity must be able to **write** the Temporal leaf without being able to **read** `fishsense-data-worker-secrets`, which holds the fishsense-api password and the Garage S3 key/secret.

- `get`/`patch`/`update` are pinned to the single `resourceName` the forwarder owns.
- `list` is omitted entirely — it cannot be name-scoped, so granting it would expose every Secret in the namespace and undo the split.
- `create` cannot be name-scoped either (there's no object to name yet), so it stays open. That permits creating *a* new Secret but never reading an existing one.

Verified against the live cluster after applying:

```
SA get/patch/update secrets/fishsense-data-worker-temporal-certs -> yes
SA create secrets                                                -> yes
SA get    secrets/fishsense-data-worker-secrets                  -> no
SA get    secrets/fishsense-deployer-token                       -> no
SA list   secrets                                                -> no
```

## Already applied

This file is **operator-applied out-of-band** — it is deliberately not in `kustomization.yaml`, so CI never applies it. I applied it by hand with an interactive kubeconfig, then re-ran the forwarder through the real `docker compose ... restart nrp-temporal-cert-sync` rotation path:

```
[nrp-temporal-cert-sync] pushing rotated leaf to e4e-fishsense/...
secret/fishsense-data-worker-temporal-certs configured
secret/fishsense-data-worker-temporal-certs annotated
[nrp-temporal-cert-sync] rolling fishsense-data-processing-workflow-worker onto the new leaf
[nrp-temporal-cert-sync] done
```

The data-worker is now up on a valid leaf (`notAfter=Aug 27 22:30:15 2026 GMT`) with **0 restarts**, after six days of `CrashLoopBackOff`.

So this PR brings git in step with the cluster rather than changing it. It also adds a note that the file must be re-applied by hand whenever the Role changes — the exact trap that caused this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)