### PR TITLE
fix(ingest): delete verify_existing, which was honoured by no code

### DIFF
--- a/docs/plans/dive-image-ingestion.md
+++ b/docs/plans/dive-image-ingestion.md
@@ -532,8 +532,10 @@ calibration_dive_id: int | None = None
 self_calibrates: bool = False      # exactly one of this / calibration_dive_id
 flip_dive_slate: bool = False
 dry_run: bool = False
-verify_existing: bool = False      # re-hash + report, never write (§4.6)
 ```
+
+**No `verify_existing`** — see §4.6. It shipped as a declared field honoured by
+no code and was removed rather than wired.
 
 ### 3.2 `IngestPreflight`, `IngestProgress`, `IngestReport`
 
@@ -682,14 +684,35 @@ Otherwise `dives.post` again with real `dive_datetime` = **max** taken_datetime
 carries the §4.2.1 containment report, so the duplicate picture is in front of the
 operator at the moment of commit.
 
-### 4.6 `verify_existing` mode
+### 4.6 Verifying existing rows — a workflow, not an ingest flag
 
-`IngestDiveRequest.verify_existing` — for a folder whose rows already exist, re-hash
-and **report** mismatches without writing. Downgraded from the previous draft's
-blocking gate now that §0.1 is resolved from source: it is a standing net against
-rows that predate spider, not a merge requirement. Also exposed as
-`tools/verify_checksum_algorithm.py` for running over a sample of arbitrary
-existing rows.
+**Resolved differently from this plan's original design.** The plan called for an
+`IngestDiveRequest.verify_existing` mode: for a folder whose rows already exist,
+re-hash and report mismatches without writing.
+
+The field shipped; the behaviour did not. It sat on the contract honoured by no
+code, so an operator setting it got a normal ingest and no warning — strictly
+worse than an absent flag, because it reads as a safety measure. **Removed**
+(#618) rather than wired.
+
+Re-hashing existing rows is `VerifyDiveChecksumsWorkflow` (one dive) and
+`VerifyAllDivesChecksumsWorkflow` (every canonical dive), which are better tools
+for the job than a mode inside ingest would have been:
+
+* **read-only by construction**, with a test tripwire asserting the module's
+  source contains no `upload` / `delete` / `post` / `put`. An ingest flag would
+  have been one `if` away from writing.
+* **findings, not failures** — a missing file or a mismatch is recorded and the
+  run continues, because that is the question being asked. Ingest inverts this
+  deliberately: it is trying to *do* something, so a missing file is a failure.
+* **no second copy of the conventions.** Both call
+  `nas_frames.file_checksum` / `read_taken_datetime`, so there is exactly one
+  definition of each — which matters because both fail silently when wrong.
+* it samples (`limit`), so "does the convention hold" costs ~20 GB rather than
+  ~930 GB.
+
+Run over all 272 canonical dives on 2026-08-17: **1,619 frames, zero checksum
+disagreements.** Two dives disagreed on timestamps — see §0.1.
 
 ---
 

--- a/libs/fishsense-shared/src/fishsense_shared/ingest_contracts.py
+++ b/libs/fishsense-shared/src/fishsense_shared/ingest_contracts.py
@@ -67,8 +67,13 @@ class IngestDiveRequest(BaseModel):
 
     #: Preflight only: list, read EXIF headers, validate, write nothing.
     dry_run: bool = False
-    #: Re-hash an already-ingested folder and report mismatches. Never writes.
-    verify_existing: bool = False
+
+    # There is deliberately no `verify_existing` here. It existed as a declared
+    # field honoured by no code, so setting it produced a normal ingest and no
+    # warning — worse than an absent flag. Re-hashing existing rows against the
+    # NAS is `VerifyDiveChecksumsWorkflow` / `VerifyAllDivesChecksumsWorkflow`,
+    # which do it read-only, with a source tripwire, and without a second
+    # half-implementation of the same conventions to keep in step.
 
 
 class PreflightImage(BaseModel):

--- a/libs/fishsense-shared/tests/test_ingest_contracts.py
+++ b/libs/fishsense-shared/tests/test_ingest_contracts.py
@@ -58,11 +58,39 @@ def test_calibration_intent_defaults_to_neither():
     assert request.self_calibrates is False
 
 
-def test_dry_run_and_verify_existing_default_to_writing_nothing_being_opt_in():
-    request = IngestDiveRequest(dive_path="d")
+def test_writing_nothing_is_opt_in():
+    """`dry_run` defaults False: the common case is an operator who means to
+    ingest. Preflight still runs either way, so a fault is caught before
+    anything is written regardless."""
+    request = IngestDiveRequest(dive_path="d", self_calibrates=True)
 
     assert request.dry_run is False
-    assert request.verify_existing is False
+
+
+def test_the_request_carries_no_verify_existing_flag():
+    """Removed, not renamed.
+
+    It was declared on this model and honoured by no code, so an operator
+    setting it got a normal ingest and no warning — worse than the flag not
+    existing. Re-hashing existing rows is `VerifyDiveChecksumsWorkflow`, which
+    does it read-only and without a second copy of the checksum convention to
+    keep in step.
+
+    Pydantic ignores unknown keys, so a stale caller passing it is silently
+    accepted rather than failing loudly. That is the right behaviour for
+    replaying an in-flight workflow's payload, and the reason this test asserts
+    the field is genuinely gone rather than trusting a rename to surface.
+    """
+    request = IngestDiveRequest(dive_path="d", self_calibrates=True)
+
+    assert "verify_existing" not in request.model_dump()
+
+    stale = IngestDiveRequest(
+        dive_path="d", self_calibrates=True, verify_existing=True
+    )
+
+    assert not hasattr(stale, "verify_existing")
+    assert "verify_existing" not in stale.model_dump()
 
 
 def test_a_preflight_image_may_have_no_timestamp():


### PR DESCRIPTION
`IngestDiveRequest.verify_existing` shipped as a declared field that **nothing
read**. An operator setting it got a normal ingest and no warning — strictly
worse than an absent flag, because the name reads as a safety measure.

Found while writing the runbook (#617), not by anything failing. That is the
point of writing documentation for a thing you built.

## Removed, not wired

The job already has a better tool. `VerifyDiveChecksumsWorkflow` /
`VerifyAllDivesChecksumsWorkflow` beat a mode inside ingest on every axis that
matters:

* **Read-only by construction**, with a tripwire asserting the module's source
  contains no `upload` / `delete` / `post` / `put`. A flag inside ingest would
  have been one `if` away from writing.
* **Findings, not failures.** A missing file or a mismatch is recorded and the
  run continues, because that is the question being asked. Ingest inverts this
  deliberately — it is trying to *do* something, so a missing file is a failure.
  One code path cannot hold both semantics honestly.
* **No second copy of the conventions.** Both call `nas_frames.file_checksum`
  and `read_taken_datetime`, so each has exactly one definition — which matters
  because both fail *silently* when wrong.
* It **samples**, so "does the convention hold" costs ~20 GB rather than ~930 GB.

## Safe for in-flight workflows

Pydantic ignores unknown keys, so a replayed payload still carrying
`verify_existing` deserialises fine rather than failing on history replay.

The test pins that tolerance explicitly, and asserts the field is genuinely gone
from `model_dump()` rather than trusting a rename to surface — a rename would
have left exactly the same silent-no-op in place under a different name.

## Plan §4.6 rewritten

It described a mode that never existed. It now records that the design changed,
what replaced it, and why — including the read-only and one-definition arguments
above, so the next person doesn't re-add the flag from the original design.

168 pass in fishsense-shared at 100% coverage, 468 in the api-worker; black
clean, pylint 10.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)