### PR TITLE
feat(data-worker): split into CPU and GPU roles on separate task queues

### DIFF
--- a/libs/fishsense-shared/src/fishsense_shared/__init__.py
+++ b/libs/fishsense-shared/src/fishsense_shared/__init__.py
@@ -33,6 +33,10 @@ from fishsense_shared.preprocess_contracts import (
     PreprocessSpeciesImagesInput,
     SlatePredictionResult,
 )
+from fishsense_shared.task_queues import (
+    DATA_PROCESSING_GPU_TASK_QUEUE,
+    DATA_PROCESSING_TASK_QUEUE,
+)
 from fishsense_shared.temporal import (
     build_tls_config,
     ensure_schedule,
@@ -49,6 +53,8 @@ __all__ = [
     "PreflightImage",
     "RejectedImage",
     "SubfolderReport",
+    "DATA_PROCESSING_GPU_TASK_QUEUE",
+    "DATA_PROCESSING_TASK_QUEUE",
     "ClusterDiveFrameImage",
     "ClusterDiveFramesInput",
     "ExceptionGroupErrorLogging",

--- a/libs/fishsense-shared/src/fishsense_shared/task_queues.py
+++ b/libs/fishsense-shared/src/fishsense_shared/task_queues.py
@@ -1,0 +1,41 @@
+"""Temporal task-queue names shared by the api-worker and the data-worker.
+
+These live here for the same reason `preprocess_contracts.py` and
+`object_store.py` do: a task-queue name is an agreement *between* the two
+workers, so neither owns it. The api-worker names the queue when it dispatches
+a child workflow; the data-worker names the queue it polls. A typo on either
+side is silent — the child is accepted by the Temporal server and simply sits
+`Running` until its execution timeout, hours later, with nothing in either
+worker's logs to say why.
+
+Two queues, split by whether the work needs a GPU:
+
+* ``DATA_PROCESSING_TASK_QUEUE`` — the CPU stages: rectify/overlay/JPEG
+  (0.1 / 2 / 5.1 / 9), frame clustering, laser calibration, fish measurement,
+  laser depth, laser-label validation. Nine activities, none of which import
+  torch.
+* ``DATA_PROCESSING_GPU_TASK_QUEUE`` — the two model-inference stages
+  (`predict_laser_image`, and the retired `predict_slate_image`), which run a
+  torch checkpoint through `fishsense_core.laser.LaserDetector`.
+
+The split exists because the two have opposite scheduling needs. Before it,
+one Deployment served everything and requested ``nvidia.com/gpu: 1`` with node
+affinity pinned to compute capability >= 7.5 — so *every* stage was gated on
+NRP finding a Turing-or-newer GPU with free capacity, and the GPU sat idle
+through the hours of rawpy decode that dominate a real dive. Now the CPU
+Deployment carries no GPU request at all and cannot be blocked by GPU scarcity.
+
+The GPU queue is deliberately served by **two** Deployments — the GPU one and a
+CPU-only fallback that runs the same checkpoint on the CPU when the GPU one
+repeatedly fails to start. They share this queue name precisely so that no
+workflow has to know which is running; see
+`fishsense_api_workflow_worker.activities.gpu_fallback`.
+"""
+
+DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
+DATA_PROCESSING_GPU_TASK_QUEUE = "fishsense_data_processing_gpu_queue"
+
+__all__ = [
+    "DATA_PROCESSING_GPU_TASK_QUEUE",
+    "DATA_PROCESSING_TASK_QUEUE",
+]

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_slate_image.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_slate_image.py
@@ -48,12 +48,45 @@ _log = logging.getLogger(__name__)
 # local checkpoint path overrides the HuggingFace download. The classical path
 # (board_mask=None) is a supported fallback (~13 pts less coverage), so any
 # load/inference failure degrades gracefully instead of failing the frame.
+#
+# This activity runs on `fishsense_data_processing_gpu_queue` and *prefers* a
+# GPU (see `_preferred_device`) without requiring one: that queue is served by
+# a GPU Deployment or, when it can't start, a CPU-only one. Two independent
+# degradations therefore sit under it — GPU -> CPU inference, and
+# BoardMasker -> classical estimator.
 DEFAULT_SLATE_CHECKPOINT_PATH = os.environ.get("E4EFS_SLATE_DETECTOR__CHECKPOINT", "")
 _MASKER: Any = None
 _MASKER_LOADED = False
 # See `_get_masker` — the flag must only ever be published *after* `_MASKER`,
 # and the lock is what stops a concurrent caller reading the pair mid-load.
 _MASKER_LOCK = threading.Lock()
+
+
+def _preferred_device() -> str:
+    """``"cuda"`` when a GPU is actually usable in this process, else ``"cpu"``.
+
+    `BoardMasker` defaults to ``device="cpu"`` and does NOT auto-select CUDA
+    the way `LaserDetector` does, so without this the mask ran on the CPU even
+    on a GPU-scheduled pod — which it silently did for this activity's whole
+    life. fishsense-core's default is a reasonable one for a 202 ms/frame model
+    that it assumed would never be GPU-scheduled; this activity now runs on the
+    GPU queue, so it asks.
+
+    "Prefer", not "require": this stage degrades all the way down — no GPU
+    means CPU inference, and no torch at all means the classical estimator
+    (`_get_masker` returns None). Any failure here just means CPU.
+    """
+    try:
+        import torch  # pylint: disable=import-error
+
+        if torch.cuda.is_available():
+            return "cuda"
+    except Exception:  # pylint: disable=broad-except
+        # torch missing or a broken CUDA runtime — the caller's own try/except
+        # would catch it later anyway, but there is no reason to ask for a
+        # device we could not verify.
+        _log.debug("no usable CUDA device; BoardMasker will run on the CPU")
+    return "cpu"
 
 
 def _get_masker() -> Any:
@@ -83,13 +116,16 @@ def _get_masker() -> Any:
                 BoardMasker,
             )
 
+            device = _preferred_device()
             if DEFAULT_SLATE_CHECKPOINT_PATH and os.path.exists(
                 DEFAULT_SLATE_CHECKPOINT_PATH
             ):
-                _MASKER = BoardMasker.from_checkpoint(DEFAULT_SLATE_CHECKPOINT_PATH)
+                _MASKER = BoardMasker.from_checkpoint(
+                    DEFAULT_SLATE_CHECKPOINT_PATH, device=device
+                )
             else:
-                _MASKER = BoardMasker.from_pretrained()
-            _log.info("loaded BoardMasker (learned board mask)")
+                _MASKER = BoardMasker.from_pretrained(device=device)
+            _log.info("loaded BoardMasker (learned board mask) device=%s", device)
         except Exception as exc:  # pylint: disable=broad-except
             # torch/hf missing, no network, or bad checkpoint — fall back to the
             # classical estimator. The mask only adds coverage; it's never required.

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/config.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/config.py
@@ -13,6 +13,8 @@ from fishsense_shared import (
     url_condition,
 )
 
+from fishsense_data_processing_workflow_worker.role_names import ROLE_ALL, ROLES
+
 APP_NAME = "e4efs_data_processing_workflow_worker"
 
 
@@ -33,6 +35,20 @@ _VALIDATORS = [
         cast=int,
         default=4,
         condition=lambda x: x > 0,
+    ),
+    # Which half of the split worker this process is. `cpu` polls
+    # `fishsense_data_processing_queue` (rectify/cluster/calibrate/measure/
+    # depth/validate); `gpu` polls `fishsense_data_processing_gpu_queue` (the
+    # two torch predict stages). `all` runs both in one process and is the
+    # default so the devcontainer and the integration tests still serve every
+    # queue the api-worker dispatches to; the k8s Deployments each set
+    # `E4EFS_GENERAL__ROLE` explicitly. See `roles.py`.
+    Validator(
+        "general.role",
+        required=True,
+        cast=str,
+        default=ROLE_ALL,
+        condition=lambda x: x in ROLES,
     ),
     Validator("temporal.host", required=True, cast=str, condition=validators.hostname),
     Validator("temporal.port", required=True, cast=int, default=7233),

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/role_names.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/role_names.py
@@ -1,0 +1,47 @@
+"""Role vocabulary: the values `general.role` accepts, and their task queues.
+
+Deliberately a leaf module — it imports nothing from this package. `config.py`
+validates `general.role` against `ROLES`, and `roles.py` (which imports every
+activity and workflow to build the registration lists) imports these names and
+re-exports them. Putting the constants in `roles.py` itself is the obvious
+thing and it does not work: `config` -> `roles` -> `activities.utils` ->
+`config` is a cycle, and it fails at worker startup rather than at test time.
+
+Split by whether the work needs a GPU:
+
+* ``cpu`` — rectify/overlay/JPEG (stages 0.1 / 2 / 5.1 / 9), frame clustering,
+  laser calibration, fish measurement, laser depth, laser-label validation.
+* ``gpu`` — the two torch stages, `predict_laser_image` and the retired
+  `predict_slate_image`.
+* ``all`` — both roles in one process. Not a third kind of work: it is what
+  the devcontainer and the integration tests run so a local process still
+  serves every queue the api-worker dispatches to.
+"""
+
+from typing import Final
+
+from fishsense_shared import (
+    DATA_PROCESSING_GPU_TASK_QUEUE,
+    DATA_PROCESSING_TASK_QUEUE,
+)
+
+ROLE_CPU: Final = "cpu"
+ROLE_GPU: Final = "gpu"
+ROLE_ALL: Final = "all"
+
+#: Every value `general.role` accepts.
+ROLES: Final = (ROLE_CPU, ROLE_GPU, ROLE_ALL)
+
+#: Single-role task queues. ``all`` is absent on purpose — it is two queues.
+ROLE_TASK_QUEUES: Final[dict[str, str]] = {
+    ROLE_CPU: DATA_PROCESSING_TASK_QUEUE,
+    ROLE_GPU: DATA_PROCESSING_GPU_TASK_QUEUE,
+}
+
+__all__ = [
+    "ROLES",
+    "ROLE_ALL",
+    "ROLE_CPU",
+    "ROLE_GPU",
+    "ROLE_TASK_QUEUES",
+]

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/roles.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/roles.py
@@ -1,0 +1,234 @@
+"""What each data-worker role registers, and on which task queue.
+
+The data-worker runs in one of two roles, and the split is by whether the work
+needs a GPU:
+
+* ``cpu`` — the nine stages that are pure CPU: rectify/overlay/JPEG for stages
+  0.1 / 2 / 5.1 / 9, frame clustering, laser calibration, fish measurement,
+  laser depth, and laser-label validation.
+* ``gpu`` — the two torch inference stages: `predict_laser_image`
+  (`fishsense_core.laser.LaserDetector`) and the retired `predict_slate_image`
+  (`fishsense_core.slate.BoardMasker`).
+
+The GPU queue means **prefer a GPU, not require one**, and that distinction is
+what makes it the right home for both. It is served by a GPU Deployment *or*,
+when that repeatedly fails to start, a CPU-only one running the same
+checkpoints — so landing a stage here buys it a GPU when there is one without
+ever gating it on there being one.
+
+The two stages want that for different reasons. The laser detector genuinely
+needs the GPU; it is slow enough on CPU that the fallback is a degradation.
+The slate masker does not — fishsense-core measures it at 202 ms/frame on CPU
+and defaults `BoardMasker(device=)` to ``"cpu"`` for exactly that reason — but
+it is still a torch model that goes faster on a card that is already there for
+the laser stage, and it costs nothing to let it use one. `predict_slate_image`
+now passes a device explicitly; before that it ran on the CPU even on the
+GPU-pinned pod, which nothing in the code said out loud.
+
+Before the split there was one process, one queue, and one Deployment that
+requested ``nvidia.com/gpu: 1`` with node affinity pinned to compute capability
+>= 7.5. That meant *every* stage waited on NRP finding a Turing-or-newer GPU
+with free capacity, and the GPU then sat idle through the hours of rawpy decode
+that dominate a real dive. Splitting the roles is what lets the CPU Deployment
+carry no GPU request at all.
+
+``all`` is not a third role — it is "both roles in one process", which is what
+the devcontainer and the integration tests use so a local run still serves
+every queue the api-worker dispatches to.
+
+**Keeping the two lists exhaustive is the whole contract here**, and
+`tests/test_worker_roles.py` asserts it, because both ways of getting it wrong
+are silent. An activity in neither list is registered nowhere: its workflow's
+`execute_activity` sits pending until schedule-to-close, hours later, with
+nothing logged by either worker. An activity in both is registered on a queue
+whose pod may have no GPU at all. Neither surfaces until a dive is being
+processed in prod. Add a new activity to exactly one list.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Final, NamedTuple, Sequence
+
+from fishsense_data_processing_workflow_worker.role_names import (
+    ROLE_ALL,
+    ROLE_CPU,
+    ROLE_GPU,
+    ROLE_TASK_QUEUES,
+    ROLES,
+)
+
+from fishsense_data_processing_workflow_worker.activities.cluster_dive_frames import (
+    cluster_dive_frames,
+)
+from fishsense_data_processing_workflow_worker.activities.compute_laser_depths_activity import (  # noqa: E501  pylint: disable=line-too-long
+    compute_laser_depths_activity,
+)
+from fishsense_data_processing_workflow_worker.activities.measure_fish_activity import (
+    measure_fish_activity,
+)
+from fishsense_data_processing_workflow_worker.activities.perform_laser_calibration_activity import (  # noqa: E501  pylint: disable=line-too-long
+    perform_laser_calibration_activity,
+)
+from fishsense_data_processing_workflow_worker.activities.predict_laser_image import (
+    predict_laser_image,
+)
+from fishsense_data_processing_workflow_worker.activities.predict_slate_image import (
+    predict_slate_image,
+)
+from fishsense_data_processing_workflow_worker.activities.preprocess_headtail_image import (  # noqa: E501  pylint: disable=line-too-long
+    preprocess_headtail_image,
+)
+from fishsense_data_processing_workflow_worker.activities.preprocess_laser_image import (
+    preprocess_laser_image,
+)
+from fishsense_data_processing_workflow_worker.activities.preprocess_slate_image import (
+    preprocess_slate_image,
+)
+from fishsense_data_processing_workflow_worker.activities.preprocess_species_image import (  # noqa: E501  pylint: disable=line-too-long
+    preprocess_species_image,
+)
+from fishsense_data_processing_workflow_worker.activities.validate_laser_labels_for_dive_activity import (  # noqa: E501  pylint: disable=line-too-long
+    validate_laser_labels_for_dive_activity,
+)
+from fishsense_data_processing_workflow_worker.workflows.compute_laser_depths_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    ComputeLaserDepthsWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.dive_frame_clustering_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    DiveFrameClusteringWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.measure_fish_workflow import (
+    MeasureFishWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.perform_laser_calibration_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PerformLaserCalibrationWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.predict_laser_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PredictLaserImagesWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.predict_slate_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PredictSlateImagesWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.preprocess_headtail_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PreprocessHeadtailImagesWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.preprocess_laser_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PreprocessLaserImagesWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.preprocess_slate_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PreprocessSlateImagesWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.preprocess_species_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PreprocessSpeciesImagesWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.validate_laser_labels_for_dive_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    ValidateLaserLabelsForDiveWorkflow,
+)
+
+CPU_WORKFLOWS: Final[Sequence[type]] = (
+    ComputeLaserDepthsWorkflow,
+    DiveFrameClusteringWorkflow,
+    MeasureFishWorkflow,
+    PerformLaserCalibrationWorkflow,
+    PreprocessHeadtailImagesWorkflow,
+    PreprocessLaserImagesWorkflow,
+    PreprocessSlateImagesWorkflow,
+    PreprocessSpeciesImagesWorkflow,
+    ValidateLaserLabelsForDiveWorkflow,
+)
+
+CPU_ACTIVITIES: Final[Sequence[Callable[..., Any]]] = (
+    cluster_dive_frames,
+    compute_laser_depths_activity,
+    measure_fish_activity,
+    perform_laser_calibration_activity,
+    preprocess_headtail_image,
+    preprocess_laser_image,
+    preprocess_slate_image,
+    preprocess_species_image,
+    validate_laser_labels_for_dive_activity,
+)
+
+# The torch inference stages. `predict_slate_image` is RETIRED (2026-08-03 —
+# the ECC gate does not transfer out of distribution) and its schedule is
+# actively deleted at api-worker startup, but it stays registered so a future
+# evaluation can start it by hand, and it should get a GPU when one is there.
+GPU_WORKFLOWS: Final[Sequence[type]] = (
+    PredictLaserImagesWorkflow,
+    PredictSlateImagesWorkflow,
+)
+
+GPU_ACTIVITIES: Final[Sequence[Callable[..., Any]]] = (
+    predict_laser_image,
+    predict_slate_image,
+)
+
+#: The union, for the exhaustiveness tripwire in `tests/test_worker_roles.py`.
+ALL_WORKFLOWS: Final[Sequence[type]] = (*CPU_WORKFLOWS, *GPU_WORKFLOWS)
+ALL_ACTIVITIES: Final[Sequence[Callable[..., Any]]] = (
+    *CPU_ACTIVITIES,
+    *GPU_ACTIVITIES,
+)
+
+
+class Registration(NamedTuple):
+    """One Temporal worker's worth of wiring: a queue and what serves it."""
+
+    task_queue: str
+    workflows: Sequence[type]
+    activities: Sequence[Callable[..., Any]]
+
+
+_REGISTRATIONS: Final[dict[str, Registration]] = {
+    ROLE_CPU: Registration(ROLE_TASK_QUEUES[ROLE_CPU], CPU_WORKFLOWS, CPU_ACTIVITIES),
+    ROLE_GPU: Registration(ROLE_TASK_QUEUES[ROLE_GPU], GPU_WORKFLOWS, GPU_ACTIVITIES),
+}
+
+
+def registration_for_role(role: str) -> Registration:
+    """Return the single role's wiring.
+
+    Raises for ``all`` as well as for an unknown role: ``all`` is two queues,
+    so there is no one answer, and quietly returning the CPU half would leave
+    the GPU queue unserved — a stall with no error anywhere.
+    """
+    try:
+        return _REGISTRATIONS[role]
+    except KeyError:
+        raise ValueError(
+            f"{role!r} is not a single data-worker role; "
+            f"expected one of {sorted(_REGISTRATIONS)} "
+            f"(use {ROLE_ALL!r} with build_workers to serve both queues)"
+        ) from None
+
+
+def registrations_for_role(role: str) -> list[Registration]:
+    """Return every worker `role` should run — two entries for ``all``."""
+    if role == ROLE_ALL:
+        return [_REGISTRATIONS[ROLE_CPU], _REGISTRATIONS[ROLE_GPU]]
+    return [registration_for_role(role)]
+
+
+def queue_for_role(role: str) -> str:
+    """Task queue a single role polls."""
+    return registration_for_role(role).task_queue
+
+
+# Re-exported from `role_names` so callers have one import for "roles": the
+# vocabulary and the wiring. `config.py` must keep importing the leaf module
+# directly — importing this one would cycle back through the activities.
+__all__ = [
+    "ALL_ACTIVITIES",
+    "ALL_WORKFLOWS",
+    "CPU_ACTIVITIES",
+    "CPU_WORKFLOWS",
+    "GPU_ACTIVITIES",
+    "GPU_WORKFLOWS",
+    "ROLES",
+    "ROLE_ALL",
+    "ROLE_CPU",
+    "ROLE_GPU",
+    "Registration",
+    "queue_for_role",
+    "registration_for_role",
+    "registrations_for_role",
+]

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
@@ -3,87 +3,34 @@
 Single ``build_worker`` construction point (shared with tests) plus the
 ``main`` scale-to-zero-friendly run loop. Caps activity concurrency to keep
 the CPU-heavy per-image rectify/decode work under the pod's memory limit.
+
+The worker runs in one of two roles — ``cpu`` or ``gpu`` — each polling its
+own task queue, or ``all`` (both, in one process) for local development. What
+each role registers lives in `roles.py`; this module only turns a role into
+Temporal ``Worker`` objects and runs them.
 """
 
 import asyncio
 import logging
 import signal
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import AsyncExitStack
 from datetime import timedelta
 
-from fishsense_shared import build_tls_config, temporal_namespace
+from fishsense_shared import (
+    DATA_PROCESSING_TASK_QUEUE,
+    build_tls_config,
+    temporal_namespace,
+)
 from temporalio.client import Client
 from temporalio.worker import Worker
 
-from fishsense_data_processing_workflow_worker.activities.cluster_dive_frames import (
-    cluster_dive_frames,
-)
-from fishsense_data_processing_workflow_worker.activities.compute_laser_depths_activity import (  # noqa: E501  pylint: disable=line-too-long
-    compute_laser_depths_activity,
-)
-from fishsense_data_processing_workflow_worker.activities.measure_fish_activity import (
-    measure_fish_activity,
-)
-from fishsense_data_processing_workflow_worker.activities.perform_laser_calibration_activity import (  # noqa: E501  pylint: disable=line-too-long
-    perform_laser_calibration_activity,
-)
-from fishsense_data_processing_workflow_worker.activities.preprocess_species_image import (
-    preprocess_species_image,
-)
-from fishsense_data_processing_workflow_worker.activities.preprocess_headtail_image import (
-    preprocess_headtail_image,
-)
-from fishsense_data_processing_workflow_worker.activities.predict_laser_image import (
-    predict_laser_image,
-)
-from fishsense_data_processing_workflow_worker.activities.predict_slate_image import (
-    predict_slate_image,
-)
-from fishsense_data_processing_workflow_worker.activities.preprocess_laser_image import (
-    preprocess_laser_image,
-)
-from fishsense_data_processing_workflow_worker.activities.preprocess_slate_image import (
-    preprocess_slate_image,
-)
-from fishsense_data_processing_workflow_worker.activities.validate_laser_labels_for_dive_activity import (  # noqa: E501  pylint: disable=line-too-long
-    validate_laser_labels_for_dive_activity,
-)
+from fishsense_data_processing_workflow_worker import roles
 from fishsense_data_processing_workflow_worker.config import configure_logging, settings
-from fishsense_data_processing_workflow_worker.workflows.dive_frame_clustering_workflow import (
-    DiveFrameClusteringWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.compute_laser_depths_workflow import (  # noqa: E501  pylint: disable=line-too-long
-    ComputeLaserDepthsWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.measure_fish_workflow import (
-    MeasureFishWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.perform_laser_calibration_workflow import (  # noqa: E501  pylint: disable=line-too-long
-    PerformLaserCalibrationWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.preprocess_species_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
-    PreprocessSpeciesImagesWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.preprocess_headtail_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
-    PreprocessHeadtailImagesWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.predict_laser_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
-    PredictLaserImagesWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.predict_slate_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
-    PredictSlateImagesWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.preprocess_laser_images_workflow import (
-    PreprocessLaserImagesWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.preprocess_slate_images_workflow import (
-    PreprocessSlateImagesWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.validate_laser_labels_for_dive_workflow import (  # noqa: E501  pylint: disable=line-too-long
-    ValidateLaserLabelsForDiveWorkflow,
-)
 
-TASK_QUEUE_NAME = "fishsense_data_processing_queue"
+# Retained for the CPU queue's historical name so existing callers and tests
+# keep reading one constant. `roles.queue_for_role` is the general form.
+TASK_QUEUE_NAME = DATA_PROCESSING_TASK_QUEUE
 
 # How long in-flight activities get to finish when the worker is asked to
 # stop. On NRP the api-worker scales this deployment to zero when idle, so
@@ -119,50 +66,63 @@ async def schedule_workflows(_: Client):
     """
 
 
+def _build(
+    client: Client,
+    activity_executor: ThreadPoolExecutor,
+    max_concurrent_activities: int,
+    registration: roles.Registration,
+) -> Worker:
+    """Turn one role's wiring into a Temporal ``Worker``."""
+    return Worker(
+        client,
+        task_queue=registration.task_queue,
+        max_concurrent_activities=max_concurrent_activities,
+        workflows=list(registration.workflows),
+        activity_executor=activity_executor,
+        activities=list(registration.activities),
+        graceful_shutdown_timeout=GRACEFUL_SHUTDOWN_TIMEOUT,
+    )
+
+
 def build_worker(
     client: Client,
     activity_executor: ThreadPoolExecutor,
     max_concurrent_activities: int = DEFAULT_MAX_CONCURRENT_ACTIVITIES,
+    role: str = roles.ROLE_CPU,
 ) -> Worker:
-    """Construct the data-worker Temporal worker.
+    """Construct one role's Temporal worker.
 
     Single construction point so the worker config (workflows, activities,
     graceful-shutdown window, activity concurrency cap) is exercised by tests
     without standing up the full ``main`` loop.
+
+    Raises ``ValueError`` for ``all`` — that is two queues, so it has no single
+    answer. Use ``build_workers``.
     """
-    return Worker(
+    return _build(
         client,
-        task_queue=TASK_QUEUE_NAME,
-        max_concurrent_activities=max_concurrent_activities,
-        workflows=[
-            ComputeLaserDepthsWorkflow,
-            DiveFrameClusteringWorkflow,
-            MeasureFishWorkflow,
-            PerformLaserCalibrationWorkflow,
-            PreprocessSpeciesImagesWorkflow,
-            PreprocessHeadtailImagesWorkflow,
-            PredictLaserImagesWorkflow,
-            PredictSlateImagesWorkflow,
-            PreprocessLaserImagesWorkflow,
-            PreprocessSlateImagesWorkflow,
-            ValidateLaserLabelsForDiveWorkflow,
-        ],
-        activity_executor=activity_executor,
-        activities=[
-            cluster_dive_frames,
-            compute_laser_depths_activity,
-            measure_fish_activity,
-            perform_laser_calibration_activity,
-            predict_laser_image,
-            predict_slate_image,
-            preprocess_species_image,
-            preprocess_headtail_image,
-            preprocess_laser_image,
-            preprocess_slate_image,
-            validate_laser_labels_for_dive_activity,
-        ],
-        graceful_shutdown_timeout=GRACEFUL_SHUTDOWN_TIMEOUT,
+        activity_executor,
+        max_concurrent_activities,
+        roles.registration_for_role(role),
     )
+
+
+def build_workers(
+    client: Client,
+    activity_executor: ThreadPoolExecutor,
+    max_concurrent_activities: int = DEFAULT_MAX_CONCURRENT_ACTIVITIES,
+    role: str = roles.ROLE_ALL,
+) -> list[Worker]:
+    """Every worker this process should run for ``role``.
+
+    One entry for ``cpu``/``gpu``; both for ``all``, which is what the
+    devcontainer and the integration tests use so a local process still serves
+    every queue the api-worker dispatches to.
+    """
+    return [
+        _build(client, activity_executor, max_concurrent_activities, registration)
+        for registration in roles.registrations_for_role(role)
+    ]
 
 
 async def main():
@@ -171,13 +131,15 @@ async def main():
     configure_logging()
     log = logging.getLogger()
 
+    role = settings.general.get("role", roles.ROLE_ALL)
     tls_config = build_tls_config(settings.temporal)
 
     log.info(
-        "connecting to Temporal host=%s:%d tls=%s",
+        "connecting to Temporal host=%s:%d tls=%s role=%s",
         settings.temporal.host,
         settings.temporal.port,
         bool(tls_config),
+        role,
     )
     client = await Client.connect(
         f"{settings.temporal.host}:{settings.temporal.port}",
@@ -191,14 +153,25 @@ async def main():
         loop.add_signal_handler(sig, interrupt_event.set)
 
     with ThreadPoolExecutor(max_workers=settings.general.max_workers) as executor:
-        async with build_worker(
+        workers = build_workers(
             client,
             executor,
             settings.general.get(
                 "max_concurrent_activities", DEFAULT_MAX_CONCURRENT_ACTIVITIES
             ),
-        ):
-            log.info("Worker started, scheduling workflows...")
+            role=role,
+        )
+        # AsyncExitStack rather than a single `async with`: the `all` role runs
+        # two workers (one per queue) in this one process, and both must be
+        # entered and — importantly — drained on the way out. Exiting the stack
+        # gives each its own graceful-shutdown window.
+        async with AsyncExitStack() as stack:
+            for worker in workers:
+                await stack.enter_async_context(worker)
+            log.info(
+                "Worker started on %s, scheduling workflows...",
+                ", ".join(worker.config()["task_queue"] for worker in workers),
+            )
             await schedule_workflows(client)
             await interrupt_event.wait()
             log.info(

--- a/services/fishsense-data-processing-workflow-worker/tests/test_predict_slate_image.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_predict_slate_image.py
@@ -137,3 +137,69 @@ def test_get_masker_falls_back_to_none_and_caches(monkeypatch):
     assert sut._get_masker() is None
     assert sut._get_masker() is None  # cached
     assert calls["n"] == 1  # loaded once, failure cached
+
+
+def _reset_masker(monkeypatch, checkpoint=""):
+    # pylint: disable=protected-access
+    monkeypatch.setattr(sut, "DEFAULT_SLATE_CHECKPOINT_PATH", checkpoint)
+    monkeypatch.setattr(sut, "_MASKER", None)
+    monkeypatch.setattr(sut, "_MASKER_LOADED", False)
+
+
+@pytest.mark.parametrize(
+    ("cuda_available", "expected"), [(True, "cuda"), (False, "cpu")]
+)
+def test_preferred_device_follows_cuda_availability(
+    monkeypatch, cuda_available, expected
+):
+    # pylint: disable=protected-access
+    """`BoardMasker` defaults to device="cpu" and, unlike `LaserDetector`, does
+    NOT auto-select CUDA — so without asking, the mask runs on the CPU even on
+    a GPU pod. It did exactly that for this activity's whole life."""
+    import torch
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: cuda_available)
+    assert sut._preferred_device() == expected
+
+
+def test_preferred_device_is_cpu_when_torch_is_unusable(monkeypatch):
+    # pylint: disable=protected-access
+    """A broken CUDA runtime must degrade to CPU, not fail the frame. This
+    stage has two independent fallbacks under it and neither should be
+    triggered by merely asking what device to use."""
+    import torch
+
+    def _boom():
+        raise RuntimeError("no CUDA driver")
+
+    monkeypatch.setattr(torch.cuda, "is_available", _boom)
+    assert sut._preferred_device() == "cpu"
+
+
+def test_masker_is_loaded_onto_the_preferred_device(monkeypatch):
+    # pylint: disable=protected-access
+    """The move to the GPU queue is cosmetic unless the device is passed
+    through — pin that it reaches both load paths."""
+    import fishsense_core.slate as slate_mod
+
+    monkeypatch.setattr(sut, "_preferred_device", lambda: "cuda")
+    seen = {}
+
+    def _from_pretrained(*_a, device="cpu", **_k):
+        seen["pretrained"] = device
+        return object()
+
+    def _from_checkpoint(_path, *_a, device="cpu", **_k):
+        seen["checkpoint"] = device
+        return object()
+
+    monkeypatch.setattr(slate_mod.BoardMasker, "from_pretrained", _from_pretrained)
+    monkeypatch.setattr(slate_mod.BoardMasker, "from_checkpoint", _from_checkpoint)
+
+    _reset_masker(monkeypatch)
+    assert sut._get_masker() is not None
+    assert seen == {"pretrained": "cuda"}
+
+    _reset_masker(monkeypatch, checkpoint=__file__)  # any path that exists
+    assert sut._get_masker() is not None
+    assert seen["checkpoint"] == "cuda"

--- a/services/fishsense-data-processing-workflow-worker/tests/test_worker_roles.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_worker_roles.py
@@ -1,0 +1,145 @@
+"""Role split: which queue a worker polls, and what it registers.
+
+The data-worker used to be one process on one queue whose pod requested
+``nvidia.com/gpu: 1``, so every stage — nine CPU activities included — was
+gated on NRP scheduling a Turing-or-newer GPU. It is now split by role: the
+``cpu`` role serves `fishsense_data_processing_queue` and the ``gpu`` role
+serves `fishsense_data_processing_gpu_queue`, which only the two torch
+inference stages land on.
+
+The load-bearing test here is `test_every_registration_lands_in_exactly_one
+_role`. The split is two hand-maintained lists, and the failure mode of
+getting it wrong is silent in both directions: an activity in neither list is
+never registered anywhere, so its workflow's `execute_activity` sits pending
+until the schedule-to-close timeout with nothing logged; an activity in both
+is registered on a queue whose pod may have no GPU. Neither shows up until a
+dive is being processed in prod.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from fishsense_shared import (
+    DATA_PROCESSING_GPU_TASK_QUEUE,
+    DATA_PROCESSING_TASK_QUEUE,
+)
+from temporalio.testing import WorkflowEnvironment
+
+from fishsense_data_processing_workflow_worker import roles
+from fishsense_data_processing_workflow_worker.activities.predict_slate_image import (
+    predict_slate_image,
+)
+from fishsense_data_processing_workflow_worker.workflows.predict_slate_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PredictSlateImagesWorkflow,
+)
+from fishsense_data_processing_workflow_worker.worker import (
+    build_worker,
+    build_workers,
+)
+
+
+def test_role_queues_are_distinct_and_come_from_the_shared_contract():
+    assert roles.queue_for_role(roles.ROLE_CPU) == DATA_PROCESSING_TASK_QUEUE
+    assert roles.queue_for_role(roles.ROLE_GPU) == DATA_PROCESSING_GPU_TASK_QUEUE
+    assert DATA_PROCESSING_TASK_QUEUE != DATA_PROCESSING_GPU_TASK_QUEUE
+
+
+def test_every_registration_lands_in_exactly_one_role():
+    """No activity or workflow may be in both role lists or in neither.
+
+    Both mistakes are silent in prod — see the module docstring.
+    """
+    assert not set(roles.CPU_ACTIVITIES) & set(roles.GPU_ACTIVITIES)
+    assert not set(roles.CPU_WORKFLOWS) & set(roles.GPU_WORKFLOWS)
+    assert set(roles.CPU_ACTIVITIES) | set(roles.GPU_ACTIVITIES) == set(
+        roles.ALL_ACTIVITIES
+    )
+    assert set(roles.CPU_WORKFLOWS) | set(roles.GPU_WORKFLOWS) == set(
+        roles.ALL_WORKFLOWS
+    )
+
+
+def test_gpu_role_holds_exactly_the_torch_inference_stages():
+    """The GPU queue carries the two torch models and nothing else. Anything
+    else there would wait on the GPU-capacity handshake for no benefit."""
+    assert {activity.__name__ for activity in roles.GPU_ACTIVITIES} == {
+        "predict_laser_image",
+        "predict_slate_image",
+    }
+    assert {workflow.__name__ for workflow in roles.GPU_WORKFLOWS} == {
+        "PredictLaserImagesWorkflow",
+        "PredictSlateImagesWorkflow",
+    }
+
+
+def test_slate_prediction_prefers_the_gpu_without_requiring_one():
+    """`predict_slate_image` is on the GPU queue even though it does not need a
+    GPU (fishsense-core measures the mask at 202 ms/frame on CPU).
+
+    That is safe precisely because the GPU queue means *prefer*, not *require*:
+    it is served by the GPU Deployment or, when that can't start, a CPU-only
+    one. So the stage gets the card the laser detector already needs, and is
+    never gated on there being one.
+    """
+    assert predict_slate_image in roles.GPU_ACTIVITIES
+    assert PredictSlateImagesWorkflow in roles.GPU_WORKFLOWS
+
+
+@pytest.mark.parametrize(
+    ("role", "expected_queue"),
+    [
+        (roles.ROLE_CPU, DATA_PROCESSING_TASK_QUEUE),
+        (roles.ROLE_GPU, DATA_PROCESSING_GPU_TASK_QUEUE),
+    ],
+)
+@pytest.mark.asyncio
+async def test_build_worker_polls_the_queue_for_its_role(role, expected_queue):
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            worker = build_worker(env.client, executor, role=role)
+            assert worker.config()["task_queue"] == expected_queue
+
+
+@pytest.mark.asyncio
+async def test_build_worker_rejects_the_all_role():
+    """``all`` is two queues, so it cannot produce one Worker. Callers that
+    want it must use ``build_workers``; silently returning just the CPU half
+    would leave the GPU queue unserved."""
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            with pytest.raises(ValueError):
+                build_worker(env.client, executor, role=roles.ROLE_ALL)
+
+
+@pytest.mark.asyncio
+async def test_build_worker_rejects_an_unknown_role():
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            with pytest.raises(ValueError):
+                build_worker(env.client, executor, role="tpu")
+
+
+@pytest.mark.asyncio
+async def test_build_workers_all_serves_both_queues_in_one_process():
+    """The devcontainer default. One process, both queues — so local runs and
+    the integration tests behave exactly as they did before the split."""
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            workers = build_workers(env.client, executor, role=roles.ROLE_ALL)
+            assert {worker.config()["task_queue"] for worker in workers} == {
+                DATA_PROCESSING_TASK_QUEUE,
+                DATA_PROCESSING_GPU_TASK_QUEUE,
+            }
+
+
+@pytest.mark.asyncio
+async def test_build_workers_single_role_returns_one_worker():
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            workers = build_workers(env.client, executor, role=roles.ROLE_GPU)
+            assert len(workers) == 1
+            assert (
+                workers[0].config()["task_queue"] == DATA_PROCESSING_GPU_TASK_QUEUE
+            )


### PR DESCRIPTION
Part 1 of 2. **Merge this with #632 — it is not a standalone deploy** (see Deploy order).

## Why

One Deployment served every data-worker stage while requesting `nvidia.com/gpu: 1` with node affinity pinned to compute capability >= 7.5. So rectify/overlay/JPEG, frame clustering, laser calibration, fish measurement, laser depth and label validation — none of which touch a GPU — were all gated on NRP finding a Turing-or-newer card with free capacity, and then held that card idle through the hours of rawpy decode that dominate a real dive.

That was already costing us: at `active_replicas = 2` the second pod sat Pending on `129 Insufficient nvidia.com/gpu` (2026-08-20), requesting and queueing for a card it never used. The settings comment recording that is the reason this exists.

## What

`general.role` selects what a worker process registers:

| Role | Queue | Stages |
|---|---|---|
| `cpu` | `fishsense_data_processing_queue` | rectify/overlay/JPEG (0.1 / 2 / 5.1 / 9), clustering, calibration, measurement, laser depth, laser-label validation |
| `gpu` | `fishsense_data_processing_gpu_queue` | `predict_laser_image`, `predict_slate_image` |
| `all` | both, in one process | everything |

`all` is the **default**, so the devcontainer and the integration tests keep serving every queue the api-worker dispatches to — no local behavior changes.

The queue names go in `fishsense_shared.task_queues` for the same reason `preprocess_contracts.py` and `object_store.py` live there: a queue name is an agreement *between* the two workers, so neither owns it. Getting one wrong is silent — the Temporal server accepts the child and it sits `Running` until its execution timeout hours later, with nothing in either worker's logs.

### Why the role vocabulary is its own leaf module

`config.py` validates `general.role`, and `roles.py` imports every activity to build the registration lists. `config -> roles -> activities.utils -> config` is a cycle that fails at **worker startup**, not at test time. `role_names.py` holds the names and imports nothing from the package.

### The exhaustiveness test is the important one

`test_worker_roles.py` asserts the two lists **partition** the full registration set. Both ways of getting that wrong are silent in prod:

- an activity in **neither** list is registered nowhere, so its workflow's `execute_activity` sits pending until schedule-to-close with nothing logged;
- one in **both** is registered on a queue whose pod may have no GPU.

Neither surfaces until a dive is being processed.

## Also here: the slate mask never actually used a GPU

While placing `predict_slate_image` I found `BoardMasker` defaults to `device="cpu"` and — unlike `LaserDetector` — does **not** auto-select CUDA. The activity passed no device, so the learned board mask has been running on the CPU **even on today's GPU-pinned pod**, for its entire life, with nothing in the code saying so.

fishsense-core's default is reasonable for a model it documents at 202 ms/frame and assumed would never be GPU-scheduled. This activity is on the GPU queue now, so it asks. Prefer, not require: a broken CUDA runtime degrades to CPU rather than failing the frame, and there are two independent fallbacks stacked under this stage — GPU -> CPU inference, and BoardMasker -> classical estimator (~13 pts less coverage).

## Deploy order

**This PR is a refactor that is only inert if #632 follows promptly.** On its own it moves the predict workflows onto a queue the current api-worker does not dispatch to, so laser prediction would go unserved until #632 ships. Merge them back to back.

Worth knowing: that window exists regardless of how the code is split, because the api-worker pin and the data-worker `newTag` are always two separate auto-deploy PRs. Blast radius is the two predict stages only — laser prediction seeds Label Studio pre-annotations (a labeler convenience, not a blocker) and slate prediction is retired. Every other stage keeps the same queue name and is unaffected.

## Verification

- 191 data-worker + 168 fishsense-shared tests pass **on this branch alone**; `black --check` clean, pylint 10.00/10 on every changed file.
- New: `test_worker_roles.py` (11 tests) and 5 tests covering the device preference, including that it reaches both `from_checkpoint` and `from_pretrained` — otherwise the move would be cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)