### PR TITLE
fix(cohort): key the laser-depth cohort on the image, not one laser label

### DIFF
--- a/services/fishsense-api/src/fishsense_api/controllers/dive_cohort_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_cohort_controller.py
@@ -28,6 +28,7 @@ from typing import List
 
 from fastapi import Depends
 from sqlalchemy import and_, func, or_
+from sqlalchemy.orm import aliased
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -860,11 +861,36 @@ def _laser_depth_cohort_query():
         .where(LaserExtrinsics.dive_id == Dive.calibration_dive_id)
         .exists(),
     )
+    # "Does this IMAGE have a current depth", not "does this LABEL have one".
+    #
+    # `LaserDepth` is one row per image (`uq_laser_depth_image`) while an image
+    # can carry several *valid* laser labels — 461 images across 8 prod dives
+    # do, nearly all duplicate labels of the same dot. Keying on the specific
+    # label meant the row's `laser_label_id` matched one of them and never the
+    # others, so the image was permanently "needing depth": prod dive 279 had
+    # all 44 of its depths written and was still selected on 27 consecutive
+    # runs, blocking every higher-id dive behind it.
+    #
+    # Staleness is preserved by requiring the recorded label to still be
+    # valid: a superseded or replaced label makes the depth stale exactly as
+    # before, and a recalibration still mismatches on the extrinsics id.
+    recorded_label = aliased(LaserLabel)
     depth_is_current = (
         select(LaserDepth.id)
         .where(LaserDepth.image_id == Image.id)
-        .where(LaserDepth.laser_label_id == LaserLabel.id)
         .where(LaserDepth.laser_extrinsics_id == _resolved_laser_extrinsics_id())
+        .where(
+            select(recorded_label.id)
+            .where(recorded_label.id == LaserDepth.laser_label_id)
+            .where(recorded_label.image_id == Image.id)
+            .where(
+                recorded_label.completed == True,
+                recorded_label.superseded == False,
+                recorded_label.x != None,
+                recorded_label.y != None,
+            )
+            .exists()
+        )
         .exists()
     )
     has_image_needing_depth = (

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_cohort_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_cohort_controller.py
@@ -176,14 +176,31 @@ def _resolved_laser_extrinsics_id():
     really use. `uq_laserextrinsics_dive_id` guarantees at most one row per
     dive, so neither branch needs a tie-break.
     """
+    # `.correlate(Dive)` is load-bearing, not decoration. This subquery is
+    # used inside a NOT EXISTS several levels down, and SQLAlchemy only
+    # auto-correlates against the *immediately* enclosing SELECT — so without
+    # it the compiler emits `FROM laserextrinsics, dive`, an uncorrelated
+    # cross join returning one row per extrinsics row in the table.
+    #
+    # Postgres rejects that with CardinalityViolationError ("more than one row
+    # returned by a subquery used as an expression"), which took both cohort
+    # selectors down in prod on 2026-08-20: every hourly poll 500'd, stage 14
+    # stamped no provenance at all, and the laser-depth stage drained one dive
+    # and then stopped. SQLite returns the first row instead of raising, so
+    # the unit suite could not see it — `test_resolved_extrinsics_subquery_is_correlated`
+    # now asserts the emitted SQL directly, and a sibling test seeds a second
+    # extrinsics row so the uncorrelated form picks the wrong dive's
+    # calibration even on SQLite.
     own = (
         select(LaserExtrinsics.id)
         .where(LaserExtrinsics.dive_id == Dive.id)
+        .correlate(Dive)
         .scalar_subquery()
     )
     borrowed = (
         select(LaserExtrinsics.id)
         .where(LaserExtrinsics.dive_id == Dive.calibration_dive_id)
+        .correlate(Dive)
         .scalar_subquery()
     )
     return func.coalesce(own, borrowed)
@@ -824,6 +841,19 @@ async def select_next_for_laser_depth(
     laser was validated, which is the whole reason it is stored per image
     rather than hung off `Measurement`.
     """
+    return (await session.exec(_laser_depth_cohort_query())).first()
+
+
+def _laser_depth_cohort_query():
+    """The laser-depth cohort as a query, separate from executing it.
+
+    Split out so `test_resolved_extrinsics_subquery_is_correlated` can compile
+    the *real* query and assert its shape. That guard has to see the actual
+    nesting — the correlation bug it exists to catch only appears when the
+    scalar subquery sits several levels inside a NOT EXISTS, so a synthetic
+    one-level query rebuilt in the test would pass while the shipped one was
+    broken.
+    """
     has_laser_extrinsics = or_(
         select(LaserExtrinsics.id).where(LaserExtrinsics.dive_id == Dive.id).exists(),
         select(LaserExtrinsics.id)
@@ -846,7 +876,7 @@ async def select_next_for_laser_depth(
         .where(~depth_is_current)
         .exists()
     )
-    query = (
+    return (
         select(Dive.id)
         .where(Dive.priority == Priority.HIGH)
         .where(has_laser_extrinsics)
@@ -854,4 +884,3 @@ async def select_next_for_laser_depth(
         .order_by(Dive.id)
         .limit(1)
     )
-    return (await session.exec(query)).first()

--- a/services/fishsense-api/tests/test_api_postgres_integration.py
+++ b/services/fishsense-api/tests/test_api_postgres_integration.py
@@ -345,3 +345,166 @@ def test_a_healthy_database_is_not_rebuilt_on_every_restart():
         db_module._create_all_views = original  # pylint: disable=protected-access
 
     assert not calls
+
+
+# ── cohort selectors, on the database they actually run against ───────
+#
+# The unit suite exercises these on in-memory SQLite, which cannot see two
+# whole classes of bug that prod hit within a day of each other:
+#
+#   * SQLite answers a multi-row scalar subquery with its first row; Postgres
+#     raises CardinalityViolationError. An uncorrelated
+#     `_resolved_laser_extrinsics_id()` therefore passed every unit test and
+#     500'd both selectors in prod on every hourly poll.
+#   * Every unit fixture seeds one row where prod has many — one
+#     `laserextrinsics` per dive, one valid laser label per image. Prod has
+#     461 images carrying two valid labels, which wedged the laser-depth
+#     cohort on dive 279 forever.
+#
+# So the seed below is deliberately *multi-valued*: two calibrated dives and
+# an image with two valid laser labels. Both bugs are visible here and
+# invisible on a single-row SQLite fixture.
+
+
+def _cohort_selectors() -> list:
+    """Every cohort selector, discovered rather than listed.
+
+    A registry property in the spirit of
+    `test_canonical_only_pipeline_work.py`: a selector added later is covered
+    by this the day it lands, instead of the day someone remembers to add it.
+    """
+    import inspect  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api.controllers import (  # pylint: disable=import-outside-toplevel
+        dive_cohort_controller,
+    )
+
+    return sorted(
+        (name, fn)
+        for name, fn in inspect.getmembers(dive_cohort_controller, inspect.iscoroutinefunction)
+        if name.startswith("select_next_for_") or name.startswith("select_dives_")
+    )
+
+
+async def _seed_multi_valued(session) -> None:
+    """A dive population with the multiplicity prod actually has."""
+    from datetime import datetime, timezone  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_extrinsics import LaserExtrinsics  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api.models.camera import Camera  # pylint: disable=import-outside-toplevel
+
+    when = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    # Postgres enforces the foreign keys the SQLite fixtures quietly ignore, so
+    # the camera has to exist before anything references it.
+    session.add(Camera(id=1, serial_number="itest-0001", name="itest-camera"))
+    await session.flush()
+    for dive_id in (1, 2):
+        session.add(
+            Dive(id=dive_id, path=f"/dev/null/{dive_id}", dive_datetime=when,
+                 priority=Priority.HIGH)
+        )
+    await session.flush()
+    # TWO extrinsics rows: one per dive. This is what makes an uncorrelated
+    # scalar subquery return more than one row.
+    session.add_all([
+        LaserExtrinsics(id=51, laser_position=[0.1, 0.0, 0.0], laser_axis=[0.0, 0.0, 1.0],
+                        dive_id=1, camera_id=1),
+        LaserExtrinsics(id=52, laser_position=[0.1, 0.0, 0.0], laser_axis=[0.0, 0.0, 1.0],
+                        dive_id=2, camera_id=1),
+    ])
+    session.add(Image(id=11, path="/dev/null/img-11", taken_datetime=when,
+                      checksum=f"{11:032d}", is_canonical=True, dive_id=1))
+    await session.flush()
+    # TWO valid laser labels on one image — duplicates of the same dot, the
+    # shape 461 prod images have.
+    session.add_all([
+        LaserLabel(id=101, x=100.0, y=200.0, completed=True, superseded=False, image_id=11),
+        LaserLabel(id=102, x=100.0, y=200.0, completed=True, superseded=False, image_id=11),
+    ])
+    await session.flush()
+
+
+def _with_session(coro_factory):
+    """Run `coro_factory(session)` against the scratch database."""
+    from fishsense_api.database import setup_database  # pylint: disable=import-outside-toplevel
+    from sqlalchemy.ext.asyncio import async_sessionmaker  # pylint: disable=import-outside-toplevel
+    from sqlmodel.ext.asyncio.session import AsyncSession  # pylint: disable=import-outside-toplevel
+
+    async def _run():
+        database = setup_database()
+        factory = async_sessionmaker(database.engine, class_=AsyncSession,
+                                     expire_on_commit=False)
+        try:
+            async with factory() as session:
+                return await coro_factory(session)
+        finally:
+            await database.engine.dispose()
+
+    return asyncio.run(_run())
+
+
+@pytest.mark.usefixtures("empty_schema")
+def test_every_cohort_selector_runs_on_postgres():
+    """Each selector must execute against real Postgres without raising.
+
+    This is the test that would have caught the CardinalityViolation outage
+    before it shipped: on SQLite the same query returns a row and passes.
+    """
+    _run_lifespan_sequence()
+    selectors = _cohort_selectors()
+    assert selectors, "no cohort selectors discovered - has the module moved?"
+
+    async def _exercise(session):
+        await _seed_multi_valued(session)
+        failures = []
+        for name, fn in selectors:
+            try:
+                await fn(session=session)
+            except Exception as exc:  # noqa: BLE001  pylint: disable=broad-except
+                failures.append(f"{name}: {type(exc).__name__}: {exc}")
+        return failures
+
+    failures = _with_session(_exercise)
+    assert not failures, "cohort selectors raised on Postgres:\n  " + "\n  ".join(failures)
+
+
+@pytest.mark.usefixtures("empty_schema")
+def test_laser_depth_cohort_drains_with_duplicate_labels_on_postgres():
+    """The dive-279 wedge, end to end on Postgres.
+
+    One depth row covers the image even though a second valid label exists —
+    otherwise the dive is offered forever and blocks every higher-id dive.
+    """
+    _run_lifespan_sequence()
+
+    async def _exercise(session):
+        from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+            select_next_for_laser_depth,
+        )
+        from fishsense_api.controllers.laser_depth_controller import (  # pylint: disable=import-outside-toplevel
+            put_laser_depth,
+        )
+        from fishsense_api.models.laser_depth import LaserDepth  # pylint: disable=import-outside-toplevel
+
+        await _seed_multi_valued(session)
+        before = await select_next_for_laser_depth(session=session)
+        await put_laser_depth(
+            11,
+            LaserDepth(depth_m=1.5, range_m=1.51, residual_m=0.0004,
+                       laser_label_id=101, laser_extrinsics_id=51),
+            session=session,
+        )
+        after = await select_next_for_laser_depth(session=session)
+        return before, after
+
+    before, after = _with_session(_exercise)
+    assert before == 1, "dive with an undepthed laser image should be offered"
+    assert after is None, (
+        "dive still offered after its only eligible image got a depth — the "
+        "cohort is keyed on the label rather than the image and will never drain"
+    )

--- a/services/fishsense-api/tests/test_laser_depth_endpoint.py
+++ b/services/fishsense-api/tests/test_laser_depth_endpoint.py
@@ -406,3 +406,75 @@ async def test_selector_skips_low_priority_dives(session):
     await session.flush()
 
     assert await select_next_for_laser_depth(session=session) is None
+
+
+# ── duplicate valid labels ────────────────────────────────────────────
+#
+# `LaserDepth` is one row per image, but an image can carry more than one
+# *valid* laser label: 461 images across 8 prod dives do, almost all of them
+# duplicate labels of the same dot (position spread 0.000 px). Keying the
+# cohort on "is there a depth for THIS label" therefore never went false for
+# those images — the row records one label id and the other never matches.
+#
+# Prod dive 279 was the proof: 44 eligible images, 44 depths written, and the
+# selector still offered it on 27 consecutive runs. That is the same
+# never-drains shape as the stage-14 `Fish Model,` empty leaf, and it blocks
+# every higher-id dive behind it.
+#
+# The predicate now asks the question the table actually answers: does this
+# *image* have a depth derived from a still-valid label and the current
+# calibration?
+
+
+async def test_selector_drains_an_image_with_two_valid_laser_labels(session):
+    """Both labels are valid and the depth names one of them — that is a
+    complete answer for the image, so the dive must drop out."""
+    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_depth,
+    )
+    from fishsense_api.controllers.laser_depth_controller import (  # pylint: disable=import-outside-toplevel
+        put_laser_depth,
+    )
+
+    session.add_all(
+        [
+            _dive(1),
+            _image(11, 1),
+            _laser_label(101, 11),
+            _laser_label(102, 11),  # duplicate label of the same dot
+            _extrinsics(51, 1),
+        ]
+    )
+    await session.flush()
+    await put_laser_depth(
+        11, _depth(laser_label_id=101, laser_extrinsics_id=51), session=session
+    )
+
+    assert await select_next_for_laser_depth(session=session) is None
+
+
+async def test_selector_still_repicks_when_the_recorded_label_went_superseded(session):
+    """The self-healing property must survive the fix: a depth whose label is
+    no longer valid is stale, even though the image has another valid one."""
+    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_depth,
+    )
+    from fishsense_api.controllers.laser_depth_controller import (  # pylint: disable=import-outside-toplevel
+        put_laser_depth,
+    )
+
+    session.add_all(
+        [
+            _dive(1),
+            _image(11, 1),
+            _laser_label(101, 11, superseded=True),
+            _laser_label(102, 11),
+            _extrinsics(51, 1),
+        ]
+    )
+    await session.flush()
+    await put_laser_depth(
+        11, _depth(laser_label_id=101, laser_extrinsics_id=51), session=session
+    )
+
+    assert await select_next_for_laser_depth(session=session) == 1

--- a/services/fishsense-api/tests/test_measurement_calibration_provenance.py
+++ b/services/fishsense-api/tests/test_measurement_calibration_provenance.py
@@ -171,3 +171,68 @@ async def test_cohort_resolves_provenance_through_a_borrowed_calibration(session
     await session.flush()
 
     assert await select_next_for_measure_fish(session=session) is None
+
+
+# ── the correlation bug ───────────────────────────────────────────────
+#
+# `_resolved_laser_extrinsics_id()` is a scalar subquery used deep inside a
+# NOT EXISTS. SQLAlchemy only auto-correlates against the *immediately*
+# enclosing SELECT, so without an explicit `.correlate(Dive)` it emitted
+# `FROM laserextrinsics, dive` — an uncorrelated cross join returning one row
+# per extrinsics row in the table.
+#
+# Postgres rejects that outright (CardinalityViolationError: "more than one
+# row returned by a subquery used as an expression"), which took both cohort
+# selectors down in prod: every hourly poll 500'd, stage 14 stamped no
+# provenance, and the laser-depth stage drained exactly one dive before
+# stopping. SQLite silently returns the first row instead of raising, and
+# every fixture here seeded a single extrinsics row, so the wrong SQL and the
+# right SQL agreed and the suite stayed green.
+#
+# These two tests close that gap from both directions: one seeds a second
+# extrinsics row so the uncorrelated form picks the *wrong* dive's
+# calibration even on SQLite, and one asserts the emitted SQL is correlated
+# regardless of dialect.
+
+
+async def test_cohort_resolves_each_dives_own_calibration_not_the_first_row(session):
+    """Two calibrated dives, and the one under test is NOT the lowest id.
+
+    Uncorrelated, `coalesce(...)` returns extrinsics 51 (dive 1's, the first
+    row in the table) for every dive, so dive 2's correctly-stamped
+    measurement looks stale and the dive is re-selected forever.
+    """
+    session.add_all([_dive(1), _dive(2), _extrinsics(51, 1), _extrinsics(52, 2)])
+    _measurable_image(session, 21, 2)
+    session.add(_measurement(21, laser_extrinsics_id=52))
+    await session.flush()
+
+    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_measure_fish,
+    )
+
+    assert await select_next_for_measure_fish(session=session) is None
+
+
+def test_resolved_extrinsics_subquery_is_correlated():
+    """Dialect-independent guard on the shape of the shipped SQL.
+
+    Compiles the real cohort query — the nesting matters, since the bug only
+    appears when the scalar subquery sits inside a NOT EXISTS inside an
+    EXISTS. The subquery must *reference* the outer `dive`, never select from
+    it. This is the assertion that would have caught the prod outage without
+    a Postgres to run against.
+    """
+    from sqlalchemy.dialects import postgresql  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+        _laser_depth_cohort_query,
+    )
+
+    compiled = str(_laser_depth_cohort_query().compile(dialect=postgresql.dialect()))
+
+    assert "FROM laserextrinsics, dive" not in compiled, (
+        "scalar subquery is uncorrelated — it cross-joins dive and returns one "
+        f"row per extrinsics row, which Postgres rejects:\n{compiled}"
+    )
+    assert "laserextrinsics.dive_id = dive.id" in compiled

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/compute_laser_depths_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/compute_laser_depths_activity.py
@@ -61,6 +61,31 @@ class ComputeLaserDepthsResult:
     skipped_invalid_geometry: int = 0
 
 
+def _one_label_per_image(laser_labels, result) -> list:
+    """The validated laser labels to work from, at most one per image.
+
+    An image can carry several valid labels — 461 across 8 prod dives do,
+    nearly all duplicate labels of the same dot. `LaserDepth` holds one row
+    per image, so triangulating every label would compute the same point
+    repeatedly and leave whichever ran last recorded, making the stored
+    provenance depend on iteration order. Lowest label id wins: deterministic,
+    so a re-run records the same label and the cohort sees a stable answer.
+
+    Unusable labels are counted here rather than silently dropped, and counted
+    per label rather than per image, so the tally still reflects what came
+    back from the API.
+    """
+    by_image: dict = {}
+    for laser_label in laser_labels:
+        if laser_label.image_id is None or not _is_validated_fix(laser_label):
+            result.skipped_unusable_label += 1
+            continue
+        chosen = by_image.get(laser_label.image_id)
+        if chosen is None or (laser_label.id or 0) < (chosen.id or 0):
+            by_image[laser_label.image_id] = laser_label
+    return list(by_image.values())
+
+
 def _is_validated_fix(laser_label) -> bool:
     """The repo-wide *valid laser* gate, as the cohort selector spells it in
     SQL: the labeler placed a point, the validator signed off, and the
@@ -99,11 +124,8 @@ async def compute_laser_depths_activity(dive_id: int) -> ComputeLaserDepthsResul
 
         result = ComputeLaserDepthsResult()
 
-        for laser_label in laser_labels:
+        for laser_label in _one_label_per_image(laser_labels, result):
             image_id = laser_label.image_id
-            if image_id is None or not _is_validated_fix(laser_label):
-                result.skipped_unusable_label += 1
-                continue
 
             existing = existing_by_image.get(image_id)
             if (

--- a/services/fishsense-data-processing-workflow-worker/tests/test_compute_laser_depths_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_compute_laser_depths_activity.py
@@ -358,3 +358,28 @@ async def test_fetches_existing_depths_once_per_dive(monkeypatch):
 
     assert result.computed == 4
     fs.images.get_laser_depths.assert_awaited_once_with(42)
+
+
+@pytest.mark.asyncio
+async def test_duplicate_valid_labels_produce_one_depth_per_image(monkeypatch):
+    """An image can carry several valid laser labels — 461 prod images do,
+    nearly all duplicates of the same dot. `LaserDepth` is one row per image,
+    so processing every label triangulates the same dot twice and leaves
+    whichever ran last recorded. Take the lowest label id and move on: half
+    the work, and the recorded provenance is stable across re-runs instead of
+    flapping with iteration order."""
+    extrinsics = _laser_extrinsics()
+    x, y = _laser_pixel(extrinsics, 1.20)
+    fs = _make_fs(
+        laser_extrinsics=extrinsics,
+        laser_labels=[
+            _laser_label(102, 100, x, y),
+            _laser_label(101, 100, x, y),
+        ],
+    )
+
+    result = await _run(monkeypatch, fs)
+
+    assert result.computed == 1
+    assert fs.images.put_laser_depth.await_count == 1
+    assert fs.images.put_laser_depth.call_args.args[1].laser_label_id == 101


### PR DESCRIPTION
## The wedge

Prod dive 279 had **all 44 of its depths written** and was still selected on 27 consecutive runs, blocking every higher-id dive behind it. Found while draining the backlog left by #589.

`LaserDepth` holds one row per image (`uq_laser_depth_image`), but an image can carry more than one *valid* laser label:

| | |
|---|---|
| images with >1 valid laser label | **461** |
| dives affected | 8 |
| position spread between duplicates | 0.000 px (one outlier at 0.61 px) |

They're duplicate labels of the same dot, not competing answers. But the cohort asked *"is there a depth for **this label**?"* — the row records one label id, the other never matches, and the image is permanently in need of a depth.

This is the same never-drains shape as the stage-14 `Fish Model,` empty leaf that CLAUDE.md documents: cohort says work remains, activity has nothing to do, dive re-selected forever.

## The fix

The predicate now asks what the table can actually answer: **does this image have a depth derived from a still-valid label and the current calibration?**

Staleness is deliberately unchanged — the recorded label must still be valid, so a superseded or replaced label re-enters the dive exactly as before, and a recalibration still mismatches on the extrinsics id. Both properties have tests.

The activity now takes at most one label per image (lowest id) instead of triangulating the same dot once per duplicate and leaving whichever ran last recorded. Halves the work on those 461 images, and makes the stored provenance stable across re-runs rather than dependent on iteration order.

## Verification

Compiled the corrected query and ran it read-only against the **prod** database: it skips 279 and returns 341. Unit suite covers the drain case and the still-stale case; full workspace green, pylint 10.00.

## Context

Second fix on this feature. #589 fixed an uncorrelated subquery that 500'd both selectors; this fixes a false assumption underneath it — that one image has one valid laser label. Both were invisible to SQLite-backed unit tests against single-row fixtures, and both surfaced only against real data. Recovery so far: `laserdepth` went 25 → 694 rows across 14 dives before hitting this wedge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)