### PR TITLE
fix(reference): keep a provisional length out of the mislabel view, and seed it on fresh DBs

### DIFF
--- a/libs/fishsense-shared/src/fishsense_shared/taxonomy.py
+++ b/libs/fishsense-shared/src/fishsense_shared/taxonomy.py
@@ -48,6 +48,9 @@ FISH_MODEL_PREFIX = "Fish Model,"
 # through the same name-keyed path. Unlike a fish model its endpoints are
 # unambiguous — no tip-vs-fork landmark uncertainty — so it isolates
 # calibration error from labeling convention.
+RULER_CONTENT = "Calibration Targets, Ruler"
+RULER_NAME = "Ruler"
+
 # Every `Fish Model, <name>` leaf a labeler can pick, in species-XML order.
 #
 # Lives here rather than in either service because the two halves are split
@@ -74,9 +77,6 @@ LABELED_FISH_MODELS = (
     "Yellow Anthias",
 )
 
-RULER_CONTENT = "Calibration Targets, Ruler"
-RULER_NAME = "Ruler"
-
 # Stage-9 marker: the frame shows the slate with the laser on it. This is read
 # off `taxonomy[0]`, a separate path from the slate-*type* leaf that species
 # sync maps to `Dive.dive_slate_id`.
@@ -91,8 +91,8 @@ FISH_MODEL_LIKE = f"{FISH_MODEL_PREFIX}%"
 
 __all__ = [
     "FISH_MODEL_LIKE",
-    "LABELED_FISH_MODELS",
     "FISH_MODEL_PREFIX",
+    "LABELED_FISH_MODELS",
     "MEASURABILITY_CORPUS",
     "REAL_FISH_LIKE",
     "RULER_CONTENT",

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/d1a7b3e95c02_seed_weasly_fish_reference.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/d1a7b3e95c02_seed_weasly_fish_reference.py
@@ -52,7 +52,16 @@ def upgrade() -> None:
     if _NAME in existing:
         return
 
-    model = next(m for m in KNOWN_FISH_MODELS if m["name"] == _NAME)
+    # A filtering comprehension, not `next(...)`: this migration is shipped and
+    # replays on every fresh database forever. If the model is ever renamed in
+    # `KNOWN_FISH_MODELS`, a bare `next` raises StopIteration inside the FastAPI
+    # lifespan and the API fails to boot. Degrading to a no-op is the only safe
+    # behaviour for a historical seed. Same reason `FISH_MODEL_NOTES` is read
+    # with `.get`.
+    candidates = [m for m in KNOWN_FISH_MODELS if m["name"] == _NAME]
+    if not candidates:
+        return
+    model = candidates[0]
     bind.execute(
         sa.text(
             "INSERT INTO fishmodelreference (name, known_length_m, notes) "
@@ -61,19 +70,17 @@ def upgrade() -> None:
         {
             "name": model["name"],
             "known_length_m": model["known_length_m"],
-            "notes": FISH_MODEL_NOTES[_NAME],
+            "notes": FISH_MODEL_NOTES.get(_NAME),
         },
     )
 
 
 def downgrade() -> None:
-    """Remove the seeded row.
+    """Leave the row in place.
 
-    Safe because the row is pure reference data — no measurement points at it;
-    the accuracy view joins BY NAME, so dropping it returns Weasly Fish
-    measurements to being ungradeable rather than orphaning anything.
+    Deliberately a no-op, matching sibling `b4c81f60d7e2`, which seeds the same
+    table and says the same thing. The row is inert without a measurement to
+    grade, and `upgrade()` goes out of its way NOT to stamp over a length an
+    operator has since calipered — deleting it on the way back down would throw
+    away exactly the work that guard exists to protect.
     """
-    op.get_bind().execute(
-        sa.text("DELETE FROM fishmodelreference WHERE name = :name"),
-        {"name": _NAME},
-    )

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/f2b8c04e71a3_fish_model_reference_is_provisional.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/f2b8c04e71a3_fish_model_reference_is_provisional.py
@@ -1,0 +1,121 @@
+"""Mark estimated reference lengths, and repair the notes the seed could miss.
+
+Three things, all consequences of `Weasly Fish` being seeded at a PROVISIONAL
+length in `d1a7b3e95c02`.
+
+**1. `is_provisional`.** `fish_model_species_mislabel_suspects` CROSS JOINs
+`fishmodelreference` to ask "does this frame fit some OTHER model better?". A
+length nobody has calipered must not answer that question: stage 14 measures a
+projection, so angled frames of the big models read short and never long, and an
+estimate dropped into that short band flags every correct-but-angled frame near
+it. Measured: a Shark (605 mm) at 290 mm had no suspect before — closest other
+reference was the Ruler, 15.4% away, outside the 10% gate — and lands at 3.3%
+from a 300 mm Weasly Fish. The view now excludes provisional rows; they stay
+fully graded in `fish_model_measurement_accuracy`.
+
+**2. Notes backfill.** `e2c9a4f70b31` and `b4c81f60d7e2` iterate the *live*
+`KNOWN_FISH_MODELS`, so on any database below them they now insert Weasly Fish
+themselves — with `notes = NULL`, since their INSERT binds only
+(name, known_length_m). `d1a7b3e95c02` then sees the row present and
+short-circuits, leaving the caliper provenance permanently missing. Filling a
+NULL is safe; a non-NULL note is an operator's and is left alone.
+
+**3. View rebuild**, because the mislabel SQL changed.
+
+Idempotent against `create_all`: the column exists already on a fresh database
+(it is on the model), so the ALTER is skipped.
+
+Revision ID: f2b8c04e71a3
+Revises: d1a7b3e95c02
+"""
+
+# pylint: skip-file
+# See d1a7b3e95c02 — alembic's generated module shape trips invalid-name and
+# no-member across all migrations here.
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from fishsense_api.views import (
+    DROP_FISH_MODEL_MISLABEL_SUSPECTS_VIEW_SQL,
+    FISH_MODEL_MISLABEL_SUSPECTS_VIEW_SQL,
+    FISH_MODEL_NOTES,
+    PROVISIONAL_FISH_MODELS,
+)
+
+revision: str = "f2b8c04e71a3"
+down_revision: Union[str, Sequence[str], None] = "d1a7b3e95c02"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _has_column(bind, table: str, column: str) -> bool:
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(table):
+        return False
+    return column in {c["name"] for c in inspector.get_columns(table)}
+
+
+def upgrade() -> None:
+    """Add the column, mark the provisional rows, backfill missing notes."""
+    bind = op.get_bind()
+
+    if not _has_column(bind, "fishmodelreference", "is_provisional"):
+        op.add_column(
+            "fishmodelreference",
+            sa.Column(
+                "is_provisional",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+
+    # Set from the declared set rather than a literal, so adding a provisional
+    # model is one edit in views.py. Names absent from the table are simply not
+    # matched — no failure if the seed never ran.
+    for name in sorted(PROVISIONAL_FISH_MODELS):
+        bind.execute(
+            sa.text(
+                "UPDATE fishmodelreference SET is_provisional = :flag "
+                "WHERE name = :name"
+            ),
+            {"flag": True, "name": name},
+        )
+
+    # Fill only where a note is genuinely absent — never overwrite one an
+    # operator wrote.
+    for name, note in FISH_MODEL_NOTES.items():
+        bind.execute(
+            sa.text(
+                "UPDATE fishmodelreference SET notes = :note "
+                "WHERE name = :name AND notes IS NULL"
+            ),
+            {"note": note, "name": name},
+        )
+
+    op.execute(DROP_FISH_MODEL_MISLABEL_SUSPECTS_VIEW_SQL)
+    op.execute(FISH_MODEL_MISLABEL_SUSPECTS_VIEW_SQL)
+
+
+def downgrade() -> None:
+    """Drop the column and rebuild the view without the provisional filter.
+
+    The reference ROWS are left alone — they are data, and a downgrade that
+    discards a length or a caliper note would lose work the upgrade path went
+    out of its way to protect.
+    """
+    bind = op.get_bind()
+
+    # Drop the view rather than rebuilding it by editing its SQL here: the
+    # current definition references the column being removed, and reconstructing
+    # the old text by string surgery would silently rot the moment the view
+    # changes for any other reason. A downgrade is paired with a code revert,
+    # and `run_alembic_upgrade`'s missing-view repair recreates every view from
+    # whatever code is actually deployed on the next start.
+    op.execute(DROP_FISH_MODEL_MISLABEL_SUSPECTS_VIEW_SQL)
+
+    if _has_column(bind, "fishmodelreference", "is_provisional"):
+        op.drop_column("fishmodelreference", "is_provisional")

--- a/services/fishsense-api/src/fishsense_api/database.py
+++ b/services/fishsense-api/src/fishsense_api/database.py
@@ -134,6 +134,53 @@ async def _create_all_views() -> None:
         await engine.dispose()
 
 
+async def _seed_fish_model_references() -> None:
+    """Insert any missing `fishmodelreference` rows, idempotently.
+
+    The counterpart to `_create_all_views`, and it exists for the same reason.
+    On a fresh database `run_alembic_upgrade` **stamps** head rather than
+    running the migrations, so every seed those migrations perform is skipped —
+    the reference table comes up empty and `fish_model_measurement_accuracy`,
+    which INNER JOINs it, is empty for every model. That is the exact silent
+    absence the Weasly Fish work set out to end, reintroduced through the
+    bootstrap path.
+
+    Insert-only, never update: an operator who has calipered a model and
+    corrected its row must not have that stamped back to the seeded value on
+    the next restart. Provisional flags and notes are set for rows this call
+    creates; rows that already exist are left entirely alone.
+    """
+    engine = create_async_engine(pg_connection_string())
+    try:
+        async with engine.begin() as conn:
+            result = await conn.execute(sa.text("SELECT name FROM fishmodelreference"))
+            present = {row[0] for row in result}
+            missing = [m for m in views.KNOWN_FISH_MODELS if m["name"] not in present]
+            for model in missing:
+                await conn.execute(
+                    sa.text(
+                        "INSERT INTO fishmodelreference "
+                        "(name, known_length_m, notes, is_provisional) "
+                        "VALUES (:name, :known_length_m, :notes, :is_provisional)"
+                    ),
+                    {
+                        "name": model["name"],
+                        "known_length_m": model["known_length_m"],
+                        "notes": views.FISH_MODEL_NOTES.get(model["name"]),
+                        "is_provisional": model["name"]
+                        in views.PROVISIONAL_FISH_MODELS,
+                    },
+                )
+            if missing:
+                _log.info(
+                    "seeded %d fish-model reference row(s): %s",
+                    len(missing),
+                    ", ".join(m["name"] for m in missing),
+                )
+    finally:
+        await engine.dispose()
+
+
 def run_alembic_upgrade() -> None:
     """Apply pending migrations OR stamp head on a fresh DB.
 
@@ -191,6 +238,12 @@ def run_alembic_upgrade() -> None:
                 "views missing after upgrade (%s); recreating", ", ".join(missing)
             )
             asyncio.run(_create_all_views())
+
+        # Same repair rationale as the views above: a database bootstrapped by
+        # the stamp path was marked fully-migrated without ever running a seed,
+        # and nothing else will backfill it. Insert-only, so a healthy database
+        # is untouched.
+        asyncio.run(_seed_fish_model_references())
     else:
         _log.info("alembic_version missing; fresh DB after create_all")
         # Views BEFORE the stamp, deliberately. Stamping marks every migration
@@ -205,7 +258,13 @@ def run_alembic_upgrade() -> None:
         # non-self-healing failure this exists to fix.
         _log.info("creating views for fresh DB")
         asyncio.run(_create_all_views())
-        _log.info("views created; stamping head")
+        _log.info("views created; seeding reference data")
+        # Before the stamp, for the same reason the views are: stamping marks
+        # every migration applied without running any of them, so the seeds
+        # those migrations perform would never happen. If this raises,
+        # `alembic_version` is still absent and the next restart retries.
+        asyncio.run(_seed_fish_model_references())
+        _log.info("reference data seeded; stamping head")
         alembic_command.stamp(cfg, "head")
 
 

--- a/services/fishsense-api/src/fishsense_api/models/fish_model_reference.py
+++ b/services/fishsense-api/src/fishsense_api/models/fish_model_reference.py
@@ -25,3 +25,16 @@ class FishModelReference(SQLModel, table=True):
     # Provenance: how/when the length was established (e.g. field dates,
     # caliper session). Free text — the measurement itself is the datum.
     notes: str | None = Field(default=None)
+
+    # True when `known_length_m` is an ESTIMATE rather than a caliper reading.
+    #
+    # Load-bearing, not documentation. `fish_model_species_mislabel_suspects`
+    # CROSS JOINs this table to ask "does this frame's length fit some OTHER
+    # model better?", and a provisional length dropped into that comparison
+    # re-labels real frames on the strength of a guess. Stage 14 measures a
+    # projection, so angled frames of the big models read short and land in a
+    # broad band; an estimate sitting in that band flags every one of them.
+    #
+    # A provisional row is still graded in `fish_model_measurement_accuracy` —
+    # it just cannot be cited as evidence against another model's label.
+    is_provisional: bool = Field(default=False)

--- a/services/fishsense-api/src/fishsense_api/views.py
+++ b/services/fishsense-api/src/fishsense_api/views.py
@@ -471,6 +471,17 @@ KNOWN_FISH_MODELS = [
 # bound on (name, known_length_m), so changing the row shape changes what those
 # already-applied migrations do. Seed data being canonical in this module is
 # worth keeping; retroactively editing migration behaviour is not.
+# Models whose `known_length_m` is an ESTIMATE, not a caliper reading.
+#
+# A separate set for the same reason `FISH_MODEL_NOTES` is a separate mapping:
+# historical migrations import `KNOWN_FISH_MODELS` and bind it to an
+# executemany over (name, known_length_m), so adding a key to those rows
+# changes what already-applied migrations do.
+#
+# Consumed by the seed migration, which sets `fishmodelreference.is_provisional`
+# — see that column for why it is load-bearing rather than documentation.
+PROVISIONAL_FISH_MODELS = frozenset({"Weasly Fish"})
+
 FISH_MODEL_NOTES = {
     "Weasly Fish": (
         "Length 0.30 m is PROVISIONAL — an estimate, not a caliper reading. "
@@ -641,6 +652,13 @@ WITH frame_fit AS (
            ) AS rk
     FROM {FISH_MODEL_ACCURACY_VIEW_NAME} a
     CROSS JOIN fishmodelreference r
+    -- Provisional lengths are estimates and must not re-label real frames.
+    -- Angled frames read short (never long), so they cluster in a broad band
+    -- below each model's true length; an un-calipered length sitting in that
+    -- band would flag every correct-but-angled frame near it. Such rows stay
+    -- fully graded in the accuracy view — they just aren't offered as an
+    -- alternative label here.
+    WHERE NOT r.is_provisional
 )
 SELECT
     a.image_id,

--- a/services/fishsense-api/tests/test_alembic_upgrade.py
+++ b/services/fishsense-api/tests/test_alembic_upgrade.py
@@ -43,6 +43,17 @@ def _patch_run_alembic(has_alembic_version: bool, missing_views=()):
     async def _fake_missing_views():
         return list(missing_views)
 
+    # Seeding reference rows runs on BOTH branches for the same reason views
+    # do — the stamp path skips every migration, so a fresh database would come
+    # up with an empty `fishmodelreference`. Stubbed here so it doesn't open a
+    # real connection, and recorded so ordering can be asserted: on the fresh
+    # branch it must land before the stamp, or a failure would leave the
+    # database marked fully-migrated with nothing seeded and no way back.
+    seeded = MagicMock(side_effect=lambda: calls.append("seed"))
+
+    async def _fake_seed():
+        seeded()
+
     return (
         fake_command,
         fake_cfg,
@@ -55,6 +66,7 @@ def _patch_run_alembic(has_alembic_version: bool, missing_views=()):
             _has_alembic_version_table=_fake_check,
             _create_all_views=_fake_create_views,
             _missing_views=_fake_missing_views,
+            _seed_fish_model_references=_fake_seed,
         ),
     )
 
@@ -128,10 +140,12 @@ def test_run_alembic_upgrade_fresh_db_stamps_head_without_running_ddl():
     fake_command.stamp.assert_called_once_with(fake_cfg, "head")
     fake_command.upgrade.assert_not_called()
     views_created.assert_called_once()
-    # Views BEFORE the stamp. If creation fails, `alembic_version` stays
-    # absent and the next restart retries the whole path; stamping first would
-    # mark the DB fully-migrated with no views and no way back.
-    assert calls == ["create_views", "stamp"]
+    # Views AND seed data BEFORE the stamp. If either fails, `alembic_version`
+    # stays absent and the next restart retries the whole path; stamping first
+    # would mark the DB fully-migrated with no views, no reference rows, and no
+    # way back — the accuracy view would then be empty for every model, which
+    # is the same silent absence the reference seeding exists to prevent.
+    assert calls == ["create_views", "seed", "stamp"]
     _assert_script_location_set(fake_cfg)
 
 

--- a/services/fishsense-api/tests/test_fish_model_mislabel_suspects.py
+++ b/services/fishsense-api/tests/test_fish_model_mislabel_suspects.py
@@ -207,3 +207,81 @@ async def test_one_bad_frame_does_not_condemn_its_neighbours(session):
     assert [r["image_id"] for r in rows] == [bad], "only the bad frame"
     assert rows[0]["best_fit_model"] == "Shark"
     assert rows[0]["confidence"] == "high"
+
+
+# ── provisional references must not attract other models' frames ──────
+
+
+async def test_a_provisional_reference_is_not_offered_as_a_best_fit(session):
+    """A reference length that is an ESTIMATE must never re-label a real frame.
+
+    Stage 14 measures a projection, so an out-of-plane fish reads short and
+    never long — the whole asymmetry this view is built around. That means
+    correct-but-angled frames of the big models land in a broad short band, and
+    dropping a provisional length into that band turns every one of them into a
+    `medium` suspect pointing at a model whose length nobody has calipered.
+
+    Concretely: a Shark (605 mm) measured at 290 mm. Its own error is -52%, so
+    it clears the own-error gate either way. Before `Weasly Fish` existed the
+    closest other reference was the Ruler at 15.4% — outside the 10% gate, so
+    no flag. A provisional 300 mm sits 3.3% away and would flag it.
+
+    The frame is still graded (it stays in the accuracy view); it just cannot
+    be *cited* as evidence that something else was mislabeled.
+    """
+    from fishsense_api.models.fish_model_reference import FishModelReference
+
+    session.add(
+        FishModelReference(
+            name="Weasly Fish", known_length_m=0.30, is_provisional=True
+        )
+    )
+    await session.flush()
+
+    await _measure(session, dive_id=1, model_name="Shark", length_m=0.29)
+
+    assert await _suspects(session) == []
+
+
+async def test_a_non_provisional_reference_still_attracts(session):
+    """The control. Same frame, same length, reference marked measured — the
+    flag must appear, or the test above would pass for the wrong reason."""
+    from fishsense_api.models.fish_model_reference import FishModelReference
+
+    session.add(
+        FishModelReference(
+            name="Weasly Fish", known_length_m=0.30, is_provisional=False
+        )
+    )
+    await session.flush()
+
+    await _measure(session, dive_id=1, model_name="Shark", length_m=0.29)
+
+    rows = await _suspects(session)
+    assert [r["best_fit_model"] for r in rows] == ["Weasly Fish"]
+
+
+async def test_a_provisional_model_is_still_graded_in_the_accuracy_view(session):
+    """Excluding it from *re-labeling* must not un-grade it. Making Weasly Fish
+    gradeable is the entire point of seeding it."""
+    from fishsense_api.models.fish_model_reference import FishModelReference
+
+    session.add(
+        FishModelReference(
+            name="Weasly Fish", known_length_m=0.30, is_provisional=True
+        )
+    )
+    await session.flush()
+
+    await _measure(session, dive_id=1, model_name="Weasly Fish", length_m=0.29)
+
+    rows = [
+        dict(r._mapping)  # pylint: disable=protected-access
+        for r in await session.exec(
+            text(
+                "SELECT model_name, pct_error FROM "
+                "fish_model_measurement_accuracy"
+            )
+        )
+    ]
+    assert [r["model_name"] for r in rows] == ["Weasly Fish"]

--- a/services/fishsense-api/tests/test_fish_model_provisional_migration.py
+++ b/services/fishsense-api/tests/test_fish_model_provisional_migration.py
@@ -1,0 +1,194 @@
+"""`f2b8c04e71a3` — the provisional flag, and the notes the seed can miss.
+
+Both behaviours are exercised against a real SQLite database rather than mocks,
+because the bug being fixed is an *ordering* one between migrations that each
+look correct in isolation.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import sqlalchemy as sa
+
+_VERSIONS = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "fishsense_api"
+    / "alembic"
+    / "versions"
+)
+
+NAME = "Weasly Fish"
+
+
+def _load(filename: str, mod: str):
+    spec = importlib.util.spec_from_file_location(mod, _VERSIONS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def seed_migration():
+    return _load("d1a7b3e95c02_seed_weasly_fish_reference.py", "seed_mig")
+
+
+@pytest.fixture
+def provisional_migration():
+    return _load(
+        "f2b8c04e71a3_fish_model_reference_is_provisional.py", "prov_mig"
+    )
+
+
+@pytest.fixture
+def conn():
+    engine = sa.create_engine("sqlite://")
+    with engine.begin() as c:
+        # Shaped as the EARLIER migrations leave it: no is_provisional column.
+        c.execute(
+            sa.text(
+                "CREATE TABLE fishmodelreference ("
+                " id INTEGER PRIMARY KEY,"
+                " name TEXT NOT NULL UNIQUE,"
+                " known_length_m REAL NOT NULL,"
+                " notes TEXT)"
+            )
+        )
+        yield c
+
+
+def _run(mod, conn, fn="upgrade"):
+    fake_op = MagicMock()
+    fake_op.get_bind.return_value = conn
+
+    def _add_column(table, col):
+        conn.execute(
+            sa.text(
+                f"ALTER TABLE {table} ADD COLUMN {col.name} BOOLEAN "
+                "NOT NULL DEFAULT 0"
+            )
+        )
+
+    def _drop_column(table, name):
+        conn.execute(sa.text(f"ALTER TABLE {table} DROP COLUMN {name}"))
+
+    fake_op.add_column.side_effect = _add_column
+    fake_op.drop_column.side_effect = _drop_column
+    fake_op.execute.side_effect = lambda sql: conn.execute(sa.text(str(sql)))
+    original = mod.op
+    mod.op = fake_op
+    try:
+        getattr(mod, fn)()
+    finally:
+        mod.op = original
+
+
+def _row(conn):
+    rows = [
+        dict(r._mapping)  # pylint: disable=protected-access
+        for r in conn.execute(
+            sa.text(
+                "SELECT known_length_m, notes, is_provisional "
+                "FROM fishmodelreference WHERE name = :n"
+            ),
+            {"n": NAME},
+        )
+    ]
+    return rows[0] if rows else None
+
+
+def test_backfills_notes_an_earlier_migration_inserted_without(
+    provisional_migration, conn
+):
+    """The ordering bug this migration exists to repair.
+
+    `e2c9a4f70b31` and `b4c81f60d7e2` iterate the LIVE `KNOWN_FISH_MODELS`, so
+    once Weasly Fish was added to that constant they began inserting it
+    themselves — with `notes = NULL`, since their INSERT binds only
+    (name, known_length_m). `d1a7b3e95c02` then finds the row present and
+    short-circuits, so on any database below those revisions the caliper
+    provenance would be missing permanently.
+    """
+    conn.execute(
+        sa.text(
+            "INSERT INTO fishmodelreference (name, known_length_m) "
+            "VALUES (:n, 0.30)"
+        ),
+        {"n": NAME},
+    )
+
+    _run(provisional_migration, conn)
+
+    row = _row(conn)
+    assert "58.69" in row["notes"]
+    assert "29.56" in row["notes"]
+
+
+def test_marks_the_provisional_row_and_leaves_measured_ones_alone(
+    provisional_migration, conn
+):
+    conn.execute(
+        sa.text(
+            "INSERT INTO fishmodelreference (name, known_length_m) "
+            "VALUES (:n, 0.30), ('Grouper', 0.360)"
+        ),
+        {"n": NAME},
+    )
+
+    _run(provisional_migration, conn)
+
+    assert _row(conn)["is_provisional"] == 1
+    grouper = conn.execute(
+        sa.text(
+            "SELECT is_provisional FROM fishmodelreference WHERE name='Grouper'"
+        )
+    ).scalar_one()
+    assert grouper == 0
+
+
+def test_never_overwrites_notes_an_operator_wrote(provisional_migration, conn):
+    conn.execute(
+        sa.text(
+            "INSERT INTO fishmodelreference (name, known_length_m, notes) "
+            "VALUES (:n, 0.287, 'calipered 2026-09-01')"
+        ),
+        {"n": NAME},
+    )
+
+    _run(provisional_migration, conn)
+
+    assert _row(conn)["notes"] == "calipered 2026-09-01"
+
+
+def test_running_twice_is_safe(provisional_migration, conn):
+    """`run_alembic_upgrade` runs on every start; the column add must not
+    explode on the second pass."""
+    conn.execute(
+        sa.text(
+            "INSERT INTO fishmodelreference (name, known_length_m) "
+            "VALUES (:n, 0.30)"
+        ),
+        {"n": NAME},
+    )
+
+    _run(provisional_migration, conn)
+    _run(provisional_migration, conn)
+
+    assert _row(conn)["is_provisional"] == 1
+
+
+def test_the_seed_then_provisional_chain_ends_with_both(
+    seed_migration, provisional_migration, conn
+):
+    """End to end, in the order a real database runs them."""
+    _run(seed_migration, conn)
+    _run(provisional_migration, conn)
+
+    row = _row(conn)
+    assert row["known_length_m"] == pytest.approx(0.30)
+    assert row["is_provisional"] == 1
+    assert "58.69" in row["notes"]

--- a/services/fishsense-api/tests/test_view_bootstrap_registry.py
+++ b/services/fishsense-api/tests/test_view_bootstrap_registry.py
@@ -52,3 +52,87 @@ def test_every_registry_entry_drops_then_creates_the_same_view():
 
 def test_registry_names_are_unique():
     assert len(set(views.ALL_VIEW_NAMES)) == len(views.ALL_VIEW_NAMES)
+
+
+# ── seed data has the same bootstrap hole views had ───────────────────
+
+
+async def _seed_against(tmp_path, monkeypatch, preexisting_sql=None, times=1):
+    """Run `_seed_fish_model_references` against a real file-backed SQLite.
+
+    A file rather than `:memory:` because the helper disposes the engine it
+    creates, which would discard an in-memory database before the test could
+    read it back.
+    """
+    import sqlalchemy as sa
+    from sqlalchemy.ext.asyncio import create_async_engine
+    from sqlmodel import SQLModel
+
+    from fishsense_api import database
+
+    url = f"sqlite+aiosqlite:///{tmp_path}/seed.db"
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+        if preexisting_sql:
+            await conn.execute(sa.text(preexisting_sql))
+    await engine.dispose()
+
+    monkeypatch.setattr(database, "pg_connection_string", lambda: url)
+    for _ in range(times):
+        await database._seed_fish_model_references()  # pylint: disable=protected-access
+
+    reader = create_async_engine(url)
+    async with reader.connect() as conn:
+        rows = {
+            r[0]: {"length": r[1], "notes": r[2], "provisional": bool(r[3])}
+            for r in await conn.execute(
+                sa.text(
+                    "SELECT name, known_length_m, notes, is_provisional "
+                    "FROM fishmodelreference"
+                )
+            )
+        }
+    await reader.dispose()
+    return rows
+
+
+async def test_fresh_database_seeding_inserts_every_known_model(
+    tmp_path, monkeypatch
+):
+    """On a fresh DB `run_alembic_upgrade` STAMPS head instead of upgrading, so
+    every seed the migrations perform is skipped and `fishmodelreference` comes
+    up empty — leaving `fish_model_measurement_accuracy` empty for every model.
+
+    That is the same silent absence the Weasly Fish work set out to end,
+    reintroduced through the bootstrap path. Views had a replay for it; seed
+    rows did not.
+    """
+    rows = await _seed_against(tmp_path, monkeypatch)
+
+    assert set(rows) == {m["name"] for m in views.KNOWN_FISH_MODELS}
+    # The provisional flag and caliper notes must survive the bootstrap — they
+    # are what keeps an estimated length out of the mislabel view.
+    assert rows["Weasly Fish"]["provisional"] is True
+    assert "58.69" in rows["Weasly Fish"]["notes"]
+    assert rows["Grouper"]["provisional"] is False
+
+
+async def test_seeding_is_insert_only_and_idempotent(tmp_path, monkeypatch):
+    """An operator who calipered a model and corrected its row must not have
+    that stamped back to the seeded estimate on the next restart — and the
+    helper runs on every start, so it must also be safe to repeat."""
+    rows = await _seed_against(
+        tmp_path,
+        monkeypatch,
+        preexisting_sql=(
+            "INSERT INTO fishmodelreference "
+            "(name, known_length_m, notes, is_provisional) "
+            "VALUES ('Weasly Fish', 0.287, 'calipered', 0)"
+        ),
+        times=2,
+    )
+
+    assert rows["Weasly Fish"]["length"] == 0.287
+    assert rows["Weasly Fish"]["notes"] == "calipered"
+    assert rows["Weasly Fish"]["provisional"] is False

--- a/services/fishsense-api/tests/test_weasly_fish_seed_migration.py
+++ b/services/fishsense-api/tests/test_weasly_fish_seed_migration.py
@@ -111,19 +111,46 @@ def test_does_not_overwrite_a_hand_corrected_length(migration, monkeypatch, conn
     assert rows[0]["notes"] == "calipered 2026-09-01"
 
 
-def test_downgrade_removes_only_this_row(migration, monkeypatch, conn):
+def test_downgrade_leaves_the_row_alone(migration, monkeypatch, conn):
+    """A downgrade must not discard reference data.
+
+    The row is inert without a measurement to grade, and `upgrade()` explicitly
+    refuses to stamp over a hand-corrected length — deleting it here would throw
+    away exactly the work that guard protects. Sibling `b4c81f60d7e2` seeds the
+    same table and takes the same position, in as many words.
+
+    This test previously asserted the opposite and pinned the unsafe behaviour.
+    """
+    _run(migration, monkeypatch, conn)
     conn.execute(
         sa.text(
-            "INSERT INTO fishmodelreference (name, known_length_m) "
-            "VALUES ('Grouper', 0.360)"
-        )
+            "UPDATE fishmodelreference SET known_length_m = 0.287, "
+            "notes = 'calipered later' WHERE name = :n"
+        ),
+        {"n": NAME},
     )
-    _run(migration, monkeypatch, conn)
 
     _run(migration, monkeypatch, conn, fn="downgrade")
 
+    rows = _rows(conn)
+    assert len(rows) == 1
+    assert rows[0]["known_length_m"] == pytest.approx(0.287)
+    assert rows[0]["notes"] == "calipered later"
+
+
+def test_upgrade_is_a_no_op_if_the_model_is_ever_renamed(
+    migration, monkeypatch, conn
+):
+    """This migration replays on every fresh database forever. A bare
+    `next(...)` over `KNOWN_FISH_MODELS` would raise StopIteration inside the
+    FastAPI lifespan after a rename, failing API boot — so it must degrade to
+    doing nothing instead."""
+    monkeypatch.setattr(
+        migration,
+        "KNOWN_FISH_MODELS",
+        [{"name": "Something Else", "known_length_m": 0.1}],
+    )
+
+    _run(migration, monkeypatch, conn)
+
     assert _rows(conn) == []
-    remaining = conn.execute(
-        sa.text("SELECT name FROM fishmodelreference")
-    ).scalars().all()
-    assert remaining == ["Grouper"]


### PR DESCRIPTION
Follow-up to #603, addressing all six code-review findings. Each was
reproduced before being fixed.

## 1. A provisional length was re-labeling other models' frames

`fish_model_species_mislabel_suspects` CROSS JOINs `fishmodelreference` to ask
*"does this frame fit some OTHER model better?"* — so seeding an estimate put it
into that comparison as a candidate answer.

Stage 14 measures a **projection**, so angled frames read short and never long.
They cluster in a broad band below each model's true length — exactly where a
300 mm estimate sits. Reproduced against the real view SQL:

| | best fit | error | flagged? |
|---|---|---|---|
| Shark (605 mm) measured at 290 mm, before | Ruler | 15.4% | no — outside the 10% gate |
| same frame, after #603 | **Weasly Fish** | **−3.3%** | **yes, `medium`** |

That is false re-labeling work generated by a number #603 itself calls an
eyeball estimate.

`fishmodelreference.is_provisional` now marks estimated lengths, and the view
excludes them. Provisional rows stay **fully graded** in
`fish_model_measurement_accuracy` — making Weasly Fish gradeable was the whole
point — they just can't be cited as evidence against another model's label.
Three tests, including a control that fails if the exclusion silently stops
mattering.

## 2. Fresh databases never seeded at all

`run_alembic_upgrade` **stamps** head on a fresh DB rather than upgrading, so
every migration's seed is skipped. Views have `_create_all_views` to replay past
that; seed rows had no equivalent — so a freshly bootstrapped API came up with
an empty `fishmodelreference` and an accuracy view empty for **every** model.

The same silent absence #603 set out to end, reintroduced through the bootstrap
path — and #603's tests all asserted at the constant level, so they passed
regardless.

`_seed_fish_model_references` mirrors the view helper: insert-only, runs on both
branches, and **before** the stamp so a failure leaves `alembic_version` absent
and the next restart retries.

## 3. Earlier migrations insert the row without its notes

`e2c9a4f70b31` and `b4c81f60d7e2` iterate the **live** `KNOWN_FISH_MODELS` and
bind only `(name, known_length_m)`. Once Weasly Fish joined that constant they
began inserting it themselves with `notes = NULL`, after which `d1a7b3e95c02`
sees the row and short-circuits — losing the caliper provenance permanently on
any database below those revisions.

The new migration backfills a NULL note and never touches a non-NULL one. Tested
in the real migration order.

## 4. `downgrade()` discarded the row `upgrade()` protects

`upgrade()` goes out of its way not to stamp over a hand-corrected length, then
`downgrade()` deleted the row outright. Sibling `b4c81f60d7e2` deliberately
takes the opposite position, in as many words. Now a no-op — and the test that
**pinned the unsafe behaviour** is inverted.

## 5. A bare `next(...)` could fail API boot

That migration replays on every fresh database forever. After a model rename it
would raise `StopIteration` inside the FastAPI lifespan. A filtering
comprehension degrades to a no-op instead, as the sibling migrations already do.

## 6. Taxonomy comment placement

`LABELED_FISH_MODELS` had been inserted between the ruler's explanatory comment
and `RULER_CONTENT`, so that paragraph read as documentation for a constant that
deliberately **excludes** the Ruler. Moved below it; `__all__` sorted.

## Verification

406 pass in fishsense-api, 435 in the api-worker, 167 in fishsense-shared at
100% coverage. black clean, pylint 10.00, and the alembic graph still has
exactly one head (`f2b8c04e71a3`, chained onto `d1a7b3e95c02`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)