### PR TITLE
fix(cohort): try every valid label, and correlate the recorded-label check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,7 +352,7 @@ dives). Per-stage cohort:
 | 9   | HIGH-priority + `dive_slate_id` set + at least one `SpeciesLabel.content_of_image='Slate, Laser on slate'` whose image carries no `DiveSlateLabel` row at all |
 | 13  | HIGH-priority + `dive_slate_id` set + no `LaserExtrinsics` + ≥2 completed `DiveSlateLabel` rows (matches the data-worker activity's `MIN_LASER_POINTS=2` precondition) |
 | 14  | HIGH-priority + has `LaserExtrinsics` (own **or borrowed** via `Dive.calibration_dive_id`) + at least one *measurable* image with no `Measurement` **naming the currently-resolved extrinsics** (same predicate as the view's `measured`; keep the two in step) |
-| depth | HIGH-priority + resolvable `LaserExtrinsics` + at least one canonical image whose valid `LaserLabel` has no `LaserDepth` row naming *that label and that calibration* |
+| depth | HIGH-priority + resolvable `LaserExtrinsics` + at least one canonical laser-labelled image with no `LaserDepth` row naming *one of that image's still-valid labels* and the currently-resolved calibration |
 
 Stages 1, 2, and 5.1 all cascade from the same "valid laser" gate.
 Stage 1 lands PREDICTION clusters that stage 2 then consumes; stage
@@ -678,6 +678,19 @@ rays meeting at the camera centre report 0 at zero or negative depth, it is
 metric so one threshold is stricter close up than far away, and the float32
 solve puts its noise floor near 1e-5 m at metre scale. A threshold should come
 from the distribution this stage is the first thing to produce.
+
+**Both cohorts are keyed on the image, and both correlate their subqueries.**
+Two prod outages taught this within a day. An uncorrelated
+`_resolved_laser_extrinsics_id()` compiled to `FROM laserextrinsics, dive` and
+Postgres rejected the multi-row scalar subquery, 500ing both selectors on every
+hourly poll; then keying the depth cohort on a *specific* laser label wedged
+dive 279 forever, because `LaserDepth` holds one row per image while 461 prod
+images carry two valid labels. SQLite masked both — it answers a multi-row
+scalar subquery with the first row, and every fixture seeded one row where prod
+has many. `test_api_postgres_integration.py` now runs every cohort selector
+against real Postgres over a deliberately multi-valued seed; anything nested
+inside an `EXISTS` needs an explicit `.correlate(...)`, because auto-correlation
+only reaches the immediately enclosing SELECT.
 
 The axis-magnitude and zero-axis guards live in fishsense-core now, not here:
 `compute_laser_point` passes the stored axis straight through, and a

--- a/services/fishsense-api/src/fishsense_api/controllers/dive_cohort_controller.py
+++ b/services/fishsense-api/src/fishsense_api/controllers/dive_cohort_controller.py
@@ -828,14 +828,21 @@ async def select_next_for_laser_depth(
     session: AsyncSession = Depends(get_async_session),
 ) -> int | None:
     """Laser depth: HIGH-priority + resolvable calibration + at least one
-    canonical image whose valid laser label has no *current* `LaserDepth`.
+    canonical laser-labelled image with no *current* `LaserDepth`.
 
-    "Current" is the point. Depth is a function of the laser label and the
-    calibration, so the stored row names both, and an image counts as needing
-    work when either differs from what would be used today — no row at all, a
-    replaced label, or a recalibration. That is what lets a recompute be an
-    ordinary drainable cohort instead of a hand-run backfill: the 2026-08-11
-    panel-offset recalibration would re-enter its dives here automatically.
+    "Current" is the point, and it is a property of the **image**: a depth
+    row whose recorded label is still one of that image's valid labels, under
+    the calibration the dive resolves to today. An image needs work when there
+    is no row, when the label it names has been superseded or replaced, or
+    when the calibration has changed. That is what lets a recompute be an
+    ordinary drainable cohort instead of a hand-run backfill — the 2026-08-11
+    panel-offset recalibration re-enters its dives here automatically.
+
+    Keyed on the image rather than on a specific label because `LaserDepth`
+    holds one row per image while an image may carry several valid labels
+    (461 in prod do, nearly all duplicates of the same dot). Asking "is there
+    a depth for THIS label" never went false for those images and wedged the
+    cohort on dive 279 with all 44 of its depths written.
 
     Unlike stage 14 this does not require head/tail labels, clusters, or a
     measurable species — the dot's distance is knowable for any frame whose
@@ -889,6 +896,13 @@ def _laser_depth_cohort_query():
                 recorded_label.x != None,
                 recorded_label.y != None,
             )
+            # Correlate both, for the same reason `_resolved_laser_extrinsics_id`
+            # does: auto-correlation only reaches the immediately enclosing
+            # SELECT, so without this the compiler emits
+            # `FROM laserlabel AS laserlabel_1, image` — a fresh `image` that
+            # shadows the outer one, turning the image check into a tautology
+            # and cross-joining the whole image table on every evaluation.
+            .correlate(LaserDepth, Image)
             .exists()
         )
         .exists()

--- a/services/fishsense-api/tests/test_api_postgres_integration.py
+++ b/services/fishsense-api/tests/test_api_postgres_integration.py
@@ -386,8 +386,15 @@ def _cohort_selectors() -> list:
     )
 
 
-async def _seed_multi_valued(session) -> None:
-    """A dive population with the multiplicity prod actually has."""
+async def _seed_multi_valued(session, *, derived_rows: bool = True) -> None:
+    """A dive population with the multiplicity prod actually has.
+
+    `derived_rows` controls whether a `LaserDepth` and a `Measurement` already
+    exist. They must, for the selector-executes test: without them the
+    selectors' `NOT EXISTS` short-circuits and the scalar subquery inside is
+    never evaluated. The drain test needs them absent so it can watch a dive
+    leave the cohort.
+    """
     from datetime import datetime, timezone  # pylint: disable=import-outside-toplevel
 
     from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
@@ -427,6 +434,27 @@ async def _seed_multi_valued(session) -> None:
         LaserLabel(id=102, x=100.0, y=200.0, completed=True, superseded=False, image_id=11),
     ])
     await session.flush()
+    # A depth and a measurement must EXIST, or the selectors' `NOT EXISTS`
+    # short-circuits and the scalar subquery inside it is never evaluated —
+    # which is exactly how an uncorrelated `coalesce(...)` slips through: the
+    # query runs, returns a row, and Postgres never gets the chance to raise
+    # CardinalityViolationError.
+    if not derived_rows:
+        return
+
+    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_depth import LaserDepth  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+
+    session.add(Fish(id=700, species_id=None))
+    await session.flush()
+    session.add_all([
+        LaserDepth(id=1, depth_m=1.5, range_m=1.51, residual_m=0.0004,
+                   image_id=11, laser_label_id=101, laser_extrinsics_id=51),
+        Measurement(id=1, length_m=0.3, image_id=11, fish_id=700,
+                    laser_extrinsics_id=51),
+    ])
+    await session.flush()
 
 
 def _with_session(coro_factory):
@@ -441,7 +469,14 @@ def _with_session(coro_factory):
                                      expire_on_commit=False)
         try:
             async with factory() as session:
-                return await coro_factory(session)
+                result = await coro_factory(session)
+                # Commit, or nothing survives the session. Seeding in one
+                # session and querying in another silently saw an empty
+                # database, so the selectors' `NOT EXISTS` short-circuited and
+                # never evaluated the scalar subquery this test exists to
+                # exercise — it passed with the bug reintroduced.
+                await session.commit()
+                return result
         finally:
             await database.engine.dispose()
 
@@ -459,17 +494,24 @@ def test_every_cohort_selector_runs_on_postgres():
     selectors = _cohort_selectors()
     assert selectors, "no cohort selectors discovered - has the module moved?"
 
-    async def _exercise(session):
-        await _seed_multi_valued(session)
-        failures = []
-        for name, fn in selectors:
+    _with_session(_seed_multi_valued)
+
+    def _exercise(name, fn):
+        # A session each: the first Postgres error aborts its transaction, and
+        # every later statement on that connection comes back
+        # InFailedSqlTransaction — which would report every selector as broken
+        # and hide which one actually is.
+        async def _run(session):
             try:
                 await fn(session=session)
+                return None
             except Exception as exc:  # noqa: BLE001  pylint: disable=broad-except
-                failures.append(f"{name}: {type(exc).__name__}: {exc}")
-        return failures
+                return f"{name}: {type(exc).__name__}: {exc}"
 
-    failures = _with_session(_exercise)
+        return _with_session(_run)
+
+    failures = [f for f in (_exercise(name, fn) for name, fn in selectors) if f]
+
     assert not failures, "cohort selectors raised on Postgres:\n  " + "\n  ".join(failures)
 
 
@@ -491,7 +533,7 @@ def test_laser_depth_cohort_drains_with_duplicate_labels_on_postgres():
         )
         from fishsense_api.models.laser_depth import LaserDepth  # pylint: disable=import-outside-toplevel
 
-        await _seed_multi_valued(session)
+        await _seed_multi_valued(session, derived_rows=False)
         before = await select_next_for_laser_depth(session=session)
         await put_laser_depth(
             11,

--- a/services/fishsense-api/tests/test_laser_depth_endpoint.py
+++ b/services/fishsense-api/tests/test_laser_depth_endpoint.py
@@ -478,3 +478,61 @@ async def test_selector_still_repicks_when_the_recorded_label_went_superseded(se
     )
 
     assert await select_next_for_laser_depth(session=session) == 1
+
+
+def test_recorded_label_check_is_correlated():
+    """The inner EXISTS must reference the outer `image`, not cross-join it.
+
+    Written as `select(...).where(recorded_label.image_id == Image.id)`, the
+    compiler emitted `FROM laserlabel AS laserlabel_1, image` — a fresh
+    `image` that shadows the outer one, making the clause a tautology and
+    cross-joining the whole image table on every evaluation. Same class of bug
+    as the uncorrelated `_resolved_laser_extrinsics_id()`, one level deeper.
+    """
+    from sqlalchemy.dialects import postgresql  # pylint: disable=import-outside-toplevel
+
+    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+        _laser_depth_cohort_query,
+    )
+
+    compiled = str(_laser_depth_cohort_query().compile(dialect=postgresql.dialect()))
+
+    assert "FROM laserlabel AS laserlabel_1, image" not in compiled, (
+        f"recorded-label EXISTS cross-joins image instead of correlating:\n{compiled}"
+    )
+
+
+async def test_selector_repicks_when_the_depth_names_another_images_label(session):
+    """Provenance has to mean *this* image's label.
+
+    With the check uncorrelated, any valid label anywhere in the table
+    satisfied it, so a depth row pointing at a different image's label read as
+    current and the image was never recomputed.
+    """
+    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+        select_next_for_laser_depth,
+    )
+    from fishsense_api.controllers.laser_depth_controller import (  # pylint: disable=import-outside-toplevel
+        put_laser_depth,
+    )
+
+    session.add_all(
+        [
+            _dive(1),
+            _image(11, 1),
+            _laser_label(101, 11),
+            _image(12, 1),
+            _laser_label(102, 12),  # a valid label, but on the OTHER image
+            _extrinsics(51, 1),
+        ]
+    )
+    await session.flush()
+    # Image 12 gets a proper depth; image 11's names image 12's label.
+    await put_laser_depth(
+        12, _depth(laser_label_id=102, laser_extrinsics_id=51), session=session
+    )
+    await put_laser_depth(
+        11, _depth(laser_label_id=102, laser_extrinsics_id=51), session=session
+    )
+
+    assert await select_next_for_laser_depth(session=session) == 1

--- a/services/fishsense-api/tests/test_measurement_calibration_provenance.py
+++ b/services/fishsense-api/tests/test_measurement_calibration_provenance.py
@@ -223,6 +223,8 @@ def test_resolved_extrinsics_subquery_is_correlated():
     it. This is the assertion that would have caught the prod outage without
     a Postgres to run against.
     """
+    import re  # pylint: disable=import-outside-toplevel
+
     from sqlalchemy.dialects import postgresql  # pylint: disable=import-outside-toplevel
 
     from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
@@ -235,4 +237,24 @@ def test_resolved_extrinsics_subquery_is_correlated():
         "scalar subquery is uncorrelated — it cross-joins dive and returns one "
         f"row per extrinsics row, which Postgres rejects:\n{compiled}"
     )
-    assert "laserextrinsics.dive_id = dive.id" in compiled
+
+    # Pin the coalesce's own subqueries, not just the absence of one string.
+    # `laserextrinsics.dive_id = dive.id` also appears in the unrelated
+    # `has_laser_extrinsics` EXISTS, so asserting on it alone passed happily
+    # while the scalar subquery was still cross-joining.
+    start = compiled.index("coalesce(") + len("coalesce")
+    depth = 0
+    end = start
+    for end, char in enumerate(compiled[start:], start):
+        depth += (char == "(") - (char == ")")
+        if depth == 0:
+            break
+    else:  # pragma: no cover - unbalanced parens would mean a broken compiler
+        raise AssertionError(f"unbalanced parentheses in compiled SQL:\n{compiled}")
+    inside_coalesce = compiled[start : end + 1]
+
+    for from_clause in re.findall(r"FROM (\w+(?:, \w+)*)", inside_coalesce):
+        assert from_clause == "laserextrinsics", (
+            "a subquery inside coalesce() selects from more than "
+            f"laserextrinsics ({from_clause!r}) — it is not correlated:\n{compiled}"
+        )

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/compute_laser_depths_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/compute_laser_depths_activity.py
@@ -61,29 +61,32 @@ class ComputeLaserDepthsResult:
     skipped_invalid_geometry: int = 0
 
 
-def _one_label_per_image(laser_labels, result) -> list:
-    """The validated laser labels to work from, at most one per image.
+def _valid_labels_by_image(laser_labels, result) -> dict:
+    """Validated labels grouped by image, each list in ascending id order.
 
     An image can carry several valid labels — 461 across 8 prod dives do,
-    nearly all duplicate labels of the same dot. `LaserDepth` holds one row
-    per image, so triangulating every label would compute the same point
-    repeatedly and leave whichever ran last recorded, making the stored
-    provenance depend on iteration order. Lowest label id wins: deterministic,
-    so a re-run records the same label and the cohort sees a stable answer.
+    nearly all duplicates of the same dot. `LaserDepth` holds one row per
+    image, so the caller wants *an* answer per image rather than one per
+    label, and ascending id makes which label it settles on deterministic
+    across re-runs.
 
-    Unusable labels are counted here rather than silently dropped, and counted
-    per label rather than per image, so the tally still reflects what came
-    back from the API.
+    Grouped rather than reduced to a single label: the lowest id is only a
+    preference. If its geometry is degenerate a sibling may still triangulate,
+    and dropping the image entirely would leave the image-keyed cohort
+    offering that dive forever.
+
+    Unusable labels are counted per label, not per image, so the tally still
+    reflects what the API returned.
     """
     by_image: dict = {}
     for laser_label in laser_labels:
         if laser_label.image_id is None or not _is_validated_fix(laser_label):
             result.skipped_unusable_label += 1
             continue
-        chosen = by_image.get(laser_label.image_id)
-        if chosen is None or (laser_label.id or 0) < (chosen.id or 0):
-            by_image[laser_label.image_id] = laser_label
-    return list(by_image.values())
+        by_image.setdefault(laser_label.image_id, []).append(laser_label)
+    for labels in by_image.values():
+        labels.sort(key=lambda label: label.id or 0)
+    return by_image
 
 
 def _is_validated_fix(laser_label) -> bool:
@@ -124,39 +127,53 @@ async def compute_laser_depths_activity(dive_id: int) -> ComputeLaserDepthsResul
 
         result = ComputeLaserDepthsResult()
 
-        for laser_label in _one_label_per_image(laser_labels, result):
-            image_id = laser_label.image_id
-
+        for image_id, labels in _valid_labels_by_image(laser_labels, result).items():
             existing = existing_by_image.get(image_id)
+            # "Current" means here what it means in the cohort selector: a
+            # depth derived from *one of* this image's still-valid labels
+            # under the calibration in force. Keying on one specific label is
+            # what wedged prod dive 279, and an activity that disagrees with
+            # its selector is how a dive never drains.
             if (
                 existing is not None
-                and existing.laser_label_id == laser_label.id
                 and existing.laser_extrinsics_id == laser_extrinsics.id
+                and existing.laser_label_id in {label.id for label in labels}
             ):
                 result.skipped_current += 1
                 continue
 
-            point = compute_laser_point(
-                laser_label, laser_extrinsics, camera_intrinsics
-            )
-            # `depth_m > 0`, not `isfinite`. The kernel reports "these rays
-            # never meet" as the origin and a dot on the wrong side of the
-            # principal point as a negative Z — both finite, and a length
-            # computed at a negative depth comes out identical to its
-            # positive twin, so nothing downstream would notice. See
-            # `test_laser_geometry.py`.
-            if not math.isfinite(point.depth_m) or point.depth_m <= 0.0:
-                activity.logger.warning(
-                    "dive_id=%d image_id=%d laser_label_id=%s: laser at (%s, %s) "
-                    "gives depth=%s (residual=%s) against "
-                    "laser_extrinsics_id=%s; no valid intersection, skipping",
+            # Ascending id, first usable geometry wins. `depth_m > 0`, not
+            # `isfinite`: the kernel reports "these rays never meet" as the
+            # origin and a dot on the wrong side of the principal point as a
+            # negative Z — both finite, and a length computed at a negative
+            # depth is identical to its positive twin, so nothing downstream
+            # would notice. See `test_laser_geometry.py`.
+            chosen = point = None
+            for laser_label in labels:
+                candidate = compute_laser_point(
+                    laser_label, laser_extrinsics, camera_intrinsics
+                )
+                if math.isfinite(candidate.depth_m) and candidate.depth_m > 0.0:
+                    chosen, point = laser_label, candidate
+                    break
+                activity.logger.debug(
+                    "dive_id=%d image_id=%d laser_label_id=%s: depth=%s; "
+                    "trying the image's next valid label",
                     dive_id,
                     image_id,
                     laser_label.id,
-                    laser_label.x,
-                    laser_label.y,
-                    point.depth_m,
-                    point.residual_m,
+                    candidate.depth_m,
+                )
+
+            if point is None:
+                activity.logger.warning(
+                    "dive_id=%d image_id=%d: none of its %d valid laser label(s) "
+                    "%s intersect laser_extrinsics_id=%s in front of the camera; "
+                    "skipping",
+                    dive_id,
+                    image_id,
+                    len(labels),
+                    [label.id for label in labels],
                     laser_extrinsics.id,
                 )
                 result.skipped_invalid_geometry += 1
@@ -170,13 +187,13 @@ async def compute_laser_depths_activity(dive_id: int) -> ComputeLaserDepthsResul
                     range_m=point.range_m,
                     # How well the dot and the calibration agreed. Recorded,
                     # not gated on: it cannot see error along the laser's
-                    # epipolar line, and being metric it means different
-                    # things at 0.9 m and 2.5 m — so a threshold belongs to
-                    # the observed distribution, which this is the first
-                    # thing to produce.
+                    # epipolar line, and being metric it means different things
+                    # at 0.9 m and 2.5 m — so a threshold belongs to the
+                    # observed distribution, which this is the first thing to
+                    # produce.
                     residual_m=point.residual_m,
                     image_id=image_id,
-                    laser_label_id=laser_label.id,
+                    laser_label_id=chosen.id,
                     laser_extrinsics_id=laser_extrinsics.id,
                 ),
             )

--- a/services/fishsense-data-processing-workflow-worker/tests/test_compute_laser_depths_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_compute_laser_depths_activity.py
@@ -383,3 +383,53 @@ async def test_duplicate_valid_labels_produce_one_depth_per_image(monkeypatch):
     assert result.computed == 1
     assert fs.images.put_laser_depth.await_count == 1
     assert fs.images.put_laser_depth.call_args.args[1].laser_label_id == 101
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_another_valid_label_when_the_first_is_degenerate(monkeypatch):
+    """Picking one label per image must not mean giving up on the image.
+
+    Deduplicating to the lowest id made an image whose lowest-id label fails
+    the `depth_m > 0` gate produce no depth at all, even with a sibling valid
+    label that triangulates fine. Under the image-keyed cohort that image is
+    never satisfied, so the dive is offered every hour forever — reintroducing
+    the dive-279 wedge from the other direction.
+    """
+    extrinsics = _laser_extrinsics()
+    good_x, good_y = _laser_pixel(extrinsics, 1.20)
+    fs = _make_fs(
+        laser_extrinsics=extrinsics,
+        laser_labels=[
+            # Lowest id, but on the wrong side of the principal point for the
+            # laser's offset: the rays only meet behind the camera.
+            _laser_label(101, 100, 30.0, 3000.0),
+            _laser_label(102, 100, good_x, good_y),
+        ],
+    )
+
+    result = await _run(monkeypatch, fs)
+
+    assert result.computed == 1, "the image has a usable label; it must be used"
+    assert fs.images.put_laser_depth.await_count == 1
+    written = fs.images.put_laser_depth.call_args.args[1]
+    assert written.laser_label_id == 102
+    assert written.depth_m > 0.0
+
+
+@pytest.mark.asyncio
+async def test_counts_the_image_once_when_every_label_is_degenerate(monkeypatch):
+    """If no label for the image yields a usable geometry, that is one
+    unusable image, not one per duplicate label."""
+    extrinsics = _laser_extrinsics()
+    fs = _make_fs(
+        laser_extrinsics=extrinsics,
+        laser_labels=[
+            _laser_label(101, 100, 30.0, 3000.0),
+            _laser_label(102, 100, 31.0, 3001.0),
+        ],
+    )
+
+    result = await _run(monkeypatch, fs)
+
+    fs.images.put_laser_depth.assert_not_awaited()
+    assert result.skipped_invalid_geometry == 1


### PR DESCRIPTION
Follow-up to a code review of #592. Five findings, all legitimate — **two are bugs #592 itself introduced.**

## 1. The per-image dedupe could strand an image

Reducing to the lowest-id valid label meant an image whose lowest-id label fails the `depth_m > 0` gate got **no depth at all**, even with a sibling valid label that triangulates fine. Reproduced: label 101 → `depth_m = -0.043`, skipped; label 102 (usable) never tried.

Under #592's image-keyed cohort that image is never satisfied, so the dive is offered every hour forever — the dive-279 wedge reintroduced from the other direction.

Labels are now grouped per image and tried in ascending id order until one yields a usable geometry; `skipped_invalid_geometry` counts the image once when none do. The activity's "already current" check is keyed the same way the selector is — *any* of the image's still-valid labels — so the two cannot disagree about what remains to be done. That agreement is the thing this whole episode has been about.

## 2. The recorded-label check was itself uncorrelated

```sql
AND (EXISTS (SELECT laserlabel_1.id
     FROM laserlabel AS laserlabel_1, image      -- ← cross join
     WHERE laserlabel_1.id = laserdepth.laser_label_id
       AND laserlabel_1.image_id = image.id ...  -- ← tautology
```

A fresh `image` shadowing the outer one: the image check was a no-op and the whole image table was cross-joined on every evaluation. Same bug as the `_resolved_laser_extrinsics_id()` one it was written alongside, one level deeper — auto-correlation only reaches the immediately enclosing SELECT. Fixed with `.correlate(LaserDepth, Image)`.

## 3. `test_every_cohort_selector_runs_on_postgres` did not test what it claimed

`_with_session` never committed, so the seed rolled back and every selector ran against an empty database. The `NOT EXISTS` short-circuited, the scalar subquery was never evaluated, and removing `.correlate(Dive)` left the test **green**.

It now commits, seeds a `LaserDepth` and a `Measurement` so the subquery is actually reached, and gives each selector its own session so the first Postgres error cannot cascade as `InFailedSqlTransaction` and hide which selector really failed.

**My earlier claim to have verified this test was wrong** — I grepped the output for `CardinalityViolationError` without checking which test produced it, and it was the sibling drain test.

## 4. An assertion that pinned nothing

`assert "laserextrinsics.dive_id = dive.id" in compiled` is satisfied by the unrelated `has_laser_extrinsics` EXISTS. It now walks the balanced parens of the `coalesce(...)` and requires every FROM inside it to be `laserextrinsics` alone.

## 5. Stale docs

Endpoint docstring and the CLAUDE.md cohort row still described the replaced label-keyed predicate. Both updated; CLAUDE.md also records why anything nested inside an `EXISTS` needs an explicit `.correlate(...)`, since that has now caused two separate defects.

## Verification

Each bug reintroduced individually, confirming the intended test — and only it — goes red:

| bug reintroduced | test that fails |
|---|---|
| `.correlate(Dive)` removed | selector-executes **and** drain |
| label-keyed predicate | drain |
| inner EXISTS uncorrelated | correlation + cross-image provenance |
| lowest-id-only dedupe | degenerate-label fallback |

1440 tests green, 11 integration against real Postgres, pylint 10.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)