### PR TITLE
test(worker): share the resolver suites' fixtures, and stop black at src/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,8 +161,8 @@ target-version = ["py313"]
 # `check.sh lint` runs `black --check` over exactly this set, so the config and
 # the gate cannot disagree about what is formatted.
 #
-# NOT yet applied to `tests/`, and the reason is measured rather than
-# aesthetic. Formatting the whole tree reformats 261 files and produces 48
+# NOT applied to `tests/`, and after actually attempting it that looks like the
+# right long-term answer rather than a temporary gap. The reason is measured. Formatting the whole tree reformats 261 files and produces 48
 # pylint findings, 14 of them `duplicate-code` pairs across five clusters of
 # near-identical test suites (the two big api predicate suites, the four
 # `resolve_*_preprocess_inputs` suites, the sync-label workflow tests, and two
@@ -170,8 +170,26 @@ target-version = ["py313"]
 # change makes those files move together — and extracting them is a piece of
 # work in its own right, comparable to the extraction that came with
 # centralising the `import-outside-toplevel` pragmas. `src/` alone is 133 files
-# and 9 findings, all fixed here. Widening this is a deliberate follow-up: do
-# the fixture extraction first, or CI goes red.
+# and 9 findings, all fixed here.
+#
+# The extraction was attempted (2026-08-25). Five of the fourteen pairs came
+# out cleanly — the resolver suites' shared builders, now in
+# `worker_tests_support/preprocess.py`. The other nine did not, and the reason
+# is that they are not helper-shaped:
+#
+#   * Four pairs are seed literals inside test bodies —
+#     `LaserLabel(...)`/`SpeciesLabel(...)` constructions repeated across
+#     `test_dive_pipeline_status_view` and `test_select_next_dive_endpoints`,
+#     133 of them across 3850 lines. Those two suites are what pin the
+#     cohort-selector/`dive_pipeline_status` agreement that CLAUDE.md requires,
+#     and rewriting their seed data to break a lint clone is a poor trade.
+#   * Five pairs are Temporal test-harness bodies — stub activities and
+#     concurrency gates whose activity names differ per stage.
+#
+# So `tests/` stays unformatted. The cost of widening is a refactor of the
+# repo's most semantically load-bearing tests; the benefit is formatting
+# consistency in files no image ships. Revisit only if those suites are being
+# restructured for their own reasons.
 #
 # `scripts/` and `tools/` are dev utilities that are not shipped; including
 # them would pull their own pre-existing lint debt into the gate.

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_headtail_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_headtail_preprocess_inputs_activity.py
@@ -13,7 +13,6 @@ from datetime import datetime, timezone
 from typing import List, Optional
 from unittest.mock import AsyncMock, MagicMock
 
-import numpy as np
 import pytest
 from temporalio.testing import ActivityEnvironment
 
@@ -26,9 +25,16 @@ from fishsense_api_workflow_worker.activities import (
     resolve_headtail_preprocess_inputs_activity as sut,
 )
 
+# Shared with the other resolver suites — see `worker_tests_support.preprocess`.
+from worker_tests_support.preprocess import (  # noqa: F401
+    CAMERA_MATRIX as _K,
+    DISTORTION as _D,
+    image as _image,
+)
+# The same laser-label builder the populate suites use.
+from worker_tests_support.populate import laser_label as _laser
 
-_K = np.array([[3000.0, 0.0, 2048.0], [0.0, 3000.0, 1536.0], [0.0, 0.0, 1.0]])
-_D = np.array([-0.05, 0.01, 0.0, 0.0, 0.0])
+
 
 
 def _dive(*, camera_id: Optional[int] = 1) -> Dive:
@@ -41,42 +47,6 @@ def _dive(*, camera_id: Optional[int] = 1) -> Dive:
         flip_dive_slate=False,
         camera_id=camera_id,
         dive_slate_id=None,
-    )
-
-
-def _image(image_id: int, checksum: str) -> Image:
-    return Image(
-        id=image_id,
-        path=f"/dev/null/{image_id}",
-        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=checksum,
-        is_canonical=True,
-        dive_id=42,
-        camera_id=1,
-    )
-
-
-def _laser(
-    image_id: int,
-    *,
-    completed: bool = True,
-    superseded: bool = False,
-    x: Optional[float] = 100.0,
-    y: Optional[float] = 200.0,
-) -> LaserLabel:
-    return LaserLabel(
-        id=image_id * 7,
-        label_studio_task_id=image_id * 10,
-        label_studio_project_id=43,
-        x=x,
-        y=y,
-        label="laser",
-        updated_at=None,
-        superseded=superseded,
-        completed=completed,
-        label_studio_json={},
-        image_id=image_id,
-        user_id=None,
     )
 
 

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_laser_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_laser_preprocess_inputs_activity.py
@@ -16,11 +16,9 @@ Pins down:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import List, Optional
 from unittest.mock import AsyncMock, MagicMock
 
-import numpy as np
 import pytest
 from temporalio.testing import ActivityEnvironment
 
@@ -32,61 +30,17 @@ from fishsense_api_workflow_worker.activities import (
     resolve_laser_preprocess_inputs_activity as sut,
 )
 
-
-_K = np.array([[3000.0, 0.0, 2048.0], [0.0, 3000.0, 1536.0], [0.0, 0.0, 1.0]])
-_D = np.array([-0.05, 0.01, 0.0, 0.0, 0.0])
-
-
-def _dive(dive_id: int = 42, *, camera_id: Optional[int] = 1) -> Dive:
-    return Dive(
-        id=dive_id,
-        name=f"dive-{dive_id}",
-        path=f"/dev/null/{dive_id}",
-        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        priority="HIGH",
-        flip_dive_slate=False,
-        camera_id=camera_id,
-        dive_slate_id=None,
-    )
+# Shared with the other resolver suites — see `worker_tests_support.preprocess`.
+from worker_tests_support.preprocess import (  # noqa: F401
+    CAMERA_MATRIX as _K,
+    DISTORTION as _D,
+    dive as _dive,
+    image as _image,
+    laser_label as _label,
+    intrinsics as _intrinsics,
+)
 
 
-def _image(image_id: int, checksum: str) -> Image:
-    return Image(
-        id=image_id,
-        path=f"/dev/null/{image_id}",
-        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=checksum,
-        is_canonical=True,
-        dive_id=42,
-        camera_id=1,
-    )
-
-
-def _label(
-    image_id: int, *, completed: bool, project_id: Optional[int] = 73
-) -> LaserLabel:
-    return LaserLabel(
-        id=None,
-        image_id=image_id,
-        label_studio_task_id=image_id * 10,
-        label_studio_project_id=project_id,
-        updated_at=None,
-        completed=completed,
-        label_studio_json={},
-        user_id=None,
-        superseded=False,
-        x=None,
-        y=None,
-        label=None,
-    )
-
-
-def _intrinsics() -> CameraIntrinsics:
-    return CameraIntrinsics(
-        camera_matrix=_K,
-        distortion_coefficients=_D,
-        camera_id=1,
-    )
 
 
 def _make_fs(

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_slate_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_slate_preprocess_inputs_activity.py
@@ -7,7 +7,6 @@ from datetime import datetime, timezone
 from typing import List, Optional
 from unittest.mock import AsyncMock, MagicMock
 
-import numpy as np
 import pytest
 from temporalio.testing import ActivityEnvironment
 
@@ -21,9 +20,14 @@ from fishsense_api_workflow_worker.activities import (
     resolve_slate_preprocess_inputs_activity as sut,
 )
 
+# Shared with the other resolver suites — see `worker_tests_support.preprocess`.
+from worker_tests_support.preprocess import (  # noqa: F401
+    CAMERA_MATRIX as _K,
+    DISTORTION as _D,
+    image as _image,
+)
 
-_K = np.array([[3000.0, 0.0, 2048.0], [0.0, 3000.0, 1536.0], [0.0, 0.0, 1.0]])
-_D = np.array([-0.05, 0.01, 0.0, 0.0, 0.0])
+
 SLATE = "Slate, Laser on slate"
 
 
@@ -48,18 +52,6 @@ def _slate(slate_id: int = 7, *, dpi: int | None = 300, refs=None) -> DiveSlate:
         path="/dev/null",
         created_at=None,
         reference_points=refs if refs is not None else [(0.0, 0.0), (1.0, 1.0)],
-    )
-
-
-def _image(image_id: int, checksum: str) -> Image:
-    return Image(
-        id=image_id,
-        path=f"/dev/null/{image_id}",
-        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=checksum,
-        is_canonical=True,
-        dive_id=42,
-        camera_id=1,
     )
 
 

--- a/services/fishsense-api-workflow-worker/tests/test_resolve_species_preprocess_inputs_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_resolve_species_preprocess_inputs_activity.py
@@ -22,11 +22,9 @@ Pins down:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import List, Optional
 from unittest.mock import AsyncMock, MagicMock
 
-import numpy as np
 import pytest
 from temporalio.testing import ActivityEnvironment
 
@@ -41,34 +39,18 @@ from fishsense_api_workflow_worker.activities import (
     resolve_species_preprocess_inputs_activity as sut,
 )
 
-
-_K = np.array([[3000.0, 0.0, 2048.0], [0.0, 3000.0, 1536.0], [0.0, 0.0, 1.0]])
-_D = np.array([-0.05, 0.01, 0.0, 0.0, 0.0])
-
-
-def _dive(dive_id: int = 42, *, camera_id: Optional[int] = 1) -> Dive:
-    return Dive(
-        id=dive_id,
-        name=f"dive-{dive_id}",
-        path=f"/dev/null/{dive_id}",
-        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        priority="HIGH",
-        flip_dive_slate=False,
-        camera_id=camera_id,
-        dive_slate_id=None,
-    )
+# Shared with the other resolver suites — see `worker_tests_support.preprocess`.
+from worker_tests_support.preprocess import (  # noqa: F401
+    CAMERA_MATRIX as _K,
+    DISTORTION as _D,
+    dive as _dive,
+    image as _image,
+    intrinsics as _intrinsics,
+)
+# The same laser-label builder the populate suites use.
+from worker_tests_support.populate import laser_label as _laser
 
 
-def _image(image_id: int, checksum: str) -> Image:
-    return Image(
-        id=image_id,
-        path=f"/dev/null/{image_id}",
-        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        checksum=checksum,
-        is_canonical=True,
-        dive_id=42,
-        camera_id=1,
-    )
 
 
 def _cluster(cluster_id: int, image_ids: List[int]) -> DiveFrameCluster:
@@ -79,30 +61,6 @@ def _cluster(cluster_id: int, image_ids: List[int]) -> DiveFrameCluster:
         updated_at=None,
         dive_id=42,
         fish_id=None,
-    )
-
-
-def _laser(
-    image_id: int,
-    *,
-    completed: bool = True,
-    superseded: bool = False,
-    x: Optional[float] = 100.0,
-    y: Optional[float] = 200.0,
-) -> LaserLabel:
-    return LaserLabel(
-        id=image_id * 7,
-        label_studio_task_id=image_id * 10,
-        label_studio_project_id=43,
-        x=x,
-        y=y,
-        label="laser",
-        updated_at=None,
-        superseded=superseded,
-        completed=completed,
-        label_studio_json={},
-        image_id=image_id,
-        user_id=None,
     )
 
 
@@ -133,14 +91,6 @@ def _species(
         fish_measurable_category=None,
         fish_angle_category=None,
         fish_curved_category=None,
-    )
-
-
-def _intrinsics() -> CameraIntrinsics:
-    return CameraIntrinsics(
-        camera_matrix=_K,
-        distortion_coefficients=_D,
-        camera_id=1,
     )
 
 

--- a/services/fishsense-api-workflow-worker/worker_tests_support/preprocess.py
+++ b/services/fishsense-api-workflow-worker/worker_tests_support/preprocess.py
@@ -1,0 +1,83 @@
+"""Fixtures shared by the resolver-activity suites.
+
+`resolve_laser/species/headtail/slate_preprocess_inputs_activity` answer the
+same question for four stages, and their tests were four copies of the same
+SDK-model builders and the same `MagicMock` client. `duplicate-code` flagged
+six pairs of them.
+
+Kept separate from `populate.py`: those suites build images on a different
+dive and camera, and forcing one builder to serve both would mean a pile of
+keyword arguments whose only job is to say which suite is calling.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+import numpy as np
+from fishsense_api_sdk.models.camera_intrinsics import CameraIntrinsics
+from fishsense_api_sdk.models.dive import Dive
+from fishsense_api_sdk.models.image import Image
+from fishsense_api_sdk.models.laser_label import LaserLabel
+
+# Olympus-scale intrinsics on a 4096x3072 frame — real enough that any
+# projection a resolver performs lands in a plausible range.
+CAMERA_MATRIX = np.array(
+    [[3000.0, 0.0, 2048.0], [0.0, 3000.0, 1536.0], [0.0, 0.0, 1.0]]
+)
+DISTORTION = np.array([-0.05, 0.01, 0.0, 0.0, 0.0])
+
+__all__ = ["CAMERA_MATRIX", "DISTORTION", "dive", "image", "laser_label", "intrinsics"]
+
+
+def dive(dive_id: int = 42, *, camera_id: Optional[int] = 1) -> Dive:
+    return Dive(
+        id=dive_id,
+        name=f"dive-{dive_id}",
+        path=f"/dev/null/{dive_id}",
+        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        priority="HIGH",
+        flip_dive_slate=False,
+        camera_id=camera_id,
+        dive_slate_id=None,
+    )
+
+
+def image(image_id: int, checksum: str) -> Image:
+    return Image(
+        id=image_id,
+        path=f"/dev/null/{image_id}",
+        taken_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        checksum=checksum,
+        is_canonical=True,
+        dive_id=42,
+        camera_id=1,
+    )
+
+
+def laser_label(
+    image_id: int, *, completed: bool, project_id: Optional[int] = 73
+) -> LaserLabel:
+    return LaserLabel(
+        id=None,
+        image_id=image_id,
+        label_studio_task_id=image_id * 10,
+        label_studio_project_id=project_id,
+        updated_at=None,
+        completed=completed,
+        label_studio_json={},
+        user_id=None,
+        superseded=False,
+        x=None,
+        y=None,
+        label=None,
+    )
+
+
+def intrinsics() -> CameraIntrinsics:
+    return CameraIntrinsics(
+        camera_matrix=CAMERA_MATRIX,
+        distortion_coefficients=DISTORTION,
+        camera_id=1,
+    )


### PR DESCRIPTION
I set out to widen black to `tests/` by extracting the five clone clusters first. **Five of the fourteen pairs came out cleanly; the other nine shouldn't be forced, and I'd recommend stopping there.**

## What's in this PR

**The resolver suites' fixtures are now shared.** `resolve_laser/species/headtail/slate_preprocess_inputs_activity` answer the same question for four stages, and their tests held four copies of `_dive`, `_image`, `_label`, `_intrinsics`, `_laser` and the `_K`/`_D` constants. They now come from `worker_tests_support/preprocess.py` — except the laser-label builder, which `populate.py` already exported byte-identically.

**Net −134 lines across 4 files.** All 1440 tests green, `check.sh lint` exit 0.

Kept separate from `populate.py` rather than merged: those suites seed images on a different dive and camera, so one builder would need keyword arguments whose only job is to say which suite is calling.

## Why the other nine stay

They aren't helper-shaped, which is what makes extraction cheap:

**Four pairs are seed literals inside test bodies** — `LaserLabel(...)` / `SpeciesLabel(...)` constructions repeated across `test_dive_pipeline_status_view` and `test_select_next_dive_endpoints`. That's **133 constructions across 3850 lines**, in precisely the two suites that pin the cohort-selector ↔ `dive_pipeline_status` agreement CLAUDE.md requires — the agreement whose drift caused the outages earlier this week.

**Five pairs are Temporal test-harness bodies** — stub activities and concurrency gates whose activity names differ per stage.

Rewriting the seed data of the suites that catch cohort drift, in order to satisfy a lint clone, is a bad trade. The cost lands on the tests that matter most; the benefit is formatting consistency in files no image ships.

So `tests/` stays unformatted, and `pyproject.toml` now records that as a **conclusion reached by attempting it**, rather than a pending TODO — including which nine pairs remain and why, so nobody repeats the experiment to find out.

## Verification

1440 unit tests, `check.sh lint` exit 0. The formatting scope is unchanged from #600, so nothing in `src/` moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)