### PR TITLE
feat(ingest): create, finalize, and the workflow that ties them together

### DIFF
--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/create_dive_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/create_dive_activity.py
@@ -1,0 +1,79 @@
+"""Activity: create the dive row, always at `priority=LOW`.
+
+Half of a two-phase commit. Ingest writes a dive twice — LOW here, then the
+requested priority in `finalize_dive_activity` once every frame has landed —
+because there is no transaction spanning the activities in between.
+
+**LOW is not negotiable, whatever the request asked for.** Every hourly cohort
+selects on HIGH, so a dive created at HIGH before its images exist would be
+picked up mid-ingest and processed against a partial set: clustered on some of
+its frames, populated into Label Studio missing others. Priority is the commit
+flag, and this is the half that keeps it closed.
+
+`dives.post` upserts on `path`, so a re-run finds the same row rather than
+creating a second one — which is also why re-running an interrupted ingest is
+safe.
+"""
+
+from __future__ import annotations
+
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.utils import get_fs_client
+from fishsense_shared.ingest_contracts import IngestDiveRequest, IngestPreflight
+
+__all__ = ["create_dive_activity"]
+
+
+def leaf_name(path: str) -> str:
+    """The folder's own name, which is what a dive is called by default.
+
+    `Dive.name` feeds the per-dive Label Studio project title, so leaving it
+    NULL gives labelers a project called just `#412 - Species Labeling`.
+    """
+    return path.rstrip("/").rsplit("/", 1)[-1]
+
+
+@activity.defn
+async def create_dive_activity(
+    request: IngestDiveRequest, preflight: IngestPreflight
+) -> int:
+    from fishsense_api_sdk.models.dive import Dive
+    from fishsense_api_sdk.models.priority import Priority
+
+    # `dive_datetime` is NOT NULL and no frame has been hashed yet, so seed it
+    # from preflight's headers. `finalize` replaces it with the scan's max,
+    # which is authoritative because the scan read every frame rather than a
+    # 1 MB prefix.
+    stamps = [i.taken_datetime for i in preflight.images if i.taken_datetime]
+    provisional = max(stamps) if stamps else None
+    if provisional is None:
+        raise ValueError(
+            "preflight produced no usable timestamps; refusing to create a dive "
+            "with a fabricated dive_datetime"
+        )
+
+    dive = Dive(
+        id=None,
+        name=request.dive_name or leaf_name(request.dive_path),
+        path=request.dive_path,
+        dive_datetime=provisional,
+        # See the module docstring: LOW regardless of `request.priority`.
+        priority=Priority.LOW,
+        flip_dive_slate=request.flip_dive_slate,
+        camera_id=preflight.resolved_camera_id,
+        dive_slate_id=request.dive_slate_id,
+        # NULL means "self-calibrates". Writing a link for a self-calibrating
+        # dive would be a lie the resolver happens to ignore (own wins).
+        calibration_dive_id=request.calibration_dive_id,
+    )
+
+    async with get_fs_client() as fs:
+        dive_id = await fs.dives.post(dive)
+
+    activity.logger.info(
+        "created dive id=%d path=%s at LOW (commit flag closed)",
+        dive_id,
+        request.dive_path,
+    )
+    return dive_id

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/finalize_dive_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/finalize_dive_activity.py
@@ -1,0 +1,178 @@
+"""Activity: verify the set is complete, then flip the dive to its real priority.
+
+The other half of the two-phase commit. `create_dive_activity` wrote the dive at
+`priority=LOW`, which keeps it out of every hourly cohort; this promotes it —
+**and only if every listed frame is accounted for.**
+
+Two refusals, both non-retryable:
+
+* **any rejection** — a frame with no readable timestamp was refused rather than
+  given a fabricated one, so the dive is missing an image. Promoting it would
+  put an incomplete set into stage-1 clustering, which has no way to know.
+* **`registered + skipped != total`** — a frame was neither written nor
+  recognised as already present. That is worse than a rejection: a rejection is
+  reported, a gap is silence.
+
+Non-retryable because neither is transient. Retrying re-reads the same bytes and
+reaches the same conclusion; the fix is an operator looking at the report.
+
+It also computes **content overlap** (§4.2.1 layer 2), which has to happen here
+rather than in preflight: containment is `|new ∩ existing| / |new|` over content
+checksums, and the checksums only exist once the scan has written the rows. Being
+a set operation on hashes it is immune to filenames and ordering, and degrades to
+a partial overlap — the properties the legacy whole-dive MD5 digest lacked, which
+is why it disappointed on a corpus that is ~50% duplicates.
+
+Overlap is **reported, never blocking**. Re-ingesting the same frames under a
+second dive path is legitimate and has already happened in prod (dives 64 and 66
+are both `082929_FishModels_FSL07`); the duplicate rows land non-canonical and
+are invisible to every pipeline cohort.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List
+
+from temporalio import activity
+from temporalio.exceptions import ApplicationError
+
+from fishsense_api_workflow_worker.activities.create_dive_activity import leaf_name
+from fishsense_api_workflow_worker.activities.utils import get_fs_client
+from fishsense_shared.ingest_contracts import (
+    DuplicateOverlap,
+    IngestDiveRequest,
+    IngestReport,
+    RejectedImage,
+)
+
+# `type` on the non-retryable failure, so a retry policy can name it.
+INCOMPLETE_INGEST_TYPE = "IncompleteIngest"
+
+# Look checksums up in chunks: the endpoint caps a request at
+# MAX_CHECKSUM_LOOKUP (1000), and a large dive can exceed that.
+_LOOKUP_CHUNK = 500
+
+__all__ = ["INCOMPLETE_INGEST_TYPE", "IngestTotals", "finalize_dive_activity"]
+
+
+@dataclass
+class IngestTotals:
+    """What the scan batches added up to, accumulated by the workflow."""
+
+    total: int = 0
+    registered: int = 0
+    skipped_existing: int = 0
+    rejected: List[RejectedImage] = field(default_factory=list)
+    max_taken_datetime: datetime | None = None
+
+
+def _chunks(items: List[str], size: int):
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+async def _content_overlap(fs, dive_id: int) -> List[DuplicateOverlap]:
+    """How much of this dive's content already exists under other dives."""
+    images = await fs.images.get(dive_id=dive_id) or []
+    checksums = sorted({i.checksum for i in images if i.checksum})
+    if not checksums:
+        return []
+
+    shared: dict[int, set[str]] = defaultdict(set)
+    for chunk in _chunks(checksums, _LOOKUP_CHUNK):
+        for checksum, hits in (await fs.images.lookup_checksums(chunk)).items():
+            for hit in hits:
+                other = hit.get("dive_id")
+                # Skip our own rows: they are in the lookup by construction, and
+                # counting them would report containment 1.0 against ourselves
+                # on every single ingest.
+                if other is not None and other != dive_id:
+                    shared[other].add(checksum)
+
+    return [
+        DuplicateOverlap(
+            dive_id=other,
+            shared_images=len(found),
+            containment=len(found) / len(checksums),
+        )
+        for other, found in sorted(shared.items(), key=lambda kv: (-len(kv[1]), kv[0]))
+    ]
+
+
+@activity.defn
+async def finalize_dive_activity(
+    dive_id: int, request: IngestDiveRequest, totals: IngestTotals
+) -> IngestReport:
+    from fishsense_api_sdk.models.dive import Dive
+    from fishsense_api_sdk.models.priority import Priority
+
+    accounted = totals.registered + totals.skipped_existing
+    if totals.rejected:
+        raise ApplicationError(
+            f"refusing to promote dive {dive_id}: {len(totals.rejected)} frame(s) "
+            f"rejected — {'; '.join(r.reason for r in totals.rejected[:3])}. "
+            "The dive stays at LOW so no pipeline stage picks up a partial set.",
+            type=INCOMPLETE_INGEST_TYPE,
+            non_retryable=True,
+        )
+    if accounted != totals.total:
+        raise ApplicationError(
+            f"refusing to promote dive {dive_id}: {accounted} of {totals.total} "
+            "frames accounted for. A frame was neither written nor recognised as "
+            "already present, which is silence rather than a reported failure.",
+            type=INCOMPLETE_INGEST_TYPE,
+            non_retryable=True,
+        )
+
+    async with get_fs_client() as fs:
+        overlap = await _content_overlap(fs, dive_id)
+
+        await fs.dives.post(
+            Dive(
+                id=dive_id,
+                name=request.dive_name or leaf_name(request.dive_path),
+                path=request.dive_path,
+                # The scan read every frame in full; preflight only saw a 1 MB
+                # prefix. MAX is how every existing `Dive.dive_datetime` was
+                # derived.
+                dive_datetime=totals.max_taken_datetime,
+                # THE COMMIT FLAG.
+                priority=Priority(request.priority),
+                flip_dive_slate=request.flip_dive_slate,
+                camera_id=None,
+                dive_slate_id=request.dive_slate_id,
+                calibration_dive_id=request.calibration_dive_id,
+            )
+        )
+
+    for item in overlap:
+        activity.logger.warning(
+            "dive %d shares %d/%d frames with dive %d (containment %.2f); "
+            "those images are non-canonical",
+            dive_id,
+            item.shared_images,
+            totals.total,
+            item.dive_id,
+            item.containment,
+        )
+    activity.logger.info(
+        "committed dive %d at %s: registered=%d skipped=%d",
+        dive_id,
+        request.priority,
+        totals.registered,
+        totals.skipped_existing,
+    )
+    return IngestReport(
+        dive_path=request.dive_path,
+        dive_id=dive_id,
+        total=totals.total,
+        registered=totals.registered,
+        skipped_existing=totals.skipped_existing,
+        rejected=[],
+        dive_datetime=totals.max_taken_datetime,
+        committed=True,
+        duplicate_overlap=overlap,
+    )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -169,6 +169,12 @@ from fishsense_api_workflow_worker.activities.sync_users_label_studio_activity i
 from fishsense_api_workflow_worker.activities.update_dive_image_groups_activity import (
     update_dive_image_groups_activity,
 )
+from fishsense_api_workflow_worker.activities.create_dive_activity import (
+    create_dive_activity,
+)
+from fishsense_api_workflow_worker.activities.finalize_dive_activity import (
+    finalize_dive_activity,
+)
 from fishsense_api_workflow_worker.activities.scan_and_register_images_activity import (  # pylint: disable=line-too-long
     scan_and_register_images_activity,
 )
@@ -259,6 +265,9 @@ from fishsense_api_workflow_worker.workflows.sync_label_studio_species_labels_wo
 )
 from fishsense_api_workflow_worker.workflows.update_dive_image_groups_workflow import (
     UpdateDiveImageGroupsWorkflow,
+)
+from fishsense_api_workflow_worker.workflows.ingest_dive_workflow import (
+    IngestDiveWorkflow,
 )
 from fishsense_api_workflow_worker.workflows.verify_all_dives_checksums_workflow import (  # pylint: disable=line-too-long
     VerifyAllDivesChecksumsWorkflow,
@@ -675,6 +684,7 @@ async def main():
                 UpdateDiveImageGroupsWorkflow,
                 VerifyDiveChecksumsWorkflow,
                 VerifyAllDivesChecksumsWorkflow,
+                IngestDiveWorkflow,
                 ClusterDiveFramesParentWorkflow,
                 PredictLaserImagesParentWorkflow,
                 PredictSlateImagesParentWorkflow,
@@ -713,6 +723,8 @@ async def main():
                 verify_dive_checksums_activity,
                 select_canonical_dive_ids_activity,
                 scan_and_register_images_activity,
+                create_dive_activity,
+                finalize_dive_activity,
                 resolve_dive_frame_clustering_inputs_activity,
                 resolve_laser_preprocess_inputs_activity,
                 resolve_laser_predict_inputs_activity,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/ingest_dive_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/ingest_dive_workflow.py
@@ -1,0 +1,182 @@
+"""Ingest one dive folder from the NAS into `Dive` + `Image` rows.
+
+On-demand, no schedule. **One request means one dive** — the frames are the
+`.ORF` files directly inside the named folder, not a recursive walk. That is
+precedent, not simplification: the retired spider crawler assigned
+`dive = image.parent`, so every one of the ~479 dive rows in prod is exactly one
+directory, and recursing would merge dives that are distinct rows today.
+
+```
+temporal workflow start \\
+    --task-queue fishsense_api_queue \\
+    --type IngestDiveWorkflow \\
+    --workflow-id ingest-<folder> \\
+    --input '{"dive_path": "2024.06.20.REEF/082929_FishModels_FSL07",
+              "self_calibrates": true, "priority": "HIGH"}'
+
+temporal workflow query --workflow-id ingest-<folder> --type progress
+```
+
+Set `"dry_run": true` to stop after preflight, having written nothing.
+
+**The shape is a two-phase commit, because there is no transaction spanning
+these activities.** The dive is created at `priority=LOW` — which every hourly
+cohort ignores — frames are registered in batches, and only then is it promoted
+to the requested priority. Priority is the commit flag. A crash anywhere in the
+middle leaves a dive and some images that no pipeline stage will touch, and
+re-running is safe: `dives.post` upserts on `path`, the scan skips frames already
+registered, and `finalize` refuses to promote an incomplete set.
+
+Batching exists so a failure costs one batch of downloads rather than the whole
+dive; the batch size is deliberately modest because each frame is ~14.5 MB and
+the NAS is shared with the hourly staging activities doing real pipeline work.
+"""
+
+from datetime import timedelta
+from typing import List
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from fishsense_api_workflow_worker.activities.finalize_dive_activity import (
+        INCOMPLETE_INGEST_TYPE,
+        IngestTotals,
+    )
+    from fishsense_api_workflow_worker.activities.list_dive_folder_activity import (
+        DiveFolderListing,
+    )
+    from fishsense_api_workflow_worker.activities.scan_and_register_images_activity import (  # noqa: E501  pylint: disable=line-too-long
+        BatchResult,
+    )
+    from fishsense_shared.ingest_contracts import (
+        IngestDiveRequest,
+        IngestPreflight,
+        IngestProgress,
+        IngestReport,
+    )
+
+# Frames per scan activity. Each is a whole-file download (~14.5 MB), so 25 is
+# roughly 360 MB of work — small enough that a failure is cheap to redo, large
+# enough not to pay activity overhead per frame.
+BATCH_SIZE = 25
+
+# A dive's frames are read serially inside the activity, so a batch can take a
+# while; the heartbeat is what distinguishes slow from wedged.
+_SCAN_TIMEOUT = timedelta(hours=2)
+
+_NAS_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=30),
+    backoff_coefficient=2.0,
+    maximum_interval=timedelta(minutes=5),
+    maximum_attempts=5,
+    # A missing file cannot be fixed by waiting.
+    non_retryable_error_types=["NasFileNotFound"],
+)
+
+
+@workflow.defn
+class IngestDiveWorkflow:
+    """List, preflight, create, scan, finalize — one dive."""
+
+    def __init__(self) -> None:
+        self._progress = IngestProgress()
+
+    @workflow.query
+    def progress(self) -> IngestProgress:
+        """Live counts. A large dive is hours of downloading, so the portal (and
+        an operator watching by hand) needs to see movement without waiting for
+        the return value."""
+        return self._progress
+
+    @workflow.run
+    async def run(self, request: IngestDiveRequest) -> IngestReport:
+        self._progress.state = "listing"
+        listing: DiveFolderListing = await workflow.execute_activity(
+            "list_dive_folder_activity",
+            args=(request,),
+            result_type=DiveFolderListing,
+            schedule_to_close_timeout=timedelta(minutes=15),
+            retry_policy=_NAS_RETRY,
+        )
+
+        self._progress.state = "preflight"
+        self._progress.total = len(listing.files)
+        preflight: IngestPreflight = await workflow.execute_activity(
+            "preflight_ingest_activity",
+            args=(request, listing),
+            result_type=IngestPreflight,
+            # Ranged 1 MB reads, serially, over every frame.
+            schedule_to_close_timeout=timedelta(hours=2),
+            heartbeat_timeout=timedelta(minutes=10),
+            retry_policy=_NAS_RETRY,
+        )
+
+        if request.dry_run or preflight.errors:
+            # Errors and a dry run leave by the same door: nothing has been
+            # written either way, and the report IS the deliverable.
+            self._progress.state = "rejected" if preflight.errors else "dry-run"
+            return IngestReport(
+                dive_path=request.dive_path,
+                total=len(listing.files),
+                committed=False,
+                preflight=preflight,
+            )
+
+        self._progress.state = "creating"
+        dive_id: int = await workflow.execute_activity(
+            "create_dive_activity",
+            args=(request, preflight),
+            result_type=int,
+            schedule_to_close_timeout=timedelta(minutes=5),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+        self._progress.dive_id = dive_id
+
+        self._progress.state = "scanning"
+        totals = IngestTotals(total=len(preflight.images))
+        paths: List[str] = [image.path for image in preflight.images]
+
+        for start in range(0, len(paths), BATCH_SIZE):
+            batch = paths[start : start + BATCH_SIZE]
+            self._progress.current_path = batch[0]
+            result: BatchResult = await workflow.execute_activity(
+                "scan_and_register_images_activity",
+                args=(dive_id, batch, preflight.resolved_camera_id),
+                result_type=BatchResult,
+                schedule_to_close_timeout=_SCAN_TIMEOUT,
+                heartbeat_timeout=timedelta(minutes=15),
+                retry_policy=_NAS_RETRY,
+            )
+            totals.registered += result.registered
+            totals.skipped_existing += result.skipped_existing
+            totals.rejected.extend(result.rejected)
+            if result.max_taken_datetime is not None and (
+                totals.max_taken_datetime is None
+                or result.max_taken_datetime > totals.max_taken_datetime
+            ):
+                totals.max_taken_datetime = result.max_taken_datetime
+
+            self._progress.scanned += len(batch)
+            self._progress.registered = totals.registered
+            self._progress.skipped_existing = totals.skipped_existing
+            self._progress.rejected = len(totals.rejected)
+
+        self._progress.state = "finalizing"
+        self._progress.current_path = None
+        report: IngestReport = await workflow.execute_activity(
+            "finalize_dive_activity",
+            args=(dive_id, request, totals),
+            result_type=IngestReport,
+            schedule_to_close_timeout=timedelta(minutes=15),
+            retry_policy=RetryPolicy(
+                maximum_attempts=3,
+                # An incomplete set is a data problem: retrying re-reads the
+                # same bytes and reaches the same conclusion.
+                non_retryable_error_types=[INCOMPLETE_INGEST_TYPE],
+            ),
+        )
+
+        self._progress.state = "done"
+        report.preflight = preflight
+        return report

--- a/services/fishsense-api-workflow-worker/tests/test_create_and_finalize_dive_activities.py
+++ b/services/fishsense-api-workflow-worker/tests/test_create_and_finalize_dive_activities.py
@@ -1,0 +1,286 @@
+"""`create_dive_activity` and `finalize_dive_activity` — the commit protocol.
+
+Ingest writes a dive in two posts, and the pair is a two-phase commit against a
+table that has no transactions across activities:
+
+  * **create** writes the dive at `priority=LOW`, *whatever the request asked
+    for*. LOW keeps it out of every hourly cohort, so a half-ingested dive
+    cannot be picked up and processed.
+  * **finalize** flips it to the requested priority — but only if every listed
+    frame landed. **Priority is the commit flag.**
+
+That is what makes a crashed or retried ingest safe: the dive exists, its images
+exist, and the pipeline ignores all of it until someone can say the set is
+complete.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from temporalio.exceptions import ApplicationError
+from temporalio.testing import ActivityEnvironment
+
+FOLDER = "2024.06.20.REEF/082929_FishModels_FSL07"
+T0 = datetime(2024, 8, 21, 8, 0, 0, tzinfo=timezone.utc)
+T1 = datetime(2024, 8, 21, 9, 30, 0, tzinfo=timezone.utc)
+
+
+def _request(**kwargs):
+    from fishsense_shared.ingest_contracts import IngestDiveRequest
+
+    kwargs.setdefault("dive_path", FOLDER)
+    kwargs.setdefault("self_calibrates", True)
+    return IngestDiveRequest(**kwargs)
+
+
+def _preflight(**kwargs):
+    from fishsense_shared.ingest_contracts import IngestPreflight, PreflightImage
+
+    kwargs.setdefault("dive_path", f"/fishsense_data/REEF/data/{FOLDER}")
+    kwargs.setdefault("resolved_camera_id", 7)
+    kwargs.setdefault(
+        "images",
+        [
+            PreflightImage(path=f"{FOLDER}/A.ORF", size=1, taken_datetime=T0),
+            PreflightImage(path=f"{FOLDER}/B.ORF", size=1, taken_datetime=T1),
+        ],
+    )
+    return IngestPreflight(**kwargs)
+
+
+def _fs(dive_id=412, images=None, lookup=None):
+    fs = MagicMock()
+    fs.dives.post = AsyncMock(return_value=dive_id)
+    fs.images.get = AsyncMock(return_value=images or [])
+    fs.images.lookup_checksums = AsyncMock(return_value=lookup or {})
+    fs.__aenter__ = AsyncMock(return_value=fs)
+    fs.__aexit__ = AsyncMock(return_value=False)
+    return fs
+
+
+def _image(path, checksum):
+    img = MagicMock()
+    img.path = path
+    img.checksum = checksum
+    return img
+
+
+async def _create(request, preflight, fs, monkeypatch):
+    from fishsense_api_workflow_worker.activities import create_dive_activity as sut
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    return await ActivityEnvironment().run(
+        sut.create_dive_activity, request, preflight
+    )
+
+
+async def _finalize(dive_id, request, totals, fs, monkeypatch):
+    from fishsense_api_workflow_worker.activities import finalize_dive_activity as sut
+
+    monkeypatch.setattr(sut, "get_fs_client", lambda: fs)
+    return await ActivityEnvironment().run(
+        sut.finalize_dive_activity, dive_id, request, totals
+    )
+
+
+def _totals(**kwargs):
+    from fishsense_api_workflow_worker.activities.finalize_dive_activity import (
+        IngestTotals,
+    )
+
+    kwargs.setdefault("total", 2)
+    kwargs.setdefault("registered", 2)
+    kwargs.setdefault("skipped_existing", 0)
+    kwargs.setdefault("rejected", [])
+    kwargs.setdefault("max_taken_datetime", T1)
+    return IngestTotals(**kwargs)
+
+
+# ── create: LOW is not negotiable ─────────────────────────────────────
+
+
+async def test_creates_the_dive_at_low_even_when_high_was_requested(monkeypatch):
+    """The whole safety property. HIGH is what the hourly cohorts select on, so
+    a dive created HIGH before its images land would be picked up mid-ingest and
+    processed against a partial set."""
+    fs = _fs()
+
+    dive_id = await _create(_request(priority="HIGH"), _preflight(), fs, monkeypatch)
+
+    assert dive_id == 412
+    (dive,), _ = fs.dives.post.call_args
+    assert dive.priority.value == "LOW"
+
+
+async def test_seeds_a_provisional_dive_datetime_from_preflight(monkeypatch):
+    """`dive_datetime` is NOT NULL, so create needs a value before any frame has
+    been hashed. Preflight already read every header, so use its max — finalize
+    replaces it with the scan's."""
+    fs = _fs()
+
+    await _create(_request(), _preflight(), fs, monkeypatch)
+
+    (dive,), _ = fs.dives.post.call_args
+    assert dive.dive_datetime == T1
+
+
+async def test_defaults_the_name_to_the_leaf_directory(monkeypatch):
+    """`Dive.name` feeds the per-dive Label Studio project title, so an unnamed
+    dive gets a title of just its id."""
+    fs = _fs()
+
+    await _create(_request(), _preflight(), fs, monkeypatch)
+
+    (dive,), _ = fs.dives.post.call_args
+    assert dive.name == "082929_FishModels_FSL07"
+
+
+async def test_an_explicit_name_wins(monkeypatch):
+    fs = _fs()
+
+    await _create(_request(dive_name="Reef dive 3"), _preflight(), fs, monkeypatch)
+
+    (dive,), _ = fs.dives.post.call_args
+    assert dive.name == "Reef dive 3"
+
+
+async def test_carries_the_camera_and_calibration_intent(monkeypatch):
+    fs = _fs()
+
+    await _create(
+        _request(self_calibrates=False, calibration_dive_id=61, dive_slate_id=3),
+        _preflight(),
+        fs,
+        monkeypatch,
+    )
+
+    (dive,), _ = fs.dives.post.call_args
+    assert dive.camera_id == 7
+    assert dive.calibration_dive_id == 61
+    assert dive.dive_slate_id == 3
+
+
+async def test_a_self_calibrating_dive_has_no_calibration_link(monkeypatch):
+    """NULL means "self-calibrate". Writing a link here would make the dive
+    borrow a calibration it does not need — own-wins resolution would ignore it,
+    but the row would be lying."""
+    fs = _fs()
+
+    await _create(_request(self_calibrates=True), _preflight(), fs, monkeypatch)
+
+    (dive,), _ = fs.dives.post.call_args
+    assert dive.calibration_dive_id is None
+
+
+# ── finalize: priority is the commit flag ─────────────────────────────
+
+
+async def test_promotes_to_the_requested_priority_when_everything_landed(
+    monkeypatch,
+):
+    fs = _fs()
+
+    report = await _finalize(412, _request(priority="HIGH"), _totals(), fs, monkeypatch)
+
+    (dive,), _ = fs.dives.post.call_args
+    assert dive.priority.value == "HIGH"
+    assert dive.dive_datetime == T1
+    assert report.committed is True
+    assert report.dive_id == 412
+
+
+async def test_refuses_when_a_frame_was_rejected(monkeypatch):
+    """A partially-ingested dive must never enter the pipeline. Non-retryable:
+    a rejected frame is a data problem, and retrying re-reads the same bytes to
+    the same conclusion."""
+    from fishsense_shared.ingest_contracts import RejectedImage
+
+    fs = _fs()
+    totals = _totals(
+        registered=1, rejected=[RejectedImage(path="x", reason="no timestamp")]
+    )
+
+    with pytest.raises(ApplicationError) as excinfo:
+        await _finalize(412, _request(), totals, fs, monkeypatch)
+
+    assert excinfo.value.non_retryable
+    assert fs.dives.post.await_count == 0
+
+
+async def test_refuses_when_the_counts_do_not_add_up(monkeypatch):
+    """registered + skipped must equal total. A gap means a frame was neither
+    written nor recognised as already present — silence rather than a rejection,
+    which is worse."""
+    fs = _fs()
+
+    with pytest.raises(ApplicationError) as excinfo:
+        await _finalize(412, _request(), _totals(registered=1), fs, monkeypatch)
+
+    assert excinfo.value.non_retryable
+    assert fs.dives.post.await_count == 0
+
+
+async def test_a_dive_that_was_entirely_skipped_still_commits(monkeypatch):
+    """Re-running a completed ingest is a no-op that must still succeed —
+    otherwise the only way to re-verify a dive is to make it fail."""
+    fs = _fs()
+
+    report = await _finalize(
+        412, _request(), _totals(registered=0, skipped_existing=2), fs, monkeypatch
+    )
+
+    assert report.committed is True
+    assert report.skipped_existing == 2
+
+
+# ── finalize: content overlap ─────────────────────────────────────────
+
+
+async def test_reports_content_overlap_with_an_existing_dive(monkeypatch):
+    """Layer 2 of duplicate detection, and the reason it runs HERE: it needs
+    every frame's checksum, which only exists once the scan has written the
+    rows. Containment is |new ∩ existing| / |new| over content hashes, so it is
+    immune to filenames and ordering — the property the legacy whole-dive MD5
+    digest lacked."""
+    fs = _fs(
+        images=[_image(f"{FOLDER}/A.ORF", "aa"), _image(f"{FOLDER}/B.ORF", "bb")],
+        lookup={
+            "aa": [{"image_id": 1, "dive_id": 64, "is_canonical": True}],
+            "bb": [],
+        },
+    )
+
+    report = await _finalize(412, _request(), _totals(), fs, monkeypatch)
+
+    assert len(report.duplicate_overlap) == 1
+    overlap = report.duplicate_overlap[0]
+    assert overlap.dive_id == 64
+    assert overlap.shared_images == 1
+    assert overlap.containment == pytest.approx(0.5)
+
+
+async def test_overlap_ignores_the_dive_being_ingested(monkeypatch):
+    """The dive's own rows are in the lookup by construction — counting them
+    would report containment 1.0 against itself on every single ingest."""
+    fs = _fs(
+        images=[_image(f"{FOLDER}/A.ORF", "aa")],
+        lookup={"aa": [{"image_id": 1, "dive_id": 412, "is_canonical": True}]},
+    )
+
+    report = await _finalize(412, _request(), _totals(total=1, registered=1), fs, monkeypatch)
+
+    assert report.duplicate_overlap == []
+
+
+async def test_a_dive_with_no_overlap_reports_none(monkeypatch):
+    fs = _fs(
+        images=[_image(f"{FOLDER}/A.ORF", "aa")],
+        lookup={"aa": []},
+    )
+
+    report = await _finalize(412, _request(), _totals(total=1, registered=1), fs, monkeypatch)
+
+    assert report.duplicate_overlap == []

--- a/services/fishsense-api-workflow-worker/tests/test_ingest_dive_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_ingest_dive_workflow.py
@@ -1,0 +1,211 @@
+"""Contract tests for `IngestDiveWorkflow` — the end-to-end ingest.
+
+In-process Temporal worker with every activity stubbed. What is pinned here is
+the *protocol*, not the activities' behaviour:
+
+  * a dry run and a failed preflight both leave without writing anything;
+  * the dive is created before any frame is registered, and promoted only after;
+  * frames are batched, and the batches' counts add up into one report.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from temporalio import activity
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from fishsense_api_workflow_worker.activities.finalize_dive_activity import (
+    IngestTotals,
+)
+from fishsense_api_workflow_worker.activities.list_dive_folder_activity import (
+    DiveFolderListing,
+)
+from fishsense_api_workflow_worker.activities.scan_and_register_images_activity import (  # noqa: E501  pylint: disable=line-too-long
+    BatchResult,
+)
+from fishsense_api_workflow_worker.workflows.ingest_dive_workflow import (
+    BATCH_SIZE,
+    IngestDiveWorkflow,
+)
+from fishsense_shared.ingest_contracts import (
+    IngestDiveRequest,
+    IngestPreflight,
+    IngestReport,
+    PreflightImage,
+)
+
+TASK_QUEUE = "test-ingest"
+FOLDER = "2024.06.20.REEF/082929_FishModels_FSL07"
+T = datetime(2024, 8, 21, 9, 30, 0, tzinfo=timezone.utc)
+
+
+def _activities(calls, *, frames=2, errors=(), rejected=()):
+    from fishsense_api_workflow_worker.nas import NasEntry
+
+    images = [
+        PreflightImage(path=f"{FOLDER}/{i:04d}.ORF", size=1, taken_datetime=T)
+        for i in range(frames)
+    ]
+
+    @activity.defn(name="list_dive_folder_activity")
+    async def _list(request: IngestDiveRequest) -> DiveFolderListing:
+        calls.append("list")
+        return DiveFolderListing(
+            folder_path=f"/root/{request.dive_path}",
+            files=[
+                NasEntry(path=i.path, name=i.path[-8:], is_dir=False, size=1)
+                for i in images
+            ],
+        )
+
+    @activity.defn(name="preflight_ingest_activity")
+    async def _preflight(  # pylint: disable=unused-argument
+        request: IngestDiveRequest, listing: DiveFolderListing
+    ) -> IngestPreflight:
+        calls.append("preflight")
+        return IngestPreflight(
+            dive_path=listing.folder_path,
+            images=images,
+            resolved_camera_id=7,
+            errors=list(errors),
+        )
+
+    @activity.defn(name="create_dive_activity")
+    async def _create(  # pylint: disable=unused-argument
+        request: IngestDiveRequest, preflight: IngestPreflight
+    ) -> int:
+        calls.append("create")
+        return 412
+
+    @activity.defn(name="scan_and_register_images_activity")
+    async def _scan(  # pylint: disable=unused-argument
+        dive_id: int, paths: list, camera_id: int
+    ) -> BatchResult:
+        calls.append(f"scan:{len(paths)}")
+        return BatchResult(
+            registered=len(paths),
+            rejected=list(rejected),
+            max_taken_datetime=T,
+        )
+
+    @activity.defn(name="finalize_dive_activity")
+    async def _finalize(
+        dive_id: int, request: IngestDiveRequest, totals: IngestTotals
+    ) -> IngestReport:
+        calls.append("finalize")
+        return IngestReport(
+            dive_path=request.dive_path,
+            dive_id=dive_id,
+            total=totals.total,
+            registered=totals.registered,
+            skipped_existing=totals.skipped_existing,
+            dive_datetime=totals.max_taken_datetime,
+            committed=True,
+        )
+
+    return [_list, _preflight, _create, _scan, _finalize]
+
+
+async def _run(request, **kwargs):
+    calls: list[str] = []
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=TASK_QUEUE,
+            workflows=[IngestDiveWorkflow],
+            activities=_activities(calls, **kwargs),
+        ):
+            report = await env.client.execute_workflow(
+                IngestDiveWorkflow.run,
+                request,
+                id=f"{TASK_QUEUE}-{uuid.uuid4()}",
+                task_queue=TASK_QUEUE,
+            )
+    return report, calls
+
+
+def _request(**kwargs):
+    kwargs.setdefault("dive_path", FOLDER)
+    kwargs.setdefault("self_calibrates", True)
+    return IngestDiveRequest(**kwargs)
+
+
+# ── the happy path ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_creates_the_dive_before_registering_and_finalizes_after():
+    """The two-phase commit, as an ordering. `create` must precede every scan
+    (frames need a dive to belong to) and `finalize` must follow all of them —
+    it is the step that opens the commit flag."""
+    report, calls = await _run(_request())
+
+    assert calls[:3] == ["list", "preflight", "create"]
+    assert calls[-1] == "finalize"
+    assert report.committed is True
+    assert report.dive_id == 412
+
+
+@pytest.mark.asyncio
+async def test_frames_are_scanned_in_batches():
+    """A failure should cost one batch of ~14.5 MB downloads, not a whole dive."""
+    frames = BATCH_SIZE * 2 + 3
+    _report, calls = await _run(_request(), frames=frames)
+
+    scans = [c for c in calls if c.startswith("scan:")]
+    assert scans == [f"scan:{BATCH_SIZE}", f"scan:{BATCH_SIZE}", "scan:3"]
+
+
+@pytest.mark.asyncio
+async def test_batch_counts_accumulate_into_one_report():
+    frames = BATCH_SIZE + 1
+    report, _calls = await _run(_request(), frames=frames)
+
+    assert report.total == frames
+    assert report.registered == frames
+    assert report.dive_datetime == T
+
+
+# ── writing nothing ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_dry_run_writes_nothing_and_returns_the_preflight():
+    report, calls = await _run(_request(dry_run=True))
+
+    assert calls == ["list", "preflight"]
+    assert report.committed is False
+    assert report.preflight is not None
+    assert report.dive_id is None
+
+
+@pytest.mark.asyncio
+async def test_a_failed_preflight_writes_nothing():
+    """Preflight reports every fault at once; the workflow's job is simply not
+    to proceed. No dive, no images — the operator fixes and resubmits."""
+    report, calls = await _run(
+        _request(), errors=["camera 7 has no intrinsics"]
+    )
+
+    assert calls == ["list", "preflight"]
+    assert report.committed is False
+    assert report.preflight.errors == ["camera 7 has no intrinsics"]
+
+
+# ── the report carries the preflight ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_committed_report_still_carries_its_preflight():
+    """Warnings — a leaf-name collision, a subfolder that is really another
+    dive, an Artist disagreeing with the resolved camera — live in the
+    preflight. Dropping it on success would discard everything the operator was
+    meant to see."""
+    report, _calls = await _run(_request())
+
+    assert report.preflight is not None
+    assert report.preflight.resolved_camera_id == 7


### PR DESCRIPTION
**Ingest works end to end after this.** A NAS folder in, a dive with its images
out — no portal needed:

```
temporal workflow start \
    --task-queue fishsense_api_queue \
    --type IngestDiveWorkflow \
    --workflow-id ingest-082929_FishModels_FSL07 \
    --input '{"dive_path": "2024.06.20.REEF/082929_FishModels_FSL07",
              "self_calibrates": true, "priority": "HIGH"}'

temporal workflow query --workflow-id ingest-... --type progress
```

`"dry_run": true` stops after preflight, having written nothing.

## Two-phase commit, because nothing spans these activities

`create_dive_activity` writes the dive at **`priority=LOW` regardless of what
the request asked for**. Every hourly cohort selects on HIGH, so a dive created
HIGH before its frames land would be picked up mid-ingest and processed against
a partial set — clustered on some of its frames, populated into Label Studio
missing others.

`finalize_dive_activity` flips it to the requested priority, and only once every
listed frame is accounted for. **Priority is the commit flag.**

It refuses twice, both non-retryable because neither is transient:

* **any rejection** — a frame was refused rather than given a fabricated
  timestamp, so the set is incomplete;
* **`registered + skipped != total`** — a frame was neither written nor
  recognised as already present. Worse than a rejection: a rejection is
  reported, a gap is *silence*.

A crash in between leaves a dive and some images that no pipeline stage will
touch. Re-running is safe — `dives.post` upserts on `path`, the scan skips
already-registered frames, and an entirely-skipped re-run **still commits**,
because otherwise the only way to re-verify a dive would be to make it fail.

## Content overlap runs in finalize, deliberately

Containment needs every frame's checksum, and those only exist once the scan has
written the rows — which is why it can't live in preflight.

`|new ∩ existing| / |new|` over content hashes: immune to filenames and
ordering, and it degrades to a partial overlap. Those are exactly the properties
the legacy whole-dive MD5 digest lacked, which is why it disappointed on a
corpus that is ~50% duplicates.

The dive's own rows are excluded — they're in the lookup by construction, and
counting them would report containment 1.0 against itself on every ingest.
Reported, **never blocking**: re-ingesting the same frames under a second path
is legitimate and already happened in prod (dives 64 and 66 are both
`082929_FishModels_FSL07`), and the duplicate rows land non-canonical and
invisible to every cohort.

## The workflow

* **Batches at 25 frames** — a failure costs ~360 MB of re-downloading rather
  than a whole dive, without paying activity overhead per frame.
* **`progress` query** for the portal and for watching by hand; a large dive is
  hours of downloading.
* **Dry run and failed preflight leave by the same door** — nothing written
  either way, and the report *is* the deliverable.
* A committed report still carries its preflight, so warnings (leaf-name
  collision, a subfolder that is really another dive, `Artist` disagreeing with
  the resolved camera) survive success.

## Tests

19 new — 13 on the two activities, 6 workflow contract tests pinning the
protocol rather than the activities' behaviour. 468 pass in the api-worker;
black clean, pylint 10.00.

Remaining for the feature: the API-side Temporal client + `ingest_controller`
(§2.7) so the portal can drive this, and then the `/portal/ingest` page. Neither
blocks ingesting a dive today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
