### PR TITLE
chore(k8s): hold a single data-worker GPU on NRP

### DIFF
--- a/deploy/incus/worker_volumes/api_worker/config/settings.toml
+++ b/deploy/incus/worker_volumes/api_worker/config/settings.toml
@@ -77,11 +77,24 @@ labels_prefix = "fishsense-lite"
 kubeconfig_path = "/run/tenant/nrp/kubeconfig"
 namespace = "e4e-fishsense"
 deployment_name = "fishsense-data-processing-workflow-worker"
-# 2 replicas (clamped range is [1, 4]). Deliberate operator choice, paired
-# with dropping the data-worker's `general.max_concurrent_activities` 4 -> 2
-# after the 2026-07-21 OOM CrashLoopBackOff: per-pod peak memory is halved,
-# and the lost throughput is recovered horizontally instead of by packing
-# more concurrent full-res rawpy decodes into one pod. Also buys active-window
-# resilience on a preemption-prone cluster.
-active_replicas = 2
+# 1 replica (clamped range is [1, 4]) — one pod, and since the Deployment
+# requests `nvidia.com/gpu: 1` per pod, exactly one GPU held while active.
+# Operator choice 2026-08-20: hold a single GPU on NRP for now.
+#
+# This was 2, paired with dropping the data-worker's
+# `general.max_concurrent_activities` 4 -> 2 after the 2026-07-21 OOM
+# CrashLoopBackOff — per-pod peak memory halved, throughput recovered
+# horizontally rather than by packing more concurrent full-res rawpy decodes
+# into one pod. Going back to 1 gives up that horizontal half, so a large dive
+# takes roughly twice as long; it does NOT reintroduce the OOM, which is
+# governed by max_concurrent_activities and is unchanged.
+#
+# It also removes a live scheduling problem: at 2 the second pod sat Pending on
+# `129 Insufficient nvidia.com/gpu` (2026-08-20), so the GPU was requested and
+# queued for without being used — NRP is GPU-contended and the only consumer of
+# that request, the slate detector, has been retired since 2026-08-03.
+#
+# Raise back to 2-4 for a giant single dive, or for active-window resilience on
+# a preemption-prone cluster. Never automatic.
+active_replicas = 1
 idle_cooldown_minutes = 15


### PR DESCRIPTION
Drops `kubernetes.active_replicas` **2 → 1**. Each pod requests `nvidia.com/gpu: 1`, so this is one GPU held during an active window instead of two.

## What we give up

The `2` was deliberate, not a default: it was paired with dropping the data-worker's `general.max_concurrent_activities` 4 → 2 after the 2026-07-21 OOM `CrashLoopBackOff`, recovering throughput *horizontally* rather than by packing more concurrent full-res rawpy decodes into one pod.

So a large dive now takes roughly twice as long. Worth knowing there's a **six-day backlog** still draining from the cert outage, and this halves the rate it clears at.

It does **not** reintroduce the OOM — peak per-pod memory is governed by `max_concurrent_activities`, which is unchanged.

## What we gain, beyond the GPU

This fixes a live scheduling problem, not just cost. At 2 replicas the second pod sat Pending on:

```
0/529 nodes are available: ... 129 Insufficient nvidia.com/gpu
```

NRP is GPU-contended, and the sole consumer of that GPU request — the slate detector — has been **retired since 2026-08-03**. So the second replica was queueing for a GPU it would never have used.

That points at a larger cleanup worth doing separately: the `nvidia.com/gpu: 1` request, the `nvidia.com/gpu` toleration, and the SM ≥ 7.5 node affinity in `deployment.yaml` are all dead weight now, and dropping them would let the worker schedule on ordinary CPU nodes. I've left them alone here because that's a bigger change than the one asked for.

## Deploying

Config-only, so this cuts no release and opens no `auto-deploy/*` PR — it reaches the slot via a manual `deploy.yml` dispatch (`target: incus`) or the nightly autoUpgrade.

Scaling the Deployment by hand first would not stick: until the api-worker re-reads this file, `ensure_data_worker_running_activity` scales it back to `active_replicas` on the next parent firing.

Raise back to 2–4 for a giant single dive, or for active-window resilience on a preemption-prone cluster. Never automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)