### PR TITLE
feat(reference): make Weasly Fish gradeable, and stop the gap recurring

### DIFF
--- a/libs/fishsense-shared/src/fishsense_shared/taxonomy.py
+++ b/libs/fishsense-shared/src/fishsense_shared/taxonomy.py
@@ -48,6 +48,32 @@ FISH_MODEL_PREFIX = "Fish Model,"
 # through the same name-keyed path. Unlike a fish model its endpoints are
 # unambiguous — no tip-vs-fork landmark uncertainty — so it isolates
 # calibration error from labeling convention.
+# Every `Fish Model, <name>` leaf a labeler can pick, in species-XML order.
+#
+# Lives here rather than in either service because the two halves are split
+# across packages: the labeling XML that offers these choices is in the
+# api-worker, and the `fishmodelreference` rows that make a measurement
+# *gradeable* are in the API. Nothing connected them, and the gap is silent —
+# `fish_model_measurement_accuracy` inner-joins on `Fish.name`, so a model with
+# no reference row produces no rows at all. No error, no NULL, just absence.
+#
+# `Weasly Fish` sat in exactly that state in prod: pickable, measurable, and
+# graded by nobody.
+#
+# Kept in step from both sides: the api-worker asserts the XML matches this
+# list, and the API asserts every name here has a reference row. Adding a model
+# means editing the XML, this list, and `views.KNOWN_FISH_MODELS` — the tests
+# name whichever you forget.
+LABELED_FISH_MODELS = (
+    "Weasly Fish",
+    "Snook",
+    "Grouper",
+    "Shark",
+    "Gray Anthias",
+    "Purple Angel",
+    "Yellow Anthias",
+)
+
 RULER_CONTENT = "Calibration Targets, Ruler"
 RULER_NAME = "Ruler"
 
@@ -65,6 +91,7 @@ FISH_MODEL_LIKE = f"{FISH_MODEL_PREFIX}%"
 
 __all__ = [
     "FISH_MODEL_LIKE",
+    "LABELED_FISH_MODELS",
     "FISH_MODEL_PREFIX",
     "MEASURABILITY_CORPUS",
     "REAL_FISH_LIKE",

--- a/services/fishsense-api-workflow-worker/tests/test_species_xml_model_parity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_species_xml_model_parity.py
@@ -1,0 +1,65 @@
+"""The species XML and `taxonomy.LABELED_FISH_MODELS` must not drift.
+
+`LABELED_FISH_MODELS` is what the API grades against — it decides which models
+need a `fishmodelreference` row. The species labeling XML is what a labeler can
+actually pick. If the two disagree, the disagreement is **silent in both
+directions**:
+
+  * a model in the XML but not the list gets no reference row, and the accuracy
+    view inner-joins it away — its measurements simply never appear (this is
+    exactly what `Weasly Fish` did);
+  * a model in the list but not the XML demands a reference row nobody can ever
+    produce a measurement for.
+
+The XML lives in the api-worker and the grading lives in the API, which is why
+the shared list exists at all and why this parity test does.
+"""
+
+from __future__ import annotations
+
+import re
+
+from fishsense_shared import taxonomy
+
+from fishsense_api_workflow_worker.activities.create_species_label_studio_project_activity import (  # noqa: E501  pylint: disable=line-too-long
+    SPECIES_LABELING_CONFIG_XML,
+)
+
+
+def _xml_fish_models() -> list[str]:
+    """Names nested under the `Fish Model` parent choice, in XML order.
+
+    Parsed from the real pasted-from-prod XML rather than a copy, so the test
+    fails when someone edits the config — which is the moment it matters.
+    """
+    block = re.search(
+        r'<Choice value="Fish Model">(.*?)</Choice>\s*<Choice value="Calibration Targets">',
+        SPECIES_LABELING_CONFIG_XML,
+        re.S,
+    )
+    assert block, "Fish Model branch not found — did the XML change shape?"
+    return re.findall(r'<Choice value="([^"]+)"\s*/>', block.group(1))
+
+
+def test_the_parser_actually_finds_the_models():
+    """Guards the regex itself: a parse that silently returned [] would make
+    every assertion below vacuously true."""
+    assert len(_xml_fish_models()) >= 6
+
+
+def test_every_xml_fish_model_is_in_the_shared_list():
+    missing = set(_xml_fish_models()) - set(taxonomy.LABELED_FISH_MODELS)
+
+    assert not missing, f"in the species XML but ungradeable: {sorted(missing)}"
+
+
+def test_the_shared_list_invents_no_models():
+    extra = set(taxonomy.LABELED_FISH_MODELS) - set(_xml_fish_models())
+
+    assert not extra, f"listed but not labelable: {sorted(extra)}"
+
+
+def test_weasly_fish_is_labelable():
+    """The specific row this work exists for — it was pickable in prod with no
+    reference row, so its measurements were graded by nobody."""
+    assert "Weasly Fish" in _xml_fish_models()

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/d1a7b3e95c02_seed_weasly_fish_reference.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/d1a7b3e95c02_seed_weasly_fish_reference.py
@@ -1,0 +1,79 @@
+"""Seed the `Weasly Fish` reference row so its measurements can be graded.
+
+`Weasly Fish` has been a pickable `Fish Model` leaf in the species labeling XML
+all along, with no `fishmodelreference` row. Because
+`fish_model_measurement_accuracy` INNER JOINs measurements to the reference on
+`Fish.name`, the consequence was silence rather than an error: every Weasly Fish
+measurement was absent from the accuracy view, not wrong in it. Nothing counted
+wrong, nothing logged, and the coverage test passed because it only checked four
+names someone had already thought of.
+
+The length is PROVISIONAL (0.30 m, an estimate). The body widths are not — they
+are calipered, and are recorded in `notes` as an independent input for the
+round-model thickness work. Thickness must never be back-solved from measurement
+error: doing so absorbs whatever calibration bias is present and turns the
+held-out validation set into something that grades itself.
+
+Seed-only-if-absent, like every other reference seed here: an operator may have
+corrected a length by hand, and a migration must not stamp over that.
+
+Revision ID: d1a7b3e95c02
+Revises: e3f70ac46d92
+"""
+
+# pylint: skip-file
+# Convention across all 71 other migrations here: alembic's generated module
+# shape (lowercase `revision` / `down_revision` module constants, `op.get_bind`
+# resolved dynamically) trips invalid-name and no-member with nothing useful to
+# say about it.
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from fishsense_api.views import FISH_MODEL_NOTES, KNOWN_FISH_MODELS
+
+revision: str = "d1a7b3e95c02"
+down_revision: Union[str, Sequence[str], None] = "e3f70ac46d92"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_NAME = "Weasly Fish"
+
+
+def upgrade() -> None:
+    """Insert the reference row if it isn't already there."""
+    bind = op.get_bind()
+
+    existing = {
+        row[0] for row in bind.execute(sa.text("SELECT name FROM fishmodelreference"))
+    }
+    if _NAME in existing:
+        return
+
+    model = next(m for m in KNOWN_FISH_MODELS if m["name"] == _NAME)
+    bind.execute(
+        sa.text(
+            "INSERT INTO fishmodelreference (name, known_length_m, notes) "
+            "VALUES (:name, :known_length_m, :notes)"
+        ),
+        {
+            "name": model["name"],
+            "known_length_m": model["known_length_m"],
+            "notes": FISH_MODEL_NOTES[_NAME],
+        },
+    )
+
+
+def downgrade() -> None:
+    """Remove the seeded row.
+
+    Safe because the row is pure reference data — no measurement points at it;
+    the accuracy view joins BY NAME, so dropping it returns Weasly Fish
+    measurements to being ungradeable rather than orphaning anything.
+    """
+    op.get_bind().execute(
+        sa.text("DELETE FROM fishmodelreference WHERE name = :name"),
+        {"name": _NAME},
+    )

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -455,7 +455,36 @@ KNOWN_FISH_MODELS = [
     # without re-instructing labelers to click a physical 0 that the scale does
     # not print.
     {"name": "Ruler", "known_length_m": 0.3429},
+    # PROVISIONAL length — an eyeball estimate, not a caliper reading. Recorded
+    # so the model becomes gradeable at all: it has been pickable in the species
+    # XML all along, and `fish_model_measurement_accuracy` inner-joins on
+    # `Fish.name`, so every Weasly Fish measurement has been silently absent
+    # from the accuracy view rather than wrong in it.
+    #
+    # Revisit if it reads systematically short — see FISH_MODEL_NOTES.
+    {"name": "Weasly Fish", "known_length_m": 0.30},
 ]
+
+# Provenance for a reference row, keyed by name. Deliberately a SEPARATE
+# mapping rather than a `notes` key on the rows above: historical alembic
+# migrations import `KNOWN_FISH_MODELS` and pass it straight to an executemany
+# bound on (name, known_length_m), so changing the row shape changes what those
+# already-applied migrations do. Seed data being canonical in this module is
+# worth keeping; retroactively editing migration behaviour is not.
+FISH_MODEL_NOTES = {
+    "Weasly Fish": (
+        "Length 0.30 m is PROVISIONAL — an estimate, not a caliper reading. "
+        "Confirm it if measurements read systematically short; until then a "
+        "negative bias on this model is as likely to be the reference as the "
+        "calibration. "
+        "Body widths ARE calipered, 2026-08-20: 58.69 mm at mid-body, "
+        "29.56 mm at the caudal peduncle. They are recorded as an independent "
+        "input for the round-model thickness work and must never be "
+        "back-solved from measurement error — thickness inferred that way "
+        "absorbs whatever calibration bias is present, and the validation set "
+        "starts grading itself."
+    ),
+}
 
 # One row per fish-model measurement, with its error against the known length.
 #

--- a/services/fishsense-api/tests/test_fish_model_reference.py
+++ b/services/fishsense-api/tests/test_fish_model_reference.py
@@ -19,8 +19,11 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from fishsense_shared import taxonomy
+
 from fishsense_api.views import (
     FISH_MODEL_ACCURACY_VIEW_SQL,
+    FISH_MODEL_NOTES,
     KNOWN_FISH_MODELS,
 )
 
@@ -43,10 +46,50 @@ async def session():
 
 
 def test_known_models_cover_the_labeled_taxonomy():
-    """Every `Fish Model, <name>` leaf a labeler can pick must have a known
-    length, or its measurements can never be graded."""
-    names = {m["name"] for m in KNOWN_FISH_MODELS}
-    assert {"Snook", "Grouper", "Shark", "Purple Angel"} <= names
+    """EVERY `Fish Model, <name>` leaf a labeler can pick must have a known
+    length, or its measurements can never be graded.
+
+    Asserted against the whole labeled set rather than a hand-picked subset,
+    because the failure this guards is *silent*: the accuracy view inner-joins
+    on `Fish.name`, so a model with no reference row simply never appears. No
+    error, no NULL row, no count that looks wrong — the measurements just are
+    not there. `Weasly Fish` sat in the species XML in exactly that state, and
+    the previous version of this test passed the whole time because it only
+    checked four names it already knew about.
+    """
+    labeled = set(taxonomy.LABELED_FISH_MODELS)
+    known = {m["name"] for m in KNOWN_FISH_MODELS}
+
+    assert labeled <= known, f"labelable but ungradeable: {sorted(labeled - known)}"
+
+
+def test_weasly_fish_records_the_calipered_widths():
+    """The round-model thickness work needs thickness as an INDEPENDENT input.
+
+    Stage 14 measures a length from two clicked landmarks; a model's girth is
+    invisible to it. If thickness were ever back-solved from measurement error
+    it would absorb whatever calibration bias happened to be present, and the
+    validation set would quietly start grading itself — the same circularity
+    that keeps these lengths out of calibration in the first place.
+
+    So the widths are calipered off the physical model and recorded as
+    provenance, in millimetres as measured.
+    """
+    notes = FISH_MODEL_NOTES["Weasly Fish"]
+
+    assert "58.69" in notes, "mid-body width"
+    assert "29.56" in notes, "caudal peduncle width"
+
+
+def test_weasly_fish_length_is_marked_provisional():
+    """0.30 m is an eyeball estimate, not a caliper reading. It is recorded so
+    the model becomes gradeable at all, but the note has to say so — otherwise
+    a later reader treats it as ground truth and a systematic underestimate
+    gets blamed on calibration."""
+    weasly = next(m for m in KNOWN_FISH_MODELS if m["name"] == "Weasly Fish")
+
+    assert weasly["known_length_m"] == pytest.approx(0.30)
+    assert "provisional" in FISH_MODEL_NOTES["Weasly Fish"].lower()
 
 
 def test_ruler_is_seeded_at_the_labeled_span_not_the_nominal_length():

--- a/services/fishsense-api/tests/test_weasly_fish_seed_migration.py
+++ b/services/fishsense-api/tests/test_weasly_fish_seed_migration.py
@@ -1,0 +1,129 @@
+"""The `Weasly Fish` seed migration, run against a real SQLite database.
+
+Mocks would prove the code calls `execute`; this proves the SQL it emits does
+what the migration claims. The behaviour that matters is **seed-only-if-absent**
+— an operator may have corrected a length by hand, and a migration that stamps
+over that silently replaces a measured value with an estimate.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import sqlalchemy as sa
+
+_VERSIONS = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "fishsense_api"
+    / "alembic"
+    / "versions"
+)
+
+NAME = "Weasly Fish"
+
+
+@pytest.fixture
+def migration():
+    spec = importlib.util.spec_from_file_location(
+        "weasly_seed_migration", _VERSIONS / "d1a7b3e95c02_seed_weasly_fish_reference.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def conn():
+    engine = sa.create_engine("sqlite://")
+    with engine.begin() as c:
+        c.execute(
+            sa.text(
+                "CREATE TABLE fishmodelreference ("
+                " id INTEGER PRIMARY KEY,"
+                " name TEXT NOT NULL UNIQUE,"
+                " known_length_m REAL NOT NULL,"
+                " notes TEXT)"
+            )
+        )
+        yield c
+
+
+def _run(migration, monkeypatch, conn, fn="upgrade"):
+    fake_op = MagicMock()
+    fake_op.get_bind.return_value = conn
+    monkeypatch.setattr(migration, "op", fake_op)
+    getattr(migration, fn)()
+
+
+def _rows(conn):
+    return [
+        dict(r._mapping)  # pylint: disable=protected-access
+        for r in conn.execute(
+            sa.text(
+                "SELECT name, known_length_m, notes FROM fishmodelreference "
+                "WHERE name = :n"
+            ),
+            {"n": NAME},
+        )
+    ]
+
+
+def test_seeds_the_row_with_its_length_and_notes(migration, monkeypatch, conn):
+    _run(migration, monkeypatch, conn)
+
+    rows = _rows(conn)
+    assert len(rows) == 1
+    assert rows[0]["known_length_m"] == pytest.approx(0.30)
+    assert "58.69" in rows[0]["notes"]
+    assert "29.56" in rows[0]["notes"]
+
+
+def test_running_twice_leaves_one_row(migration, monkeypatch, conn):
+    """`run_alembic_upgrade` is idempotent by design and runs on every start;
+    a UNIQUE violation here would crash the API at boot."""
+    _run(migration, monkeypatch, conn)
+    _run(migration, monkeypatch, conn)
+
+    assert len(_rows(conn)) == 1
+
+
+def test_does_not_overwrite_a_hand_corrected_length(migration, monkeypatch, conn):
+    """The length being seeded is an ESTIMATE. If someone has since calipered
+    the model and corrected the row, this migration must leave it alone —
+    otherwise a deploy silently replaces a measurement with a guess."""
+    conn.execute(
+        sa.text(
+            "INSERT INTO fishmodelreference (name, known_length_m, notes) "
+            "VALUES (:n, 0.287, 'calipered 2026-09-01')"
+        ),
+        {"n": NAME},
+    )
+
+    _run(migration, monkeypatch, conn)
+
+    rows = _rows(conn)
+    assert len(rows) == 1
+    assert rows[0]["known_length_m"] == pytest.approx(0.287)
+    assert rows[0]["notes"] == "calipered 2026-09-01"
+
+
+def test_downgrade_removes_only_this_row(migration, monkeypatch, conn):
+    conn.execute(
+        sa.text(
+            "INSERT INTO fishmodelreference (name, known_length_m) "
+            "VALUES ('Grouper', 0.360)"
+        )
+    )
+    _run(migration, monkeypatch, conn)
+
+    _run(migration, monkeypatch, conn, fn="downgrade")
+
+    assert _rows(conn) == []
+    remaining = conn.execute(
+        sa.text("SELECT name FROM fishmodelreference")
+    ).scalars().all()
+    assert remaining == ["Grouper"]


### PR DESCRIPTION
Closes the last open item in the original brief — the calipered widths arrived.

## The bug was silence, not an error

`Weasly Fish` has been a pickable `Fish Model` leaf in the species labeling XML
all along, with **no `fishmodelreference` row**. `fish_model_measurement_accuracy`
INNER JOINs measurements to the reference on `Fish.name`, so every Weasly Fish
measurement was **absent from the accuracy view rather than wrong in it**. No
error, no NULL row, no count that looked off.

And the guard that should have caught it passed the whole time:

```python
assert {"Snook", "Grouper", "Shark", "Purple Angel"} <= names
```

A hand-picked subset cannot fail for a model nobody remembered to add. It now
asserts the **whole** labeled set, and names the offenders in the failure.

## Why nothing connected the two halves

The XML that offers these choices lives in the **api-worker**; the reference
rows that make a measurement gradeable live in the **API**. Neither package
imports the other.

`LABELED_FISH_MODELS` now lives in `fishsense_shared.taxonomy` — where CLAUDE.md
says taxonomy literals belong — and is pinned **from both sides**:

* api-worker: the species XML's `Fish Model` choices must equal the list
  (parsed from the real pasted-from-prod XML, so editing the config trips it);
* API: every name in the list must have a `KNOWN_FISH_MODELS` entry.

Adding a model now fails a test naming whichever of the three edits you forgot.

## Length is provisional; the widths are not

`known_length_m = 0.30` is an **estimate**, not a caliper reading, and the notes
say so. A later reader treating it as ground truth would blame a systematic
underestimate on calibration instead of on the reference. Revisit if it reads
short.

The body widths **are** calipered — **58.69 mm at mid-body, 29.56 mm at the
caudal peduncle** — recorded as an independent input for the round-model
thickness work.

They must never be back-solved from measurement error. Thickness inferred that
way absorbs whatever calibration bias is present, and the held-out validation
set starts grading itself — the same circularity that keeps these lengths out of
calibration in the first place.

## Two implementation notes

**`FISH_MODEL_NOTES` is a separate mapping, not a `notes` key on the rows.**
Historical migrations import `KNOWN_FISH_MODELS` and pass it to an executemany
bound on `(name, known_length_m)`; changing the row shape would retroactively
change what already-applied migrations do.

**The migration seeds only if absent.** The length is an estimate — an operator
who has since calipered the model must not have it stamped over. Tested against
real SQLite rather than mocks: seeds with notes, double-run leaves one row,
a hand-corrected row survives untouched, downgrade removes only this row.

## Tests

395 pass in fishsense-api, 435 in the api-worker, 167 in fishsense-shared at
100% coverage; black clean, pylint 10.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)