### PR TITLE
chore(lint): move import-outside-toplevel to the root config, extract the clones it exposed

### DIFF
--- a/libs/fishsense-api-sdk/tests/clients/test_image_client.py
+++ b/libs/fishsense-api-sdk/tests/clients/test_image_client.py
@@ -172,7 +172,7 @@ class TestImageClientLaserDepth:
                 assert await client.get_laser_depth(11) is None
 
     async def test_get_laser_depth_parses_the_row(self):
-        from fishsense_api_sdk.models.laser_depth import (  # pylint: disable=import-outside-toplevel
+        from fishsense_api_sdk.models.laser_depth import (
             LaserDepth,
         )
 
@@ -201,7 +201,7 @@ class TestImageClientLaserDepth:
         assert (depth.laser_label_id, depth.laser_extrinsics_id) == (5, 7)
 
     async def test_put_laser_depth_targets_the_image_route(self):
-        from fishsense_api_sdk.models.laser_depth import (  # pylint: disable=import-outside-toplevel
+        from fishsense_api_sdk.models.laser_depth import (
             LaserDepth,
         )
 

--- a/libs/fishsense-api-sdk/tests/clients/test_label_client.py
+++ b/libs/fishsense-api-sdk/tests/clients/test_label_client.py
@@ -71,7 +71,7 @@ class TestLabelClient:  # pylint: disable=too-many-public-methods
                 assert await client.get_laser_label(label_studio_id=999) is None
 
     async def test_put_laser_prediction_puts_to_image_endpoint(self):
-        from fishsense_api_sdk.models.laser_prediction import (  # pylint: disable=import-outside-toplevel
+        from fishsense_api_sdk.models.laser_prediction import (
             LaserPrediction,
         )
 

--- a/libs/fishsense-shared/tests/test_build_tls_config.py
+++ b/libs/fishsense-shared/tests/test_build_tls_config.py
@@ -47,7 +47,7 @@ def certs(tmp_path):
 def test_tls_disabled_returns_none_so_local_dev_connects_plaintext():
     """`temporal server start-dev` has no TLS; returning None is what lets the
     same call site work in both environments."""
-    from fishsense_shared.temporal import (  # pylint: disable=import-outside-toplevel
+    from fishsense_shared.temporal import (
         build_tls_config,
     )
 
@@ -58,7 +58,7 @@ def test_reads_the_cert_files_from_disk_as_bytes(certs):
     """The certs are paths in settings but bytes on the wire — passing the path
     through would produce a TLSConfig that fails at connect time, far from
     here."""
-    from fishsense_shared.temporal import (  # pylint: disable=import-outside-toplevel
+    from fishsense_shared.temporal import (
         build_tls_config,
     )
 
@@ -77,7 +77,7 @@ def test_reads_the_cert_files_from_disk_as_bytes(certs):
 
 
 def test_server_root_ca_is_read_when_present(certs):
-    from fishsense_shared.temporal import (  # pylint: disable=import-outside-toplevel
+    from fishsense_shared.temporal import (
         build_tls_config,
     )
 
@@ -97,7 +97,7 @@ def test_server_root_ca_is_read_when_present(certs):
 def test_server_root_ca_is_none_when_absent(certs):
     """Optional: a public CA needs no explicit root. The key thing is that the
     absence is detected by membership, not by reading a missing file."""
-    from fishsense_shared.temporal import (  # pylint: disable=import-outside-toplevel
+    from fishsense_shared.temporal import (
         build_tls_config,
     )
 
@@ -117,7 +117,7 @@ def test_domain_is_passed_through_when_present(certs):
     """`domain` is the serverName the client verifies against. krg-prod's cert
     is issued for a name that isn't the connection host, so dropping this
     fails the handshake."""
-    from fishsense_shared.temporal import (  # pylint: disable=import-outside-toplevel
+    from fishsense_shared.temporal import (
         build_tls_config,
     )
 
@@ -135,7 +135,7 @@ def test_domain_is_passed_through_when_present(certs):
 
 
 def test_domain_is_none_when_absent(certs):
-    from fishsense_shared.temporal import (  # pylint: disable=import-outside-toplevel
+    from fishsense_shared.temporal import (
         build_tls_config,
     )
 
@@ -155,7 +155,7 @@ def test_a_missing_cert_file_raises_rather_than_connecting_without_tls(tmp_path)
     """Fail loud. Silently degrading to no client identity would connect to
     Temporal unauthenticated (or not at all) with nothing pointing at the
     missing file."""
-    from fishsense_shared.temporal import (  # pylint: disable=import-outside-toplevel
+    from fishsense_shared.temporal import (
         build_tls_config,
     )
 

--- a/libs/fishsense-shared/tests/test_config.py
+++ b/libs/fishsense-shared/tests/test_config.py
@@ -21,7 +21,7 @@ import pytest
 
 def _reload_with(monkeypatch, value: str | None):
     """Re-import `fishsense_shared.config` with `E4EFS_DOCKER` set to `value`."""
-    from fishsense_shared import config  # pylint: disable=import-outside-toplevel
+    from fishsense_shared import config
 
     if value is None:
         monkeypatch.delenv("E4EFS_DOCKER", raising=False)
@@ -34,7 +34,7 @@ def _reload_with(monkeypatch, value: str | None):
 def _restore_module():
     """Leave the module as the rest of the suite found it."""
     yield
-    from fishsense_shared import config  # pylint: disable=import-outside-toplevel
+    from fishsense_shared import config
 
     importlib.reload(config)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,28 @@ disable = [
     # Pydantic BaseModel + workflow input DTOs are data-only by design;
     # this warning treats every one of them as a code smell.
     "too-few-public-methods",
+    # Function-local imports are a deliberate, repo-wide pattern here, not an
+    # oversight, and three separate mechanisms depend on them:
+    #
+    #   * Dynaconf validates EVERY validator on first attribute access of
+    #     `settings`, so a module-level import of anything that touches config
+    #     forces every unrelated setting to be present. Tests and activities
+    #     import inside the function to control when that happens.
+    #   * `fishsense_api.controllers` registers routes as an import side
+    #     effect; the API's tests import controllers inside the test body so
+    #     registration order stays under the test's control rather than
+    #     pytest's collection order.
+    #   * The api tests import SQLModel classes inside fixtures so the module
+    #     imports cleanly on a default `-m "not integration"` run, before any
+    #     database settings exist.
+    #
+    # This was previously spelled as 694 inline pragmas across 71 files, which
+    # is exactly what CLAUDE.md says not to do ("put any lint exemption in the
+    # root pyproject.toml where it is reviewable in one place. Never inline").
+    # They also made `black` unusable: reflowing a long import moved the
+    # trailing pragma onto the closing paren, where pylint no longer applied
+    # it, turning 3 findings into ~30 in a single file.
+    "import-outside-toplevel",
 ]
 
 # `duplicate-code` (R0801) is ENABLED on purpose — see CLAUDE.md's

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/k8s_scaling.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/k8s_scaling.py
@@ -97,7 +97,6 @@ def apps_v1_api(kubeconfig_path: str):
     activities — doesn't pull the dependency in until scaling is
     actually used.
     """
-    # pylint: disable=import-outside-toplevel
     from kubernetes import client as k8s_client, config as k8s_config
 
     configuration = k8s_client.Configuration()

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/object_store.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/object_store.py
@@ -47,7 +47,6 @@ def open_object_store_client() -> "ObjectStoreClient":
     gotcha in CLAUDE.md) — only calling this at activity runtime does.
     Activities call this; tests patch it to inject a moto-backed client.
     """
-    # pylint: disable=import-outside-toplevel
     from fishsense_api_workflow_worker.config import settings
 
     return open_client(settings, ObjectStoreClient)

--- a/services/fishsense-api-workflow-worker/tests/conftest.py
+++ b/services/fishsense-api-workflow-worker/tests/conftest.py
@@ -64,7 +64,7 @@ def configure_worker_settings(
         # registration time — a placeholder endpoint would 500. Force a
         # settings reload so any earlier placeholder-based attribute
         # access is invalidated.
-        from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+        from fishsense_api_workflow_worker import config as cfg
 
         cfg.settings.reload()
         yield

--- a/services/fishsense-api-workflow-worker/tests/test_cleanup_raw_bytes_for_dive_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_cleanup_raw_bytes_for_dive_activity.py
@@ -115,7 +115,7 @@ def test_activity_module_imports_no_nas_client():
     client module into cleanup, this test fails — a deliberate tripwire
     so nobody accidentally adds a NAS-delete path to the cleanup
     activity."""
-    import inspect  # pylint: disable=import-outside-toplevel
+    import inspect
 
     source = inspect.getsource(sut)
     assert "fishsense_api_workflow_worker.nas" not in source, (

--- a/services/fishsense-api-workflow-worker/tests/test_create_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_create_laser_label_studio_project_activity.py
@@ -204,7 +204,7 @@ async def test_ensure_s3_storage_registers_presigned_source_when_absent(
     )
     monkeypatch.setenv("E4EFS_OBJECT_STORE__ACCESS_KEY", "ak")
     monkeypatch.setenv("E4EFS_OBJECT_STORE__SECRET_KEY", "sk")
-    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import config as cfg
     cfg.settings.reload()
 
     ls = _make_ls_with_storage(existing_storages=[])
@@ -233,7 +233,7 @@ async def test_ensure_s3_storage_is_idempotent_when_already_registered(
     """Re-running create on an existing project must not register a
     duplicate storage — match is on (bucket, title)."""
     monkeypatch.setenv("E4EFS_OBJECT_STORE__BUCKET", "fishsense-test")
-    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import config as cfg
     cfg.settings.reload()
 
     existing = [
@@ -261,7 +261,7 @@ async def test_ensure_s3_storage_uses_presign_credentials_when_set(monkeypatch):
     monkeypatch.setenv("E4EFS_OBJECT_STORE__SECRET_KEY", "rw-secret")
     monkeypatch.setenv("E4EFS_OBJECT_STORE__PRESIGN_ACCESS_KEY", "ro-key")
     monkeypatch.setenv("E4EFS_OBJECT_STORE__PRESIGN_SECRET_KEY", "ro-secret")
-    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import config as cfg
     cfg.settings.reload()
 
     ls = _make_ls_with_storage(existing_storages=[])

--- a/services/fishsense-api-workflow-worker/tests/test_exif.py
+++ b/services/fishsense-api-workflow-worker/tests/test_exif.py
@@ -51,7 +51,7 @@ _REAL_ORF = (
 
 
 def _read(data: bytes):
-    from fishsense_api_workflow_worker.exif import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker.exif import (
         read_exif,
     )
 

--- a/services/fishsense-api-workflow-worker/tests/test_list_dive_folder_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_list_dive_folder_activity.py
@@ -25,7 +25,7 @@ from temporalio.exceptions import ApplicationError
 
 
 def _entry(path: str, *, is_dir: bool = False, size: int = 1024):
-    from fishsense_api_workflow_worker.nas import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker.nas import (
         NasEntry,
     )
 
@@ -57,7 +57,7 @@ def _listing_client(tree: dict[str, list]):
 
 
 async def _run(request, client, monkeypatch):
-    from fishsense_api_workflow_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker.activities import (
         list_dive_folder_activity as sut,
     )
 
@@ -66,7 +66,7 @@ async def _run(request, client, monkeypatch):
 
 
 def _request(**kwargs):
-    from fishsense_shared.ingest_contracts import (  # pylint: disable=import-outside-toplevel
+    from fishsense_shared.ingest_contracts import (
         IngestDiveRequest,
     )
 
@@ -246,7 +246,7 @@ async def test_a_missing_folder_fails_non_retryably(monkeypatch):
     """Synology 408 is "no such file". A mistyped path cannot be fixed by
     waiting, so Temporal must not burn its retry budget on it — the same
     classification the staging activity makes."""
-    from synology_filestation import DSMError  # pylint: disable=import-outside-toplevel
+    from synology_filestation import DSMError
 
     client = MagicMock()
     client.list_dir.side_effect = DSMError("Synology API error 408")
@@ -262,7 +262,7 @@ async def test_a_transient_nas_error_propagates_for_temporal_to_retry(monkeypatc
     """502 is FileStation's shared download backend falling over — routine and
     self-healing. It must reach Temporal's bounded jittered policy rather than
     being converted into a permanent failure."""
-    from synology_filestation import DSMError  # pylint: disable=import-outside-toplevel
+    from synology_filestation import DSMError
 
     client = MagicMock()
     client.list_dir.side_effect = DSMError("Synology API error 502")

--- a/services/fishsense-api-workflow-worker/tests/test_nas_client.py
+++ b/services/fishsense-api-workflow-worker/tests/test_nas_client.py
@@ -46,7 +46,7 @@ def test_external_shape_preserved_for_activity_call_sites(monkeypatch):
     several activities import the narrow alias for documentation
     intent.
     """
-    from fishsense_api_workflow_worker import nas as sut  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import nas as sut
 
     assert sut.NasDownloadClient is sut.NasClient
 
@@ -79,7 +79,7 @@ def test_download_to_raises_when_underlying_client_signals_failure(
     leaving DSM JSON-error bodies on disk for the activity to read
     back as `.ORF` content.
     """
-    from fishsense_api_workflow_worker import nas as sut  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import nas as sut
 
     src_path = "/share/data/2024.06.20.REEF/img.ORF"
 
@@ -124,7 +124,7 @@ def test_download_to_raises_when_underlying_client_signals_failure(
 
 
 def _client_with(monkeypatch, fake_fs):
-    from fishsense_api_workflow_worker import nas as sut  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import nas as sut
 
     monkeypatch.setattr(sut.Client, "login", lambda *a, **kw: fake_fs)
     return sut.NasClient(

--- a/services/fishsense-api-workflow-worker/tests/test_populate_dive_slate_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_dive_slate_label_studio_project_activity.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import base64
 
-from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import List
 from unittest.mock import AsyncMock, MagicMock
@@ -13,24 +11,18 @@ import pytest
 from temporalio.testing import ActivityEnvironment
 
 from fishsense_api_sdk.models.dive_slate_label import DiveSlateLabel
-from fishsense_api_sdk.models.image import Image
 from fishsense_api_sdk.models.species_label import SpeciesLabel
 from fishsense_api_workflow_worker.activities import (
+
     populate_dive_slate_label_studio_project_activity as sut,
     populate_utils as sut_utils,
 )
 
-
-def _image(image_id: int, checksum: str) -> Image:
-    return Image(
-        id=image_id,
-        path=f"path/{image_id}.ORF",
-        taken_datetime=datetime(2024, 8, 21, tzinfo=timezone.utc),
-        checksum=checksum,
-        is_canonical=True,
-        dive_id=1,
-        camera_id=6,
-    )
+# Shared with the other populate suites — see `worker_tests_support.populate`.
+from worker_tests_support.populate import (  # noqa: F401
+    image as _image,
+    fake_label_studio_client as _make_ls_client,
+)
 
 
 def _species_label(image_id: int, *, content: str | None) -> SpeciesLabel:
@@ -103,7 +95,7 @@ def test_build_task_emits_dual_image_and_img_keys(monkeypatch):
     """Pinned: dual-key `image` + `img` shape for legacy LS project
     XML compatibility — see laser populate test of the same name."""
     monkeypatch.setenv("E4EFS_OBJECT_STORE__BUCKET", "fishsense-test")
-    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import config as cfg
     cfg.settings.reload()
 
     expected_url = "s3://fishsense-test/preprocess_slate_images_jpeg/abc123.JPG"
@@ -135,36 +127,6 @@ def _make_fs_client(
     fs.labels.put_dive_slate_label = AsyncMock()
     fs.labels.get_slate_predictions = AsyncMock(return_value=[])
     return fs
-
-
-def _make_ls_client(returned_task_ids: List[int]):
-    # Fake hosted LS: import creates tasks (assigning ids from
-    # `returned_task_ids` in order) and `tasks.list` serves them back. The
-    # import response carries NO task_ids -- hosted LS imports asynchronously.
-    ls = MagicMock()
-    ls.projects = MagicMock()
-    _stored: List = []
-    _ids = iter(returned_task_ids)
-
-    def _import(project_id, request, return_task_ids=False):  # pylint: disable=unused-argument
-        for task in request:
-            _tid = next(_ids)
-            _s3 = task["data"].get("image") or task["data"].get("img")
-            _fileuri = base64.b64encode(_s3.encode()).decode()
-            # hosted LS lists tasks with a per-task presign resolve-wrapper,
-            # NOT the imported s3:// URL — mirror that so dedup is exercised.
-            _stored.append(
-                SimpleNamespace(
-                    id=_tid,
-                    data={"image": f"/tasks/{_tid}/resolve/?fileuri={_fileuri}"},
-                )
-            )
-        return SimpleNamespace(import_=1)
-
-    ls.projects.import_tasks = MagicMock(side_effect=_import)
-    ls.tasks = MagicMock()
-    ls.tasks.list = MagicMock(side_effect=lambda project=None: list(_stored))
-    return ls
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_headtail_label_studio_project_activity.py
@@ -12,59 +12,30 @@ Two correctness invariants particular to stage 5.3:
 
 from __future__ import annotations
 
-import base64
 
-from datetime import datetime, timezone
-from types import SimpleNamespace
-from typing import List, Optional
+from typing import List
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from temporalio.testing import ActivityEnvironment
 
 from fishsense_api_sdk.models.headtail_label import HeadTailLabel
-from fishsense_api_sdk.models.image import Image
 from fishsense_api_sdk.models.laser_label import LaserLabel
 from fishsense_api_workflow_worker.activities import (
+
     populate_headtail_label_studio_project_activity as sut,
     populate_utils as sut_utils,
 )
 
-
-def _image(image_id: int, checksum: str) -> Image:
-    return Image(
-        id=image_id,
-        path=f"path/{image_id}.ORF",
-        taken_datetime=datetime(2024, 8, 21, tzinfo=timezone.utc),
-        checksum=checksum,
-        is_canonical=True,
-        dive_id=1,
-        camera_id=6,
-    )
-
-
-def _laser(
-    image_id: int,
-    *,
-    completed: bool = True,
-    superseded: bool = False,
-    x: Optional[float] = 100.0,
-    y: Optional[float] = 200.0,
-) -> LaserLabel:
-    return LaserLabel(
-        id=image_id * 7,
-        label_studio_task_id=image_id * 10,
-        label_studio_project_id=43,
-        x=x,
-        y=y,
-        label="laser",
-        updated_at=None,
-        superseded=superseded,
-        completed=completed,
-        label_studio_json={},
-        image_id=image_id,
-        user_id=None,
-    )
+# Shared with the other populate suites — see `worker_tests_support.populate`.
+from worker_tests_support.populate import (  # noqa: F401
+    images_for,
+    laser_label_matrix,
+    patch_jpeg_gate,
+    image as _image,
+    laser_label as _laser,
+    fake_label_studio_client as _make_ls_client,
+)
 
 
 def _headtail_label(
@@ -97,29 +68,12 @@ def _all_jpegs_present(monkeypatch):
     """Default the JPEG gate to "present" so activity tests exercise the
     import path; the gate test overrides this with a selective fake.
     Mirrors the species populate test harness."""
-    store = MagicMock()
-    store.has_processed_jpeg = AsyncMock(return_value=True)
-    monkeypatch.setattr(sut, "open_object_store_client", lambda: store)
-    return store
+    return patch_jpeg_gate(monkeypatch, sut)
 
 
 def test_select_targets_filters_by_valid_laser_and_drops_completed():
-    laser = [
-        _laser(1),                             # valid + completed headtail -> drop
-        _laser(2, completed=False),            # incomplete laser -> drop
-        _laser(3),                             # valid + no headtail -> keep
-        _laser(4, superseded=True),            # superseded laser -> drop
-        _laser(5, x=None),                     # null x -> drop
-        _laser(6, y=None),                     # null y -> drop
-    ]
-    images_by_id = {
-        1: _image(1, "a"),
-        2: _image(2, "b"),
-        3: _image(3, "c"),
-        4: _image(4, "d"),
-        5: _image(5, "e"),
-        6: _image(6, "f"),
-    }
+    laser = laser_label_matrix()
+    images_by_id = images_for()
     existing = [_headtail_label(1, completed=True)]
 
     selected = sut._select_target_images(laser, images_by_id, existing)  # pylint: disable=protected-access
@@ -133,7 +87,7 @@ def test_build_task_emits_dual_image_and_img_keys(monkeypatch):
     Reverting either key would re-introduce the populate regression
     observed on 2026-05-03."""
     monkeypatch.setenv("E4EFS_OBJECT_STORE__BUCKET", "fishsense-test")
-    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import config as cfg
     cfg.settings.reload()
 
     expected_url = "s3://fishsense-test/preprocess_headtail_jpeg/abc123.JPG"
@@ -164,36 +118,6 @@ def _make_fs_client(
     fs.labels.get_headtail_labels = AsyncMock(return_value=existing_headtail)
     fs.labels.put_headtail_label = AsyncMock()
     return fs
-
-
-def _make_ls_client(returned_task_ids: List[int]):
-    # Fake hosted LS: import creates tasks (assigning ids from
-    # `returned_task_ids` in order) and `tasks.list` serves them back. The
-    # import response carries NO task_ids -- hosted LS imports asynchronously.
-    ls = MagicMock()
-    ls.projects = MagicMock()
-    _stored: List = []
-    _ids = iter(returned_task_ids)
-
-    def _import(project_id, request, return_task_ids=False):  # pylint: disable=unused-argument
-        for task in request:
-            _tid = next(_ids)
-            _s3 = task["data"].get("image") or task["data"].get("img")
-            _fileuri = base64.b64encode(_s3.encode()).decode()
-            # hosted LS lists tasks with a per-task presign resolve-wrapper,
-            # NOT the imported s3:// URL — mirror that so dedup is exercised.
-            _stored.append(
-                SimpleNamespace(
-                    id=_tid,
-                    data={"image": f"/tasks/{_tid}/resolve/?fileuri={_fileuri}"},
-                )
-            )
-        return SimpleNamespace(import_=1)
-
-    ls.projects.import_tasks = MagicMock(side_effect=_import)
-    ls.tasks = MagicMock()
-    ls.tasks.list = MagicMock(side_effect=lambda project=None: list(_stored))
-    return ls
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_laser_label_studio_project_activity.py
@@ -10,10 +10,7 @@ rows.
 
 from __future__ import annotations
 
-import base64
 
-from datetime import datetime, timezone
-from types import SimpleNamespace
 from typing import List
 from unittest.mock import AsyncMock, MagicMock
 
@@ -24,8 +21,15 @@ from fishsense_api_sdk.models.image import Image
 from fishsense_api_sdk.models.laser_label import LaserLabel
 from fishsense_api_sdk.models.laser_prediction import LaserPrediction
 from fishsense_api_workflow_worker.activities import (
+
     populate_laser_label_studio_project_activity as sut,
     populate_utils as sut_utils,
+)
+
+# Shared with the other populate suites — see `worker_tests_support.populate`.
+from worker_tests_support.populate import (  # noqa: F401
+    image as _image,
+    fake_label_studio_client as _make_ls_client,
 )
 
 
@@ -49,18 +53,6 @@ def _prediction(image_id: int, *, x=100.0, y=200.0, width=4000, height=3000):
         confidence=0.9,
         width=width,
         height=height,
-    )
-
-
-def _image(image_id: int, checksum: str) -> Image:
-    return Image(
-        id=image_id,
-        path=f"path/{image_id}.ORF",
-        taken_datetime=datetime(2024, 8, 21, tzinfo=timezone.utc),
-        checksum=checksum,
-        is_canonical=True,
-        dive_id=1,
-        camera_id=6,
     )
 
 
@@ -151,7 +143,7 @@ def test_build_task_uses_configured_url_base_and_dual_keys(monkeypatch):
     populate regression observed on 2026-05-03.
     """
     monkeypatch.setenv("E4EFS_OBJECT_STORE__BUCKET", "fishsense-test")
-    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import config as cfg
     cfg.settings.reload()
 
     # LS presigns this `s3://` URI via the per-project Garage source
@@ -220,36 +212,6 @@ def _make_fs_client(
         predictions = [_prediction(image.id) for image in images]
     fs.labels.get_laser_predictions = AsyncMock(return_value=predictions)
     return fs
-
-
-def _make_ls_client(returned_task_ids: List[int]):
-    # Fake hosted LS: import creates tasks (assigning ids from
-    # `returned_task_ids` in order) and `tasks.list` serves them back. The
-    # import response carries NO task_ids -- hosted LS imports asynchronously.
-    ls = MagicMock()
-    ls.projects = MagicMock()
-    _stored: List = []
-    _ids = iter(returned_task_ids)
-
-    def _import(project_id, request, return_task_ids=False):  # pylint: disable=unused-argument
-        for task in request:
-            _tid = next(_ids)
-            _s3 = task["data"].get("image") or task["data"].get("img")
-            _fileuri = base64.b64encode(_s3.encode()).decode()
-            # hosted LS lists tasks with a per-task presign resolve-wrapper,
-            # NOT the imported s3:// URL — mirror that so dedup is exercised.
-            _stored.append(
-                SimpleNamespace(
-                    id=_tid,
-                    data={"image": f"/tasks/{_tid}/resolve/?fileuri={_fileuri}"},
-                )
-            )
-        return SimpleNamespace(import_=1)
-
-    ls.projects.import_tasks = MagicMock(side_effect=_import)
-    ls.tasks = MagicMock()
-    ls.tasks.list = MagicMock(side_effect=lambda project=None: list(_stored))
-    return ls
 
 
 @pytest.mark.asyncio

--- a/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_species_label_studio_project_activity.py
@@ -14,59 +14,30 @@ project's own in-progress rows.
 
 from __future__ import annotations
 
-import base64
 
-from datetime import datetime, timezone
-from types import SimpleNamespace
-from typing import List, Optional
+from typing import List
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from temporalio.testing import ActivityEnvironment
 
-from fishsense_api_sdk.models.image import Image
 from fishsense_api_sdk.models.laser_label import LaserLabel
 from fishsense_api_sdk.models.species_label import SpeciesLabel
 from fishsense_api_workflow_worker.activities import (
+
     populate_species_label_studio_project_activity as sut,
     populate_utils as sut_utils,
 )
 
-
-def _image(image_id: int, checksum: str) -> Image:
-    return Image(
-        id=image_id,
-        path=f"path/{image_id}.ORF",
-        taken_datetime=datetime(2024, 8, 21, tzinfo=timezone.utc),
-        checksum=checksum,
-        is_canonical=True,
-        dive_id=1,
-        camera_id=6,
-    )
-
-
-def _laser(
-    image_id: int,
-    *,
-    completed: bool = True,
-    superseded: bool = False,
-    x: Optional[float] = 100.0,
-    y: Optional[float] = 200.0,
-) -> LaserLabel:
-    return LaserLabel(
-        id=image_id * 7,
-        label_studio_task_id=image_id * 10,
-        label_studio_project_id=43,
-        x=x,
-        y=y,
-        label="laser",
-        updated_at=None,
-        superseded=superseded,
-        completed=completed,
-        label_studio_json={},
-        image_id=image_id,
-        user_id=None,
-    )
+# Shared with the other populate suites — see `worker_tests_support.populate`.
+from worker_tests_support.populate import (  # noqa: F401
+    images_for,
+    laser_label_matrix,
+    patch_jpeg_gate,
+    image as _image,
+    laser_label as _laser,
+    fake_label_studio_client as _make_ls_client,
+)
 
 
 def _species_label(
@@ -104,29 +75,12 @@ def _species_label(
 def _all_jpegs_present(monkeypatch):
     """Default the JPEG gate to "present" so activity tests exercise the
     import path; the gate test overrides this with a selective fake."""
-    store = MagicMock()
-    store.has_processed_jpeg = AsyncMock(return_value=True)
-    monkeypatch.setattr(sut, "open_object_store_client", lambda: store)
-    return store
+    return patch_jpeg_gate(monkeypatch, sut)
 
 
 def test_select_targets_filters_by_valid_laser_and_drops_completed():
-    laser = [
-        _laser(1),                             # valid + completed species -> drop
-        _laser(2, completed=False),            # incomplete laser -> drop
-        _laser(3),                             # valid + no species -> keep
-        _laser(4, superseded=True),            # superseded laser -> drop
-        _laser(5, x=None),                     # null x -> drop
-        _laser(6, y=None),                     # null y -> drop
-    ]
-    images_by_id = {
-        1: _image(1, "a"),
-        2: _image(2, "b"),
-        3: _image(3, "c"),
-        4: _image(4, "d"),
-        5: _image(5, "e"),
-        6: _image(6, "f"),
-    }
+    laser = laser_label_matrix()
+    images_by_id = images_for()
     existing = [_species_label(1, completed=True)]
 
     selected = sut._select_target_images(laser, images_by_id, existing, 70)  # pylint: disable=protected-access
@@ -155,7 +109,7 @@ def test_build_task_uses_groups_jpeg_folder_and_dual_keys(monkeypatch):
     test of the same name for the rationale (legacy LS project XML
     uses both conventions; emitting one fails import_tasks)."""
     monkeypatch.setenv("E4EFS_OBJECT_STORE__BUCKET", "fishsense-test")
-    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import config as cfg
     cfg.settings.reload()
 
     # Physical Garage prefix (preprocess_groups_jpeg) + `.JPG`; LS
@@ -188,36 +142,6 @@ def _make_fs_client(
     fs.labels.get_species_labels = AsyncMock(return_value=existing_species)
     fs.labels.put_species_label = AsyncMock()
     return fs
-
-
-def _make_ls_client(returned_task_ids: List[int]):
-    # Fake hosted LS: import creates tasks (assigning ids from
-    # `returned_task_ids` in order) and `tasks.list` serves them back. The
-    # import response carries NO task_ids -- hosted LS imports asynchronously.
-    ls = MagicMock()
-    ls.projects = MagicMock()
-    _stored: List = []
-    _ids = iter(returned_task_ids)
-
-    def _import(project_id, request, return_task_ids=False):  # pylint: disable=unused-argument
-        for task in request:
-            _tid = next(_ids)
-            _s3 = task["data"].get("image") or task["data"].get("img")
-            _fileuri = base64.b64encode(_s3.encode()).decode()
-            # hosted LS lists tasks with a per-task presign resolve-wrapper,
-            # NOT the imported s3:// URL — mirror that so dedup is exercised.
-            _stored.append(
-                SimpleNamespace(
-                    id=_tid,
-                    data={"image": f"/tasks/{_tid}/resolve/?fileuri={_fileuri}"},
-                )
-            )
-        return SimpleNamespace(import_=1)
-
-    ls.projects.import_tasks = MagicMock(side_effect=_import)
-    ls.tasks = MagicMock()
-    ls.tasks.list = MagicMock(side_effect=lambda project=None: list(_stored))
-    return ls
 
 
 @pytest.mark.asyncio
@@ -363,7 +287,7 @@ async def test_writes_label_with_image_url_and_groups_jpeg_folder(monkeypatch):
     image_url uses the species JPEG prefix, matching the LS task
     URL — so downstream sync can recover the JPEG from the row."""
     monkeypatch.setenv("E4EFS_OBJECT_STORE__BUCKET", "fishsense-test")
-    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import config as cfg
     cfg.settings.reload()
 
     laser = [_laser(1)]

--- a/services/fishsense-api-workflow-worker/tests/test_populate_utils_workspace.py
+++ b/services/fishsense-api-workflow-worker/tests/test_populate_utils_workspace.py
@@ -182,8 +182,8 @@ async def test_ensure_s3_storage_registers_labels_bucket_and_prefix(monkeypatch)
 
 
 async def _title_for(monkeypatch, dive_id, name, suffix):
-    from contextlib import asynccontextmanager  # pylint: disable=import-outside-toplevel
-    from types import SimpleNamespace  # pylint: disable=import-outside-toplevel
+    from contextlib import asynccontextmanager
+    from types import SimpleNamespace
 
     fake = MagicMock()
 
@@ -222,7 +222,7 @@ async def test_title_nameless_dive_is_id_and_suffix(monkeypatch):
 
 
 def test_normalize_image_url_decodes_hosted_ls_resolve_wrapper():
-    import base64  # pylint: disable=import-outside-toplevel
+    import base64
 
     s3 = "s3://labels-fishsense-lite/fishsense-lite/preprocess_groups_jpeg/abc.JPG"
     wrapper = "/tasks/999/resolve/?fileuri=" + base64.b64encode(s3.encode()).decode()
@@ -297,7 +297,7 @@ async def test_heal_fetches_detail_when_list_omits_config():
 async def test_heal_survives_ls_rejecting_the_config():
     """LS refuses a config that would invalidate existing annotations. That
     must not fail the whole populate stage."""
-    from label_studio_sdk.core import ApiError  # pylint: disable=import-outside-toplevel
+    from label_studio_sdk.core import ApiError
 
     ls = _fake_ls()
     ls.projects.update.side_effect = ApiError(status_code=400, body="in use")
@@ -333,9 +333,9 @@ def _species_taxonomy_branch(label: str) -> list[str]:
     structure — a value nested under the wrong parent would still satisfy
     an `in xml` check.
     """
-    import xml.etree.ElementTree as ET  # pylint: disable=import-outside-toplevel
+    import xml.etree.ElementTree as ET
 
-    from fishsense_api_workflow_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker.activities import (
         create_species_label_studio_project_activity as species_sut,
     )
 
@@ -358,7 +358,7 @@ def test_species_xml_carries_the_current_fish_model_set():
         "Yellow Anthias",
     ]
     # Retired model names must be gone, or annotators keep seeing them.
-    from fishsense_api_workflow_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker.activities import (
         create_species_label_studio_project_activity as species_sut,
     )
 

--- a/services/fishsense-api-workflow-worker/tests/test_preflight_ingest_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_preflight_ingest_activity.py
@@ -40,7 +40,7 @@ FOLDER = f"{ROOT}/2024.06.20.REEF/082929_FishModels_FSL07"
 
 
 def _camera(camera_id=7, serial=SERIAL, name="FSL-07"):
-    from fishsense_api_sdk.models.camera import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api_sdk.models.camera import (
         Camera,
     )
 
@@ -48,7 +48,7 @@ def _camera(camera_id=7, serial=SERIAL, name="FSL-07"):
 
 
 def _entry(name: str, size: int = 15_000_000):
-    from fishsense_api_workflow_worker.nas import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker.nas import (
         NasEntry,
     )
 
@@ -58,7 +58,7 @@ def _entry(name: str, size: int = 15_000_000):
 
 
 def _listing(names=("PA010001.ORF", "PA010002.ORF"), subfolders=()):
-    from fishsense_api_workflow_worker.activities.list_dive_folder_activity import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker.activities.list_dive_folder_activity import (
         DiveFolderListing,
     )
 
@@ -70,7 +70,7 @@ def _listing(names=("PA010001.ORF", "PA010002.ORF"), subfolders=()):
 
 
 def _request(**kwargs):
-    from fishsense_shared.ingest_contracts import (  # pylint: disable=import-outside-toplevel
+    from fishsense_shared.ingest_contracts import (
         IngestDiveRequest,
     )
 
@@ -100,7 +100,7 @@ async def _run(request, listing, monkeypatch, *, fs=None, headers=None):
     `headers` maps a file name to the bytes its ranged read returns; anything
     unlisted gets a well-formed default header.
     """
-    from fishsense_api_workflow_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker.activities import (
         preflight_ingest_activity as sut,
     )
 
@@ -370,7 +370,7 @@ async def test_reads_only_the_first_megabyte_of_each_frame(monkeypatch):
     500-frame dive previews for 0.5 GB rather than 7.5 GB. The saving is in
     bytes moved, so it holds whether the client resolves the read over SMB or
     falls back to FileStation."""
-    from fishsense_api_workflow_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker.activities import (
         preflight_ingest_activity as sut,
     )
 
@@ -391,7 +391,7 @@ async def test_reads_only_the_first_megabyte_of_each_frame(monkeypatch):
 
 
 async def test_totals_and_subfolders_are_carried_into_the_report(monkeypatch):
-    from fishsense_shared.ingest_contracts import (  # pylint: disable=import-outside-toplevel
+    from fishsense_shared.ingest_contracts import (
         SubfolderReport,
     )
 

--- a/services/fishsense-api-workflow-worker/tests/test_reconcile_labeling_configs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_reconcile_labeling_configs_activity.py
@@ -124,7 +124,7 @@ async def test_leaves_projects_it_does_not_own_alone(monkeypatch):
 async def test_one_rejected_project_does_not_stop_the_pass(monkeypatch):
     """LS refuses a config that would invalidate existing annotations. That
     must not abort the walk — the remaining projects still reconcile."""
-    from label_studio_sdk.core import ApiError  # pylint: disable=import-outside-toplevel
+    from label_studio_sdk.core import ApiError
 
     ls = _fake_ls(
         [

--- a/services/fishsense-api-workflow-worker/tests/test_scale_down_query_integration.py
+++ b/services/fishsense-api-workflow-worker/tests/test_scale_down_query_integration.py
@@ -54,7 +54,6 @@ def _temporal_target_from_ci_env(monkeypatch):
         monkeypatch.setenv("E4EFS_TEMPORAL__HOST", host)
     if port:
         monkeypatch.setenv("E4EFS_TEMPORAL__PORT", port)
-    # pylint: disable=import-outside-toplevel
     from fishsense_api_workflow_worker import config as cfg
 
     cfg.settings.reload()

--- a/services/fishsense-api-workflow-worker/tests/test_stage_raw_bytes_for_dive_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_stage_raw_bytes_for_dive_activity.py
@@ -154,7 +154,7 @@ async def test_stages_new_checksums_via_nas_download_then_put(monkeypatch):
     monkeypatch.setenv(
         "E4EFS_E4E_NAS__RAW_ROOT_PATH", "/fishsense_data/REEF/data"
     )
-    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import config as cfg
     cfg.settings.reload()
 
     images = [_image(1, checksum="aaa")]
@@ -231,7 +231,7 @@ async def test_failed_nas_download_does_not_upload_to_object_store(monkeypatch):
     monkeypatch.setenv(
         "E4EFS_E4E_NAS__RAW_ROOT_PATH", "/fishsense_data/REEF/data"
     )
-    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import config as cfg
     cfg.settings.reload()
 
     images = [_image(1, checksum="aaa")]
@@ -282,7 +282,7 @@ def test_resolve_nas_path_prepends_root_to_relative_paths(monkeypatch):
     monkeypatch.setenv(
         "E4EFS_E4E_NAS__RAW_ROOT_PATH", "/fishsense_data/REEF/data"
     )
-    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import config as cfg
     cfg.settings.reload()
 
     assert (
@@ -315,7 +315,7 @@ async def test_relative_image_paths_get_prefixed_before_nas_download(monkeypatch
     monkeypatch.setenv(
         "E4EFS_E4E_NAS__RAW_ROOT_PATH", "/fishsense_data/REEF/data"
     )
-    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import config as cfg
     cfg.settings.reload()
 
     images = [
@@ -426,7 +426,7 @@ def test_stage_raw_retry_policy_is_bounded_and_marks_missing_file_non_retryable(
     non-retryable ApplicationError `type` the activity raises for a
     permanent (408) error must be exactly what the policy lists in
     `non_retryable_error_types`, and attempts must be bounded (no storm)."""
-    from fishsense_api_workflow_worker.workflows._retry_policies import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker.workflows._retry_policies import (
         STAGE_RAW_RETRY_POLICY,
     )
 
@@ -438,7 +438,7 @@ def test_stage_raw_retry_policy_is_bounded_and_marks_missing_file_non_retryable(
 
 def test_stage_concurrency_defaults_to_one(monkeypatch):
     # FileStation is fragile; default to a single serial download stream.
-    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import config as cfg
 
     monkeypatch.delenv("E4EFS_E4E_NAS__STAGE_CONCURRENCY", raising=False)
     cfg.settings.reload()
@@ -446,7 +446,7 @@ def test_stage_concurrency_defaults_to_one(monkeypatch):
 
 
 def test_stage_concurrency_reads_config(monkeypatch):
-    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import config as cfg
 
     monkeypatch.setenv("E4EFS_E4E_NAS__STAGE_CONCURRENCY", "3")
     cfg.settings.reload()
@@ -454,7 +454,7 @@ def test_stage_concurrency_reads_config(monkeypatch):
 
 
 def test_stage_concurrency_clamps_to_at_least_one(monkeypatch):
-    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import config as cfg
 
     monkeypatch.setenv("E4EFS_E4E_NAS__STAGE_CONCURRENCY", "0")
     cfg.settings.reload()

--- a/services/fishsense-api-workflow-worker/tests/test_stage_slate_pdf_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_stage_slate_pdf_activity.py
@@ -112,7 +112,7 @@ async def test_downloads_and_puts_when_pdf_missing(monkeypatch):
     monkeypatch.setenv(
         "E4EFS_E4E_NAS__RAW_ROOT_PATH", "/fishsense_data/REEF/data"
     )
-    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import config as cfg
     cfg.settings.reload()
 
     fs = _make_fs([_slate(7)])
@@ -169,7 +169,7 @@ async def test_relative_slate_path_gets_prefixed_before_nas_download(monkeypatch
     monkeypatch.setenv(
         "E4EFS_E4E_NAS__RAW_ROOT_PATH", "/fishsense_data/REEF/data"
     )
-    from fishsense_api_workflow_worker import config as cfg  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker import config as cfg
     cfg.settings.reload()
 
     fs = _make_fs([_slate(7, path="slates/v1/slate.pdf")])

--- a/services/fishsense-api-workflow-worker/tests/test_verify_dive_checksums_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_verify_dive_checksums_activity.py
@@ -86,7 +86,7 @@ def _nas(contents: dict[str, bytes]):
     def _download_to(*, src_path: str, dest_dir: str):
         name = src_path.rsplit("/", 1)[-1]
         if name not in contents:
-            from synology_filestation import (  # pylint: disable=import-outside-toplevel
+            from synology_filestation import (
                 DSMError,
             )
 
@@ -98,7 +98,7 @@ def _nas(contents: dict[str, bytes]):
 
 
 async def _run(images, contents, monkeypatch, **kwargs):
-    from fishsense_api_workflow_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker.activities import (
         verify_dive_checksums_activity as sut,
     )
 
@@ -285,9 +285,9 @@ def test_the_module_imports_no_write_capable_client():
     to answer a question; it must not be able to change the answer. Catches a
     future edit that reaches for `upload`, `delete` or an SDK write.
     """
-    import inspect  # pylint: disable=import-outside-toplevel
+    import inspect
 
-    from fishsense_api_workflow_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api_workflow_worker.activities import (
         verify_dive_checksums_activity as sut,
     )
 

--- a/services/fishsense-api-workflow-worker/worker_tests_support/__init__.py
+++ b/services/fishsense-api-workflow-worker/worker_tests_support/__init__.py
@@ -1,0 +1,9 @@
+"""Test helpers shared across this package's test modules.
+
+Named `worker_tests_support`, not `tests_support`, and deliberately so. The
+changed-files pylint run passes every package's files in one invocation, and
+two packages sharing a module name means whichever lands on sys.path first
+wins — a sibling import then resolves against the wrong package and fails.
+`services/fishsense-api/tests_support` already holds that name, so this one is
+distinct. Same reasoning that kept these out of `tests/` in the first place.
+"""

--- a/services/fishsense-api-workflow-worker/worker_tests_support/populate.py
+++ b/services/fishsense-api-workflow-worker/worker_tests_support/populate.py
@@ -1,0 +1,136 @@
+"""Fixtures shared by the four populate-activity test suites.
+
+Laser, species, head/tail and dive-slate populate are near-identical stages,
+and their tests were near-identical files: the same image and laser-label
+builders and the same fake hosted-Label-Studio client, byte for byte, four
+times over. `duplicate-code` flagged five pairs of them.
+
+The fake LS client is the piece worth having in one place — it encodes how
+hosted Label Studio actually behaves: imports are asynchronous, so the import
+response carries no task ids, and `tasks.list` serves back a per-task presign
+resolve-wrapper URL rather than the `s3://` URI that was imported. That
+behaviour is exactly what the #343 dedup fix turns on, and four copies of it
+are four chances to drift away from the thing being tested.
+"""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+from fishsense_api_sdk.models.image import Image
+from fishsense_api_sdk.models.laser_label import LaserLabel
+
+__all__ = [
+    "image",
+    "laser_label",
+    "fake_label_studio_client",
+    "patch_jpeg_gate",
+    "laser_label_matrix",
+    "images_for",
+]
+
+
+def image(image_id: int, checksum: str) -> Image:
+    return Image(
+        id=image_id,
+        path=f"path/{image_id}.ORF",
+        taken_datetime=datetime(2024, 8, 21, tzinfo=timezone.utc),
+        checksum=checksum,
+        is_canonical=True,
+        dive_id=1,
+        camera_id=6,
+    )
+
+
+def laser_label(
+    image_id: int,
+    *,
+    completed: bool = True,
+    superseded: bool = False,
+    x: Optional[float] = 100.0,
+    y: Optional[float] = 200.0,
+) -> LaserLabel:
+    return LaserLabel(
+        id=image_id * 7,
+        label_studio_task_id=image_id * 10,
+        label_studio_project_id=43,
+        x=x,
+        y=y,
+        label="laser",
+        updated_at=None,
+        superseded=superseded,
+        completed=completed,
+        label_studio_json={},
+        image_id=image_id,
+        user_id=None,
+    )
+
+
+def fake_label_studio_client(returned_task_ids: List[int]):
+    # Fake hosted LS: import creates tasks (assigning ids from
+    # `returned_task_ids` in order) and `tasks.list` serves them back. The
+    # import response carries NO task_ids -- hosted LS imports asynchronously.
+    ls = MagicMock()
+    ls.projects = MagicMock()
+    _stored: List = []
+    _ids = iter(returned_task_ids)
+
+    def _import(project_id, request, return_task_ids=False):  # pylint: disable=unused-argument
+        for task in request:
+            _tid = next(_ids)
+            _s3 = task["data"].get("image") or task["data"].get("img")
+            _fileuri = base64.b64encode(_s3.encode()).decode()
+            # hosted LS lists tasks with a per-task presign resolve-wrapper,
+            # NOT the imported s3:// URL — mirror that so dedup is exercised.
+            _stored.append(
+                SimpleNamespace(
+                    id=_tid,
+                    data={"image": f"/tasks/{_tid}/resolve/?fileuri={_fileuri}"},
+                )
+            )
+        return SimpleNamespace(import_=1)
+
+    ls.projects.import_tasks = MagicMock(side_effect=_import)
+    ls.tasks = MagicMock()
+    ls.tasks.list = MagicMock(side_effect=lambda project=None: list(_stored))
+    return ls
+
+
+def patch_jpeg_gate(monkeypatch, module, present: bool = True):
+    """Point a populate activity's object-store client at a fake.
+
+    Every populate suite defaults this gate to "the JPEG is there" so its
+    tests decide populate purely on label state; the gate's own tests override
+    it with a selective fake. Takes the module rather than patching a fixed
+    target because each suite patches its own activity module.
+    """
+    store = MagicMock()
+    store.has_processed_jpeg = AsyncMock(return_value=present)
+    monkeypatch.setattr(module, "open_object_store_client", lambda: store)
+    return store
+
+
+def laser_label_matrix() -> List[LaserLabel]:
+    """Six laser labels covering every branch of the *valid laser* gate.
+
+    Ids 1-6 are, in order: valid, incomplete, valid, superseded, null x,
+    null y. The suites that cascade from a valid laser (species, head/tail)
+    assert the same selection over exactly this set.
+    """
+    return [
+        laser_label(1),
+        laser_label(2, completed=False),
+        laser_label(3),
+        laser_label(4, superseded=True),
+        laser_label(5, x=None),
+        laser_label(6, y=None),
+    ]
+
+
+def images_for(count: int = 6) -> dict:
+    """`{image_id: Image}` for ids 1..count, checksums 'a', 'b', ..."""
+    return {i: image(i, chr(ord("a") + i - 1)) for i in range(1, count + 1)}

--- a/services/fishsense-api/tests/conftest.py
+++ b/services/fishsense-api/tests/conftest.py
@@ -1,0 +1,36 @@
+"""Fixtures pytest injects into every test module in this package.
+
+The in-memory sqlite `session` lives here rather than in `tests_support.db`
+so no test module has to import it: pytest resolves fixtures by name, and an
+imported-but-never-called fixture reads as an unused import to every static
+analyser. The row builders stay in `tests_support.db`, since those are
+ordinary functions that tests call explicitly.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    """A session over a fresh in-memory schema, disposed afterwards.
+
+    Importing `fishsense_api.database` is load-bearing, not an unused import:
+    it is the model registry, and without it `SQLModel.metadata.create_all`
+    sees only whichever models the test module happened to import.
+    """
+    # pylint: disable=unused-import
+    #   Imported for its side effect: it is the model registry.
+    import fishsense_api.database  # noqa: F401
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as open_session:
+        yield open_session
+    await engine.dispose()

--- a/services/fishsense-api/tests/test_alembic_upgrade.py
+++ b/services/fishsense-api/tests/test_alembic_upgrade.py
@@ -155,7 +155,7 @@ def test_a_failure_creating_views_leaves_the_database_unstamped():
 async def test_lifespan_runs_alembic_upgrade_after_setup(monkeypatch):
     """Wired-up regression: the FastAPI lifespan must invoke the
     upgrade so the deployed image catches up the schema on its own."""
-    from fishsense_api import server  # pylint: disable=import-outside-toplevel
+    from fishsense_api import server
 
     fake_db = MagicMock()
     fake_engine_begin = MagicMock()

--- a/services/fishsense-api/tests/test_api_postgres_integration.py
+++ b/services/fishsense-api/tests/test_api_postgres_integration.py
@@ -55,9 +55,9 @@ def _point_settings_at_the_scratch_database():
     enough on its own; `reload()` re-runs the loaders. Both are undone
     afterwards so the rest of the session sees what it did before.
     """
-    from _pytest.monkeypatch import MonkeyPatch  # pylint: disable=import-outside-toplevel
+    from _pytest.monkeypatch import MonkeyPatch
 
-    from fishsense_api.config import settings  # pylint: disable=import-outside-toplevel
+    from fishsense_api.config import settings
 
     monkeypatch = MonkeyPatch()
     monkeypatch.setenv("E4EFS_POSTGRES__HOST", _PG_HOST)
@@ -81,7 +81,7 @@ def _admin_dsn(dbname: str = "postgres") -> str:
 @pytest.fixture(scope="module", autouse=True)
 def scratch_database():
     """A database of our own, dropped afterwards. Never `fishsense`."""
-    import psycopg  # pylint: disable=import-outside-toplevel
+    import psycopg
 
     with psycopg.connect(_admin_dsn(), autocommit=True) as conn:
         conn.execute(f'DROP DATABASE IF EXISTS "{_SCRATCH_DB}" WITH (FORCE)')
@@ -98,7 +98,7 @@ def empty_schema():
     Dropping the schema rather than the database keeps the connection string
     (and therefore dynaconf's cached settings) stable.
     """
-    import psycopg  # pylint: disable=import-outside-toplevel
+    import psycopg
 
     with psycopg.connect(_admin_dsn(_SCRATCH_DB), autocommit=True) as conn:
         conn.execute("DROP SCHEMA public CASCADE")
@@ -108,7 +108,7 @@ def empty_schema():
 
 def _run_lifespan_sequence() -> None:
     """Exactly what `fishsense_api.server.lifespan` does, in order."""
-    from fishsense_api.database import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.database import (
         run_alembic_upgrade,
         setup_database,
     )
@@ -124,7 +124,7 @@ def _run_lifespan_sequence() -> None:
 
 
 def _query(sql: str):
-    import psycopg  # pylint: disable=import-outside-toplevel
+    import psycopg
 
     with psycopg.connect(_admin_dsn(_SCRATCH_DB)) as conn:
         return conn.execute(sql).fetchall()
@@ -178,7 +178,7 @@ def test_startup_on_a_fresh_database_creates_every_view():
     environment — the local stack, integration CI, a disaster-recovery restore
     into an empty database — silently loses every Superset dashboard.
     """
-    from fishsense_api.views import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.views import (
         DIVE_PIPELINE_STATUS_VIEW_NAME,
         FISH_LENGTH_ESTIMATE_VIEW_NAME,
         FISH_MODEL_ACCURACY_VIEW_NAME,
@@ -200,7 +200,7 @@ def test_every_view_is_actually_queryable_on_postgres():
     """Existing is not the same as valid. These views use Postgres-only
     constructs that SQLite either parses differently or not at all, so a
     malformed one can pass the entire unit suite."""
-    from fishsense_api.views import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.views import (
         DIVE_PIPELINE_STATUS_VIEW_NAME,
         FISH_LENGTH_ESTIMATE_VIEW_NAME,
         FISH_MODEL_ACCURACY_VIEW_NAME,
@@ -253,7 +253,7 @@ def test_dive_pipeline_status_reports_a_seeded_dive_on_postgres():
     SQL against the engine it runs on, with one row through it end to end."""
     _run_lifespan_sequence()
 
-    import psycopg  # pylint: disable=import-outside-toplevel
+    import psycopg
 
     with psycopg.connect(_admin_dsn(_SCRATCH_DB), autocommit=True) as conn:
         conn.execute(
@@ -287,7 +287,7 @@ def test_recreating_the_views_when_they_already_exist_does_not_fail():
     Dropping everything in reverse order first fixes it — and this is the test
     that would have caught it, because SQLite has no such dependency tracking.
     """
-    from fishsense_api.database import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.database import (
         _create_all_views,
     )
 
@@ -308,7 +308,7 @@ def test_an_already_stamped_database_with_no_views_is_repaired():
     alembic finds nothing to do. Without an explicit repair those databases
     stay viewless permanently.
     """
-    import psycopg  # pylint: disable=import-outside-toplevel
+    import psycopg
 
     _run_lifespan_sequence()
 
@@ -327,7 +327,7 @@ def test_an_already_stamped_database_with_no_views_is_repaired():
 def test_a_healthy_database_is_not_rebuilt_on_every_restart():
     """The repair must be conditional. Dropping and recreating every view on
     each startup would break whatever Superset had mid-query, for no reason."""
-    from fishsense_api import database as db_module  # pylint: disable=import-outside-toplevel
+    from fishsense_api import database as db_module
 
     _run_lifespan_sequence()
 
@@ -373,9 +373,9 @@ def _cohort_selectors() -> list:
     `test_canonical_only_pipeline_work.py`: a selector added later is covered
     by this the day it lands, instead of the day someone remembers to add it.
     """
-    import inspect  # pylint: disable=import-outside-toplevel
+    import inspect
 
-    from fishsense_api.controllers import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers import (
         dive_cohort_controller,
     )
 
@@ -395,15 +395,15 @@ async def _seed_multi_valued(session, *, derived_rows: bool = True) -> None:
     never evaluated. The drain test needs them absent so it can watch a dive
     leave the cohort.
     """
-    from datetime import datetime, timezone  # pylint: disable=import-outside-toplevel
+    from datetime import datetime, timezone
 
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.laser_extrinsics import LaserExtrinsics  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.image import Image
+    from fishsense_api.models.laser_extrinsics import LaserExtrinsics
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.priority import Priority
 
-    from fishsense_api.models.camera import Camera  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.camera import Camera
 
     when = datetime(2025, 1, 1, tzinfo=timezone.utc)
     # Postgres enforces the foreign keys the SQLite fixtures quietly ignore, so
@@ -442,9 +442,9 @@ async def _seed_multi_valued(session, *, derived_rows: bool = True) -> None:
     if not derived_rows:
         return
 
-    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.laser_depth import LaserDepth  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.fish import Fish
+    from fishsense_api.models.laser_depth import LaserDepth
+    from fishsense_api.models.measurement import Measurement
 
     session.add(Fish(id=700, species_id=None))
     await session.flush()
@@ -459,9 +459,9 @@ async def _seed_multi_valued(session, *, derived_rows: bool = True) -> None:
 
 def _with_session(coro_factory):
     """Run `coro_factory(session)` against the scratch database."""
-    from fishsense_api.database import setup_database  # pylint: disable=import-outside-toplevel
-    from sqlalchemy.ext.asyncio import async_sessionmaker  # pylint: disable=import-outside-toplevel
-    from sqlmodel.ext.asyncio.session import AsyncSession  # pylint: disable=import-outside-toplevel
+    from fishsense_api.database import setup_database
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+    from sqlmodel.ext.asyncio.session import AsyncSession
 
     async def _run():
         database = setup_database()
@@ -525,13 +525,13 @@ def test_laser_depth_cohort_drains_with_duplicate_labels_on_postgres():
     _run_lifespan_sequence()
 
     async def _exercise(session):
-        from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+        from fishsense_api.controllers.dive_cohort_controller import (
             select_next_for_laser_depth,
         )
-        from fishsense_api.controllers.laser_depth_controller import (  # pylint: disable=import-outside-toplevel
+        from fishsense_api.controllers.laser_depth_controller import (
             put_laser_depth,
         )
-        from fishsense_api.models.laser_depth import LaserDepth  # pylint: disable=import-outside-toplevel
+        from fishsense_api.models.laser_depth import LaserDepth
 
         await _seed_multi_valued(session, derived_rows=False)
         before = await select_next_for_laser_depth(session=session)

--- a/services/fishsense-api/tests/test_calibration_candidates_endpoint.py
+++ b/services/fishsense-api/tests/test_calibration_candidates_endpoint.py
@@ -21,7 +21,7 @@ _T0 = datetime(2024, 6, 1, tzinfo=timezone.utc)
 
 @pytest.fixture
 async def session():
-    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  # pylint: disable=unused-import
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -33,8 +33,8 @@ async def session():
 
 
 def _dive(dive_id: int, camera_id: int | None, *, days: int = 0):
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.priority import (
         Priority,
     )
 
@@ -50,7 +50,7 @@ def _dive(dive_id: int, camera_id: int | None, *, days: int = 0):
 
 def _line(dive_id: int, angle_deg: float, c: float, *, confidence: float = 5000.0):
     """A unit-normal Hesse line rotated `angle_deg` from the x-axis normal."""
-    from fishsense_api.models.dive_laser_line import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_laser_line import (
         DiveLaserLine,
     )
 
@@ -70,7 +70,7 @@ def _line(dive_id: int, angle_deg: float, c: float, *, confidence: float = 5000.
 
 
 def _extrinsics(dive_id: int, camera_id: int):
-    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_extrinsics import (
         LaserExtrinsics,
     )
 
@@ -84,7 +84,7 @@ def _extrinsics(dive_id: int, camera_id: int):
 
 
 async def _candidates(session, dive_id, **kw):
-    from fishsense_api.controllers.calibration_candidate_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.calibration_candidate_controller import (
         get_calibration_candidates,
     )
 
@@ -183,7 +183,7 @@ async def test_returns_empty_when_target_has_no_fingerprint(session):
 
 async def test_sign_flipped_line_still_matches(session):
     # (a,b,c) and (-a,-b,-c) are the same physical line; must compare equal.
-    from fishsense_api.models.dive_laser_line import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_laser_line import (
         DiveLaserLine,
     )
 

--- a/services/fishsense-api/tests/test_calibration_source_endpoints.py
+++ b/services/fishsense-api/tests/test_calibration_source_endpoints.py
@@ -18,39 +18,15 @@ from datetime import datetime, timezone
 
 import pytest
 from fastapi import HTTPException
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-from sqlmodel import SQLModel
-from sqlmodel.ext.asyncio.session import AsyncSession
 
-
-@pytest.fixture
-async def session():
-    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
-
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.create_all)
-    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-    async with factory() as s:
-        yield s
-    await engine.dispose()
-
-
-def _dive(dive_id: int, *, calibration_dive_id=None):
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
-
-    return Dive(
-        id=dive_id,
-        path=f"/dev/null/{dive_id}",
-        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        priority=Priority.HIGH,
-        calibration_dive_id=calibration_dive_id,
-    )
+# Shared with the other controller tests — see `tests_support.db`.
+from tests_support.db import (  # noqa: F401
+    dive as _dive,
+)
 
 
 def _extrinsics(dive_id: int, *, position, created_at):
-    from fishsense_api.models.laser_extrinsics import LaserExtrinsics  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_extrinsics import LaserExtrinsics
 
     return LaserExtrinsics(
         dive_id=dive_id,
@@ -65,7 +41,7 @@ def _extrinsics(dive_id: int, *, position, created_at):
 
 
 async def test_own_extrinsics_win_over_the_link(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         get_laser_extrinsics_for_dive,
     )
 
@@ -86,7 +62,7 @@ async def test_own_extrinsics_win_over_the_link(session):
 
 
 async def test_falls_back_to_linked_source_when_no_own_extrinsics(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         get_laser_extrinsics_for_dive,
     )
 
@@ -103,7 +79,7 @@ async def test_falls_back_to_linked_source_when_no_own_extrinsics(session):
 
 
 async def test_404_when_neither_own_nor_linked_extrinsics(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         get_laser_extrinsics_for_dive,
     )
 
@@ -116,7 +92,7 @@ async def test_404_when_neither_own_nor_linked_extrinsics(session):
 
 
 async def test_no_link_and_no_own_extrinsics_is_404(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         get_laser_extrinsics_for_dive,
     )
 
@@ -132,10 +108,10 @@ async def test_no_link_and_no_own_extrinsics_is_404(session):
 
 
 async def test_set_calibration_source_links_the_dives(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         set_dive_calibration_source,
     )
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
 
     session.add_all([_dive(1), _dive(2)])
     await session.flush()
@@ -146,7 +122,7 @@ async def test_set_calibration_source_links_the_dives(session):
 
 
 async def test_set_calibration_source_rejects_self_link(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         set_dive_calibration_source,
     )
 
@@ -159,7 +135,7 @@ async def test_set_calibration_source_rejects_self_link(session):
 
 
 async def test_set_calibration_source_404_when_source_missing(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         set_dive_calibration_source,
     )
 
@@ -172,7 +148,7 @@ async def test_set_calibration_source_404_when_source_missing(session):
 
 
 async def test_set_calibration_source_404_when_dive_missing(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         set_dive_calibration_source,
     )
 
@@ -185,10 +161,10 @@ async def test_set_calibration_source_404_when_dive_missing(session):
 
 
 async def test_clear_calibration_source_unlinks(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         clear_dive_calibration_source,
     )
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
 
     session.add_all([_dive(1), _dive(2, calibration_dive_id=1)])
     await session.flush()
@@ -198,10 +174,10 @@ async def test_clear_calibration_source_unlinks(session):
 
 
 async def test_clear_calibration_source_is_idempotent(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         clear_dive_calibration_source,
     )
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
 
     session.add(_dive(1))
     await session.flush()
@@ -211,7 +187,7 @@ async def test_clear_calibration_source_is_idempotent(session):
 
 
 async def test_clear_calibration_source_404_when_dive_missing(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         clear_dive_calibration_source,
     )
 

--- a/services/fishsense-api/tests/test_canonical_checksum_index_migration.py
+++ b/services/fishsense-api/tests/test_canonical_checksum_index_migration.py
@@ -89,8 +89,8 @@ def _run_upgrade(migration, conn):
     migration is run through a real (if minimal) alembic context rather than by
     monkeypatching `op`.
     """
-    from alembic.migration import MigrationContext  # pylint: disable=import-outside-toplevel
-    from alembic.operations import Operations  # pylint: disable=import-outside-toplevel
+    from alembic.migration import MigrationContext
+    from alembic.operations import Operations
 
     with Operations.context(MigrationContext.configure(conn)):
         migration.upgrade()
@@ -184,8 +184,8 @@ def test_downgrade_removes_the_index_and_is_safe_when_absent(migration, engine):
         _seed(conn, table, [(1, "a" * 32, True)])
         _run_upgrade(migration, conn)
 
-        from alembic.migration import MigrationContext  # pylint: disable=import-outside-toplevel
-        from alembic.operations import Operations  # pylint: disable=import-outside-toplevel
+        from alembic.migration import MigrationContext
+        from alembic.operations import Operations
 
         with Operations.context(MigrationContext.configure(conn)):
             migration.downgrade()

--- a/services/fishsense-api/tests/test_canonical_only_pipeline_work.py
+++ b/services/fishsense-api/tests/test_canonical_only_pipeline_work.py
@@ -33,7 +33,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 @pytest.fixture
 async def session():
-    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  pylint: disable=unused-import
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -45,8 +45,8 @@ async def session():
 
 
 def _dive(dive_id: int, **kwargs):
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.priority import Priority
 
     kwargs.setdefault("priority", Priority.HIGH)
     return Dive(
@@ -58,7 +58,7 @@ def _dive(dive_id: int, **kwargs):
 
 
 def _image(image_id: int, dive_id: int, *, is_canonical: bool):
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image
 
     return Image(
         id=image_id,
@@ -82,7 +82,7 @@ async def test_a_dive_of_only_duplicate_frames_is_not_laser_preprocessing_work(s
     appears, so the dive never drains — re-staging raw `.ORF`s from the NAS
     every hour and blocking every higher-id dive.
     """
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_preprocessing,
     )
 
@@ -95,7 +95,7 @@ async def test_a_dive_of_only_duplicate_frames_is_not_laser_preprocessing_work(s
 
 async def test_a_canonical_frame_is_still_laser_preprocessing_work(session):
     """The other half — the gate must not swallow real work."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_preprocessing,
     )
 
@@ -109,7 +109,7 @@ async def test_a_canonical_frame_is_still_laser_preprocessing_work(session):
 async def test_a_mixed_dive_is_still_work_for_its_canonical_frames(session):
     """A dive holding one original and one duplicate is real work. Excluding
     the whole dive would strand the original."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_preprocessing,
     )
 
@@ -133,10 +133,10 @@ def test_every_cohort_selector_filters_on_is_canonical():
     Every `Image.dive_id == Dive.id` correlation must be paired with an
     `Image.is_canonical` predicate.
     """
-    import inspect  # pylint: disable=import-outside-toplevel
-    import re  # pylint: disable=import-outside-toplevel
+    import inspect
+    import re
 
-    from fishsense_api.controllers import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers import (
         dive_cohort_controller,
         dive_controller,
     )
@@ -164,9 +164,9 @@ def test_every_cohort_selector_filters_on_is_canonical():
 
 
 async def _pipeline_row(session, dive_id: int):
-    from sqlalchemy import text  # pylint: disable=import-outside-toplevel
+    from sqlalchemy import text
 
-    from fishsense_api.views import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.views import (
         DIVE_PIPELINE_STATUS_VIEW_SQL,
     )
 
@@ -209,7 +209,7 @@ async def test_the_view_ignores_duplicate_frames_like_the_selectors_do(session):
 
 async def test_the_view_still_reports_canonical_frames(session):
     """The gate must not blind the dashboard to real work."""
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     session.add(_image(11, 1, is_canonical=True))
@@ -225,7 +225,7 @@ async def test_the_view_still_reports_canonical_frames(session):
 async def test_view_and_selector_agree_on_a_duplicate_dive(session):
     """The property, stated directly: for the same dive, the view must not
     claim outstanding work that the selector refuses to schedule."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_preprocessing,
     )
 

--- a/services/fishsense-api/tests/test_dive_ingest_endpoints.py
+++ b/services/fishsense-api/tests/test_dive_ingest_endpoints.py
@@ -34,7 +34,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 @pytest.fixture
 async def session():
-    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  # pylint: disable=unused-import
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -46,8 +46,8 @@ async def session():
 
 
 async def _seed_camera(session, camera_id: int = 1, *, with_intrinsics: bool = True):
-    from fishsense_api.models.camera import Camera  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.camera_intrinsics import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.camera import Camera
+    from fishsense_api.models.camera_intrinsics import (
         CameraIntrinsics,
     )
 
@@ -67,8 +67,8 @@ async def _seed_camera(session, camera_id: int = 1, *, with_intrinsics: bool = T
 
 
 def _dive(path: str, **kwargs):
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.priority import Priority
 
     kwargs.setdefault("camera_id", 1)
     kwargs.setdefault("priority", Priority.LOW)
@@ -83,10 +83,10 @@ def _dive(path: str, **kwargs):
 
 
 async def test_post_dive_creates_a_row_and_returns_its_id(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         post_dive,
     )
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
 
     await _seed_camera(session)
 
@@ -105,11 +105,11 @@ async def test_post_dive_is_an_upsert_on_path_not_a_duplicate_insert(session):
     finalize step re-POSTing to flip `priority` LOW -> HIGH. A blind
     `session.merge(id=None)` INSERTs and trips the unique index on `path`.
     """
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         post_dive,
     )
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.priority import Priority
 
     await _seed_camera(session)
     path = "2024 REEF/082124_Alligator_FSL06"
@@ -133,7 +133,7 @@ async def test_post_dive_is_an_upsert_on_path_not_a_duplicate_insert(session):
 
 async def test_post_dive_rejects_a_missing_camera_id(session):
     """No camera means no intrinsics means stage 14 can never measure it."""
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         post_dive,
     )
 
@@ -143,7 +143,7 @@ async def test_post_dive_rejects_a_missing_camera_id(session):
 
 
 async def test_post_dive_rejects_an_unknown_camera_id(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         post_dive,
     )
 
@@ -155,7 +155,7 @@ async def test_post_dive_rejects_an_unknown_camera_id(session):
 async def test_post_dive_rejects_a_camera_without_intrinsics(session):
     """The silent-failure case this endpoint exists to make loud: the dive would
     be created happily and then never reach `measured`, with no error anywhere."""
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         post_dive,
     )
 
@@ -179,9 +179,9 @@ def test_an_over_long_dive_path_is_rejected_when_the_body_is_validated():
     That asymmetry is exactly why the endpoint keeps its own explicit check
     (next test) rather than trusting the model.
     """
-    from pydantic import ValidationError  # pylint: disable=import-outside-toplevel
+    from pydantic import ValidationError
 
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
 
     _dive("x" * 256)  # constructing is NOT validated — no raise
 
@@ -199,10 +199,10 @@ async def test_post_dive_rejects_an_over_long_path_that_bypassed_validation(sess
     """`model_construct` skips pydantic. Postgres would reject the value, but
     sqlite silently stores it, and a truncated `Dive.path` no longer resolves
     on the NAS — so the endpoint checks explicitly, before re-validating."""
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         post_dive,
     )
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
 
     await _seed_camera(session)
     smuggled = Dive.model_construct(
@@ -218,7 +218,7 @@ async def test_post_dive_rejects_an_over_long_path_that_bypassed_validation(sess
 
 
 async def test_post_dive_rejects_a_self_referential_calibration_source(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         post_dive,
     )
 
@@ -231,7 +231,7 @@ async def test_post_dive_rejects_a_self_referential_calibration_source(session):
 
 
 async def test_post_dive_rejects_an_unknown_calibration_source(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         post_dive,
     )
 
@@ -245,10 +245,10 @@ async def test_post_dive_rejects_an_unknown_calibration_source(session):
 async def test_post_dive_accepts_a_valid_calibration_source(session):
     """A fish-only dive borrowing a sibling slate dive's calibration is the
     whole point of `calibration_dive_id` — it must not be blocked."""
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         post_dive,
     )
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
 
     await _seed_camera(session)
     slate_dive = await post_dive(_dive("d/slate"), session=session)
@@ -280,11 +280,11 @@ async def test_reposting_a_dive_preserves_fields_the_body_did_not_mention(sessio
     Ingest itself re-POSTs the dive at finalize, so it would have tripped this
     on its own. Only fields the caller actually sent may be written.
     """
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         post_dive,
     )
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.priority import Priority
 
     await _seed_camera(session)
     slate_dive = await post_dive(_dive("d/slate"), session=session)
@@ -320,10 +320,10 @@ async def test_reposting_a_dive_can_still_clear_a_field_explicitly(session):
     """Partial update must not become "you can never null anything". An
     explicit `None` in the body is a real instruction — that is how an
     operator drops a wrong calibration link."""
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         post_dive,
     )
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
 
     await _seed_camera(session)
     slate_dive = await post_dive(_dive("d/slate"), session=session)
@@ -346,7 +346,7 @@ async def test_reposting_a_dive_can_still_clear_a_field_explicitly(session):
 
 
 async def test_post_dive_rejects_an_empty_path(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         post_dive,
     )
 
@@ -360,10 +360,10 @@ async def test_post_dive_rejects_an_empty_path(session):
 async def test_post_dive_honours_an_explicit_id_instead_of_resolving_by_path(session):
     """The `id is not None` branch — an update targeted by primary key, which
     skips natural-key resolution (and so also skips the partial overlay)."""
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         post_dive,
     )
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
 
     await _seed_camera(session)
     dive_id = await post_dive(_dive("d/original"), session=session)

--- a/services/fishsense-api/tests/test_dive_laser_line_endpoint.py
+++ b/services/fishsense-api/tests/test_dive_laser_line_endpoint.py
@@ -17,7 +17,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 @pytest.fixture
 async def session():
-    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  # pylint: disable=unused-import
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -29,7 +29,7 @@ async def session():
 
 
 def _line(dive_id: int, *, a, b, c, confidence=10.0):
-    from fishsense_api.models.dive_laser_line import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_laser_line import (
         DiveLaserLine,
     )
 
@@ -48,7 +48,7 @@ def _line(dive_id: int, *, a, b, c, confidence=10.0):
 
 
 async def _count(session: AsyncSession, dive_id: int) -> int:
-    from fishsense_api.models.dive_laser_line import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_laser_line import (
         DiveLaserLine,
     )
 
@@ -59,7 +59,7 @@ async def _count(session: AsyncSession, dive_id: int) -> int:
 
 
 async def test_put_upserts_on_dive_id(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         get_dive_laser_line,
         put_dive_laser_line,
     )
@@ -75,7 +75,7 @@ async def test_put_upserts_on_dive_id(session):
 
 
 async def test_put_stamps_non_null_fitted_at(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         get_dive_laser_line,
         put_dive_laser_line,
     )
@@ -87,7 +87,7 @@ async def test_put_stamps_non_null_fitted_at(session):
 
 
 async def test_get_returns_none_when_absent(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         get_dive_laser_line,
     )
 

--- a/services/fishsense-api/tests/test_dive_pipeline_status_view.py
+++ b/services/fishsense-api/tests/test_dive_pipeline_status_view.py
@@ -35,7 +35,7 @@ from fishsense_api.views import (
 @pytest.fixture
 async def session():
     """In-memory sqlite + the view created on top via raw SQL."""
-    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  # pylint: disable=unused-import
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -57,8 +57,8 @@ def _dive(
     calibration_dive_id=None,
     name=None,
 ):
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.priority import Priority
 
     return Dive(
         id=dive_id,
@@ -76,7 +76,7 @@ def _image(image_id: int, dive_id: int, *, is_canonical: bool = True):
     False on the model, which made every seeded image a duplicate; harmless
     while nothing read the flag, misleading now that the cohort selectors gate
     on it."""
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image
 
     return Image(
         id=image_id,
@@ -178,7 +178,7 @@ async def test_dive_name_null_passes_through_as_none(session):
 
 
 async def test_laser_preprocessed_true_when_every_image_has_laser_row(session):
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -196,7 +196,7 @@ async def test_laser_preprocessed_true_when_every_image_has_laser_row(session):
 
 
 async def test_laser_preprocessed_false_when_one_image_lacks_label(session):
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -214,7 +214,7 @@ async def test_laser_preprocessed_false_when_one_image_lacks_label(session):
 async def test_laser_labeling_complete_true_when_all_completed_and_none_incomplete(
     session,
 ):
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -242,7 +242,7 @@ async def test_laser_labeling_complete_false_when_zero_labels(session):
 
 
 async def test_laser_labeling_complete_false_when_any_incomplete(session):
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -262,7 +262,7 @@ async def test_laser_labeling_complete_false_when_any_incomplete(session):
 async def test_laser_labeling_complete_ignores_superseded_incomplete(session):
     """Superseded incomplete rows are dead; they must not block
     completion. Mirrors the laser-validate flow's behavior."""
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -285,8 +285,8 @@ async def test_laser_labeling_complete_ignores_superseded_incomplete(session):
 async def test_headtail_preprocessed_true_when_every_valid_laser_image_has_headtail(
     session,
 ):
-    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.head_tail_label import HeadTailLabel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -307,7 +307,7 @@ async def test_headtail_preprocessed_true_when_every_valid_laser_image_has_headt
 
 
 async def test_headtail_preprocessed_false_when_no_valid_laser_images(session):
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -324,7 +324,7 @@ async def test_headtail_preprocessed_false_when_no_valid_laser_images(session):
 async def test_headtail_preprocessed_false_when_valid_laser_image_lacks_headtail(
     session,
 ):
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -344,8 +344,8 @@ async def test_headtail_preprocessed_false_when_valid_laser_image_lacks_headtail
 async def test_headtail_preprocessed_ignores_sentinel_headtail_rows(session):
     """A sentinel HeadTailLabel (label_studio_project_id NULL) does
     NOT count as preprocessed — matches the cohort selector."""
-    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.head_tail_label import HeadTailLabel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -373,7 +373,7 @@ async def test_headtail_preprocessed_ignores_sentinel_headtail_rows(session):
 async def test_headtail_labeling_complete_true_when_all_completed_and_none_incomplete(
     session,
 ):
-    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.head_tail_label import HeadTailLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -391,7 +391,7 @@ async def test_headtail_labeling_complete_true_when_all_completed_and_none_incom
 
 
 async def test_headtail_labeling_complete_false_when_any_incomplete(session):
-    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.head_tail_label import HeadTailLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -424,7 +424,7 @@ async def test_headtail_labeling_complete_false_when_zero_labels(session):
 async def test_species_labeling_complete_ignores_superseded(session):
     """A superseded incomplete species row must not block completion —
     the new `superseded` column on SpeciesLabel."""
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -450,7 +450,7 @@ async def test_species_labeling_complete_ignores_superseded(session):
 async def test_slate_labeling_complete_ignores_superseded(session):
     """A superseded incomplete slate row must not block completion —
     the new `superseded` column on DiveSlateLabel."""
-    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -477,7 +477,7 @@ async def test_slate_labeling_complete_ignores_superseded(session):
 
 
 async def test_has_prediction_clusters_reflects_data_source(session):
-    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster
 
     session.add_all([_dive(1), _dive(2)])
     await session.flush()
@@ -503,12 +503,12 @@ async def test_dive_images_preprocessed_requires_clusters_and_laser_valid_specie
 ):
     """Predicate (post 2026-05-05): PREDICTION cluster present AND
     every laser-valid image has a non-sentinel SpeciesLabel row."""
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
         DiveFrameClusterImageMapping,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -542,8 +542,8 @@ async def test_dive_images_preprocessed_requires_clusters_and_laser_valid_specie
 async def test_dive_images_preprocessed_false_without_prediction_cluster(session):
     """No PREDICTION cluster → dive_images_preprocessed must be False
     even if every laser-valid image has a species row."""
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -566,9 +566,9 @@ async def test_dive_images_preprocessed_false_when_laser_valid_image_lacks_speci
 ):
     """Laser-valid image 12 lacks a species row → dive_images_preprocessed
     is False. Image 11 having a species row isn't enough."""
-    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -601,7 +601,7 @@ async def test_dive_images_preprocessed_false_when_no_laser_valid_images(session
     """Vacuous-truth guard: a dive with PREDICTION clusters but no
     laser-valid images must read False, not True. Mirrors the
     headtail_preprocessed convention."""
-    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster
 
     session.add(_dive(1))
     await session.flush()
@@ -623,12 +623,12 @@ async def test_dive_images_preprocessed_ignores_images_without_valid_laser(sessi
     species row on it doesn't fail dive_images_preprocessed. As long
     as the laser-valid image (11) has a species row, the predicate
     holds."""
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
         DiveFrameClusterImageMapping,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -672,15 +672,15 @@ async def test_view_and_selector_agree_on_species_predicate(session):
       B. dive done       → view True,  selector returns None
       C. dive ineligible → view False, selector returns None
     """
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_species_preprocessing,
     )
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
         DiveFrameClusterImageMapping,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     # dive 1 (Case A): valid laser IN a cluster + no species → cohort.
     # dive 2 (Case B): valid laser IN a cluster + species labeled → done.
@@ -740,7 +740,7 @@ async def test_view_and_selector_agree_on_species_predicate(session):
 
 
 async def test_species_labeling_complete_true_when_all_completed(session):
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -758,7 +758,7 @@ async def test_species_labeling_complete_true_when_all_completed(session):
 
 
 async def test_species_labeling_complete_false_when_any_incomplete(session):
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -793,8 +793,8 @@ async def test_slate_applicable_tracks_dive_slate_id(session):
 
 
 async def test_slate_preprocessed_true_when_marked_images_have_slate_rows(session):
-    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1, dive_slate_id=42))
     await session.flush()
@@ -817,7 +817,7 @@ async def test_slate_preprocessed_true_when_marked_images_have_slate_rows(sessio
 async def test_slate_preprocessed_false_when_no_slate_marked_images(session):
     """No species label says 'Slate, Laser on slate' -> there's
     nothing to preprocess yet -> False, not vacuously True."""
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1, dive_slate_id=42))
     await session.flush()
@@ -837,8 +837,8 @@ async def test_slate_preprocessed_false_when_no_slate_marked_images(session):
 async def test_slate_preprocessed_false_when_dive_lacks_slate_id(session):
     """Even if labels exist, no dive_slate_id means slate path doesn't
     apply to this dive at all."""
-    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1, dive_slate_id=None))
     await session.flush()
@@ -857,7 +857,7 @@ async def test_slate_preprocessed_false_when_dive_lacks_slate_id(session):
 
 
 async def test_slate_labeling_complete_true_when_all_completed(session):
-    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel
 
     session.add(_dive(1, dive_slate_id=42))
     await session.flush()
@@ -878,7 +878,7 @@ async def test_slate_labeling_complete_true_when_all_completed(session):
 
 
 async def test_calibrated_true_when_laser_extrinsics_row_exists(session):
-    from fishsense_api.models.laser_extrinsics import LaserExtrinsics  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_extrinsics import LaserExtrinsics
 
     session.add(_dive(1))
     await session.flush()
@@ -898,7 +898,7 @@ async def test_calibrated_false_when_no_laser_extrinsics(session):
 async def test_calibrated_true_when_borrowed_via_calibration_dive_id(session):
     """A fish-only dive linked to a slate dive that owns extrinsics reads
     calibrated=true even though it has none of its own."""
-    from fishsense_api.models.laser_extrinsics import LaserExtrinsics  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_extrinsics import LaserExtrinsics
 
     session.add(_dive(1))  # slate dive: owns the calibration
     session.add(_dive(2, calibration_dive_id=1))  # fish dive: borrows it
@@ -1050,7 +1050,7 @@ async def test_measured_ignores_unbound_clusters_with_no_measurable_image(sessio
     measured=false forever. In prod dive 466 carried 1632 such clusters
     against only 24 measurable images.
     """
-    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import DiveFrameCluster
 
     session.add(_dive(1))
     await session.flush()
@@ -1115,7 +1115,7 @@ async def test_measured_true_through_a_borrowed_calibration(session):
 
 async def test_measured_ignores_non_top_three_images(session):
     """Stage 14 only measures top-three photos, so others can't block."""
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -1176,13 +1176,13 @@ async def test_dive_images_preprocessed_ignores_unclustered_and_superseded(sessi
     forever on a dive the selector correctly never re-fires on (the prod
     poison pill).
     """
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
         DiveFrameClusterImageMapping,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -1215,13 +1215,13 @@ async def test_dive_images_preprocessed_ignores_unclustered_and_superseded(sessi
 
 async def test_dive_images_preprocessed_false_when_only_species_row_superseded(session):
     """A dead-lettered species row is not evidence the work is done."""
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
         DiveFrameClusterImageMapping,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -1259,7 +1259,7 @@ async def test_dive_images_preprocessed_false_when_only_species_row_superseded(s
 
 
 async def test_calibration_source_own_when_the_dive_has_its_own_extrinsics(session):
-    from fishsense_api.models.laser_extrinsics import LaserExtrinsics  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_extrinsics import LaserExtrinsics
 
     session.add(_dive(1))
     await session.flush()
@@ -1270,7 +1270,7 @@ async def test_calibration_source_own_when_the_dive_has_its_own_extrinsics(sessi
 
 
 async def test_calibration_source_borrowed_when_only_the_link_has_extrinsics(session):
-    from fishsense_api.models.laser_extrinsics import LaserExtrinsics  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_extrinsics import LaserExtrinsics
 
     session.add_all([_dive(2), _dive(1, calibration_dive_id=2)])
     await session.flush()
@@ -1283,7 +1283,7 @@ async def test_calibration_source_borrowed_when_only_the_link_has_extrinsics(ses
 async def test_calibration_source_own_wins_over_a_link(session):
     """Mirrors `get_laser_extrinsics_for_dive`: a dive with its own row uses it
     even when `calibration_dive_id` is also set, so provenance must say 'own'."""
-    from fishsense_api.models.laser_extrinsics import LaserExtrinsics  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_extrinsics import LaserExtrinsics
 
     session.add_all([_dive(2), _dive(1, calibration_dive_id=2)])
     await session.flush()
@@ -1323,10 +1323,10 @@ async def test_measurable_species_sql_agrees_with_taxonomy_is_measurable(session
     re-selects the dive every hour forever. So both representations are run
     over the same corpus and compared row by row.
     """
-    from fishsense_shared import taxonomy  # pylint: disable=import-outside-toplevel
+    from fishsense_shared import taxonomy
 
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.views import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel
+    from fishsense_api.views import (
         _MEASURABLE_SPECIES_SQL,
     )
 
@@ -1368,15 +1368,15 @@ async def test_measurable_species_sql_agrees_with_taxonomy_is_measurable(session
 async def test_measurable_species_sql_agrees_with_the_sqlalchemy_conditions(session):
     """The view's raw SQL and the cohort selector's SQLAlchemy build the same
     predicate from the same constants; assert they select the same rows."""
-    from sqlmodel import select  # pylint: disable=import-outside-toplevel
+    from sqlmodel import select
 
-    from fishsense_shared import taxonomy  # pylint: disable=import-outside-toplevel
+    from fishsense_shared import taxonomy
 
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         _measurable_species_conditions,
     )
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.views import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel
+    from fishsense_api.views import (
         _MEASURABLE_SPECIES_SQL,
     )
 
@@ -1425,10 +1425,10 @@ async def test_sql_is_broader_than_python_only_where_pinned(session):
     so widening the predicate — or tightening the Python parser, which is how
     this regressed once already — is caught here rather than in prod.
     """
-    from fishsense_shared import taxonomy  # pylint: disable=import-outside-toplevel
+    from fishsense_shared import taxonomy
 
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.views import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel
+    from fishsense_api.views import (
         _MEASURABLE_SPECIES_SQL,
     )
 

--- a/services/fishsense-api/tests/test_dive_route_disambiguation.py
+++ b/services/fishsense-api/tests/test_dive_route_disambiguation.py
@@ -14,42 +14,18 @@ the matching parametrize case.
 
 from __future__ import annotations
 
-import os
-
 import pytest
-from starlette.routing import Match
+from tests_support.app import resolve_route, seed_placeholder_settings
 
 
 @pytest.fixture(scope="module")
 def app():
-    os.environ.setdefault("E4EFS_POSTGRES__HOST", "ignored")
-    os.environ.setdefault("E4EFS_POSTGRES__PORT", "5432")
-    os.environ.setdefault("E4EFS_POSTGRES__USERNAME", "ignored")
-    os.environ.setdefault("E4EFS_POSTGRES__PASSWORD", "ignored")
-    os.environ.setdefault("E4EFS_POSTGRES__DATABASE", "ignored")
+    seed_placeholder_settings()
 
-    import fishsense_api.controllers.dive_controller  # noqa: F401, pylint: disable=import-outside-toplevel,unused-import
-    from fishsense_api.server import app  # pylint: disable=import-outside-toplevel
+    import fishsense_api.controllers.dive_controller  # noqa: F401, pylint: disable=unused-import
+    from fishsense_api.server import app
 
     return app
-
-
-def _resolve(app, path: str) -> str | None:
-    scope = {
-        "type": "http",
-        "method": "GET",
-        "path": path,
-        "path_params": {},
-        "route_path": path,
-        "headers": [],
-    }
-    for route in app.routes:
-        if not hasattr(route, "matches"):
-            continue
-        match, _ = route.matches(scope)
-        if match == Match.FULL:
-            return route.endpoint.__name__
-    return None
 
 
 @pytest.mark.parametrize(
@@ -93,5 +69,6 @@ def _resolve(app, path: str) -> str | None:
         ("/api/v1/dives/123", "get_dive"),
     ],
 )
+
 def test_dive_route_resolves_to_expected_endpoint(app, path, expected_endpoint):
-    assert _resolve(app, path) == expected_endpoint
+    assert resolve_route(app, path) == expected_endpoint

--- a/services/fishsense-api/tests/test_dives_with_complete_laser_labeling_endpoint.py
+++ b/services/fishsense-api/tests/test_dives_with_complete_laser_labeling_endpoint.py
@@ -9,49 +9,13 @@ referential integrity.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-
-import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-from sqlmodel import SQLModel
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 
-@pytest.fixture
-async def session():
-    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
-
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.create_all)
-    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-    async with factory() as s:
-        yield s
-    await engine.dispose()
-
-
-def _dive(dive_id: int):
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
-
-    return Dive(
-        id=dive_id,
-        path=f"/dev/null/{dive_id}",
-        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        priority=Priority.HIGH,
-    )
-
-
-def _image(image_id: int, dive_id: int):
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
-
-    return Image(
-        id=image_id,
-        path=f"/dev/null/img-{image_id}",
-        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"{image_id:032d}",
-        dive_id=dive_id,
-    )
+# Shared with the other controller tests — see `tests_support.db`.
+from tests_support.db import (  # noqa: F401
+    dive as _dive,
+    image as _image,
+)
 
 
 def _laser_label(
@@ -62,7 +26,7 @@ def _laser_label(
     superseded: bool = False,
     project_id: int | None = 42,
 ):
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     return LaserLabel(
         id=label_id,
@@ -74,7 +38,7 @@ def _laser_label(
 
 
 async def _call(session):
-    from fishsense_api.controllers.label_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.label_controller import (
         get_dives_with_complete_laser_labeling,
     )
 

--- a/services/fishsense-api/tests/test_fish_controller.py
+++ b/services/fishsense-api/tests/test_fish_controller.py
@@ -19,7 +19,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 @pytest.fixture
 async def session():
-    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  pylint: disable=unused-import
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -31,13 +31,13 @@ async def session():
 
 
 def _fish(name=None, species_id=None, fish_id=None):
-    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.fish import Fish
 
     return Fish(id=fish_id, name=name, species_id=species_id)
 
 
 async def _get_by_name(session, name: str):
-    from fishsense_api.controllers.fish_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.fish_controller import (
         get_fish_by_name,
     )
 
@@ -45,7 +45,7 @@ async def _get_by_name(session, name: str):
 
 
 async def _post(session, fish):
-    from fishsense_api.controllers.fish_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.fish_controller import (
         post_fish,
     )
 
@@ -74,7 +74,7 @@ async def test_get_fish_by_name_404s_when_absent(session):
 
 
 async def test_post_fish_creates_named(session):
-    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.fish import Fish
 
     new_id = await _post(session, _fish(name="Grouper"))
     await session.flush()
@@ -87,7 +87,7 @@ async def test_post_fish_creates_named(session):
 
 async def test_post_fish_upserts_on_name(session):
     """Second POST of the same model name must not insert a duplicate."""
-    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.fish import Fish
 
     first = await _post(session, _fish(name="Grouper"))
     await session.flush()
@@ -101,7 +101,7 @@ async def test_post_fish_upserts_on_name(session):
 
 async def test_post_fish_null_names_do_not_collide(session):
     """Real fish (name=None) must both insert under the nullable-unique key."""
-    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.fish import Fish
 
     await _post(session, _fish(name=None, species_id=None))
     await session.flush()

--- a/services/fishsense-api/tests/test_fish_length_estimate_view.py
+++ b/services/fishsense-api/tests/test_fish_length_estimate_view.py
@@ -26,7 +26,7 @@ from fishsense_api.views import FISH_LENGTH_ESTIMATE_VIEW_SQL
 
 @pytest.fixture
 async def session():
-    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  pylint: disable=unused-import
 
     _SEEDED_DIVES.clear()
     _SEEDED_FISH.clear()
@@ -45,11 +45,11 @@ _SEEDED_FISH: set[int] = set()
 
 
 def _seed(session, fish_id: int, dive_id: int, lengths: list[float], base: int = 0):
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.fish import Fish
+    from fishsense_api.models.image import Image
+    from fishsense_api.models.measurement import Measurement
+    from fishsense_api.models.priority import Priority
 
     if dive_id not in _SEEDED_DIVES:
         _SEEDED_DIVES.add(dive_id)
@@ -147,8 +147,8 @@ async def test_one_row_per_fish_and_dive(session):
 
 async def test_measurements_without_a_length_are_excluded(session):
     _seed(session, 1, 1, [1.00, 1.00])
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image
+    from fishsense_api.models.measurement import Measurement
 
     session.add(
         Image(

--- a/services/fishsense-api/tests/test_fish_model_mislabel_suspects.py
+++ b/services/fishsense-api/tests/test_fish_model_mislabel_suspects.py
@@ -40,7 +40,7 @@ _KNOWN = {
 
 @pytest.fixture
 async def session():
-    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  pylint: disable=unused-import
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -55,7 +55,7 @@ async def session():
 
 
 async def _seed_reference(session):
-    from fishsense_api.models.fish_model_reference import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.fish_model_reference import (
         FishModelReference,
     )
 
@@ -69,14 +69,14 @@ _NEXT = {"image": 1000}
 
 async def _measure(session, *, dive_id, model_name, length_m):
     """Seed one measurement of `model_name` at `length_m` in `dive_id`."""
-    from datetime import datetime, timezone  # pylint: disable=import-outside-toplevel
+    from datetime import datetime, timezone
 
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
-    from sqlmodel import select  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.fish import Fish
+    from fishsense_api.models.image import Image
+    from fishsense_api.models.measurement import Measurement
+    from fishsense_api.models.priority import Priority
+    from sqlmodel import select
 
     if (await session.exec(select(Dive).where(Dive.id == dive_id))).first() is None:
         session.add(

--- a/services/fishsense-api/tests/test_fish_model_reference.py
+++ b/services/fishsense-api/tests/test_fish_model_reference.py
@@ -27,7 +27,7 @@ from fishsense_api.views import (
 
 @pytest.fixture
 async def session():
-    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  pylint: disable=unused-import
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -79,7 +79,7 @@ def test_known_model_names_are_unique():
 
 
 async def test_reference_row_round_trips(session):
-    from fishsense_api.models.fish_model_reference import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.fish_model_reference import (
         FishModelReference,
     )
 
@@ -99,13 +99,13 @@ async def test_reference_row_round_trips(session):
 
 
 async def _seed_measurement(session, *, dive_id, image_id, model_name, length_m):
-    from datetime import datetime, timezone  # pylint: disable=import-outside-toplevel
+    from datetime import datetime, timezone
 
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.fish import Fish
+    from fishsense_api.models.image import Image
+    from fishsense_api.models.measurement import Measurement
+    from fishsense_api.models.priority import Priority
 
     existing = (await session.exec(select(Dive).where(Dive.id == dive_id))).first()
     if existing is None:
@@ -151,7 +151,7 @@ async def _rows(session):
 
 
 async def test_accuracy_view_computes_error_against_known_length(session):
-    from fishsense_api.models.fish_model_reference import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.fish_model_reference import (
         FishModelReference,
     )
 
@@ -174,14 +174,14 @@ async def test_accuracy_view_computes_error_against_known_length(session):
 async def test_accuracy_view_excludes_real_fish(session):
     """Real (wild) fish carry name=NULL and have no reference row — they must
     not appear, or the view stops being a model-accuracy view."""
-    from datetime import datetime, timezone  # pylint: disable=import-outside-toplevel
+    from datetime import datetime, timezone
 
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.fish_model_reference import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.fish import Fish
+    from fishsense_api.models.image import Image
+    from fishsense_api.models.measurement import Measurement
+    from fishsense_api.models.priority import Priority
+    from fishsense_api.models.fish_model_reference import (
         FishModelReference,
     )
 

--- a/services/fishsense-api/tests/test_generated_sdk_models_freshness.py
+++ b/services/fishsense-api/tests/test_generated_sdk_models_freshness.py
@@ -35,7 +35,7 @@ GENERATED_OUTPUT = (
 
 
 def _dump_openapi_schema() -> dict:
-    # pylint: disable=import-outside-toplevel,unused-import
+    # pylint: disable=unused-import
     # Controllers register routes via @app.get/.put/etc. side effects on
     # import; they MUST be imported after the env-var seed below so dynaconf's
     # eager validation has placeholders to find.

--- a/services/fishsense-api/tests/test_get_clusters_data_source_filter.py
+++ b/services/fishsense-api/tests/test_get_clusters_data_source_filter.py
@@ -26,9 +26,9 @@ async def session():
     # which the sqlite/StaticPool combo rejects.
     # Importing fishsense_api.database wires every model into SQLModel.metadata
     # so create_all sees them.
-    from sqlalchemy.ext.asyncio import create_async_engine  # pylint: disable=import-outside-toplevel
+    from sqlalchemy.ext.asyncio import create_async_engine
 
-    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  # pylint: disable=unused-import
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -40,11 +40,11 @@ async def session():
 
 
 async def test_get_clusters_returns_only_requested_data_source(session):
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         get_clusters,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
         DiveFrameClusterImageMapping,
     )
@@ -97,11 +97,11 @@ async def test_get_clusters_returns_only_requested_data_source(session):
 async def test_get_clusters_handles_cluster_with_no_mappings(session):
     """Defensive: a cluster of the requested data_source with zero rows in
     the mapping table must surface as image_ids=[], not KeyError."""
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         get_clusters,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
     )
 

--- a/services/fishsense-api/tests/test_image_ingest_endpoints.py
+++ b/services/fishsense-api/tests/test_image_ingest_endpoints.py
@@ -31,7 +31,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 @pytest.fixture
 async def session():
-    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  # pylint: disable=unused-import
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -43,8 +43,8 @@ async def session():
 
 
 async def _seed_dive(session, dive_id: int, path: str):
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.priority import Priority
 
     session.add(
         Dive(
@@ -59,7 +59,7 @@ async def _seed_dive(session, dive_id: int, path: str):
 
 
 def _image(path: str, checksum: str, **kwargs):
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image
 
     kwargs.setdefault("camera_id", 1)
     return Image(
@@ -78,10 +78,10 @@ CK_B = "0b7cd4da72d54172f1f9daf40ce4047f"
 
 
 async def test_post_image_creates_a_row_and_binds_it_to_the_path_dive(session):
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_image,
     )
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image
 
     await _seed_dive(session, 7, "d/7")
 
@@ -99,10 +99,10 @@ async def test_post_image_creates_a_row_and_binds_it_to_the_path_dive(session):
 async def test_post_image_is_an_upsert_on_path_not_a_duplicate_insert(session):
     """`Image.path` is unique. Resuming a partial scan re-posts paths that are
     already there; a blind merge would 500 on the unique index."""
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_image,
     )
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image
 
     await _seed_dive(session, 7, "d/7")
     path = "d/7/P8210001.ORF"
@@ -120,10 +120,10 @@ async def test_post_image_is_an_upsert_on_path_not_a_duplicate_insert(session):
 
 async def test_first_image_with_a_checksum_is_canonical_later_duplicates_are_not(session):
     """The dives-64/66 rule, from `9e5bc64`."""
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_image,
     )
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image
 
     await _seed_dive(session, 64, "d/64")
     await _seed_dive(session, 66, "d/66")
@@ -144,10 +144,10 @@ async def test_reposting_the_same_path_does_not_demote_it_to_non_canonical(sessi
     is *itself*, so 'a row with this checksum already exists' must not flip it
     to False — that would quietly strip canonical status from a whole dive on
     every re-run."""
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_image,
     )
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image
 
     await _seed_dive(session, 7, "d/7")
     path = "d/7/P8210001.ORF"
@@ -166,10 +166,10 @@ async def test_promoting_a_copy_demotes_the_incumbent(session):
     Promotion must be a *swap*, not an addition: exactly one row per checksum
     is canonical. Before `uq_image_canonical_checksum` existed this endpoint
     happily produced two, and nothing complained."""
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_image,
     )
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image
 
     await _seed_dive(session, 64, "d/64")
     await _seed_dive(session, 66, "d/66")
@@ -188,7 +188,7 @@ async def test_promoting_a_copy_demotes_the_incumbent(session):
 
 
 async def test_post_image_rejects_a_path_longer_than_the_column(session):
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_image,
     )
 
@@ -202,7 +202,7 @@ async def test_post_image_rejects_a_path_longer_than_the_column(session):
 async def test_post_image_rejects_a_checksum_that_is_not_a_32_char_md5(session):
     """A wrong-width checksum means the hashing changed underneath us; every
     duplicate check downstream would silently stop matching."""
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_image,
     )
 
@@ -215,7 +215,7 @@ async def test_post_image_rejects_a_checksum_that_is_not_a_32_char_md5(session):
 
 
 async def test_post_image_rejects_an_unknown_dive(session):
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_image,
     )
 
@@ -228,7 +228,7 @@ async def test_post_image_rejects_an_unknown_dive(session):
 
 
 async def test_checksum_lookup_reports_every_dive_holding_each_checksum(session):
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_checksum_lookup,
         post_image,
     )
@@ -251,7 +251,7 @@ async def test_checksum_lookup_reports_every_dive_holding_each_checksum(session)
 async def test_checksum_lookup_returns_an_empty_list_for_unknown_checksums(session):
     """Empty list, not a missing key — the caller computes
     `|new n existing| / |new|` and should not have to guard every lookup."""
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_checksum_lookup,
     )
 
@@ -268,7 +268,7 @@ async def test_checksum_lookup_is_a_set_operation_not_an_ordered_digest(session)
     is why it never worked well: near-duplicates are the common case, and
     filename order changed the digest even when the bytes matched.
     """
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_checksum_lookup,
         post_image,
     )
@@ -290,10 +290,10 @@ async def test_checksum_lookup_is_a_set_operation_not_an_ordered_digest(session)
 async def test_reposting_an_image_preserves_fields_the_body_did_not_mention(session):
     """Same destructive-upsert class as the dive endpoint. A resumed scan
     re-posts paths it has already written; anything it omits must survive."""
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_image,
     )
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image
 
     await _seed_dive(session, 7, "d/7")
     path = "d/7/P8210001.ORF"
@@ -314,7 +314,7 @@ async def test_reposting_an_image_preserves_fields_the_body_did_not_mention(sess
 
 
 async def test_post_image_rejects_an_empty_path(session):
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_image,
     )
 
@@ -328,10 +328,10 @@ async def test_post_image_rejects_an_empty_path(session):
 async def test_post_image_rejects_a_missing_taken_datetime(session):
     """Stage-1 clustering is pure timestamp math, so a defaulted or absent
     `taken_datetime` would corrupt it with nothing to show for it."""
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_image,
     )
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image
 
     await _seed_dive(session, 7, "d/7")
     no_date = Image(path="d/7/P1.ORF", checksum=CK_A, taken_datetime=None)
@@ -343,7 +343,7 @@ async def test_post_image_rejects_a_missing_taken_datetime(session):
 
 async def test_checksum_lookup_rejects_an_oversized_batch(session):
     """Unbounded `IN (...)` from a bad caller."""
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         MAX_CHECKSUM_LOOKUP,
         post_checksum_lookup,
     )
@@ -357,7 +357,7 @@ async def test_checksum_lookup_rejects_an_oversized_batch(session):
 
 async def test_checksum_lookup_handles_an_empty_batch(session):
     """A dive folder that turned out to hold nothing new still calls this."""
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_checksum_lookup,
     )
 
@@ -368,7 +368,7 @@ async def test_checksum_lookup_deduplicates_repeated_checksums(session):
     """Duplicate frames inside one folder are exactly the case this is for, so
     the same checksum arriving twice must not double-count toward the cap or
     produce duplicate hits."""
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_checksum_lookup,
         post_image,
     )
@@ -394,7 +394,7 @@ async def test_the_database_refuses_a_second_canonical_row_for_one_checksum(sess
     This drives the constraint directly, bypassing the endpoint, because that
     is precisely the state the endpoint's own logic cannot rule out.
     """
-    from sqlalchemy.exc import IntegrityError  # pylint: disable=import-outside-toplevel
+    from sqlalchemy.exc import IntegrityError
 
     await _seed_dive(session, 64, "d/64")
     session.add(_image("d/64/P1.ORF", CK_A, dive_id=64, is_canonical=True))
@@ -408,10 +408,10 @@ async def test_the_database_refuses_a_second_canonical_row_for_one_checksum(sess
 async def test_the_constraint_allows_many_non_canonical_rows_per_checksum(session):
     """The duplicate case is the normal case — only *canonical* is exclusive.
     A unique index on `checksum` alone would break dives 64/66 outright."""
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_image,
     )
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image
 
     for dive_id in (64, 66, 70):
         await _seed_dive(session, dive_id, f"d/{dive_id}")
@@ -425,10 +425,10 @@ async def test_the_constraint_allows_many_non_canonical_rows_per_checksum(sessio
 async def test_post_image_honours_an_explicit_id_instead_of_resolving_by_path(session):
     """The `id is not None` branch — an update targeted by primary key, which
     skips natural-key resolution entirely."""
-    from fishsense_api.controllers.image_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.image_controller import (
         post_image,
     )
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image
 
     await _seed_dive(session, 7, "d/7")
     image_id = await post_image(7, _image("d/7/P1.ORF", CK_A), session=session)

--- a/services/fishsense-api/tests/test_ingest_endpoints_http.py
+++ b/services/fishsense-api/tests/test_ingest_endpoints_http.py
@@ -23,12 +23,15 @@ real lifespan, which calls `create_all` against Postgres and then
 
 from __future__ import annotations
 
-import os
-
 import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
+
+from tests_support.app import (
+    seed_camera_with_intrinsics,
+    seed_placeholder_settings,
+)
 
 CK_A = "45dc5a454b35601b9dafabf24822195d"
 CK_B = "0b7cd4da72d54172f1f9daf40ce4047f"
@@ -38,23 +41,14 @@ _DIVE_DT = "2024-08-21T08:56:51Z"
 
 @pytest.fixture
 async def client():
-    from fastapi.testclient import TestClient  # pylint: disable=import-outside-toplevel
+    from fastapi.testclient import TestClient
+    seed_placeholder_settings()
 
-    os.environ.setdefault("E4EFS_POSTGRES__HOST", "ignored")
-    os.environ.setdefault("E4EFS_POSTGRES__PORT", "5432")
-    os.environ.setdefault("E4EFS_POSTGRES__USERNAME", "ignored")
-    os.environ.setdefault("E4EFS_POSTGRES__PASSWORD", "ignored")
-    os.environ.setdefault("E4EFS_POSTGRES__DATABASE", "ignored")
-
-    import fishsense_api.controllers  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
-    from fishsense_api.database import (  # pylint: disable=import-outside-toplevel
+    import fishsense_api.controllers  # noqa: F401  pylint: disable=unused-import
+    from fishsense_api.database import (
         get_async_session,
     )
-    from fishsense_api.models.camera import Camera  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.camera_intrinsics import (  # pylint: disable=import-outside-toplevel
-        CameraIntrinsics,
-    )
-    from fishsense_api.server import app  # pylint: disable=import-outside-toplevel
+    from fishsense_api.server import app
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -62,16 +56,7 @@ async def client():
     factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     session = factory()
-    session.add(Camera(id=1, serial_number="BJ6C67989", name="FSL-07"))
-    await session.flush()
-    session.add(
-        CameraIntrinsics(
-            camera_id=1,
-            camera_matrix=[[3000.0, 0.0, 2000.0], [0.0, 3000.0, 1500.0], [0.0, 0.0, 1.0]],
-            distortion_coefficients=[-0.05, 0.01, 0.0, 0.0, 0.0],
-        )
-    )
-    await session.flush()
+    await seed_camera_with_intrinsics(session)
 
     async def _override():
         yield session
@@ -194,7 +179,7 @@ def test_priority_is_stored_as_the_enum_not_the_raw_json_string(client):
     up front is what keeps `jsonable_encoder` from emitting a pydantic
     serializer warning on every request — run the suite with `-W error` and an
     uncoerced body fails here."""
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority
 
     created = client.post("/api/v1/dives/", json=_dive_body("d/p", priority="HIGH"))
     assert created.status_code == 201

--- a/services/fishsense-api/tests/test_label_route_disambiguation.py
+++ b/services/fishsense-api/tests/test_label_route_disambiguation.py
@@ -9,42 +9,18 @@ validation. The literal route is registered first in
 
 from __future__ import annotations
 
-import os
-
 import pytest
-from starlette.routing import Match
+from tests_support.app import resolve_route, seed_placeholder_settings
 
 
 @pytest.fixture(scope="module")
 def app():
-    os.environ.setdefault("E4EFS_POSTGRES__HOST", "ignored")
-    os.environ.setdefault("E4EFS_POSTGRES__PORT", "5432")
-    os.environ.setdefault("E4EFS_POSTGRES__USERNAME", "ignored")
-    os.environ.setdefault("E4EFS_POSTGRES__PASSWORD", "ignored")
-    os.environ.setdefault("E4EFS_POSTGRES__DATABASE", "ignored")
+    seed_placeholder_settings()
 
-    import fishsense_api.controllers.label_controller  # noqa: F401, pylint: disable=import-outside-toplevel,unused-import
-    from fishsense_api.server import app  # pylint: disable=import-outside-toplevel
+    import fishsense_api.controllers.label_controller  # noqa: F401, pylint: disable=unused-import
+    from fishsense_api.server import app
 
     return app
-
-
-def _resolve(app, path: str) -> str | None:
-    scope = {
-        "type": "http",
-        "method": "GET",
-        "path": path,
-        "path_params": {},
-        "route_path": path,
-        "headers": [],
-    }
-    for route in app.routes:
-        if not hasattr(route, "matches"):
-            continue
-        match, _ = route.matches(scope)
-        if match == Match.FULL:
-            return route.endpoint.__name__
-    return None
 
 
 @pytest.mark.parametrize(
@@ -84,5 +60,6 @@ def _resolve(app, path: str) -> str | None:
         ),
     ],
 )
+
 def test_label_route_resolves_to_expected_endpoint(app, path, expected_endpoint):
-    assert _resolve(app, path) == expected_endpoint
+    assert resolve_route(app, path) == expected_endpoint

--- a/services/fishsense-api/tests/test_label_studio_project_ids_superseded.py
+++ b/services/fishsense-api/tests/test_label_studio_project_ids_superseded.py
@@ -23,7 +23,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 @pytest.fixture
 async def session():
-    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  pylint: disable=unused-import
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -35,7 +35,7 @@ async def session():
 
 
 def _image(image_id: int):
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image
 
     return Image(
         id=image_id,
@@ -47,7 +47,7 @@ def _image(image_id: int):
 
 
 def _laser_label(label_id, image_id, *, completed, superseded=False, project_id):
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     return LaserLabel(
         id=label_id,
@@ -59,7 +59,7 @@ def _laser_label(label_id, image_id, *, completed, superseded=False, project_id)
 
 
 def _headtail_label(label_id, image_id, *, completed, superseded=False, project_id):
-    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.head_tail_label import HeadTailLabel
 
     return HeadTailLabel(
         id=label_id,
@@ -71,7 +71,7 @@ def _headtail_label(label_id, image_id, *, completed, superseded=False, project_
 
 
 async def _laser_ids(session, *, incomplete=False):
-    from fishsense_api.controllers.label_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.label_controller import (
         get_laser_label_studio_project_ids,
     )
 
@@ -80,7 +80,7 @@ async def _laser_ids(session, *, incomplete=False):
 
 
 async def _headtail_ids(session, *, incomplete=False):
-    from fishsense_api.controllers.label_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.label_controller import (
         get_headtail_label_studio_project_ids,
     )
 

--- a/services/fishsense-api/tests/test_label_upsert_endpoint.py
+++ b/services/fishsense-api/tests/test_label_upsert_endpoint.py
@@ -25,7 +25,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 @pytest.fixture
 async def session():
-    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  pylint: disable=unused-import
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -37,22 +37,22 @@ async def session():
 
 
 def _cases():
-    from fishsense_api.controllers.label_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.label_controller import (
         put_dive_slate_label,
         put_headtail_label,
         put_laser_label,
         put_species_label,
     )
-    from fishsense_api.models.dive_slate_label import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_slate_label import (
         DiveSlateLabel,
     )
-    from fishsense_api.models.head_tail_label import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.head_tail_label import (
         HeadTailLabel,
     )
-    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import (
         LaserLabel,
     )
-    from fishsense_api.models.species_label import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import (
         SpeciesLabel,
     )
 

--- a/services/fishsense-api/tests/test_laser_depth_endpoint.py
+++ b/services/fishsense-api/tests/test_laser_depth_endpoint.py
@@ -28,7 +28,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 @pytest.fixture
 async def session():
-    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  # pylint: disable=unused-import
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -40,8 +40,8 @@ async def session():
 
 
 def _dive(dive_id: int, *, priority=None, calibration_dive_id: int | None = None):
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.priority import Priority
 
     return Dive(
         id=dive_id,
@@ -53,7 +53,7 @@ def _dive(dive_id: int, *, priority=None, calibration_dive_id: int | None = None
 
 
 def _image(image_id: int, dive_id: int, *, is_canonical: bool = True):
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image
 
     return Image(
         id=image_id,
@@ -66,7 +66,7 @@ def _image(image_id: int, dive_id: int, *, is_canonical: bool = True):
 
 
 def _laser_label(label_id: int, image_id: int, *, completed=True, superseded=False):
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     return LaserLabel(
         id=label_id,
@@ -79,7 +79,7 @@ def _laser_label(label_id: int, image_id: int, *, completed=True, superseded=Fal
 
 
 def _extrinsics(extrinsics_id: int, dive_id: int):
-    from fishsense_api.models.laser_extrinsics import LaserExtrinsics  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_extrinsics import LaserExtrinsics
 
     return LaserExtrinsics(
         id=extrinsics_id,
@@ -98,7 +98,7 @@ def _depth(
     laser_label_id=None,
     laser_extrinsics_id=None,
 ):
-    from fishsense_api.models.laser_depth import LaserDepth  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_depth import LaserDepth
 
     return LaserDepth(
         depth_m=depth_m,
@@ -113,10 +113,10 @@ def _depth(
 
 
 async def test_put_creates_a_depth(session):
-    from fishsense_api.controllers.laser_depth_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.laser_depth_controller import (
         put_laser_depth,
     )
-    from fishsense_api.models.laser_depth import LaserDepth  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_depth import LaserDepth
 
     session.add_all([_dive(1), _image(11, 1)])
     await session.flush()
@@ -142,10 +142,10 @@ async def test_put_records_the_triangulation_residual(session):
     depth. Recording it first means a threshold can be chosen from the real
     distribution instead of guessed.
     """
-    from fishsense_api.controllers.laser_depth_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.laser_depth_controller import (
         put_laser_depth,
     )
-    from fishsense_api.models.laser_depth import LaserDepth  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_depth import LaserDepth
 
     session.add_all([_dive(1), _image(11, 1)])
     await session.flush()
@@ -160,11 +160,11 @@ async def test_put_upserts_on_image_id(session):
     """Recompute overwrites. `merge` on `id=None` would always INSERT and
     violate `uq_laser_depth_image` — the same natural-key trap that
     duplicated measurements and 500'd the label writeback."""
-    from fishsense_api.controllers.laser_depth_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.laser_depth_controller import (
         put_laser_depth,
     )
-    from fishsense_api.models.laser_depth import LaserDepth  # pylint: disable=import-outside-toplevel
-    from sqlmodel import select  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_depth import LaserDepth
+    from sqlmodel import select
 
     session.add_all([_dive(1), _image(11, 1)])
     await session.flush()
@@ -179,9 +179,9 @@ async def test_put_upserts_on_image_id(session):
 
 
 async def test_get_returns_404_when_the_image_has_no_depth(session):
-    from fastapi import HTTPException  # pylint: disable=import-outside-toplevel
+    from fastapi import HTTPException
 
-    from fishsense_api.controllers.laser_depth_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.laser_depth_controller import (
         get_laser_depth,
     )
 
@@ -194,7 +194,7 @@ async def test_get_returns_404_when_the_image_has_no_depth(session):
 
 
 async def test_get_returns_the_stored_depth(session):
-    from fishsense_api.controllers.laser_depth_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.laser_depth_controller import (
         get_laser_depth,
         put_laser_depth,
     )
@@ -210,7 +210,7 @@ async def test_get_returns_the_stored_depth(session):
 async def test_get_for_dive_returns_only_that_dives_rows(session):
     """Empty list, not 404, when a dive has none — "no depth yet" is a
     normal pipeline state, not an error, and the caller iterates."""
-    from fishsense_api.controllers.laser_depth_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.laser_depth_controller import (
         get_laser_depths_for_dive,
         put_laser_depth,
     )
@@ -230,7 +230,7 @@ async def test_get_for_dive_returns_only_that_dives_rows(session):
 
 
 async def test_selector_picks_a_dive_whose_laser_images_have_no_depth(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_depth,
     )
 
@@ -246,7 +246,7 @@ async def test_selector_requires_calibration(session):
     """No extrinsics, no depth: `compute_world_point_from_laser` needs the
     laser's position and axis. Such a dive is stage 13's problem, not this
     stage's, and must not sit in the cohort forever."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_depth,
     )
 
@@ -259,7 +259,7 @@ async def test_selector_requires_calibration(session):
 async def test_selector_accepts_borrowed_calibration(session):
     """Mirrors `get_laser_extrinsics_for_dive`: a fish-only dive borrows a
     sibling slate dive's rig calibration via `Dive.calibration_dive_id`."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_depth,
     )
 
@@ -280,10 +280,10 @@ async def test_selector_accepts_borrowed_calibration(session):
 async def test_selector_skips_a_dive_whose_depths_are_current(session):
     """Drains. The depth row names the label and the calibration it came
     from; when both still match, there is nothing to recompute."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_depth,
     )
-    from fishsense_api.controllers.laser_depth_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.laser_depth_controller import (
         put_laser_depth,
     )
 
@@ -302,10 +302,10 @@ async def test_selector_repicks_a_dive_after_recalibration(session):
     """The 2026-08-11 slate panel-offset fix recalibrated dives whose depths
     had already been computed. A depth carrying the superseded extrinsics id
     is stale, and staleness is the whole reason the provenance columns exist."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_depth,
     )
-    from fishsense_api.controllers.laser_depth_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.laser_depth_controller import (
         put_laser_depth,
     )
 
@@ -323,10 +323,10 @@ async def test_selector_repicks_a_dive_after_recalibration(session):
 async def test_selector_repicks_a_dive_after_the_laser_label_changes(session):
     """A superseded-then-replaced laser label moves the dot, which moves the
     depth. Keyed on the label id, so the replacement re-enters the cohort."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_depth,
     )
-    from fishsense_api.controllers.laser_depth_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.laser_depth_controller import (
         put_laser_depth,
     )
 
@@ -350,7 +350,7 @@ async def test_selector_repicks_a_dive_after_the_laser_label_changes(session):
 async def test_selector_ignores_images_without_a_valid_laser(session):
     """Incomplete, superseded, or coordinate-less labels are not a laser
     fix — the same `_valid_laser_conditions` gate stages 1/2/5.1/14 use."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_depth,
     )
 
@@ -372,7 +372,7 @@ async def test_selector_ignores_images_without_a_valid_laser(session):
 async def test_selector_ignores_non_canonical_images(session):
     """The prod dive 60 wedge: a duplicate dive's frames never drain because
     the pipeline declines to work on them. Every selector filters canonical."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_depth,
     )
 
@@ -390,10 +390,10 @@ async def test_selector_ignores_non_canonical_images(session):
 
 
 async def test_selector_skips_low_priority_dives(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_depth,
     )
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.priority import Priority
 
     session.add_all(
         [
@@ -429,10 +429,10 @@ async def test_selector_skips_low_priority_dives(session):
 async def test_selector_drains_an_image_with_two_valid_laser_labels(session):
     """Both labels are valid and the depth names one of them — that is a
     complete answer for the image, so the dive must drop out."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_depth,
     )
-    from fishsense_api.controllers.laser_depth_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.laser_depth_controller import (
         put_laser_depth,
     )
 
@@ -456,10 +456,10 @@ async def test_selector_drains_an_image_with_two_valid_laser_labels(session):
 async def test_selector_still_repicks_when_the_recorded_label_went_superseded(session):
     """The self-healing property must survive the fix: a depth whose label is
     no longer valid is stale, even though the image has another valid one."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_depth,
     )
-    from fishsense_api.controllers.laser_depth_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.laser_depth_controller import (
         put_laser_depth,
     )
 
@@ -489,9 +489,9 @@ def test_recorded_label_check_is_correlated():
     cross-joining the whole image table on every evaluation. Same class of bug
     as the uncorrelated `_resolved_laser_extrinsics_id()`, one level deeper.
     """
-    from sqlalchemy.dialects import postgresql  # pylint: disable=import-outside-toplevel
+    from sqlalchemy.dialects import postgresql
 
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         _laser_depth_cohort_query,
     )
 
@@ -509,10 +509,10 @@ async def test_selector_repicks_when_the_depth_names_another_images_label(sessio
     satisfied it, so a depth row pointing at a different image's label read as
     current and the image was never recomputed.
     """
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_depth,
     )
-    from fishsense_api.controllers.laser_depth_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.laser_depth_controller import (
         put_laser_depth,
     )
 

--- a/services/fishsense-api/tests/test_laser_extrinsics_upsert.py
+++ b/services/fishsense-api/tests/test_laser_extrinsics_upsert.py
@@ -23,7 +23,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 @pytest.fixture
 async def session():
-    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  # pylint: disable=unused-import
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -35,7 +35,7 @@ async def session():
 
 
 def _extrinsics(dive_id: int, *, position, created_at=None):
-    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_extrinsics import (
         LaserExtrinsics,
     )
 
@@ -49,7 +49,7 @@ def _extrinsics(dive_id: int, *, position, created_at=None):
 
 
 async def _count_for_dive(session: AsyncSession, dive_id: int) -> int:
-    from fishsense_api.models.laser_extrinsics import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_extrinsics import (
         LaserExtrinsics,
     )
 
@@ -62,7 +62,7 @@ async def _count_for_dive(session: AsyncSession, dive_id: int) -> int:
 
 
 async def test_put_upserts_on_dive_id_no_duplicate(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         get_laser_extrinsics_for_dive,
         put_laser_extrinsics_for_dive,
     )
@@ -82,7 +82,7 @@ async def test_put_upserts_on_dive_id_no_duplicate(session):
 
 
 async def test_put_stamps_non_null_created_at(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         get_laser_extrinsics_for_dive,
         put_laser_extrinsics_for_dive,
     )
@@ -99,7 +99,7 @@ async def test_put_stamps_non_null_created_at(session):
 
 
 async def test_put_independent_across_dives(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         put_laser_extrinsics_for_dive,
     )
 

--- a/services/fishsense-api/tests/test_laser_prediction_endpoint.py
+++ b/services/fishsense-api/tests/test_laser_prediction_endpoint.py
@@ -6,62 +6,27 @@ the controller functions directly.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 
-import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-from sqlmodel import SQLModel, select
-from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlmodel import select
 
-
-@pytest.fixture
-async def session():
-    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
-
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.create_all)
-    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-    async with factory() as s:
-        yield s
-    await engine.dispose()
-
-
-def _dive(dive_id: int):
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
-
-    return Dive(
-        id=dive_id,
-        path=f"/dev/null/{dive_id}",
-        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        priority=Priority.HIGH,
-    )
-
-
-def _image(image_id: int, dive_id: int):
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
-
-    return Image(
-        id=image_id,
-        path=f"/dev/null/img-{image_id}",
-        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"{image_id:032d}",
-        dive_id=dive_id,
-    )
+# Shared with the other controller tests — see `tests_support.db`.
+from tests_support.db import (  # noqa: F401
+    dive as _dive,
+    image as _image,
+)
 
 
 def _prediction(*, x=1.0, y=2.0, confidence=0.9):
-    from fishsense_api.models.laser_prediction import LaserPrediction  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_prediction import LaserPrediction
 
     return LaserPrediction(x=x, y=y, confidence=confidence)
 
 
 async def test_put_creates_a_prediction(session):
-    from fishsense_api.controllers.laser_prediction_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.laser_prediction_controller import (
         put_laser_prediction,
     )
-    from fishsense_api.models.laser_prediction import LaserPrediction  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_prediction import LaserPrediction
 
     session.add_all([_dive(1), _image(11, 1)])
     await session.flush()
@@ -73,10 +38,10 @@ async def test_put_creates_a_prediction(session):
 
 
 async def test_put_upserts_on_image_id(session):
-    from fishsense_api.controllers.laser_prediction_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.laser_prediction_controller import (
         put_laser_prediction,
     )
-    from fishsense_api.models.laser_prediction import LaserPrediction  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_prediction import LaserPrediction
 
     session.add_all([_dive(1), _image(11, 1)])
     await session.flush()
@@ -97,7 +62,7 @@ async def test_put_upserts_on_image_id(session):
 
 
 async def test_get_returns_predictions_for_the_dive(session):
-    from fishsense_api.controllers.laser_prediction_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.laser_prediction_controller import (
         get_laser_predictions_for_dive,
         put_laser_prediction,
     )
@@ -113,7 +78,7 @@ async def test_get_returns_predictions_for_the_dive(session):
 
 
 async def test_get_returns_empty_list_when_none(session):
-    from fishsense_api.controllers.laser_prediction_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.laser_prediction_controller import (
         get_laser_predictions_for_dive,
     )
 

--- a/services/fishsense-api/tests/test_measurement_calibration_provenance.py
+++ b/services/fishsense-api/tests/test_measurement_calibration_provenance.py
@@ -17,12 +17,12 @@ length half of the depth backfill, and it converges without a separate script.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 
-import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-from sqlmodel import SQLModel
-from sqlmodel.ext.asyncio.session import AsyncSession
+
+# Shared with the other controller tests — see `tests_support.db`.
+from tests_support.db import (  # noqa: F401
+    dive as _dive,
+)
 
 from tests_support.stage14_fixtures import (
     fish_model_measurable_image as _measurable_image,
@@ -30,34 +30,8 @@ from tests_support.stage14_fixtures import (
 )
 
 
-@pytest.fixture
-async def session():
-    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
-
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.create_all)
-    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-    async with factory() as s:
-        yield s
-    await engine.dispose()
-
-
-def _dive(dive_id: int, *, calibration_dive_id: int | None = None):
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
-
-    return Dive(
-        id=dive_id,
-        path=f"/dev/null/{dive_id}",
-        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        priority=Priority.HIGH,
-        calibration_dive_id=calibration_dive_id,
-    )
-
-
 def _extrinsics(extrinsics_id: int, dive_id: int):
-    from fishsense_api.models.laser_extrinsics import LaserExtrinsics  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_extrinsics import LaserExtrinsics
 
     return LaserExtrinsics(
         id=extrinsics_id,
@@ -75,10 +49,10 @@ def _measurement(image_id: int, *, laser_extrinsics_id=None, fish_id: int = 100)
 
 
 async def test_post_measurement_persists_the_calibration_it_used(session):
-    from fishsense_api.controllers.fish_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.fish_controller import (
         post_measurement,
     )
-    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.measurement import Measurement
 
     session.add_all([_dive(1), _extrinsics(51, 1)])
     _measurable_image(session, 11, 1)
@@ -96,10 +70,10 @@ async def test_post_measurement_updates_provenance_on_re_measure(session):
     """The upsert keys on `(image_id, fish_id)`, so a re-measure after a
     recalibration must move the provenance forward with the length — a row
     still claiming the old calibration would be re-selected forever."""
-    from fishsense_api.controllers.fish_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.fish_controller import (
         post_measurement,
     )
-    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.measurement import Measurement
 
     session.add_all([_dive(1), _extrinsics(51, 1)])
     _measurable_image(session, 11, 1)
@@ -118,7 +92,7 @@ async def test_post_measurement_updates_provenance_on_re_measure(session):
 
 
 async def test_cohort_skips_a_dive_measured_with_the_current_calibration(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_measure_fish,
     )
 
@@ -131,7 +105,7 @@ async def test_cohort_skips_a_dive_measured_with_the_current_calibration(session
 
 
 async def test_cohort_repicks_a_dive_after_recalibration(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_measure_fish,
     )
 
@@ -146,7 +120,7 @@ async def test_cohort_repicks_a_dive_after_recalibration(session):
 async def test_cohort_repicks_a_dive_whose_measurements_predate_provenance(session):
     """Every measurement in prod today carries NULL here. They re-enter the
     cohort once, get recomputed under the current calibration, and drain."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_measure_fish,
     )
 
@@ -161,7 +135,7 @@ async def test_cohort_repicks_a_dive_whose_measurements_predate_provenance(sessi
 async def test_cohort_resolves_provenance_through_a_borrowed_calibration(session):
     """A fish-only dive is measured with the sibling's extrinsics row, so
     that is the id its measurements must carry — not its own (it has none)."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_measure_fish,
     )
 
@@ -207,7 +181,7 @@ async def test_cohort_resolves_each_dives_own_calibration_not_the_first_row(sess
     session.add(_measurement(21, laser_extrinsics_id=52))
     await session.flush()
 
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_measure_fish,
     )
 
@@ -223,11 +197,11 @@ def test_resolved_extrinsics_subquery_is_correlated():
     it. This is the assertion that would have caught the prod outage without
     a Postgres to run against.
     """
-    import re  # pylint: disable=import-outside-toplevel
+    import re
 
-    from sqlalchemy.dialects import postgresql  # pylint: disable=import-outside-toplevel
+    from sqlalchemy.dialects import postgresql
 
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         _laser_depth_cohort_query,
     )
 

--- a/services/fishsense-api/tests/test_measurements_endpoint.py
+++ b/services/fishsense-api/tests/test_measurements_endpoint.py
@@ -19,59 +19,25 @@ composition and write semantics, not referential integrity.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-from sqlmodel import SQLModel, select
-from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlmodel import select
 
-
-@pytest.fixture
-async def session():
-    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
-
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.create_all)
-    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-    async with factory() as s:
-        yield s
-    await engine.dispose()
-
-
-def _dive(dive_id: int):
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
-
-    return Dive(
-        id=dive_id,
-        path=f"/dev/null/{dive_id}",
-        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        priority=Priority.HIGH,
-    )
-
-
-def _image(image_id: int, dive_id: int):
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
-
-    return Image(
-        id=image_id,
-        path=f"/dev/null/img-{image_id}",
-        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"{image_id:032d}",
-        dive_id=dive_id,
-    )
+# Shared with the other controller tests — see `tests_support.db`.
+from tests_support.db import (  # noqa: F401
+    dive as _dive,
+    image as _image,
+)
 
 
 def _fish(fish_id: int):
-    from fishsense_api.models.fish import Fish  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.fish import Fish
 
     return Fish(id=fish_id, species_id=None)
 
 
 def _measurement(measurement_id: int | None, image_id: int, fish_id: int, length_m: float):
-    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.measurement import Measurement
 
     return Measurement(
         id=measurement_id,
@@ -89,7 +55,7 @@ async def _seed_dive(session, dive_id: int, image_ids: list[int]):
 
 
 async def _get_measurements(session, dive_id: int):
-    from fishsense_api.controllers.fish_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.fish_controller import (
         get_measurements_for_dive,
     )
 
@@ -97,7 +63,7 @@ async def _get_measurements(session, dive_id: int):
 
 
 async def _post(session, fish_id: int, measurement):
-    from fishsense_api.controllers.fish_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.fish_controller import (
         post_measurement,
     )
 
@@ -145,7 +111,7 @@ async def test_post_measurement_creates_row(session):
     new_id = await _post(session, 101, _measurement(None, 11, 101, 0.30))
     await session.flush()
 
-    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.measurement import Measurement
 
     rows = (await session.exec(select(Measurement))).all()
     assert len(rows) == 1
@@ -164,7 +130,7 @@ async def test_post_measurement_twice_does_not_duplicate(session):
     second_id = await _post(session, 101, _measurement(None, 11, 101, 0.31))
     await session.flush()
 
-    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.measurement import Measurement
 
     rows = (await session.exec(select(Measurement))).all()
     assert len(rows) == 1, "re-posting the same (image, fish) must upsert, not insert"
@@ -183,7 +149,7 @@ async def test_post_measurement_distinct_fish_on_same_image_both_persist(session
     await _post(session, 102, _measurement(None, 11, 102, 0.40))
     await session.flush()
 
-    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.measurement import Measurement
 
     rows = (await session.exec(select(Measurement))).all()
     assert len(rows) == 2
@@ -198,7 +164,7 @@ async def test_post_measurement_binds_fish_id_from_path(session):
     await _post(session, 101, _measurement(None, 11, 999, 0.30))
     await session.flush()
 
-    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.measurement import Measurement
 
     rows = (await session.exec(select(Measurement))).all()
     assert rows[0].fish_id == 101
@@ -215,7 +181,7 @@ async def test_post_measurement_binds_fish_id_from_path(session):
 
 
 async def _delete(session, fish_id: int, image_id: int):
-    from fishsense_api.controllers.fish_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.fish_controller import (
         delete_measurement,
     )
 
@@ -235,7 +201,7 @@ async def test_delete_measurement_removes_only_that_binding(session):
     await _delete(session, 101, 11)
     await session.flush()
 
-    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.measurement import Measurement
 
     rows = (await session.exec(select(Measurement))).all()
     assert [(r.image_id, r.fish_id) for r in rows] == [(11, 102)]
@@ -250,6 +216,6 @@ async def test_delete_measurement_is_idempotent(session):
     await _delete(session, 101, 11)  # nothing there — must not raise
     await session.flush()
 
-    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.measurement import Measurement
 
     assert (await session.exec(select(Measurement))).all() == []

--- a/services/fishsense-api/tests/test_sdk_api_contract.py
+++ b/services/fishsense-api/tests/test_sdk_api_contract.py
@@ -17,7 +17,6 @@ The app is not entered as a context manager; that would run the real lifespan
 from __future__ import annotations
 
 import asyncio
-import os
 from datetime import datetime, timezone
 
 import httpx
@@ -26,6 +25,11 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from tests_support.app import (
+    seed_camera_with_intrinsics,
+    seed_placeholder_settings,
+)
+
 CK_A = "45dc5a454b35601b9dafabf24822195d"
 CK_B = "0b7cd4da72d54172f1f9daf40ce4047f"
 
@@ -33,25 +37,17 @@ CK_B = "0b7cd4da72d54172f1f9daf40ce4047f"
 @pytest.fixture
 async def sdk():
     """A real `DiveClient`/`ImageClient` pair wired to the in-process app."""
-    os.environ.setdefault("E4EFS_POSTGRES__HOST", "ignored")
-    os.environ.setdefault("E4EFS_POSTGRES__PORT", "5432")
-    os.environ.setdefault("E4EFS_POSTGRES__USERNAME", "ignored")
-    os.environ.setdefault("E4EFS_POSTGRES__PASSWORD", "ignored")
-    os.environ.setdefault("E4EFS_POSTGRES__DATABASE", "ignored")
+    seed_placeholder_settings()
 
-    import fishsense_api.controllers  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
-    from fishsense_api.database import (  # pylint: disable=import-outside-toplevel
+    import fishsense_api.controllers  # noqa: F401  pylint: disable=unused-import
+    from fishsense_api.database import (
         get_async_session,
     )
-    from fishsense_api.models.camera import Camera  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.camera_intrinsics import (  # pylint: disable=import-outside-toplevel
-        CameraIntrinsics,
-    )
-    from fishsense_api.server import app  # pylint: disable=import-outside-toplevel
-    from fishsense_api_sdk.clients.dive_client import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.server import app
+    from fishsense_api_sdk.clients.dive_client import (
         DiveClient,
     )
-    from fishsense_api_sdk.clients.image_client import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api_sdk.clients.image_client import (
         ImageClient,
     )
 
@@ -60,16 +56,7 @@ async def sdk():
         await conn.run_sync(SQLModel.metadata.create_all)
     factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
     session = factory()
-    session.add(Camera(id=1, serial_number="BJ6C67989", name="FSL-07"))
-    await session.flush()
-    session.add(
-        CameraIntrinsics(
-            camera_id=1,
-            camera_matrix=[[3000.0, 0.0, 2000.0], [0.0, 3000.0, 1500.0], [0.0, 0.0, 1.0]],
-            distortion_coefficients=[-0.05, 0.01, 0.0, 0.0, 0.0],
-        )
-    )
-    await session.flush()
+    await seed_camera_with_intrinsics(session)
 
     async def _override():
         yield session
@@ -94,8 +81,8 @@ async def sdk():
 
 
 def _sdk_dive(path: str, **kwargs):
-    from fishsense_api_sdk.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api_sdk.models.priority import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api_sdk.models.dive import Dive
+    from fishsense_api_sdk.models.priority import (
         Priority,
     )
 
@@ -115,7 +102,7 @@ def _sdk_dive(path: str, **kwargs):
 
 
 def _sdk_image(path: str, checksum: str, **kwargs):
-    from fishsense_api_sdk.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api_sdk.models.image import Image
 
     body = {
         "id": None,
@@ -189,8 +176,8 @@ async def test_reposting_a_dive_through_the_sdk_preserves_unmentioned_fields(sdk
     reaches the API as a genuinely partial body. This is the combination that
     triggers the destructive-upsert bug in production, and neither suite could
     see it alone."""
-    from fishsense_api_sdk.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api_sdk.models.priority import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api_sdk.models.dive import Dive
+    from fishsense_api_sdk.models.priority import (
         Priority,
     )
 

--- a/services/fishsense-api/tests/test_select_next_dive_endpoints.py
+++ b/services/fishsense-api/tests/test_select_next_dive_endpoints.py
@@ -23,7 +23,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 @pytest.fixture
 async def session():
-    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  # pylint: disable=unused-import
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -35,8 +35,8 @@ async def session():
 
 
 def _dive(dive_id: int, *, priority="HIGH", dive_slate_id=None, calibration_dive_id=None):
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.priority import Priority
 
     return Dive(
         id=dive_id,
@@ -58,7 +58,7 @@ def _image(image_id: int, dive_id: int, *, is_canonical: bool = True):
     reality. Pass `is_canonical=False` to model a duplicate frame — see
     test_canonical_only_pipeline_work.py.
     """
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image
 
     return Image(
         id=image_id,
@@ -87,7 +87,7 @@ def _image(image_id: int, dive_id: int, *, is_canonical: bool = True):
 async def test_laser_preprocessing_picks_lowest_high_priority_with_unlabeled_images(
     session,
 ):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_preprocessing,
     )
 
@@ -108,10 +108,10 @@ async def test_laser_preprocessing_picks_lowest_high_priority_with_unlabeled_ima
 
 
 async def test_laser_preprocessing_skips_dives_with_every_image_labeled(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_preprocessing,
     )
-    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import (
         LaserLabel,
     )
 
@@ -154,10 +154,10 @@ async def test_laser_preprocessing_treats_incomplete_label_as_labeled(session):
     immediately after pushing an LS task — the JPEG already exists on
     the file-exchange and on NAS.
     """
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_preprocessing,
     )
-    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import (
         LaserLabel,
     )
 
@@ -185,10 +185,10 @@ async def test_laser_preprocessing_excludes_dive_with_only_incomplete_labels(ses
     period. Without the predicate change, the dive would stay in the
     cohort and re-fire preprocess hourly until labelers completed.
     """
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_preprocessing,
     )
-    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import (
         LaserLabel,
     )
 
@@ -214,10 +214,10 @@ async def test_laser_preprocessing_excludes_dive_when_sentinel_coexists_with_rea
     real-project row should still drop the dive (the real row counts).
     Pinned because a future refactor that 'simplifies' the predicate
     to ignore project_id entirely would silently break this."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_preprocessing,
     )
-    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import (
         LaserLabel,
     )
 
@@ -248,10 +248,10 @@ async def test_laser_preprocessing_ignores_null_project_sentinels(session):
     permanently drain the cohort. Mirrors the
     `project_id != None` filter the discovery endpoint at
     `label_controller.py:274` already has."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_preprocessing,
     )
-    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import (
         LaserLabel,
     )
 
@@ -277,10 +277,10 @@ async def test_laser_preprocessing_ignores_null_project_sentinels(session):
 
 
 async def test_laser_preprocessing_returns_none_when_no_unlabeled_images(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_preprocessing,
     )
-    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import (
         LaserLabel,
     )
 
@@ -300,7 +300,7 @@ async def test_laser_preprocessing_returns_none_when_no_unlabeled_images(session
 
 
 async def test_laser_preprocessing_returns_none_with_no_high_priority(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_preprocessing,
     )
 
@@ -329,13 +329,13 @@ async def test_laser_discovery_and_selector_agree_on_real_label_definition(sessi
     excludes NULL and a selector pick that includes only the
     sentinel-only dives.
     """
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_preprocessing,
     )
-    from fishsense_api.controllers.label_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.label_controller import (
         get_laser_label_studio_project_ids,
     )
-    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import (
         LaserLabel,
     )
 
@@ -382,10 +382,10 @@ async def test_laser_preprocessing_prod_state_sentinels_dont_drain_cohort(sessio
     sentinel row, must still produce the lowest-id dive from the
     selector.
     """
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_preprocessing,
     )
-    from fishsense_api.models.laser_label import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import (
         LaserLabel,
     )
 
@@ -414,7 +414,7 @@ async def test_laser_preprocessing_prod_state_sentinels_dont_drain_cohort(sessio
 
 async def test_laser_preprocessing_excludes_dive_with_no_images(session):
     """A dive with no images has no work for stage 0.1 — excluded."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_preprocessing,
     )
 
@@ -434,14 +434,14 @@ async def test_laser_preprocessing_excludes_dive_with_no_images(session):
 
 
 async def test_clustering_requires_valid_laser_and_no_prediction_cluster(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_dive_frame_clustering,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     # dive 1: valid laser + already has PREDICTION cluster -> excluded.
     # dive 2: valid laser + no clusters -> picked.
@@ -476,14 +476,14 @@ async def test_clustering_excludes_dive_with_only_label_studio_cluster(session):
     """LABEL_STUDIO clusters come from stage 6.1 (label-time grouping)
     and don't count as PREDICTION clusters from stage 1. A dive whose
     only clusters are LABEL_STUDIO must still be picked for stage 1."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_dive_frame_clustering,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -506,10 +506,10 @@ async def test_clustering_excludes_incomplete_or_superseded_or_null_xy_lasers(se
     not superseded AND have both x and y populated to count as
     'valid laser', because that's what calibration and the validator
     treat as usable."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_dive_frame_clustering,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add_all([_dive(1), _dive(2), _dive(3), _dive(4)])
     await session.flush()
@@ -541,10 +541,10 @@ async def test_clustering_excludes_incomplete_or_superseded_or_null_xy_lasers(se
 
 
 async def test_clustering_returns_none_with_no_high_priority(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_dive_frame_clustering,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1, priority="LOW"))
     await session.flush()
@@ -574,14 +574,14 @@ async def test_clustering_partial_persist_is_a_poison_pill(session):
     images covered by some cluster") doesn't silently change the
     operational story without updating the activity docstring.
     """
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_dive_frame_clustering,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -624,17 +624,17 @@ async def test_clustering_partial_persist_is_a_poison_pill(session):
 async def test_species_preprocessing_requires_prediction_cluster_and_valid_laser(
     session,
 ):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_species_preprocessing,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
     )
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameClusterImageMapping,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     # dive 1: no PREDICTION cluster -> excluded.
     # dive 2: PREDICTION cluster but no laser-valid image -> excluded.
@@ -675,15 +675,15 @@ async def test_species_preprocessing_excludes_dive_with_only_incomplete_species_
     """Once populate seeds an incomplete SpeciesLabel (with a real
     project_id) for every laser-valid image, the dive drops out of
     the cohort."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_species_preprocessing,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -717,15 +717,15 @@ async def test_species_preprocessing_excludes_dive_when_sentinel_coexists_with_r
     session,
 ):
     """Defensive — see laser-stage analogue."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_species_preprocessing,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -756,17 +756,17 @@ async def test_species_preprocessing_ignores_null_project_species_sentinels(sess
     """NULL-`project_id` rows are legacy sentinels — see the laser
     cohort docstring. They must NOT drop a dive from the species
     cohort."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_species_preprocessing,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameClusterImageMapping,
     )
 
@@ -797,14 +797,14 @@ async def test_species_preprocessing_excludes_incomplete_or_superseded_or_null_x
 ):
     """Same gate as headtail — the species cohort cascades from the
     same 'valid laser' definition."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_species_preprocessing,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add_all([_dive(1), _dive(2), _dive(3), _dive(4)])
     await session.flush()
@@ -842,14 +842,14 @@ async def test_species_preprocessing_excludes_incomplete_or_superseded_or_null_x
 async def test_species_preprocessing_returns_none_when_only_label_studio_clusters(
     session,
 ):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_species_preprocessing,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -877,10 +877,10 @@ async def test_species_preprocessing_returns_none_when_only_label_studio_cluster
 async def test_needing_species_population_picks_laser_valid_without_live_species(
     session,
 ):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_dives_needing_species_population,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add_all([_dive(1), _dive(2, priority="LOW")])
     await session.flush()
@@ -911,17 +911,17 @@ async def test_needing_species_population_reincludes_superseded_only_dive(sessio
     (old dead project) must re-enter BOTH cohorts. species-preprocessing
     used to exclude it (its check ignored `superseded`); the two
     selectors disagreeing deadlocked the stage — fixed 2026-07-21."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_dives_needing_species_population,
         select_next_for_species_preprocessing,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
         DiveFrameClusterImageMapping,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -957,11 +957,11 @@ async def test_needing_species_population_reincludes_superseded_only_dive(sessio
 async def test_needing_species_population_excludes_dive_with_live_species(session):
     """A non-superseded, real-project species row is a live task -> the
     image no longer needs population, so the dive drops out."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_dives_needing_species_population,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -985,10 +985,10 @@ async def test_needing_species_population_excludes_dive_with_live_species(sessio
 
 async def test_needing_species_population_excludes_invalid_laser(session):
     """Same valid-laser gate as the other cascade cohorts."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_dives_needing_species_population,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -1019,11 +1019,11 @@ async def test_needing_species_population_excludes_invalid_laser(session):
 async def test_headtail_preprocessing_requires_valid_laser_without_any_headtail(
     session,
 ):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_headtail_preprocessing,
     )
-    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.head_tail_label import HeadTailLabel
+    from fishsense_api.models.laser_label import LaserLabel
 
     # dive 1: valid laser + headtail row exists -> excluded.
     # dive 2: valid laser, no headtail row -> picked.
@@ -1062,11 +1062,11 @@ async def test_headtail_preprocessing_excludes_dive_with_only_incomplete_headtai
     """Once populate seeds an incomplete HeadTailLabel (with a real
     project_id) for every laser-cascaded image, the dive drops out of
     the cohort."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_headtail_preprocessing,
     )
-    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.head_tail_label import HeadTailLabel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -1091,11 +1091,11 @@ async def test_headtail_preprocessing_excludes_dive_when_sentinel_coexists_with_
     session,
 ):
     """Defensive — see laser-stage analogue."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_headtail_preprocessing,
     )
-    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.head_tail_label import HeadTailLabel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -1125,11 +1125,11 @@ async def test_headtail_preprocessing_ignores_null_project_sentinels(session):
     """NULL-`project_id` HeadTailLabel rows are legacy sentinels — see
     the dive-image cohort docstring. They must NOT drop a dive from
     the headtail cohort."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_headtail_preprocessing,
     )
-    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.head_tail_label import HeadTailLabel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -1156,10 +1156,10 @@ async def test_headtail_preprocessing_excludes_incomplete_or_superseded_or_null_
     """A laser label only counts if completed AND not superseded AND
     has both x and y populated. Anything weaker is not a "valid
     label" per the gate."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_headtail_preprocessing,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     # dive 1: laser is not completed.
     # dive 2: laser is superseded.
@@ -1197,7 +1197,7 @@ async def test_headtail_preprocessing_excludes_incomplete_or_superseded_or_null_
 
 
 async def test_headtail_preprocessing_returns_none_when_no_laser_labels(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_headtail_preprocessing,
     )
 
@@ -1213,11 +1213,11 @@ async def test_headtail_preprocessing_returns_none_when_no_laser_labels(session)
 
 
 async def test_slate_preprocessing_requires_dive_slate_id_and_marker(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         SLATE_CONTENT_MARKER,
         select_next_for_slate_preprocessing,
     )
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     # dive 1: HIGH but no dive_slate_id -> excluded.
     # dive 2: HIGH + dive_slate_id but no slate-marked species_label -> excluded.
@@ -1245,12 +1245,12 @@ async def test_slate_preprocessing_requires_dive_slate_id_and_marker(session):
 
 
 async def test_slate_preprocessing_skips_when_every_slate_image_labeled(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         SLATE_CONTENT_MARKER,
         select_next_for_slate_preprocessing,
     )
-    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add_all([_dive(1, dive_slate_id=99), _dive(2, dive_slate_id=99)])
     await session.flush()
@@ -1276,12 +1276,12 @@ async def test_slate_preprocessing_excludes_dive_with_only_incomplete_slate_labe
     """Once populate seeds an incomplete DiveSlateLabel (with a real
     project_id) for every slate-marked image, the dive drops out of
     the cohort."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         SLATE_CONTENT_MARKER,
         select_next_for_slate_preprocessing,
     )
-    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1, dive_slate_id=99))
     await session.flush()
@@ -1301,12 +1301,12 @@ async def test_slate_preprocessing_excludes_dive_when_sentinel_coexists_with_rea
     session,
 ):
     """Defensive — see laser-stage analogue."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         SLATE_CONTENT_MARKER,
         select_next_for_slate_preprocessing,
     )
-    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1, dive_slate_id=99))
     await session.flush()
@@ -1331,14 +1331,14 @@ async def test_slate_preprocessing_excludes_dive_when_sentinel_coexists_with_rea
 
 
 async def test_slate_prediction_requires_marker_and_no_prediction_or_label(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         SLATE_CONTENT_MARKER,
         select_next_for_slate_prediction,
     )
-    from fishsense_api.models.slate_prediction import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.slate_prediction import (
         SlatePrediction,
     )
-    from fishsense_api.models.species_label import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import (
         SpeciesLabel,
     )
 
@@ -1368,14 +1368,14 @@ async def test_slate_prediction_placeholder_label_still_needs_prediction(session
     """Unlike the preprocess cohort, an incomplete (populate-seeded) slate
     label must NOT exclude the frame — it still needs a prediction. The
     prediction cohort keys on `completed`, not on project_id."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         SLATE_CONTENT_MARKER,
         select_next_for_slate_prediction,
     )
-    from fishsense_api.models.dive_slate_label import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_slate_label import (
         DiveSlateLabel,
     )
-    from fishsense_api.models.species_label import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import (
         SpeciesLabel,
     )
 
@@ -1392,14 +1392,14 @@ async def test_slate_prediction_placeholder_label_still_needs_prediction(session
 
 
 async def test_slate_prediction_excludes_completed_but_reenters_when_superseded(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         SLATE_CONTENT_MARKER,
         select_next_for_slate_prediction,
     )
-    from fishsense_api.models.dive_slate_label import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_slate_label import (
         DiveSlateLabel,
     )
-    from fishsense_api.models.species_label import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import (
         SpeciesLabel,
     )
 
@@ -1426,12 +1426,12 @@ async def test_slate_preprocessing_ignores_null_project_sentinels(session):
     """NULL-`project_id` DiveSlateLabel rows are legacy sentinels — see
     the dive-image cohort docstring. They must NOT drop a dive from
     the slate cohort."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         SLATE_CONTENT_MARKER,
         select_next_for_slate_preprocessing,
     )
-    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1, dive_slate_id=99))
     await session.flush()
@@ -1451,10 +1451,10 @@ async def test_slate_preprocessing_ignores_null_project_sentinels(session):
 
 
 async def test_laser_calibration_requires_min_completed_slate_labels(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_calibration,
     )
-    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel
 
     # dive 1: 1 completed slate label -> below threshold, excluded.
     # dive 2: 2 completed slate labels -> picked.
@@ -1496,10 +1496,10 @@ async def test_laser_calibration_requires_min_completed_slate_labels(session):
 
 
 async def test_laser_calibration_requires_dive_slate_id(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_calibration,
     )
-    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel
 
     session.add(_dive(1, dive_slate_id=None))
     await session.flush()
@@ -1538,7 +1538,7 @@ from tests_support.stage14_fixtures import (  # noqa: E402  pylint: disable=wron
 async def test_measure_fish_requires_extrinsics_and_an_unmeasured_measurable_image(
     session,
 ):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_measure_fish,
     )
 
@@ -1570,9 +1570,9 @@ def _fish_model_measurable_image(
     """A fish-model image the way prod has it: top-three `Fish Model, <name>`
     species label + valid laser + valid headtail, but NO LABEL_STUDIO cluster
     (models carry no grouping labels). The cohort must still select it."""
-    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.head_tail_label import HeadTailLabel
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_image(image_id, dive_id))
     session.add(
@@ -1597,7 +1597,7 @@ async def test_measure_fish_selects_fish_model_dive_without_cluster(session):
     """A borrowed-calibration fish-model dive with no LABEL_STUDIO cluster is
     selected once it has an unmeasured model image (the cluster gate is waived
     for models)."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_measure_fish,
     )
 
@@ -1618,7 +1618,7 @@ async def test_measure_fish_selects_fish_model_dive_without_cluster(session):
 async def test_measure_fish_returns_none_when_everything_measurable_is_measured(
     session,
 ):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_measure_fish,
     )
 
@@ -1637,11 +1637,11 @@ async def test_measure_fish_returns_none_when_everything_measurable_is_measured(
 async def test_measure_fish_ignores_unbound_clusters_with_no_measurable_image(session):
     """The regression: an unbound cluster stage 14 can never touch must
     not keep the dive in the cohort forever."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_measure_fish,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
     )
 
@@ -1665,7 +1665,7 @@ async def test_measure_fish_ignores_unbound_clusters_with_no_measurable_image(se
 async def test_measure_fish_selects_dive_with_borrowed_calibration(session):
     """A fish dive with no extrinsics of its own is still measurable when it
     links to a slate dive that owns extrinsics via `calibration_dive_id`."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_measure_fish,
     )
 
@@ -1687,7 +1687,7 @@ async def test_measure_fish_selects_dive_with_borrowed_calibration(session):
 async def test_measure_fish_link_to_uncalibrated_source_does_not_select(session):
     """A link to a source that owns no extrinsics doesn't fabricate
     calibration — the fish dive stays out of the cohort."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_measure_fish,
     )
 
@@ -1719,17 +1719,17 @@ async def test_species_preprocessing_reenters_dive_with_only_superseded_species(
     session,
 ):
     """A superseded real-project SpeciesLabel must NOT gate the image out."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_species_preprocessing,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameClusterImageMapping,
     )
 
@@ -1762,11 +1762,11 @@ async def test_headtail_preprocessing_reenters_dive_with_only_superseded_headtai
     session,
 ):
     """Same dead-letter rule for the head/tail cohort."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_headtail_preprocessing,
     )
-    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.head_tail_label import HeadTailLabel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -1792,15 +1792,15 @@ async def test_headtail_preprocessing_reenters_dive_with_only_superseded_headtai
 async def test_species_preprocessing_still_excludes_live_real_species_row(session):
     """Guard the other direction: a LIVE (non-superseded) real-project row
     must still drop the dive, or preprocess would loop forever."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_species_preprocessing,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -1843,7 +1843,7 @@ async def test_measure_fish_skips_species_rows_without_a_scientific_name(session
     """Calibration Targets / nameless rows must not hold a dive in the cohort —
     nothing downstream can ever measure them. (Fish models ARE measurable now —
     see test_measure_fish_selects_fish_model_dive_without_cluster.)"""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_measure_fish,
     )
 
@@ -1865,7 +1865,7 @@ async def test_measure_fish_skips_species_rows_without_a_scientific_name(session
 
 async def test_measure_fish_still_selects_a_real_fish_row(session):
     """Guard the other direction — the `Fish` branch stays measurable."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_measure_fish,
     )
 
@@ -1894,15 +1894,15 @@ async def test_species_preprocessing_skips_qualifying_image_not_in_a_cluster(ses
 
     So a qualifying image that is NOT clustered must not select the dive.
     """
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_species_preprocessing,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
         DiveFrameClusterImageMapping,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -1930,7 +1930,7 @@ async def test_species_preprocessing_skips_qualifying_image_not_in_a_cluster(ses
     # image 11 (clustered) has no species row either, so on its own it WOULD
     # select the dive; give it one so the only *unlabeled* image is the
     # unclustered 12. Now nothing processable remains.
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(
         SpeciesLabel(image_id=11, completed=False, label_studio_project_id=70)
@@ -1945,15 +1945,15 @@ async def test_species_preprocessing_picks_dive_with_a_clustered_qualifying_imag
 ):
     """Guard the other direction: when the qualifying image IS clustered, the
     dive is still selected — the fix must not over-exclude."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_species_preprocessing,
     )
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
         DiveFrameClusterImageMapping,
     )
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     session.add(_dive(1))
     await session.flush()
@@ -1982,7 +1982,7 @@ async def test_species_preprocessing_picks_dive_with_a_clustered_qualifying_imag
 
 
 def _laser_label(image_id: int, *, project_id=73, completed=False, superseded=False):
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
 
     return LaserLabel(
         image_id=image_id,
@@ -1993,13 +1993,13 @@ def _laser_label(image_id: int, *, project_id=73, completed=False, superseded=Fa
 
 
 def _laser_prediction(image_id: int):
-    from fishsense_api.models.laser_prediction import LaserPrediction  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_prediction import LaserPrediction
 
     return LaserPrediction(image_id=image_id, x=1.0, y=2.0, confidence=0.9)
 
 
 async def test_laser_prediction_selects_dive_with_unpredicted_unlabeled_image(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_prediction,
     )
 
@@ -2017,7 +2017,7 @@ async def test_laser_prediction_selects_dive_with_unpredicted_unlabeled_image(se
 
 
 async def test_laser_prediction_none_when_all_predicted_or_labeled(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_prediction,
     )
 
@@ -2032,7 +2032,7 @@ async def test_laser_prediction_none_when_all_predicted_or_labeled(session):
 async def test_laser_prediction_sentinel_label_does_not_exclude(session):
     """A NULL-project sentinel LaserLabel doesn't count as labeled — the
     image still needs a prediction."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_prediction,
     )
 
@@ -2050,7 +2050,7 @@ async def test_laser_prediction_seeded_placeholder_does_not_exclude(session):
     needs a prediction. This is the dive-84 case: a dive populated before
     the detector shipped has project-id-bearing incomplete rows that must
     not starve the predict cohort."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_prediction,
     )
 
@@ -2068,7 +2068,7 @@ async def test_laser_prediction_superseded_completed_label_does_not_exclude(sess
     invalidated label — the image has no live human label and still needs a
     prediction. Regression for dive 60's straggler 4747, whose only completed
     row was superseded."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_prediction,
     )
 
@@ -2082,7 +2082,7 @@ async def test_laser_prediction_superseded_completed_label_does_not_exclude(sess
 
 async def test_laser_prediction_live_completed_label_excludes(session):
     """A completed, non-superseded label is a live human label — excluded."""
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_next_for_laser_prediction,
     )
 
@@ -2101,7 +2101,7 @@ async def test_laser_prediction_live_completed_label_excludes(session):
 
 
 async def test_needing_laser_population_lists_predicted_incomplete_dives(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_dives_needing_laser_population,
     )
 
@@ -2115,8 +2115,8 @@ async def test_needing_laser_population_lists_predicted_incomplete_dives(session
     session.add(_laser_label(21, project_id=73))  # completed below
     await session.flush()
     # mark dive 2's label completed
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from sqlmodel import select as _select  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_label import LaserLabel
+    from sqlmodel import select as _select
 
     lbl = (await session.exec(_select(LaserLabel).where(LaserLabel.image_id == 21))).first()
     lbl.completed = True
@@ -2128,7 +2128,7 @@ async def test_needing_laser_population_lists_predicted_incomplete_dives(session
 
 
 async def test_needing_laser_population_empty_when_nothing_predicted(session):
-    from fishsense_api.controllers.dive_cohort_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_cohort_controller import (
         select_dives_needing_laser_population,
     )
 

--- a/services/fishsense-api/tests/test_set_dive_slate_endpoint.py
+++ b/services/fishsense-api/tests/test_set_dive_slate_endpoint.py
@@ -18,7 +18,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 @pytest.fixture
 async def session():
-    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  # pylint: disable=unused-import
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -30,8 +30,8 @@ async def session():
 
 
 def _dive(dive_id: int, *, dive_slate_id=None):
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.priority import Priority
 
     return Dive(
         id=dive_id,
@@ -43,7 +43,7 @@ def _dive(dive_id: int, *, dive_slate_id=None):
 
 
 def _dive_slate(slate_id: int):
-    from fishsense_api.models.dive_slate import DiveSlate  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_slate import DiveSlate
 
     return DiveSlate(
         id=slate_id,
@@ -54,10 +54,10 @@ def _dive_slate(slate_id: int):
 
 
 async def test_set_dive_slate_sets_the_fk(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         set_dive_slate,
     )
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
 
     session.add(_dive(1))
     session.add(_dive_slate(9))
@@ -69,10 +69,10 @@ async def test_set_dive_slate_sets_the_fk(session):
 
 
 async def test_set_dive_slate_overwrites_existing(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         set_dive_slate,
     )
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
 
     session.add(_dive(1, dive_slate_id=8))
     session.add_all([_dive_slate(8), _dive_slate(9)])
@@ -83,7 +83,7 @@ async def test_set_dive_slate_overwrites_existing(session):
 
 
 async def test_set_dive_slate_404_when_dive_missing(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         set_dive_slate,
     )
 
@@ -96,7 +96,7 @@ async def test_set_dive_slate_404_when_dive_missing(session):
 
 
 async def test_set_dive_slate_404_when_template_missing(session):
-    from fishsense_api.controllers.dive_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.dive_controller import (
         set_dive_slate,
     )
 

--- a/services/fishsense-api/tests/test_slate_prediction_endpoint.py
+++ b/services/fishsense-api/tests/test_slate_prediction_endpoint.py
@@ -6,55 +6,19 @@ controller functions directly.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-from sqlmodel import SQLModel, select
-from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlmodel import select
 
-
-@pytest.fixture
-async def session():
-    import fishsense_api.database  # noqa: F401  # pylint: disable=import-outside-toplevel,unused-import
-
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.create_all)
-    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-    async with factory() as s:
-        yield s
-    await engine.dispose()
-
-
-def _dive(dive_id: int):
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import (  # pylint: disable=import-outside-toplevel
-        Priority,
-    )
-
-    return Dive(
-        id=dive_id,
-        path=f"/dev/null/{dive_id}",
-        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        priority=Priority.HIGH,
-    )
-
-
-def _image(image_id: int, dive_id: int):
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
-
-    return Image(
-        id=image_id,
-        path=f"/dev/null/img-{image_id}",
-        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"{image_id:032d}",
-        dive_id=dive_id,
-    )
+# Shared with the other controller tests — see `tests_support.db`.
+from tests_support.db import (  # noqa: F401
+    dive as _dive,
+    image as _image,
+)
 
 
 def _prediction(*, reference_points=None, confidence=0.9, rejected_reason=None):
-    from fishsense_api.models.slate_prediction import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.slate_prediction import (
         SlatePrediction,
     )
 
@@ -68,7 +32,7 @@ def _prediction(*, reference_points=None, confidence=0.9, rejected_reason=None):
 
 
 async def _count(session, image_id):
-    from fishsense_api.models.slate_prediction import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.slate_prediction import (
         SlatePrediction,
     )
 
@@ -81,7 +45,7 @@ async def _count(session, image_id):
 
 
 async def test_put_upserts_on_image_id(session):
-    from fishsense_api.controllers.slate_prediction_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.slate_prediction_controller import (
         get_slate_predictions_for_dive,
         put_slate_prediction,
     )
@@ -106,7 +70,7 @@ async def test_put_upserts_on_image_id(session):
 
 
 async def test_put_stores_rejection_with_null_points(session):
-    from fishsense_api.controllers.slate_prediction_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.slate_prediction_controller import (
         get_slate_predictions_for_dive,
         put_slate_prediction,
     )
@@ -126,7 +90,7 @@ async def test_put_stores_rejection_with_null_points(session):
 
 
 async def test_get_empty_when_dive_has_no_predictions(session):
-    from fishsense_api.controllers.slate_prediction_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.slate_prediction_controller import (
         get_slate_predictions_for_dive,
     )
 

--- a/services/fishsense-api/tests/test_species_slate_reads_superseded.py
+++ b/services/fishsense-api/tests/test_species_slate_reads_superseded.py
@@ -18,7 +18,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 @pytest.fixture
 async def session():
-    import fishsense_api.database  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+    import fishsense_api.database  # noqa: F401  pylint: disable=unused-import
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
@@ -30,8 +30,8 @@ async def session():
 
 
 def _dive(dive_id=1):
-    from fishsense_api.models.dive import Dive  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.priority import Priority  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.priority import Priority
 
     return Dive(
         id=dive_id,
@@ -42,7 +42,7 @@ def _dive(dive_id=1):
 
 
 def _image(image_id, dive_id=1):
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.image import Image
 
     return Image(
         id=image_id,
@@ -54,7 +54,7 @@ def _image(image_id, dive_id=1):
 
 
 def _species(label_id, image_id, *, completed=False, superseded=False, project_id, task_id):
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     return SpeciesLabel(
         id=label_id,
@@ -67,7 +67,7 @@ def _species(label_id, image_id, *, completed=False, superseded=False, project_i
 
 
 def _slate(label_id, image_id, *, completed=False, superseded=False, project_id, task_id):
-    from fishsense_api.models.dive_slate_label import DiveSlateLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.dive_slate_label import DiveSlateLabel
 
     return DiveSlateLabel(
         id=label_id,
@@ -83,7 +83,7 @@ def _slate(label_id, image_id, *, completed=False, superseded=False, project_id,
 
 
 async def test_species_project_ids_exclude_superseded_only(session):
-    from fishsense_api.controllers.label_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.label_controller import (
         get_species_label_studio_project_ids,
     )
 
@@ -102,7 +102,7 @@ async def test_species_project_ids_exclude_superseded_only(session):
 
 
 async def test_species_get_by_image_excludes_superseded(session):
-    from fishsense_api.controllers.label_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.label_controller import (
         get_species_label,
     )
 
@@ -119,7 +119,7 @@ async def test_species_get_by_image_excludes_superseded(session):
 
 
 async def test_slate_project_ids_exclude_superseded_only(session):
-    from fishsense_api.controllers.label_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.label_controller import (
         get_dive_slate_label_studio_project_ids,
     )
 
@@ -138,7 +138,7 @@ async def test_slate_project_ids_exclude_superseded_only(session):
 
 
 async def test_slate_get_by_image_excludes_superseded(session):
-    from fishsense_api.controllers.label_controller import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.controllers.label_controller import (
         get_dive_slate_label,
     )
 

--- a/services/fishsense-api/tests_support/app.py
+++ b/services/fishsense-api/tests_support/app.py
@@ -1,0 +1,87 @@
+"""Helpers for the tests that stand up the FastAPI app itself.
+
+Three things recur across those tests and had drifted into per-file copies:
+seeding dynaconf placeholders, seeding the camera an ingest request needs, and
+resolving a path against the route table.
+
+The env seeding in particular is not boilerplate that could be deleted — it is
+the documented dynaconf gotcha. Dynaconf validates EVERY validator on first
+attribute access of `settings`, so importing any module that touches config
+requires every unrelated setting to be present, whether or not the test uses
+it. `setdefault`, never assignment: the Postgres integration tests point the
+same variables at a real scratch database, and clobbering them there would
+silently aim an in-memory suite at it.
+"""
+
+from __future__ import annotations
+
+import os
+
+__all__ = ["seed_placeholder_settings", "seed_camera_with_intrinsics", "resolve_route"]
+
+_PLACEHOLDER_SETTINGS = {
+    "E4EFS_POSTGRES__HOST": "ignored",
+    "E4EFS_POSTGRES__PORT": "5432",
+    "E4EFS_POSTGRES__USERNAME": "ignored",
+    "E4EFS_POSTGRES__PASSWORD": "ignored",
+    "E4EFS_POSTGRES__DATABASE": "ignored",
+}
+
+
+def seed_placeholder_settings() -> None:
+    """Give dynaconf something to validate before any controller is imported."""
+    for key, value in _PLACEHOLDER_SETTINGS.items():
+        os.environ.setdefault(key, value)
+
+
+async def seed_camera_with_intrinsics(session) -> None:
+    """The camera an ingest/measurement request resolves against.
+
+    Real-ish values: an Olympus-scale 3000 px focal length on a 4000x3000
+    frame, which keeps any projection a test performs in a plausible range.
+    """
+    from fishsense_api.models.camera import Camera
+    from fishsense_api.models.camera_intrinsics import CameraIntrinsics
+
+    session.add(Camera(id=1, serial_number="BJ6C67989", name="FSL-07"))
+    await session.flush()
+    session.add(
+        CameraIntrinsics(
+            camera_id=1,
+            camera_matrix=[[3000.0, 0.0, 2000.0], [0.0, 3000.0, 1500.0], [0.0, 0.0, 1.0]],
+            distortion_coefficients=[-0.05, 0.01, 0.0, 0.0, 0.0],
+        )
+    )
+    await session.flush()
+
+
+def resolve_route(app, path: str) -> str | None:
+    """The name of the endpoint function `path` matches, in declaration order.
+
+    Returns the endpoint's `__name__`, not the route template: the assertion
+    these tests want to make is "this URL reaches THAT handler", and the
+    template alone would not distinguish two handlers registered on the same
+    path.
+
+    The question the disambiguation tests exist to ask: `/dives/select-next/...`
+    must win over `/dives/{dive_id}`, and across modules that ordering is
+    decided by import order in `controllers/__init__.py`. Get it wrong and
+    every cohort poll 422s in prod while the unit tests stay green.
+    """
+    from starlette.routing import Match
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "path_params": {},
+        "route_path": path,
+        "headers": [],
+    }
+    for route in app.routes:
+        if not hasattr(route, "matches"):
+            continue
+        match, _ = route.matches(scope)
+        if match == Match.FULL:
+            return route.endpoint.__name__
+    return None

--- a/services/fishsense-api/tests_support/db.py
+++ b/services/fishsense-api/tests_support/db.py
@@ -1,0 +1,69 @@
+"""In-memory sqlite session and row builders shared by the controller tests.
+
+Every controller test needs the same three things — a fresh SQLModel schema on
+in-memory sqlite, a HIGH-priority dive, and a canonical image on it — and they
+each grew their own copy. `duplicate-code` flagged ten such pairs the moment a
+tree-wide change made those files move together; six of them reproduce on
+untouched main, so the duplication was real and simply invisible to a
+changed-files lint run.
+
+FK-less by design: these tests exercise query composition and write semantics,
+not referential integrity. Postgres enforces the foreign keys sqlite ignores —
+see `test_api_postgres_integration.py`, whose seed needs a real `camera` row.
+
+These are plain functions, called explicitly. The in-memory `session` fixture
+lives in `tests/conftest.py` instead, so pytest injects it by name and no test
+module has to import a fixture it never calls.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+# One instant for every seeded row. Tests that care about ordering pass their
+# own; the rest only need a valid timestamp.
+SEED_DATETIME = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+__all__ = ["SEED_DATETIME", "dive", "image"]
+
+
+def dive(
+    dive_id: int,
+    *,
+    priority=None,
+    calibration_dive_id: int | None = None,
+    dive_slate_id: int | None = None,
+    name: str | None = None,
+):
+    """A HIGH-priority dive, which is what every cohort selector filters on."""
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.priority import Priority
+
+    return Dive(
+        id=dive_id,
+        path=f"/dev/null/{dive_id}",
+        dive_datetime=SEED_DATETIME,
+        priority=Priority.HIGH if priority is None else priority,
+        calibration_dive_id=calibration_dive_id,
+        dive_slate_id=dive_slate_id,
+        name=name,
+    )
+
+
+def image(image_id: int, dive_id: int, *, is_canonical: bool = True):
+    """Canonical by default — the normal case.
+
+    `Image.is_canonical` defaults to False on the model, which made every
+    seeded image a duplicate; harmless while nothing read the flag, misleading
+    now that the cohort selectors gate on it.
+    """
+    from fishsense_api.models.image import Image
+
+    return Image(
+        id=image_id,
+        path=f"/dev/null/img-{image_id}",
+        taken_datetime=SEED_DATETIME,
+        checksum=f"{image_id:032d}",
+        is_canonical=is_canonical,
+        dive_id=dive_id,
+    )

--- a/services/fishsense-api/tests_support/stage14_fixtures.py
+++ b/services/fishsense-api/tests_support/stage14_fixtures.py
@@ -14,7 +14,7 @@ from.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from tests_support.db import image
 
 # A real `Fish` row: stage 14 needs a `Common (Scientific)` name to measure
 # against, so a species label without one builds an image the pipeline can
@@ -26,23 +26,6 @@ MEASURABLE_CONTENT = "Fish, Hogfish (Lachnolaimus maximus)"
 # recalibration, or None to model a row written before
 # `Measurement.laser_extrinsics_id` existed.
 CALIBRATION_ID = 51
-
-
-def image(image_id: int, dive_id: int, *, is_canonical: bool = True):
-    """Canonical by default — the normal case. `Image.is_canonical` defaults
-    to False on the model, which made every seeded image a duplicate; harmless
-    while nothing read the flag, misleading now that the cohort selectors gate
-    on it."""
-    from fishsense_api.models.image import Image  # pylint: disable=import-outside-toplevel
-
-    return Image(
-        id=image_id,
-        path=f"/dev/null/img-{image_id}",
-        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=f"{image_id:032d}",
-        is_canonical=is_canonical,
-        dive_id=dive_id,
-    )
 
 
 def measurable_image(
@@ -59,14 +42,14 @@ def measurable_image(
     Returns the cluster mapping rather than adding it, because the caller has
     to flush the image first for the FK-less sqlite fixtures to line up.
     """
-    from fishsense_api.models.data_source import DataSource  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.dive_frame_cluster import (  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.data_source import DataSource
+    from fishsense_api.models.dive_frame_cluster import (
         DiveFrameCluster,
         DiveFrameClusterImageMapping,
     )
-    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.head_tail_label import HeadTailLabel
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(image(image_id, dive_id))
     session.add(
@@ -113,9 +96,9 @@ def fish_model_measurable_image(
     (`Fish Model, <name>`) + valid laser + valid headtail, but **no**
     LABEL_STUDIO cluster (models carry no grouping labels). Stage 14 measures
     these by waiving the cluster gate, so the cohort and the view must too."""
-    from fishsense_api.models.head_tail_label import HeadTailLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.laser_label import LaserLabel  # pylint: disable=import-outside-toplevel
-    from fishsense_api.models.species_label import SpeciesLabel  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.head_tail_label import HeadTailLabel
+    from fishsense_api.models.laser_label import LaserLabel
+    from fishsense_api.models.species_label import SpeciesLabel
 
     session.add(image(image_id, dive_id))
     session.add(
@@ -145,7 +128,7 @@ def fish_model_measurable_image(
 
 
 def calibration(dive_id: int, extrinsics_id: int = CALIBRATION_ID):
-    from fishsense_api.models.laser_extrinsics import LaserExtrinsics  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.laser_extrinsics import LaserExtrinsics
 
     return LaserExtrinsics(id=extrinsics_id, dive_id=dive_id, camera_id=1)
 
@@ -153,7 +136,7 @@ def calibration(dive_id: int, extrinsics_id: int = CALIBRATION_ID):
 def measurement(
     image_id: int, fish_id: int = 100, laser_extrinsics_id: int | None = CALIBRATION_ID
 ):
-    from fishsense_api.models.measurement import Measurement  # pylint: disable=import-outside-toplevel
+    from fishsense_api.models.measurement import Measurement
 
     return Measurement(
         image_id=image_id,

--- a/services/fishsense-backup-worker/src/fishsense_backup_worker/activities/pg_dump_database.py
+++ b/services/fishsense-backup-worker/src/fishsense_backup_worker/activities/pg_dump_database.py
@@ -33,7 +33,6 @@ _log = logging.getLogger(__name__)
 
 
 def _input_model():
-    # pylint: disable=import-outside-toplevel
     from fishsense_backup_worker.workflows.backup_databases_workflow \
         import PgDumpDatabaseInput
 

--- a/services/fishsense-backup-worker/src/fishsense_backup_worker/activities/prune_database_backups.py
+++ b/services/fishsense-backup-worker/src/fishsense_backup_worker/activities/prune_database_backups.py
@@ -17,7 +17,6 @@ _log = logging.getLogger(__name__)
 
 
 def _input_model():
-    # pylint: disable=import-outside-toplevel
     from fishsense_backup_worker.workflows.backup_databases_workflow \
         import PruneDatabaseBackupsInput
 

--- a/services/fishsense-backup-worker/tests/test_nas_backup_client.py
+++ b/services/fishsense-backup-worker/tests/test_nas_backup_client.py
@@ -31,7 +31,7 @@ def test_external_shape_preserved_for_activity_call_sites(monkeypatch):
     (call sites use `getattr` via `asyncio.to_thread`), so pin the
     shape here.
     """
-    from fishsense_backup_worker import nas as sut  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker import nas as sut
 
     fake = MagicMock(name="synology_filestation.Client")
     fake.list_dir.return_value = []
@@ -61,7 +61,7 @@ def test_upload_propagates_underlying_failure(monkeypatch):
     swallowing typed exceptions from `Client.upload`. Pin the
     contract so it can't.
     """
-    from fishsense_backup_worker import nas as sut  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker import nas as sut
 
     fake = MagicMock(name="synology_filestation.Client")
     fake.upload.side_effect = SidNotFound("session expired")
@@ -82,7 +82,7 @@ def test_delete_propagates_underlying_failure(monkeypatch):
     deletion failures bubbling up so retention violations don't
     silently no-op.
     """
-    from fishsense_backup_worker import nas as sut  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker import nas as sut
 
     fake = MagicMock(name="synology_filestation.Client")
     fake.delete.side_effect = NoSuchFile("file not found")
@@ -105,7 +105,7 @@ def test_ensure_dir_treats_already_exists_as_success(monkeypatch):
     wrapper must treat that as success rather than propagate (the
     folder-already-exists case is the common steady-state path).
     """
-    from fishsense_backup_worker import nas as sut  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker import nas as sut
 
     fake = MagicMock(name="synology_filestation.Client")
     fake.create_folder.side_effect = AlreadyExists("folder exists")
@@ -129,7 +129,7 @@ def test_list_filenames_returns_basenames(monkeypatch):
     string-matching logic works (`backup_naming.filenames_to_prune`
     operates on filenames, not absolute paths).
     """
-    from fishsense_backup_worker import nas as sut  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker import nas as sut
 
     fake = MagicMock(name="synology_filestation.Client")
     fake.list_dir.return_value = [

--- a/services/fishsense-backup-worker/tests/test_pg_dump_database_activity.py
+++ b/services/fishsense-backup-worker/tests/test_pg_dump_database_activity.py
@@ -41,7 +41,7 @@ def test_each_invocation_uses_an_isolated_tempdir(monkeypatch):
     """A single call must produce a path that's unique to its own
     tempdir, not a shared `/tmp` location. This is the static
     property that makes parallel callers safe."""
-    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker.activities import (
         pg_dump_database as sut,
     )
 
@@ -93,7 +93,7 @@ def test_concurrent_calls_for_three_dbs_all_succeed(monkeypatch):
     three threads sit between `run_pg_dump` and `nas.upload`
     simultaneously — exactly the window the prior bug raced on.
     """
-    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker.activities import (
         pg_dump_database as sut,
     )
 

--- a/services/fishsense-backup-worker/tests/test_prune_database_backups_activity.py
+++ b/services/fishsense-backup-worker/tests/test_prune_database_backups_activity.py
@@ -38,7 +38,7 @@ def _settings_env(monkeypatch):
 @pytest.fixture
 def nas(monkeypatch):
     """A stand-in NAS whose `list_filenames`/`delete` calls are recorded."""
-    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker.activities import (
         prune_database_backups as sut,
     )
 
@@ -49,7 +49,7 @@ def nas(monkeypatch):
 
 
 def _prune(**kwargs):
-    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker.activities import (
         prune_database_backups as sut,
     )
 
@@ -79,7 +79,7 @@ def test_a_trailing_slash_on_the_root_does_not_produce_a_double_slash(nas):
 
 
 def test_deletes_each_pruned_file_by_full_path(nas, monkeypatch):
-    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker.activities import (
         prune_database_backups as sut,
     )
 
@@ -95,7 +95,7 @@ def test_deletes_each_pruned_file_by_full_path(nas, monkeypatch):
 def test_deletes_nothing_when_retention_says_nothing_to_prune(nas, monkeypatch):
     """The steady state on a fresh install. A wrapper that deleted on an empty
     prune list would clear the whole directory."""
-    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker.activities import (
         prune_database_backups as sut,
     )
 
@@ -109,7 +109,7 @@ def test_deletes_nothing_when_retention_says_nothing_to_prune(nas, monkeypatch):
 def test_deletes_only_what_the_retention_helper_returned(nas, monkeypatch):
     """The wrapper must not re-derive the set. Everything the helper didn't
     name has to survive."""
-    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker.activities import (
         prune_database_backups as sut,
     )
 
@@ -128,7 +128,7 @@ def test_deletes_only_what_the_retention_helper_returned(nas, monkeypatch):
 def test_passes_keep_through_to_the_retention_helper(monkeypatch):
     """`keep` is the retention window. Dropping or defaulting it silently
     changes how much history survives."""
-    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker.activities import (
         prune_database_backups as sut,
     )
 
@@ -147,7 +147,7 @@ def test_passes_keep_through_to_the_retention_helper(monkeypatch):
 
 def test_only_the_listed_files_are_considered(nas, monkeypatch):
     """The helper sees exactly what the NAS reported — no synthesised names."""
-    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker.activities import (
         prune_database_backups as sut,
     )
 
@@ -170,10 +170,10 @@ def test_only_the_listed_files_are_considered(nas, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_activity_accepts_an_already_typed_payload(nas, monkeypatch):
-    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker.activities import (
         prune_database_backups as sut,
     )
-    from fishsense_backup_worker.workflows.backup_databases_workflow import (  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker.workflows.backup_databases_workflow import (
         PruneDatabaseBackupsInput,
     )
 
@@ -192,7 +192,7 @@ async def test_activity_accepts_an_already_typed_payload(nas, monkeypatch):
 async def test_activity_validates_a_dict_payload(nas, monkeypatch):
     """Temporal hands the activity whatever the data converter produced; a
     plain dict must be coerced rather than attribute-errored."""
-    from fishsense_backup_worker.activities import (  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker.activities import (
         prune_database_backups as sut,
     )
 

--- a/services/fishsense-backup-worker/tests/test_worker_wiring.py
+++ b/services/fishsense-backup-worker/tests/test_worker_wiring.py
@@ -32,7 +32,7 @@ def _settings_env(monkeypatch):
 @pytest.fixture
 def wired(monkeypatch):
     """Run `main()` with Temporal replaced; hand back the recorded calls."""
-    from fishsense_backup_worker import worker as sut  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker import worker as sut
 
     client = MagicMock()
     connect = AsyncMock(return_value=client)
@@ -56,13 +56,13 @@ async def test_registers_both_activities_and_the_workflow(wired):
     """The runtime failure this guards: a schedule that fires into a worker
     which cannot execute what the workflow calls."""
     sut, _connect, _ensure, worker_cls, _instance = wired
-    from fishsense_backup_worker.activities.pg_dump_database import (  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker.activities.pg_dump_database import (
         pg_dump_database,
     )
-    from fishsense_backup_worker.activities.prune_database_backups import (  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker.activities.prune_database_backups import (
         prune_database_backups,
     )
-    from fishsense_backup_worker.workflows.backup_databases_workflow import (  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker.workflows.backup_databases_workflow import (
         BackupDatabasesWorkflow,
     )
 
@@ -137,7 +137,7 @@ async def test_the_worker_is_actually_started(wired):
 
 
 def test_run_drives_main_under_asyncio(monkeypatch):
-    from fishsense_backup_worker import worker as sut  # pylint: disable=import-outside-toplevel
+    from fishsense_backup_worker import worker as sut
 
     called = []
     monkeypatch.setattr(sut.asyncio, "run", called.append)

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_laser_image.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_laser_image.py
@@ -49,7 +49,7 @@ def _load_detector(checkpoint_path: str) -> Any:
     torch/segmentation-models extra is only required at run time."""
     # no-name-in-module: LaserDetector ships in fishsense-core >= 2.2.0; the
     # pinned wheel is bumped to 2.3.0 in the deps/GPU phase of this feature.
-    from fishsense_core.laser import (  # pylint: disable=import-outside-toplevel,import-error,no-name-in-module
+    from fishsense_core.laser import (  # pylint: disable=import-error,no-name-in-module
         LaserDetector,
     )
 
@@ -91,10 +91,10 @@ def _predict_from_raw(
     keypoint percentages downstream). `cv2.undistort` preserves the image
     size, so the rectified dims equal the decoded raw dims.
     """
-    import numpy as np  # pylint: disable=import-outside-toplevel
+    import numpy as np
     # no-name-in-module: linear_raw_image ships in fishsense-core >= 2.2.0
     # (bumped to 2.3.0 in the deps/GPU phase).
-    from fishsense_core.image.linear_raw_image import (  # pylint: disable=import-outside-toplevel,import-error,no-name-in-module
+    from fishsense_core.image.linear_raw_image import (  # pylint: disable=import-error,no-name-in-module
         LinearRawImage,
     )
 
@@ -112,7 +112,6 @@ def _predict_from_raw(
 
 
 def _models():
-    # pylint: disable=import-outside-toplevel
     from fishsense_data_processing_workflow_worker.workflows.predict_laser_images_workflow import (
         LaserPredictionResult,
         PredictLaserImageInput,

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_slate_image.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_slate_image.py
@@ -79,7 +79,7 @@ def _get_masker() -> Any:
             return _MASKER
         try:
             # no-name-in-module: BoardMasker ships in fishsense_core[slate] >= 2.4.0
-            from fishsense_core.slate import (  # pylint: disable=import-outside-toplevel,import-error,no-name-in-module
+            from fishsense_core.slate import (  # pylint: disable=import-error,no-name-in-module
                 BoardMasker,
             )
 
@@ -161,8 +161,8 @@ def _render_template_gray(pdf_bytes: bytes, dpi: int):
     """Render page 0 of the slate template PDF to a grayscale array at `dpi`
     (the DiveSlate.dpi the reference points are expressed in, so template pixels
     and template_points share a scale)."""
-    import numpy as np  # pylint: disable=import-outside-toplevel
-    import pymupdf  # pylint: disable=import-outside-toplevel
+    import numpy as np
+    import pymupdf
 
     with pymupdf.open(stream=pdf_bytes, filetype="pdf") as document:
         page = document.load_page(0)
@@ -187,17 +187,17 @@ def _predict_from_bytes(  # pylint: disable=too-many-locals
 
     Returns `(reference_points | None, confidence, reason, width, height)`.
     """
-    import numpy as np  # pylint: disable=import-outside-toplevel
-    from fishsense_api_sdk.models.camera_intrinsics import (  # pylint: disable=import-outside-toplevel
+    import numpy as np
+    from fishsense_api_sdk.models.camera_intrinsics import (
         CameraIntrinsics,
     )
-    from fishsense_core.image.raw_image import (  # pylint: disable=import-outside-toplevel,no-name-in-module
+    from fishsense_core.image.raw_image import (  # pylint: disable=no-name-in-module
         RawImage,
     )
-    from fishsense_core.image.rectified_image import (  # pylint: disable=import-outside-toplevel,no-name-in-module
+    from fishsense_core.image.rectified_image import (  # pylint: disable=no-name-in-module
         RectifiedImage,
     )
-    from fishsense_core.slate import (  # pylint: disable=import-outside-toplevel,no-name-in-module
+    from fishsense_core.slate import (  # pylint: disable=no-name-in-module
         estimate_plane,
     )
 
@@ -239,7 +239,6 @@ def _predict_from_bytes(  # pylint: disable=too-many-locals
 
 
 def _models():
-    # pylint: disable=import-outside-toplevel
     from fishsense_data_processing_workflow_worker.workflows.predict_slate_images_workflow import (
         PredictSlateImageInput,
         SlatePredictionResult,

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/preprocess_headtail_image.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/preprocess_headtail_image.py
@@ -44,7 +44,6 @@ def _rectify_and_encode_jpeg(
 
 
 def _input_model():
-    # pylint: disable=import-outside-toplevel
     from fishsense_data_processing_workflow_worker.workflows.preprocess_headtail_images_workflow \
         import PreprocessHeadtailImageInput
 

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/preprocess_laser_image.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/preprocess_laser_image.py
@@ -60,7 +60,6 @@ def _rectify_overlay_bbox_encode(
 
 
 def _input_model():
-    # pylint: disable=import-outside-toplevel
     from fishsense_data_processing_workflow_worker.workflows.preprocess_laser_images_workflow \
         import PreprocessLaserImageInput
 

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/preprocess_slate_image.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/preprocess_slate_image.py
@@ -113,7 +113,6 @@ def _build_slate_jpeg(
 
 
 def _input_model():
-    # pylint: disable=import-outside-toplevel
     from fishsense_data_processing_workflow_worker.workflows.preprocess_slate_images_workflow \
         import PreprocessSlateImageInput
 

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/preprocess_species_image.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/preprocess_species_image.py
@@ -68,7 +68,6 @@ def _rectify_overlay_encode(
 # Imported lazily to keep this module importable without the workflow
 # package side-effects during unit-test collection.
 def _input_model():
-    # pylint: disable=import-outside-toplevel
     from fishsense_data_processing_workflow_worker.workflows.preprocess_species_images_workflow \
         import PreprocessSpeciesImageInput
 

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/object_store.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/object_store.py
@@ -46,7 +46,6 @@ def open_object_store_client() -> "ObjectStoreClient":
     doesn't eagerly trigger Dynaconf validation — only calling this at
     activity runtime does. The 4 preprocess activities call this.
     """
-    # pylint: disable=import-outside-toplevel
     from fishsense_data_processing_workflow_worker.config import settings
 
     return open_client(settings, ObjectStoreClient)

--- a/services/fishsense-data-processing-workflow-worker/tests/test_perform_laser_calibration_activity.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_perform_laser_calibration_activity.py
@@ -288,7 +288,7 @@ async def test_reflection_contaminated_scene_is_rejected_not_persisted(monkeypat
     gate must raise and nothing may persist — the old behavior shipped the
     broken calibration, and a borrowing fish-model dive measured +31..+137%
     length errors."""
-    from fishsense_data_processing_workflow_worker.calibration_consistency import (  # pylint: disable=import-outside-toplevel
+    from fishsense_data_processing_workflow_worker.calibration_consistency import (
         CalibrationInconsistentError,
     )
 

--- a/services/fishsense-data-processing-workflow-worker/tests/test_predict_slate_image.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_predict_slate_image.py
@@ -89,7 +89,7 @@ def test_get_masker_returns_the_masker_to_a_concurrent_caller(monkeypatch):
     So the whole first concurrent batch of frames lost the learned mask, with
     nothing in the logs to say so.
     """
-    import fishsense_core.slate as slate_mod  # pylint: disable=import-outside-toplevel
+    import fishsense_core.slate as slate_mod
 
     sentinel = object()
     loading_started = threading.Event()
@@ -121,7 +121,7 @@ def test_get_masker_falls_back_to_none_and_caches(monkeypatch):
     # pylint: disable=protected-access
     """A BoardMasker that can't load (no net / no checkpoint) must degrade to
     the classical path (None), and the failure is cached (no per-frame retry)."""
-    import fishsense_core.slate as slate_mod  # pylint: disable=import-outside-toplevel
+    import fishsense_core.slate as slate_mod
 
     calls = {"n": 0}
 


### PR DESCRIPTION
Step 1 of making `black` usable here — and it turned out to be mostly a different job than advertised.

## The intended change

**694 inline `# pylint: disable=import-outside-toplevel` pragmas across 71 files → one entry in the root `pyproject.toml`.**

Function-local imports are a deliberate, repo-wide pattern: dynaconf validates *every* validator on first attribute access, `fishsense_api.controllers` registers routes as an import side effect, and the api tests import models inside fixtures so modules stay importable without database settings. That's an exemption, and CLAUDE.md is explicit about where exemptions go — *"in the root pyproject.toml where it is reviewable in one place. Never inline."*

It also unblocks `black`, which is currently unusable: reflowing a long import moves the trailing pragma onto the closing paren where pylint no longer applies it. Measured on one file, that turns **3 findings into ~30**.

## Most of this diff is something else

Touching 71 files at once made pylint compare files that had never moved together, and `duplicate-code` surfaced **ten pre-existing clone pairs**. I verified they're pre-existing: **six reproduce on untouched `main`** across just 8 files. None of this duplication is new — it was invisible to a changed-files lint run, exactly as CLAUDE.md warns (*"useful, but not a safety net"*).

Extracted, not suppressed:

| new module | what it absorbs |
|---|---|
| `fishsense-api/tests_support/db.py` | dive + image row builders from 8 controller tests |
| `fishsense-api/tests/conftest.py` | the in-memory sqlite `session` fixture |
| `fishsense-api/tests_support/app.py` | dynaconf placeholder env, camera seed, route resolver |
| `fishsense-api-workflow-worker/worker_tests_support/populate.py` | image/laser builders, JPEG-gate patch, fake hosted-LS client |

Two details worth review attention:

**The `session` fixture went to `conftest.py`, not the shared module.** pytest resolves fixtures by name, so no test imports it — an imported-but-never-called fixture reads as an unused import to every static analyser, which is a trap for the next person.

**The fake Label Studio client is the one genuinely worth centralising.** It encodes that hosted LS imports asynchronously (no task ids in the response) and lists tasks through a presign resolve-wrapper rather than the imported `s3://` URI — precisely what the #343 dedup fix turns on. Four byte-identical copies were four chances to drift away from the behaviour under test.

**`worker_tests_support`, not `tests_support`** — two packages sharing a module name collide in the single-invocation pylint run. Same reason these live outside `tests/` at all.

## Verification

`./check.sh lint` **exit 0**, 10.00/10 — the first clean run since the removal started; every intermediate state had real findings, none suppressed. Full workspace green: 1440 unit tests, 11 Postgres integration tests.

Net **−500 lines** on the pragma/clone work. One inline pragma is added, in the new `conftest.py`, for an import kept solely for its model-registry side effect.

## Not in this PR

Steps 2 and 3 of the black sequence — `[tool.black] line-length = 100`, the tree-wide reformat with a `.git-blame-ignore-revs` entry, and `black --check` in CI. Those are now unblocked but are a separate, much larger diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)