### PR TITLE
fix(cohort): correlate the resolved-extrinsics subquery to the outer dive

### DIFF
--- a/services/fishsense-api/src/fishsense_api/controllers/dive_cohort_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_cohort_controller.py
@@ -176,14 +176,31 @@ def _resolved_laser_extrinsics_id():
     really use. `uq_laserextrinsics_dive_id` guarantees at most one row per
     dive, so neither branch needs a tie-break.
     """
+    # `.correlate(Dive)` is load-bearing, not decoration. This subquery is
+    # used inside a NOT EXISTS several levels down, and SQLAlchemy only
+    # auto-correlates against the *immediately* enclosing SELECT — so without
+    # it the compiler emits `FROM laserextrinsics, dive`, an uncorrelated
+    # cross join returning one row per extrinsics row in the table.
+    #
+    # Postgres rejects that with CardinalityViolationError ("more than one row
+    # returned by a subquery used as an expression"), which took both cohort
+    # selectors down in prod on 2026-08-20: every hourly poll 500'd, stage 14
+    # stamped no provenance at all, and the laser-depth stage drained one dive
+    # and then stopped. SQLite returns the first row instead of raising, so
+    # the unit suite could not see it — `test_resolved_extrinsics_subquery_is_correlated`
+    # now asserts the emitted SQL directly, and a sibling test seeds a second
+    # extrinsics row so the uncorrelated form picks the wrong dive's
+    # calibration even on SQLite.
     own = (
         select(LaserExtrinsics.id)
         .where(LaserExtrinsics.dive_id == Dive.id)
+        .correlate(Dive)
         .scalar_subquery()
     )
     borrowed = (
         select(LaserExtrinsics.id)
         .where(LaserExtrinsics.dive_id == Dive.calibration_dive_id)
+        .correlate(Dive)
         .scalar_subquery()
     )
     return func.coalesce(own, borrowed)
@@ -824,6 +841,19 @@ async def select_next_for_laser_depth(
     laser was validated, which is the whole reason it is stored per image
     rather than hung off `Measurement`.
     """
+    return (await session.exec(_laser_depth_cohort_query())).first()
+
+
+def _laser_depth_cohort_query():
+    """The laser-depth cohort as a query, separate from executing it.
+
+    Split out so `test_resolved_extrinsics_subquery_is_correlated` can compile
+    the *real* query and assert its shape. That guard has to see the actual
+    nesting — the correlation bug it exists to catch only appears when the
+    scalar subquery sits several levels inside a NOT EXISTS, so a synthetic
+    one-level query rebuilt in the test would pass while the shipped one was
+    broken.
+    """
     has_laser_extrinsics = or_(
         select(LaserExtrinsics.id).where(LaserExtrinsics.dive_id == Dive.id).exists(),
         select(LaserExtrinsics.id)
@@ -846,7 +876,7 @@ async def select_next_for_laser_depth(
         .where(~depth_is_current)
         .exists()
     )
-    query = (
+    return (
         select(Dive.id)
         .where(Dive.priority == Priority.HIGH)
         .where(has_laser_extrinsics)
@@ -854,4 +884,3 @@ async def select_next_for_laser_depth(
         .order_by(Dive.id)
         .limit(1)
     )
-    return (await session.exec(query)).first()

--- a/services/fishsense-api/tests/test_measurement_calibration_provenance.py
+++ b/services/fishsense-api/tests/test_measurement_calibration_provenance.py
@@ -171,3 +171,68 @@ async def test_cohort_resolves_provenance_through_a_borrowed_calibration(session
     await session.flush()
 
     assert await select_next_for_measure_fish(session=session) is None
+
+
+# ── the correlation bug ───────────────────────────────────────────────
+#
+# `_resolved_laser_extrinsics_id()` is a scalar subquery used deep inside a
+# NOT EXISTS. SQLAlchemy only auto-correlates against the *immediately*
+# enclosing SELECT, so without an explicit `.correlate(Dive)` it emitted
+# `FROM laserextrinsics, dive` — an uncorrelated cross join returning one row
+# per extrinsics row in the table.
+#
+# Postgres rejects that outright (CardinalityViolationError: "more than one
+# row returned by a subquery used as an expression"), which took both cohort
+# selectors down in prod: every hourly poll 500'd, stage 14 stamped no
+# provenance, and the laser-depth stage drained exactly one dive before
+# stopping. SQLite silently returns the first row instead of raising, and
+# every fixture here seeded a single extrinsics row, so the wrong SQL and the
+# right SQL agreed and the suite stayed green.
+#
+# These two tests close that gap from both directions: one seeds a second
+# extrinsics row so the uncorrelated form picks the *wrong* dive's
+# calibration even on SQLite, and one asserts the emitted SQL is correlated
+# regardless of dialect.
+
+
+async def test_cohort_resolves_each_dives_own_calibration_not_the_first_row(session):
+    """Two calibrated dives, and the one under test is NOT the lowest id.
+
+    Uncorrelated, `coalesce(...)` returns extrinsics 51 (dive 1's, the first
+    row in the table) for every dive, so dive 2's correctly-stamped
+    measurement looks stale and the dive is re-selected forever.
+    """
+    session.add_all([_dive(1), _dive(2), _extrinsics(51, 1), _extrinsics(52, 2)])
+    _measurable_image(session, 21, 2)
+    session.add(_measurement(21, laser_extrinsics_id=52))
+    await session.flush()
+
+    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_measure_fish,
+    )
+
+    assert await select_next_for_measure_fish(session=session) is None
+
+
+def test_resolved_extrinsics_subquery_is_correlated():
+    """Dialect-independent guard on the shape of the shipped SQL.
+
+    Compiles the real cohort query — the nesting matters, since the bug only
+    appears when the scalar subquery sits inside a NOT EXISTS inside an
+    EXISTS. The subquery must *reference* the outer `dive`, never select from
+    it. This is the assertion that would have caught the prod outage without
+    a Postgres to run against.
+    """
+    from sqlalchemy.dialects import postgresql  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+        _laser_depth_cohort_query,
+    )
+
+    compiled = str(_laser_depth_cohort_query().compile(dialect=postgresql.dialect()))
+
+    assert "FROM laserextrinsics, dive" not in compiled, (
+        "scalar subquery is uncorrelated — it cross-joins dive and returns one "
+        f"row per extrinsics row, which Postgres rejects:\n{compiled}"
+    )
+    assert "laserextrinsics.dive_id = dive.id" in compiled


### PR DESCRIPTION
## The outage

Both cohort selectors have been returning **500** in prod since `fishsense-api` v1.47.0 deployed yesterday.

```
asyncpg.exceptions.CardinalityViolationError:
  more than one row returned by a subquery used as an expression
```

`_resolved_laser_extrinsics_id()` is a scalar subquery used inside a `NOT EXISTS` inside an `EXISTS`. SQLAlchemy only auto-correlates against the *immediately* enclosing SELECT, so it compiled to:

```sql
coalesce((SELECT laserextrinsics.id FROM laserextrinsics, dive
          WHERE laserextrinsics.dive_id = dive.id), ...)
```

`FROM laserextrinsics, **dive**` is an uncorrelated cross join — one row per extrinsics row in the table (13 in prod). Postgres rejects a multi-row scalar subquery outright.

## Impact, measured on the slot

| | |
|---|---|
| `GET /dives/select-next/laser-depth/` | 500 on every hourly poll |
| `GET /dives/select-next/measure-fish/` | 500 × 21 in 24h |
| `laserdepth` rows | 25 — dive 58 only, complete, then nothing |
| dives still needing depth | 19 (~1100 eligible images) |
| `measurement.laser_extrinsics_id` stamped | **0 of 590** |
| `dive_pipeline_status.measured` true | 0 dives |

Nothing was written incorrectly — both stages simply could not *select*. Dive 58 got its 25 depths during the deploy window before the first poll failed, and it's 25/25, so the stage itself is correct.

## The fix

`.correlate(Dive)` on both branches of the coalesce.

## Why the tests missed it, and what now catches it

SQLite answers a multi-row scalar subquery with the first row instead of raising, and every fixture seeded exactly one `laserextrinsics` row — so the uncorrelated and correlated forms agreed and the suite stayed green.

Two regression tests, deliberately from different angles:

1. **Behavioural, and it fails on SQLite.** Seeds a *second* extrinsics row and puts the dive under test second, so the uncorrelated form resolves the wrong dive's calibration and mis-selects.
2. **Structural, dialect-independent.** Compiles the real cohort query and asserts the subquery references `dive` rather than selecting from it.

For (2) the cohort query moved into `_laser_depth_cohort_query()` so the guard compiles what actually ships, nesting included — I first wrote it against a synthetic one-level query, which auto-correlates and passed while the shipped query was broken.

## Verification

Ran the corrected SQL read-only against the **prod** database: returns dive 59 instead of raising. Full workspace green, pylint 10.00.

## After deploy

Both stages resume at their normal cadence, one dive per hour: ~19 hours to clear the depth backlog, ~13 to stamp provenance across the measured dives. `measured` returns to true per dive as stage 14 revisits it. No manual backfill needed — the cohorts were designed to drain, they just couldn't be queried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)