### PR TITLE
docs(ingest): operator runbook, and record the subsystem in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ landed; the clones behind them are now collapsed into
 | Service | Purpose | Task queue |
 |---|---|---|
 | `services/fishsense-api/` | FastAPI app (DB CRUD, label endpoints) | — |
-| `services/fishsense-api-workflow-worker/` | api-side Temporal worker: hourly Label Studio sync (laser/headtail/dive-slate/species), on-demand Create/Populate × {Laser,Species,HeadTail,DiveSlate} LS project workflows, hourly preprocess parents for stages 0.1 / 1 / 2 / 5.1 / 9 (select + resolve; dispatch child to data-worker) | `fishsense_api_queue` |
+| `services/fishsense-api-workflow-worker/` | api-side Temporal worker: hourly Label Studio sync (laser/headtail/dive-slate/species), on-demand Create/Populate × {Laser,Species,HeadTail,DiveSlate} LS project workflows, on-demand dive ingestion (`IngestDiveWorkflow`, see below) + checksum verification, hourly preprocess parents for stages 0.1 / 1 / 2 / 5.1 / 9 (select + resolve; dispatch child to data-worker) | `fishsense_api_queue` |
 | `apps/fishsense-lite-web/` | Next.js 15 (App Router) + React + TS landing page at `fishsense.e4e.ucsd.edu`. SSR fetches LS project IDs from fishsense-api, resolves names from Label Studio, renders categorized link cards. Auth.js (next-auth v5) with Authentik OIDC gates `/portal/*`; landing stays public. Replaces the prior mafl dashboard + its hourly config-writer workflow. Will grow into a full web app. | — |
 | `services/fishsense-data-processing-workflow-worker/` | image preprocessing (rectify/overlay/JPEG), laser calibration, fish measurement | `fishsense_data_processing_queue` |
 | `services/fishsense-backup-worker/` | nightly Postgres → NAS backups + retention | `fishsense_backup_queue` |
@@ -713,6 +713,91 @@ axis belongs to the dive's calibration, so it makes every image in that dive
 unprocessable. `test_laser_geometry.py` pins all of this, the epipolar
 blindness included, so nobody later promotes the residual into a gate on its
 own.
+
+## Dive ingestion (`IngestDiveWorkflow`)
+
+Turns a NAS folder of `.ORF` files into a `Dive` and its `Image` rows. Before
+this, rows were only ever created by an external crawler
+(`UCSD-E4E/fishsense-data-processing-spider`) that is now retired and archived.
+
+Operator runbook: [docs/ingest.md](docs/ingest.md). Design and archaeology:
+[docs/plans/dive-image-ingestion.md](docs/plans/dive-image-ingestion.md).
+On-demand, no schedule, api-worker, `fishsense_api_queue`.
+
+**Every convention below was recovered by reading spider's source and then
+re-verified against the corpus** — `VerifyAllDivesChecksumsWorkflow` re-hashed
+1,619 frames across all 272 canonical dives on 2026-08-17 with zero checksum
+disagreements. They are not inferences.
+
+| Field | Convention | Where |
+|---|---|---|
+| `Image.checksum` | `md5` of the **whole file**, streamed in 8192-byte chunks | `nas_frames.file_checksum` |
+| `Image.taken_datetime` | naive EXIF tag **0x0132** (NOT 0x9003) stamped UTC, camera offset **not applied** | `nas_frames.read_taken_datetime` |
+| `Dive.dive_datetime` | **MAX** of the frames' timestamps | `finalize_dive_activity` |
+| `Image.is_canonical` | first-checksum-wins, computed **server-side** | `image_controller` |
+| dive identity | `dive = image.parent` — exactly one directory | `list_dive_folder_activity` |
+
+Both of the first two fail **silently** when wrong, which is why they live in
+one module: a divergent checksum makes duplicate detection report *zero overlap*
+rather than erroring, and a divergent timestamp corrupts stage-1 clustering,
+which is pure timestamp arithmetic. `nas_frames.py` was extracted when
+`duplicate-code` flagged 42 identical lines and `_build_nas_client` turned out
+to be copied six times.
+
+**The pipeline shape:**
+
+```
+list_dive_folder -> preflight_ingest -> create_dive -> scan_and_register (xN) -> finalize_dive
+                         (writes nothing)     LOW              batches of 25            HIGH
+```
+
+**Priority is the commit flag.** `create_dive` writes the dive at `LOW`
+*regardless of the request*, because every hourly cohort selects on HIGH — a dive
+created HIGH before its frames land gets clustered on some of them and populated
+into Label Studio missing others. `finalize_dive` promotes it only when
+`registered + skipped == total` and nothing was rejected, both refusals being
+non-retryable. A crash in between therefore leaves a dive and images that no
+stage will touch, and re-running is safe (`dives.post` upserts on `path`, the
+scan skips registered frames without downloading, a fully-skipped re-run still
+commits).
+
+**Non-recursion is precedent, not simplification.** Spider walked the tree but
+assigned `dive = image.parent.relative_to(data_root)`, so a nested folder always
+became its own dive row. Attaching a subdirectory's frames to the named dive
+would merge dives that are distinct rows in prod, with nothing left in the data
+to say which frames came from where. Subdirectories holding `.ORF`s are
+*reported* — the Olympus rollover case, where the TG-6 wraps its counter at
+`PA199999` and starts a child folder mid-dive.
+
+**Preflight reports every fault at once, and refuses on unstated intent.** The
+one worth knowing: exactly one of `self_calibrates` / `calibration_dive_id` is
+required, because a fish-only dive with no slate can never self-calibrate and
+nothing in the files reveals that. There is deliberately **no fallback from the
+MakerNote serial to the EXIF `Artist` tag** — a free-text rig label would bind
+intrinsics belonging to different glass and stage 14 would report confident wrong
+lengths.
+
+**Duplicate detection is containment, not the legacy MD5 aggregate.**
+`|new ∩ existing| / |new|` over content checksums, computed in `finalize`
+because it needs checksums that only exist once the scan has written the rows.
+Set-based, so immune to filenames and ordering, and it degrades to a partial
+overlap — which the whole-dive digest (`MD5(STRING_AGG(basename || ':' || md5))`)
+could not do, and is why it disappointed on a corpus that is ~50% duplicates.
+Reported, never blocking: duplicate rows land non-canonical and are invisible to
+every cohort.
+
+**`VerifyDiveChecksumsWorkflow` / `VerifyAllDivesChecksumsWorkflow`** re-hash
+existing rows against the NAS, read-only, with a source tripwire. Note they
+invert the staging activities' failure semantics on purpose: a missing file is a
+*finding*, because verification is asking a question, whereas staging and ingest
+are trying to do something and a missing file is a failure.
+
+**Open:** `IngestDiveRequest.verify_existing` is declared and honoured nowhere —
+wire it or delete it. The API-side Temporal client + `ingest_controller`
+(plan §2.7) and `/portal/ingest` are unbuilt, so ingest is CLI-only. When the
+controller lands, **add `fishsense-api` to `temporal.reload` in `flake.nix`** —
+the tell is the service gaining a `/run/tenant/temporal` mount, and missing it
+means the API silently holds an expired cert until something else restarts it.
 
 ## Data-worker activity pattern
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -792,8 +792,13 @@ invert the staging activities' failure semantics on purpose: a missing file is a
 *finding*, because verification is asking a question, whereas staging and ingest
 are trying to do something and a missing file is a failure.
 
-**Open:** `IngestDiveRequest.verify_existing` is declared and honoured nowhere —
-wire it or delete it. The API-side Temporal client + `ingest_controller`
+There is deliberately **no `verify_existing` flag** on an ingest request. One
+shipped briefly, honoured by no code — a declared safety measure that did
+nothing — and was removed rather than wired (#618): verification wants to be
+read-only and to report findings rather than fail, which is the opposite of what
+ingest wants, and one code path cannot hold both honestly.
+
+**Open:** the API-side Temporal client + `ingest_controller`
 (plan §2.7) and `/portal/ingest` are unbuilt, so ingest is CLI-only. When the
 controller lands, **add `fishsense-api` to `temporal.reload` in `flake.nix`** —
 the tell is the service gaining a `/run/tenant/temporal` mount, and missing it

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -1,0 +1,204 @@
+# Ingesting a dive
+
+How to turn a folder of `.ORF` files on the NAS into a `Dive` and its `Image`
+rows. Before this existed, rows were only ever created by an external crawler
+that has since been retired and archived.
+
+**One request means one dive.** The frames are the `.ORF` files *directly inside*
+the folder you name — not a recursive walk. That is precedent, not a
+simplification: the retired crawler assigned `dive = image.parent`, so every one
+of the ~479 dive rows in production is exactly one directory. Recursing would
+merge dives that are distinct rows today, silently and irreversibly.
+
+---
+
+## The short version
+
+```bash
+# 1. Dry run. Writes nothing, reports every problem at once.
+temporal workflow start \
+    --task-queue fishsense_api_queue \
+    --type IngestDiveWorkflow \
+    --workflow-id ingest-101923_Alligator1_FSL06-dry \
+    --input '{"dive_path": "2024.06.20.REEF/101923_Alligator1_FSL06",
+              "self_calibrates": true,
+              "priority": "HIGH",
+              "dry_run": true}'
+
+temporal workflow result --workflow-id ingest-101923_Alligator1_FSL06-dry
+
+# 2. Read the report. Fix anything in `errors`. Then commit:
+temporal workflow start \
+    --task-queue fishsense_api_queue \
+    --type IngestDiveWorkflow \
+    --workflow-id ingest-101923_Alligator1_FSL06 \
+    --input '{"dive_path": "2024.06.20.REEF/101923_Alligator1_FSL06",
+              "self_calibrates": true,
+              "priority": "HIGH"}'
+
+# 3. Watch it. A large dive is hours of downloading.
+temporal workflow query \
+    --workflow-id ingest-101923_Alligator1_FSL06 --type progress
+```
+
+**Always dry-run first.** It costs ~1 MB per frame instead of ~14.5 MB, because
+preflight only reads each file's EXIF header. On a 500-frame dive that is 0.5 GB
+rather than 7.5 GB, and it is the only chance to see every problem before
+anything is written.
+
+---
+
+## The request
+
+| Field | Meaning |
+|---|---|
+| `dive_path` | **Required.** Folder path relative to `e4e_nas.raw_root_path`. An absolute path also works and is not double-prefixed. |
+| `self_calibrates` / `calibration_dive_id` | **Exactly one is required** — see below. |
+| `priority` | `HIGH` (default) or `LOW`. HIGH is what every hourly cohort selects on. |
+| `dive_name` | Defaults to the leaf directory name. |
+| `camera_id` | Override camera resolution. Normally unset. |
+| `dive_slate_id` | The dive's slate, if it has one. |
+| `flip_dive_slate` | Passed through to the dive row. |
+| `dry_run` | Stop after preflight, having written nothing. |
+| `verify_existing` | **Declared but not implemented — it does nothing.** See "Known gaps". |
+
+### Calibration intent is required, and cannot be inferred
+
+Exactly one of `self_calibrates: true` or `calibration_dive_id: <id>`.
+
+A fish-only dive with no slate frames of its own can never self-calibrate, so
+stage 14 can never measure it — and *nothing in the files reveals that*. Ingest
+refuses rather than guessing, because the failure mode is a dive that sits in the
+pipeline forever without ever producing a measurement and without ever saying
+why.
+
+Passing both is also refused: `get_laser_extrinsics_for_dive` resolves own-wins,
+so a dive with its own slate would silently ignore the link you took the trouble
+to specify.
+
+---
+
+## What preflight refuses, and what to do
+
+Preflight reports **every** problem at once rather than stopping at the first —
+you get one round trip, not a sequence of them. A non-empty `errors` list means
+nothing was written.
+
+| Error | What it means | Fix |
+|---|---|---|
+| `Camera serial <S> matches no Camera row` | The frames' Olympus MakerNote serial has no `Camera`. | Add the camera **with its intrinsics**. Ingest deliberately does **not** fall back to the EXIF `Artist` tag — a free-text rig label would bind intrinsics belonging to different glass, and stage 14 would report confident wrong lengths. |
+| `Frames span more than one camera serial` | One folder, two rigs. | Split the folder and submit each dive separately. The schema cannot express a two-rig dive. |
+| `Camera <id> has no intrinsics` | The camera exists but has no calibration. | Add intrinsics. Otherwise the dive sits in the stage-14 cohort forever. |
+| `No calibration intent given` / `Contradictory calibration intent` | See above. | Pass exactly one. |
+| `No readable EXIF timestamp in <path>` | The frame has no usable tag 0x0132 or 0x9003. | Investigate the file. Ingest will not default a timestamp — stage-1 clustering is pure timestamp arithmetic and cannot tell a fabricated value from a real one. |
+| `Path exceeds 255 characters` | `Image.path` is `varchar(255)`. | Shorten the path on the NAS. The offending file is named. |
+| `No .ORF frames directly inside <folder>` | Usually a mistyped path — or you named a parent. | Check the path; see the subfolder warning below. |
+
+### Warnings are informational — ingest proceeds
+
+* **`<path> contains N .ORF files ... that is a separate dive`** — a subdirectory
+  holding raws. Under the existing convention it is its own dive, so submit it as
+  its own request. This is the Olympus rollover case: the TG-6 wraps its frame
+  counter at `PA199999` and starts a child folder mid-dive, which reads as "more
+  frames" to a person and as "a second dive" to every convention in the database.
+* **`Dive <id> has the same folder name`** — a leaf-name collision. Dive names are
+  not unique in production (dives 64 and 66 are both `082929_FishModels_FSL07`),
+  so this is a hint, not a fault.
+* **`EXIF Artist <A> disagrees with the resolved camera's name <N>`** — the serial
+  is authoritative, so ingest proceeds. It usually means a mislabelled `Camera`
+  row or a re-housed body, and nothing else in the pipeline would ever notice.
+* **`<path> has no DateTime (0x0132); fell back to DateTimeOriginal`** — usable,
+  but this body is not the one the convention was derived from.
+
+---
+
+## What actually happens on commit
+
+Ingest is a **two-phase commit**, because no database transaction spans the steps.
+
+1. **`create_dive`** writes the dive at **`priority=LOW`, whatever you asked
+   for.** Every hourly cohort selects on HIGH, so a dive created HIGH before its
+   frames land would be picked up mid-ingest and processed against a partial set
+   — clustered on some of its frames, populated into Label Studio missing others.
+2. **`scan_and_register_images`** downloads frames in batches of 25, computes each
+   checksum, and creates the `Image` rows.
+3. **`finalize_dive`** flips the dive to the priority you asked for — **and only
+   if every listed frame is accounted for.**
+
+**Priority is the commit flag.** A crash or a cancellation anywhere in the middle
+leaves a dive and some images that no pipeline stage will touch.
+
+`finalize` refuses, non-retryably, when:
+
+* **any frame was rejected** — the set is incomplete;
+* **`registered + skipped != total`** — a frame was neither written nor recognised
+  as already present. That is worse than a rejection: a rejection is reported, a
+  gap is silence.
+
+Both leave the dive at LOW. Read the report, fix the cause, re-run.
+
+### Re-running is safe
+
+* `dives.post` upserts on `path`, so you get the same dive row, not a second one.
+* The scan skips frames already registered **without downloading them**, so a
+  re-run over a completed folder moves no bytes.
+* A fully-skipped re-run still commits — otherwise the only way to re-verify a
+  dive would be to make it fail.
+
+---
+
+## Duplicate content
+
+After the scan, `finalize` reports **containment** against every other dive that
+shares frames:
+
+```
+containment = |new ∩ existing| / |new|
+```
+
+over content checksums. `1.0` means this folder is wholly contained in that dive;
+`0.87` means 48 of 55 frames already exist there. Being a set operation on hashes
+it is immune to filenames and ordering, and it degrades to a partial overlap.
+
+**It is reported, never blocking.** Re-ingesting the same frames under a second
+dive path is legitimate and has already happened in production. The duplicate
+rows land `is_canonical=False`, which makes them invisible to every pipeline
+cohort — they cannot be measured twice.
+
+About half of production's image rows are duplicate content, so expect this to
+fire often.
+
+---
+
+## Verifying what is already there
+
+Separate, read-only, and unrelated to a new ingest:
+
+```bash
+# One dive, sampling 25 frames
+temporal workflow start --task-queue fishsense_api_queue \
+    --type VerifyDiveChecksumsWorkflow \
+    --workflow-id verify-checksums-412 --input 412 --input 25
+
+# Every canonical dive, 5 frames each (~20 GB); pass null for every frame (~930 GB)
+temporal workflow start --task-queue fishsense_api_queue \
+    --type VerifyAllDivesChecksumsWorkflow \
+    --workflow-id verify-sweep --input 5
+```
+
+It re-hashes real files and reports checksum mismatches, timestamp mismatches,
+missing files and NULL checksums separately, because they have different
+consequences. Run on 2026-08-17 across all 272 canonical dives: **1,619 frames,
+zero checksum disagreements.**
+
+---
+
+## Known gaps
+
+* **`verify_existing` does nothing.** The field exists on `IngestDiveRequest` and
+  is honoured by no code. Use `VerifyDiveChecksumsWorkflow` above instead. The
+  flag should be either wired up or removed — a flag that silently does nothing
+  is worse than an absent one.
+* **No API or portal route yet.** Ingest is CLI-only; the Temporal client and
+  `ingest_controller` in fishsense-api are unbuilt (see
+  `docs/plans/dive-image-ingestion.md` §2.7), and `/portal/ingest` after that.

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -60,7 +60,6 @@ anything is written.
 | `dive_slate_id` | The dive's slate, if it has one. |
 | `flip_dive_slate` | Passed through to the dive row. |
 | `dry_run` | Stop after preflight, having written nothing. |
-| `verify_existing` | **Declared but not implemented — it does nothing.** See "Known gaps". |
 
 ### Calibration intent is required, and cannot be inferred
 
@@ -195,10 +194,12 @@ zero checksum disagreements.**
 
 ## Known gaps
 
-* **`verify_existing` does nothing.** The field exists on `IngestDiveRequest` and
-  is honoured by no code. Use `VerifyDiveChecksumsWorkflow` above instead. The
-  flag should be either wired up or removed — a flag that silently does nothing
-  is worse than an absent one.
 * **No API or portal route yet.** Ingest is CLI-only; the Temporal client and
   `ingest_controller` in fishsense-api are unbuilt (see
   `docs/plans/dive-image-ingestion.md` §2.7), and `/portal/ingest` after that.
+
+There is deliberately **no `verify_existing` option on an ingest request.** One
+shipped briefly, honoured by no code, so setting it produced a normal ingest and
+no warning; it was removed rather than wired (#618). Verification is the
+workflows above — read-only by construction, sampling, and sharing exactly one
+definition of the checksum and timestamp conventions with ingest itself.

--- a/docs/plans/dive-image-ingestion.md
+++ b/docs/plans/dive-image-ingestion.md
@@ -12,7 +12,7 @@ Status: **approved; in progress.** Two independent deliverables:
 |---|---|---|
 | 1 | fishsense-api write endpoints + SDK client methods (§2.1, §2.2, §4.2.1 lookup) | **merged** — #554 |
 | 1b | canonical-only pipeline work: 11 cohort selectors, 8 resolvers, `dive_pipeline_status` | **merged** — #555, folded into #554's branch |
-| 2 | api-worker ingest workflow | **in progress** — see below |
+| 2 | api-worker ingest workflow | **merged** — #557, #559, #611, #613. Ingest works end to end from the CLI; runbook at [docs/ingest.md](../ingest.md) |
 | 3 | `/portal/ingest` page (§5) | not started |
 | 4 | Part 2 — `Weasly Fish` reference row (§7) | blocked on the calipered widths |
 
@@ -25,9 +25,10 @@ Status: **approved; in progress.** Two independent deliverables:
 | `fishsense_shared.ingest_contracts` | **merged** — #557 |
 | `list_dive_folder_activity` (§4.1) | **merged** — #559, 11 tests |
 | `preflight_ingest_activity` (§4.2) | **merged** — #559, 19 tests |
-| `create_dive` / `scan_and_register_images` / `finalize_dive` (§4.3–4.5) | not started |
-| `IngestDiveWorkflow` + `progress` query | not started |
-| Temporal client + `ingest_controller` in fishsense-api (§2.7) | not started |
+| `scan_and_register_images_activity` (§4.4) | **merged** — #611, 14 tests |
+| `create_dive_activity` / `finalize_dive_activity` (§4.3, §4.5) | **merged** — #613, 13 tests |
+| `IngestDiveWorkflow` + `progress` query | **merged** — #613, 6 contract tests |
+| Temporal client + `ingest_controller` in fishsense-api (§2.7) | not started — ingest is CLI-only until this lands |
 
 Unplanned, added while building the above because §0.1's caveat turned out to be
 answerable rather than merely noted:


### PR DESCRIPTION
Ingest works end to end as of #613 and had **no documentation of either kind**.
CLAUDE.md documents every pipeline stage but not the thing that creates the rows
they operate on, and there was no runbook for using it.

Two documents, two audiences.

## `docs/ingest.md` — the operator's

Written around the **failure modes**, not the happy path. The happy path is
three commands; the refusals are where the judgement is.

* Dry-run-first, with the reason: ~1 MB per frame instead of ~14.5 MB, so a
  500-frame preview costs 0.5 GB rather than 7.5 GB.
* A table of every preflight refusal and what to do about it — including *why*
  there is deliberately no fallback from the MakerNote serial to the EXIF
  `Artist` tag (a free-text rig label would bind intrinsics belonging to
  different glass, and stage 14 would report confident wrong lengths).
* What the warnings mean, especially the subfolder one — under the existing
  convention that folder is a **separate dive**, which is the Olympus rollover
  case.
* Why re-running is safe, and what `finalize`'s two refusals actually protect.
* Containment: reported, never blocking, and expect it often since about half of
  production's image rows are duplicate content.

## The CLAUDE.md section — the engineer's

The five recovered conventions and which module owns each, plus why the two that
fail **silently** (checksum, timestamp) live in one module: a divergent checksum
makes duplicate detection report *zero overlap* rather than erroring, and a
divergent timestamp corrupts stage-1 clustering.

Also: the two-phase commit and why priority is the commit flag; why
non-recursion is precedent rather than simplification; and why containment
replaced the legacy whole-dive MD5 aggregate.

Marked as verified rather than inferred — `VerifyAllDivesChecksumsWorkflow`
re-hashed 1,619 frames across all 272 canonical dives with zero disagreements.

## One thing the writing turned up

**`IngestDiveRequest.verify_existing` is declared in the contract and honoured
by no code.** An operator setting it would get a normal ingest and no warning.

A flag that silently does nothing is worse than an absent one, so it is recorded
as an open gap in both documents; the runbook points at
`VerifyDiveChecksumsWorkflow`, which already does that job properly. It should be
wired or deleted — happy to do either.

Docs only; no code change. Also updates the plan's progress table, which still
said the activities were "not started".

🤖 Generated with [Claude Code](https://claude.com/claude-code)