### PR TITLE
feat(api-worker): GPU queue for prediction, with an automatic CPU fallback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -354,7 +354,31 @@ jobs:
             echo "::warning::Deployment is absent and will be recreated - NRP's 2-week GC has collected it. Request a permanent-service exception for the e4e-fishsense namespace (Matrix, https://nrp.ai/contact); see deploy/k8s/data-worker/README.md."
           fi
           kubectl apply -k deploy/k8s/data-worker
-          kubectl rollout status deployment/fishsense-data-processing-workflow-worker --timeout=5m
+          # Three Deployments now: the CPU worker, the GPU worker, and the GPU
+          # worker's CPU-only fallback. Roll them out one at a time.
+          #
+          # The GPU one is allowed to be unschedulable — that is the whole
+          # reason the fallback exists — so a `rollout status` failure there
+          # must NOT fail the deploy. It is reported and moved past; the
+          # api-worker's `ensure_gpu_worker_running_activity` handles it at
+          # runtime by routing predict work to the CPU fallback. Failing here
+          # instead would mean a GPU shortage on NRP blocked shipping the CPU
+          # stages, which is exactly the coupling this release removes.
+          #
+          # Each is normally scaled to 0, and `rollout status` returns
+          # immediately for a Deployment with no desired replicas.
+          for dep in fishsense-data-processing-workflow-worker \
+                     fishsense-data-processing-workflow-worker-gpu-cpu-fallback; do
+            kubectl rollout status "deployment/$dep" --timeout=5m
+          done
+          if ! kubectl rollout status \
+                 deployment/fishsense-data-processing-workflow-worker-gpu --timeout=5m; then
+            echo "::warning::The GPU data-worker did not roll out. This does NOT block the pipeline - after $E4EFS_GPU_MAX_FAILURES failed starts the api-worker routes laser prediction to the CPU fallback. Check GPU capacity/quota on NRP if it persists."
+          fi
+        env:
+          # Only used in the warning text above; keep in step with
+          # `kubernetes.gpu_max_start_failures` in the api-worker settings.
+          E4EFS_GPU_MAX_FAILURES: "3"
 
       - name: Diagnose a failed rollout
         if: failure()

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -81,7 +81,10 @@ jobs:
       - name: Apply the data-worker manifests (server-side validation)
         run: |
           kubectl apply -k deploy/k8s/data-worker
-          kubectl get deployment fishsense-data-processing-workflow-worker -n e4e-fishsense -o yaml
+          # All three: the CPU worker, the GPU worker, and the GPU worker's
+          # CPU-only fallback. The GPU one stays Unschedulable here (kind has no
+          # GPU nodes) — that is expected, and is what the wedge tests rely on.
+          kubectl get deployments -n e4e-fishsense -o wide
 
       - name: Test the slot-side Temporal cert forwarder
         # deploy/incus/nrp_cert_sync/sync.sh runs on the Incus slot and pushes the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,8 @@ landed; the clones behind them are now collapsed into
 | `services/fishsense-api/` | FastAPI app (DB CRUD, label endpoints) | — |
 | `services/fishsense-api-workflow-worker/` | api-side Temporal worker: hourly Label Studio sync (laser/headtail/dive-slate/species), on-demand Create/Populate × {Laser,Species,HeadTail,DiveSlate} LS project workflows, on-demand dive ingestion (`IngestDiveWorkflow`, see below) + checksum verification, hourly preprocess parents for stages 0.1 / 1 / 2 / 5.1 / 9 (select + resolve; dispatch child to data-worker) | `fishsense_api_queue` |
 | `apps/fishsense-lite-web/` | Next.js 15 (App Router) + React + TS landing page at `fishsense.e4e.ucsd.edu`. SSR fetches LS project IDs from fishsense-api, resolves names from Label Studio, renders categorized link cards. Auth.js (next-auth v5) with Authentik OIDC gates `/portal/*`; landing stays public. Replaces the prior mafl dashboard + its hourly config-writer workflow. Will grow into a full web app. | — |
-| `services/fishsense-data-processing-workflow-worker/` | image preprocessing (rectify/overlay/JPEG), laser calibration, fish measurement | `fishsense_data_processing_queue` |
+| `services/fishsense-data-processing-workflow-worker/` | image preprocessing (rectify/overlay/JPEG), laser calibration, fish measurement, laser depth, clustering, label validation | `fishsense_data_processing_queue` (role `cpu`) |
+| ⤷ same package, role `gpu` | torch inference: laser detector + slate masker | `fishsense_data_processing_gpu_queue` |
 | `services/fishsense-backup-worker/` | nightly Postgres → NAS backups + retention | `fishsense_backup_queue` |
 
 The backup worker is **deliberately separate** from the data-processing
@@ -254,7 +255,9 @@ do it as a deliberate, separate change and drain the queue first.
      only raised while a prior populate for that dive is still
      *running*, and the parent catches it so
      the post-cleanup run still completes successfully.
-* **Child** on data-worker (`fishsense_data_processing_queue`). Thin
+* **Child** on data-worker (`fishsense_data_processing_queue`; the two
+  predict children go to `fishsense_data_processing_gpu_queue`
+  instead — see "GPU/CPU worker split"). Thin
   pre-input workflow that fans out per-image activities. No SDK
   calls and no NAS calls; all bytes already in Garage, all decisions
   baked into the input DTO.
@@ -803,6 +806,107 @@ ingest wants, and one code path cannot hold both honestly.
 controller lands, **add `fishsense-api` to `temporal.reload` in `flake.nix`** —
 the tell is the service gaining a `/run/tenant/temporal` mount, and missing it
 means the API silently holds an expired cert until something else restarts it.
+
+## GPU/CPU worker split + CPU fallback
+
+**Added 2026-08-25.** The data-worker is one package that runs in one of two
+roles, on two task queues, as three Kubernetes Deployments.
+
+| Role | Queue | Stages |
+|---|---|---|
+| `cpu` | `fishsense_data_processing_queue` | rectify/overlay/JPEG (0.1 / 2 / 5.1 / 9), clustering, calibration, measurement, laser depth, laser-label validation |
+| `gpu` | `fishsense_data_processing_gpu_queue` | `predict_laser_image`, `predict_slate_image` |
+
+`general.role` selects it (`cpu` / `gpu` / `all`); the registration lists live
+in `roles.py`, the vocabulary in the leaf `role_names.py` (config imports the
+leaf — `config -> roles -> activities.utils -> config` is a cycle), and the two
+queue names in
+[fishsense_shared.task_queues](libs/fishsense-shared/src/fishsense_shared/task_queues.py)
+because they are a cross-worker contract, like `preprocess_contracts.py`.
+`all` runs both in one process and is the default, so the devcontainer and the
+integration tests are unaffected by the split.
+
+**Why.** One Deployment used to serve everything while requesting
+`nvidia.com/gpu: 1` with node affinity pinned to compute capability >= 7.5. So
+every stage — nine of which never touch a GPU — was gated on NRP finding a
+Turing-or-newer card with free capacity, and then held that card idle through
+the hours of rawpy decode that dominate a real dive. At `active_replicas = 2`
+the second pod sat Pending on `Insufficient nvidia.com/gpu` (2026-08-20). The
+CPU Deployment now requests no GPU and cannot be blocked by GPU scarcity.
+
+**The GPU queue means "prefer a GPU", not "require one".** That is the whole
+reason both torch stages live on it. Before the CPU fallback existed, putting a
+stage on a GPU-requesting Deployment *was* gating it on GPU availability; now
+the queue is served by the GPU Deployment or a CPU-only one running the same
+checkpoints, so a stage there gets a card when there is one and still runs when
+there isn't.
+
+The two stages want that for different reasons, and the difference is worth
+knowing. `predict_laser_image` genuinely needs the GPU — CPU inference is a
+real degradation. `predict_slate_image` does not: fishsense-core measures
+`BoardMasker` at 202 ms/frame on CPU and defaults its `device=` to `"cpu"`
+saying as much. It is on the GPU queue anyway because it is still a torch model
+and the card is already there for the laser stage.
+
+That last point needed a code change to be true at all. Unlike `LaserDetector`,
+which picks `"cuda" if torch.cuda.is_available() else "cpu"` internally,
+`BoardMasker` defaults to CPU and never auto-selects — and the activity passed
+no device. So the slate mask ran on the CPU **even on the old GPU-pinned pod**,
+for its whole life, with nothing in the code saying so.
+`predict_slate_image._preferred_device` now asks. Note there are two
+independent degradations stacked under this stage: GPU → CPU inference, and
+BoardMasker → classical estimator (~13 pts less coverage). (It is also RETIRED
+as of 2026-08-03; nothing schedules it.)
+
+**The CPU fallback is the "never block on a GPU" half.** The GPU queue is
+served by *two* Deployments — `...-worker-gpu` and
+`...-worker-gpu-cpu-fallback` — running the same image in the same `gpu` role,
+one with a GPU request and one without. Exactly one is scaled up at a time.
+`LaserDetector.__init__` already defaults to
+`"cuda" if torch.cuda.is_available() else "cpu"` and `predict_laser_image`
+passes no device, so **the fallback needed no detector code at all** — it
+produces the same predictions, slowly.
+
+The policy is pure and lives in
+[activities/gpu_fallback.py](services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/gpu_fallback.py):
+after `gpu_max_start_failures` (3) consecutive failed GPU starts, scale the GPU
+one to 0 and the fallback to `gpu_fallback_replicas` for `gpu_fallback_minutes`
+(180), then probe the GPU again. A "failed start" is `deployment_is_wedged`
+after waiting out `gpu_start_timeout_seconds` (600) — long enough that an image
+pull is not mistaken for an outage. **The window expires on purpose**: without
+it, one bad afternoon on NRP would strand the stage on CPU inference forever.
+
+Three things about it are load-bearing:
+
+* **State lives in annotations on the GPU Deployment**
+  (`fishsense.e4e.ucsd.edu/gpu-start-failures`, `gpu-wedged-since`,
+  `gpu-fallback-until`), not in the api-worker. A counter that reset on every
+  api-worker restart or slot converge would never accumulate across the
+  multi-hour outage the fallback exists for. They are absent when healthy, so
+  their presence is the signal, and an operator can force or end a fallback
+  with `kubectl annotate`.
+* **The hourly sweeper writes only `deployments/scale`, never the
+  annotations.** If routine idle scale-downs also cleared them, a long GPU
+  outage would reset its own failure counter every hour and could never reach
+  the fallback. There is a tripwire test.
+* **`wedge_grace` is clamped to `gpu_start_timeout_seconds`** in
+  `resolve_scaling_config`. The activity waits out the start timeout and *then*
+  observes; a longer grace would swallow every observation and the fallback
+  could never trip.
+
+`ensure_gpu_worker_running_activity` returns `gpu` / `cpu_fallback` /
+`unavailable`. On `unavailable` both predict parents **return before
+staging any bytes** — dispatching onto an unserved queue does not fail, it
+hangs until the child's execution timeout, having staged the dive's raw `.ORF`s
+from NAS for nothing. The dive stays in the cohort for the next firing.
+
+`kubernetes.gpu_active_replicas` is deliberately separate from
+`active_replicas`: the latter now sizes CPU pods, where more is just more
+throughput, while each GPU pod holds a card on a contended cluster.
+
+Operator notes, the annotation table, and the CI behavior (a GPU rollout
+failure is a *warning*, so a GPU shortage cannot block shipping the CPU stages)
+are in `deploy/k8s/data-worker/README.md`.
 
 ## Data-worker activity pattern
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1147,10 +1147,16 @@ two consumers are arranged differently.
   k8s Secret `fishsense-data-worker-temporal-certs`. vault-agent cannot
   reach the cluster, so the slot forwards it:
   `deploy/incus/nrp_cert_sync/` is a one-shot compose service, also listed
-  in `temporal.reload`, that upserts the Secret and `rollout restart`s the
-  Deployment. It short-circuits on an unchanged leaf via a
-  `fishsense.e4e.ucsd.edu/leaf-sha256` annotation, so running it on every
-  converge costs nothing.
+  in `temporal.reload`, that upserts the Secret and `rollout restart`s
+  **every Deployment that mounts it** — since the GPU/CPU split that is all
+  three (`...-worker`, `-gpu`, `-gpu-cpu-fallback`), via `DEPLOY_NAMES` in
+  `sync.sh`. Rolling only one would leave the others holding the expired leaf
+  and crash-looping on `CertificateExpired`, i.e. the 2026-08-14 outage
+  reintroduced through the back door; `test_sync.sh` asserts each one's
+  `restartedAt` actually changes. **Add a Deployment there whenever one gains
+  a `fishsense-data-worker-temporal-certs` mount.** It short-circuits on an
+  unchanged leaf via a `fishsense.e4e.ucsd.edu/leaf-sha256` annotation, so
+  running it on every converge costs nothing.
 
 **This is the shape of the 2026-08-14 outage.** The NRP copy was minted by
 hand at `ttl=720h` and renewed by nobody. It expired, every data-worker pod

--- a/deploy/incus/nrp_cert_sync/sync.sh
+++ b/deploy/incus/nrp_cert_sync/sync.sh
@@ -33,7 +33,15 @@ TEMPORAL_CERT_DIR="${TEMPORAL_CERT_DIR:-/run/tenant/temporal}"
 KUBECONFIG="${KUBECONFIG:-/run/tenant/nrp/kubeconfig}"
 NRP_NAMESPACE="${NRP_NAMESPACE:-e4e-fishsense}"
 SECRET_NAME="${SECRET_NAME:-fishsense-data-worker-temporal-certs}"
+# EVERY Deployment that mounts $SECRET_NAME must be rolled, not just the first.
+# The data-worker is three Deployments as of the GPU/CPU split (cpu, gpu, and
+# the gpu CPU-fallback) and all three mount this same leaf. Rolling only one
+# would leave the others holding an expired cert and crash-looping on
+# `CertificateExpired` — which is precisely the 2026-08-14 outage this whole
+# forwarder exists to prevent, reintroduced through the back door.
+# Space-separated and overridable so CI can point it at one name.
 DEPLOY_NAME="${DEPLOY_NAME:-fishsense-data-processing-workflow-worker}"
+DEPLOY_NAMES="${DEPLOY_NAMES:-${DEPLOY_NAME} ${DEPLOY_NAME}-gpu ${DEPLOY_NAME}-gpu-cpu-fallback}"
 # Records which leaf the Secret currently holds, so a converge that changed
 # nothing does not roll the data-worker.
 FP_ANNOTATION="fishsense.e4e.ucsd.edu/leaf-sha256"
@@ -89,21 +97,31 @@ kubectl -n "$NRP_NAMESPACE" annotate secret "$SECRET_NAME" \
 # at Client.connect - so running pods keep the old leaf until they are replaced.
 # A no-op when the api-worker has it scaled to 0: the annotation lands on the
 # pod template and the next scale-up starts on the new cert.
-log "rolling $DEPLOY_NAME onto the new leaf"
-# kubectl refuses a second `rollout restart` inside the same second ("if restart
-# has already been triggered within the past second"). That guard firing means a
-# restart just landed, which is the outcome we wanted - take it rather than
-# failing the sync under `set -e`. Any other failure is real and propagates.
-if restart_out="$(kubectl -n "$NRP_NAMESPACE" rollout restart "deployment/$DEPLOY_NAME" 2>&1)"; then
-    log "$restart_out"
-else
-    case "$restart_out" in
-        *"within the past second"*)
-            log "a rollout was already triggered this second - taking it" ;;
-        *)
-            log "ERROR: $restart_out"
-            exit 1 ;;
-    esac
-fi
+for deploy in $DEPLOY_NAMES; do
+    # A Deployment that does not exist is skipped rather than fatal: the GPU
+    # pair only exists once the split's manifests have been applied, and a
+    # rotation must not start failing on a cluster that is mid-upgrade.
+    if ! kubectl -n "$NRP_NAMESPACE" get "deployment/$deploy" >/dev/null 2>&1; then
+        log "$deploy not present - skipping"
+        continue
+    fi
+    log "rolling $deploy onto the new leaf"
+    # kubectl refuses a second `rollout restart` inside the same second ("if
+    # restart has already been triggered within the past second"). That guard
+    # firing means a restart just landed, which is the outcome we wanted - take
+    # it rather than failing the sync under `set -e`. Any other failure is real
+    # and propagates.
+    if restart_out="$(kubectl -n "$NRP_NAMESPACE" rollout restart "deployment/$deploy" 2>&1)"; then
+        log "$restart_out"
+    else
+        case "$restart_out" in
+            *"within the past second"*)
+                log "a rollout was already triggered this second - taking it" ;;
+            *)
+                log "ERROR: $restart_out"
+                exit 1 ;;
+        esac
+    fi
+done
 
 log "done ($fingerprint)"

--- a/deploy/incus/nrp_cert_sync/test_sync.sh
+++ b/deploy/incus/nrp_cert_sync/test_sync.sh
@@ -11,6 +11,10 @@ set -euo pipefail
 NS="${NRP_NAMESPACE:-e4e-fishsense}"
 SECRET=fishsense-data-worker-temporal-certs
 DEPLOY=fishsense-data-processing-workflow-worker
+# Every Deployment that mounts the leaf. All three must roll on a rotation, or
+# the ones left behind hold an expired cert and crash-loop on
+# `CertificateExpired` - the 2026-08-14 outage, reintroduced.
+DEPLOYS=("$DEPLOY" "$DEPLOY-gpu" "$DEPLOY-gpu-cpu-fallback")
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 WORK="$(mktemp -d)"
@@ -22,8 +26,14 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 pass() { echo "  ok - $*"; }
 
 restarted_at() {
-    kubectl -n "$NS" get "deployment/$DEPLOY" \
+    kubectl -n "$NS" get "deployment/${1:-$DEPLOY}" \
         -o 'jsonpath={.spec.template.metadata.annotations.kubectl\.kubernetes\.io/restartedAt}' 2>/dev/null || true
+}
+# Concatenated restart stamps for every Deployment, so a check covers the whole
+# set rather than whichever one happens to be first.
+all_restarted_at() {
+    local d
+    for d in "${DEPLOYS[@]}"; do printf '%s=%s;' "$d" "$(restarted_at "$d")"; done
 }
 leaf_annotation() {
     kubectl -n "$NS" get secret "$SECRET" \
@@ -47,8 +57,8 @@ printf 'leaf-v1\n' > "$CERTS/tls.crt"
 printf 'key-v1\n'  > "$CERTS/tls.key"
 printf 'ca-v1\n'   > "$CERTS/ca.crt"
 
-echo "3. first run pushes the leaf and rolls the deployment"
-before_roll="$(restarted_at)"
+echo "3. first run pushes the leaf and rolls every deployment"
+before_roll="$(all_restarted_at)"
 run_sync >/dev/null
 [[ "$(kubectl -n "$NS" get secret "$SECRET" -o jsonpath='{.data.client\.pem}' | base64 -d)" == "leaf-v1" ]] \
     || fail "client.pem was not updated from tls.crt"
@@ -58,30 +68,41 @@ run_sync >/dev/null
     || fail "root-ca.pem was not updated from ca.crt"
 expected="$(sha256sum "$CERTS/tls.crt" | cut -d' ' -f1)"
 [[ "$(leaf_annotation)" == "$expected" ]] || fail "leaf-sha256 annotation not recorded"
-after_roll="$(restarted_at)"
-[[ -n "$after_roll" && "$after_roll" != "$before_roll" ]] || fail "deployment was not rolled"
-pass "secret upserted, annotated, deployment rolled"
+after_roll="$(all_restarted_at)"
+[[ "$after_roll" != "$before_roll" ]] || fail "deployments were not rolled"
+# Assert EACH one individually - a concatenated compare would pass while some
+# were skipped, which is exactly the failure mode being guarded against.
+for d in "${DEPLOYS[@]}"; do
+    [[ -n "$(restarted_at "$d")" ]] || fail "$d was not rolled onto the new leaf"
+done
+pass "secret upserted, annotated, all ${#DEPLOYS[@]} deployments rolled"
 
-echo "4. an unchanged leaf does not roll the deployment again"
+echo "4. an unchanged leaf does not roll the deployments again"
 sleep 1   # restartedAt is second-resolution; without this a real roll could alias
-before_roll="$(restarted_at)"
+before_roll="$(all_restarted_at)"
 out="$(run_sync)"
 grep -q "leaf unchanged" <<<"$out" || fail "expected the unchanged short-circuit, got: $out"
-[[ "$(restarted_at)" == "$before_roll" ]] || fail "deployment was rolled on an unchanged leaf"
+[[ "$(all_restarted_at)" == "$before_roll" ]] || fail "deployments rolled on an unchanged leaf"
 pass "no-op on a converge that rotated nothing"
 
-echo "5. a rotated leaf is pushed and rolls the deployment"
+echo "5. a rotated leaf is pushed and rolls every deployment"
 printf 'leaf-v2\n' > "$CERTS/tls.crt"
 printf 'key-v2\n'  > "$CERTS/tls.key"
 sleep 1
-before_roll="$(restarted_at)"
+before_roll="$(all_restarted_at)"
+declare -A before_each
+for d in "${DEPLOYS[@]}"; do before_each["$d"]="$(restarted_at "$d")"; done
 run_sync >/dev/null
 [[ "$(kubectl -n "$NS" get secret "$SECRET" -o jsonpath='{.data.client\.pem}' | base64 -d)" == "leaf-v2" ]] \
     || fail "rotated client.pem was not pushed"
 [[ "$(leaf_annotation)" == "$(sha256sum "$CERTS/tls.crt" | cut -d' ' -f1)" ]] \
     || fail "leaf-sha256 annotation not updated on rotation"
-[[ "$(restarted_at)" != "$before_roll" ]] || fail "deployment was not rolled on rotation"
-pass "rotation propagates and rolls"
+[[ "$(all_restarted_at)" != "$before_roll" ]] || fail "deployments were not rolled on rotation"
+for d in "${DEPLOYS[@]}"; do
+    [[ "$(restarted_at "$d")" != "${before_each[$d]}" ]] \
+        || fail "$d was not rolled on rotation - it would keep the expired leaf"
+done
+pass "rotation propagates and rolls all ${#DEPLOYS[@]}"
 
 echo "6. it recreates the Secret if it is missing entirely"
 kubectl -n "$NS" delete secret "$SECRET" >/dev/null

--- a/deploy/incus/worker_volumes/api_worker/config/settings.toml
+++ b/deploy/incus/worker_volumes/api_worker/config/settings.toml
@@ -76,10 +76,16 @@ labels_prefix = "fishsense-lite"
 [kubernetes]
 kubeconfig_path = "/run/tenant/nrp/kubeconfig"
 namespace = "e4e-fishsense"
+# The CPU worker. The GPU worker and its CPU-only fallback default off this
+# name (`-gpu`, `-gpu-cpu-fallback`), so all three move together if it changes.
 deployment_name = "fishsense-data-processing-workflow-worker"
-# 1 replica (clamped range is [1, 4]) — one pod, and since the Deployment
-# requests `nvidia.com/gpu: 1` per pod, exactly one GPU held while active.
-# Operator choice 2026-08-20: hold a single GPU on NRP for now.
+# How many CPU worker pods to hold while a stage is active (clamped [1, 4]).
+#
+# As of the 2026-08-25 GPU split this no longer holds a GPU: the CPU Deployment
+# requests none, and the GPU count is `gpu_active_replicas` below. The
+# "Insufficient nvidia.com/gpu" scheduling problem described next therefore no
+# longer applies to this setting — raising it is now an ordinary throughput
+# decision, bounded only by NRP CPU/memory quota.
 #
 # This was 2, paired with dropping the data-worker's
 # `general.max_concurrent_activities` 4 -> 2 after the 2026-07-21 OOM
@@ -89,12 +95,39 @@ deployment_name = "fishsense-data-processing-workflow-worker"
 # takes roughly twice as long; it does NOT reintroduce the OOM, which is
 # governed by max_concurrent_activities and is unchanged.
 #
-# It also removes a live scheduling problem: at 2 the second pod sat Pending on
-# `129 Insufficient nvidia.com/gpu` (2026-08-20), so the GPU was requested and
-# queued for without being used — NRP is GPU-contended and the only consumer of
-# that request, the slate detector, has been retired since 2026-08-03.
+# It also removed a live scheduling problem, which is the history that led to
+# the split: at 2 the second pod sat Pending on `129 Insufficient
+# nvidia.com/gpu` (2026-08-20), so a GPU was requested and queued for without
+# being used. Every CPU stage was paying for a card it never touched.
 #
 # Raise back to 2-4 for a giant single dive, or for active-window resilience on
 # a preemption-prone cluster. Never automatic.
 active_replicas = 1
 idle_cooldown_minutes = 15
+
+# --- GPU worker + CPU fallback ------------------------------------------------
+#
+# `fishsense_data_processing_gpu_queue` carries one stage, `predict_laser_image`
+# (the laser detector). It is served by two Deployments — `...-gpu`, which
+# requests a card, and `...-gpu-cpu-fallback`, which does not and runs the same
+# checkpoint on the CPU. Exactly one is scaled up at a time.
+#
+# After `gpu_max_start_failures` consecutive failed GPU starts the api-worker
+# scales the GPU one to 0 and the fallback to `gpu_fallback_replicas` for
+# `gpu_fallback_minutes`, then probes the GPU again. Slower predictions beat
+# none, and the window expires so a transient NRP shortage can't strand us on
+# CPU permanently. State is kept in annotations on the GPU Deployment
+# (`kubectl describe deploy fishsense-data-processing-workflow-worker-gpu`);
+# absent annotations mean nothing has gone wrong.
+#
+# One card. NRP is GPU-contended (see above) and the detector is fast; this is
+# deliberately decoupled from `active_replicas` so scaling CPU throughput never
+# silently asks for more GPUs.
+gpu_active_replicas = 1
+gpu_fallback_replicas = 1
+# 10 minutes covers an NRP cold start (image pull is the slow part). Anything
+# longer than this and the pod is not coming.
+gpu_start_timeout_seconds = 600
+gpu_max_start_failures = 3
+gpu_fallback_minutes = 180
+gpu_wedge_grace_minutes = 5

--- a/deploy/k8s/data-worker/README.md
+++ b/deploy/k8s/data-worker/README.md
@@ -13,9 +13,11 @@ differs.
 
 | File | What |
 |---|---|
-| `deployment.yaml` | The Deployment. `replicas` is **omitted** — the api-worker owns the count (scales it up on demand, back to 0 when idle; see below). amd64 nodeSelector, resource requests/limits, `maxSurge: 0`, no PDB, emptyDir scratch, no PVC/GPU/NAS. |
+| `deployment.yaml` | The **CPU** worker (`role=cpu`), serving `fishsense_data_processing_queue`. `replicas` is **omitted** — the api-worker owns the count (scales it up on demand, back to 0 when idle; see below). amd64 nodeSelector, resource requests/limits, `maxSurge: 0`, no PDB, emptyDir scratch, no PVC/GPU/NAS. |
+| `deployment-gpu.yaml` | The **GPU** worker (`role=gpu`), serving `fishsense_data_processing_gpu_queue` (laser detector + slate masker). Adds `nvidia.com/gpu: 1`, the `nvidia.com/gpu:NoSchedule` toleration, and SM >= 7.5 node affinity. Allowed to be unschedulable — see "GPU split" below. |
+| `deployment-gpu-cpu-fallback.yaml` | The **CPU fallback** for the GPU queue (`role=gpu`, no GPU request). Runs the same checkpoint on the CPU when the GPU worker repeatedly fails to start. Normally 0 replicas, indefinitely. |
 | `settings.toml` | Source for the `fishsense-data-worker-settings` ConfigMap (built by kustomize's `configMapGenerator`; mounted at `/e4efs/config/settings.toml`). Credentials are **not** here — they're env vars from a Secret. |
-| `kustomization.yaml` | `kubectl apply -k` entrypoint. Holds the overridable image tag (CI bumps it). |
+| `kustomization.yaml` | `kubectl apply -k` entrypoint. Holds the overridable image tag (CI bumps it) — one entry covers all three Deployments, which share an image and differ only by `E4EFS_GENERAL__ROLE`. |
 | `deployer-rbac.yaml` | The **deploy identity**: ServiceAccount `fishsense-deployer` + a least-privilege Role (deployments/scale/configmaps) + RoleBinding + a token-minting Secret. **Not** in `kustomization.yaml` — operator-applied out-of-band (the SA can't create its own RBAC). Credential-free: the token controller populates the Secret's `.data.token` in-cluster; the JWT never enters git. |
 
 ## Who scales it
@@ -25,12 +27,16 @@ no pods run, and work just waits on `fishsense_data_processing_queue`
 until a worker appears. The **api-worker** (running in the Incus slot,
 outside this cluster) brings it back:
 
-* Each parent workflow that dispatches a data-worker child calls
-  `ensure_data_worker_running_activity` first — scales this Deployment
+* Each parent workflow that dispatches a CPU data-worker child calls
+  `ensure_data_worker_running_activity` first — scales `deployment.yaml`
   to `kubernetes.active_replicas` (default 1).
-* `ScaleDownIdleDataWorkerWorkflow` runs hourly and scales it to 0 once
-  the data-worker task queue has had no running or recently-closed
-  workflow for `kubernetes.idle_cooldown_minutes`.
+* The two predict parents instead call
+  `ensure_gpu_worker_running_activity`, which scales **one of** the GPU
+  Deployment or its CPU fallback (see the next section).
+* `ScaleDownIdleDataWorkerWorkflow` runs hourly and scales each of the
+  three to 0 once the queue *it* serves has had no running or
+  recently-closed workflow for `kubernetes.idle_cooldown_minutes`. A busy
+  CPU queue therefore never keeps a GPU pod alive.
 
 For that to work the api-worker needs the `e4e-fishsense` kubeconfig
 (vault-agent-rendered from OpenBao to `/run/tenant/nrp/kubeconfig`, #245)
@@ -39,6 +45,69 @@ and the `[kubernetes]` config section (`kubeconfig_path`, `namespace =
 `idle_cooldown_minutes`) — see the api-worker's `settings.toml` in
 `deploy/incus/worker_volumes/api_worker/config/`. The same kubeconfig is
 what CI uses to `kubectl apply` (repo secret `NRP_KUBECONFIG`).
+
+## GPU split, and why nothing waits on a GPU
+
+Until 2026-08-25 there was one Deployment, one queue, and every stage
+requested `nvidia.com/gpu: 1` with SM >= 7.5 node affinity. So rectify,
+clustering, calibration, measurement and laser depth — none of which touch a
+GPU — were all gated on NRP finding a Turing-or-newer card with free capacity,
+and then held that card idle through the hours of rawpy decode that dominate a
+real dive. At `active_replicas = 2` the second pod sat Pending on
+`Insufficient nvidia.com/gpu` (2026-08-20), paying for a card it never used.
+
+Now:
+
+* **`fishsense_data_processing_queue`** — eight stages, no GPU request. Cannot
+  be blocked by GPU scarcity.
+* **`fishsense_data_processing_gpu_queue`** — the two torch inference stages,
+  `predict_laser_image` and (retired) `predict_slate_image`. Served by *either*
+  `...-worker-gpu` or `...-worker-gpu-cpu-fallback`, never both.
+
+This queue means **prefer a GPU, not require one** — which is what makes it
+safe for a stage that merely benefits from a card. Both detectors run on the
+CPU fallback and produce the **same** output there, just slower.
+
+**The fallback state machine.** After `kubernetes.gpu_max_start_failures`
+(default 3) consecutive failed GPU starts, the api-worker scales the GPU
+Deployment to 0 and the fallback to `kubernetes.gpu_fallback_replicas`, for
+`kubernetes.gpu_fallback_minutes` (default 180), then probes the GPU again. A
+"failed start" is `spec.replicas > 0` with no Ready pod after
+`kubernetes.gpu_start_timeout_seconds` (default 600) — long enough that an
+image pull is not mistaken for an outage. The window expires so a transient NRP
+shortage cannot strand the stage on CPU inference permanently.
+
+Bookkeeping lives in annotations on the **GPU** Deployment:
+
+```
+kubectl -n e4e-fishsense describe deploy fishsense-data-processing-workflow-worker-gpu
+```
+
+| Annotation | Meaning |
+|---|---|
+| `fishsense.e4e.ucsd.edu/gpu-start-failures` | consecutive failed starts |
+| `fishsense.e4e.ucsd.edu/gpu-wedged-since` | when the current wedge was first seen |
+| `fishsense.e4e.ucsd.edu/gpu-fallback-until` | CPU fallback holds until this time |
+
+**All three are absent when everything is healthy**, so seeing any of them is
+itself the signal. They are operator-editable:
+
+```bash
+# Force CPU inference now (e.g. you know the GPU pool is drained):
+kubectl -n e4e-fishsense annotate deploy fishsense-data-processing-workflow-worker-gpu \
+  fishsense.e4e.ucsd.edu/gpu-start-failures=3 --overwrite
+
+# End a fallback early and retry the GPU on the next firing:
+kubectl -n e4e-fishsense annotate deploy fishsense-data-processing-workflow-worker-gpu \
+  fishsense.e4e.ucsd.edu/gpu-fallback-until- fishsense.e4e.ucsd.edu/gpu-start-failures-
+```
+
+`kubectl apply` does not clear them — apply only prunes fields it previously
+managed, and these are written by the api-worker.
+
+**A red GPU rollout in CI is a warning, not a failure.** `deploy.yml` rolls out
+all three but only warns if the GPU one does not converge, precisely so a GPU
+shortage on NRP cannot block shipping the CPU stages.
 
 ## One-time bootstrap (per NRP namespace)
 

--- a/deploy/k8s/data-worker/deployment-gpu-cpu-fallback.yaml
+++ b/deploy/k8s/data-worker/deployment-gpu-cpu-fallback.yaml
@@ -1,0 +1,164 @@
+# fishsense-data-processing-workflow-worker-gpu-cpu-fallback — NRP Deployment.
+#
+# The **CPU fallback** for the GPU queue. Same image, same `gpu` role, same
+# `fishsense_data_processing_gpu_queue` — and no GPU request at all. It exists
+# so that the torch inference stages degrade rather than stop when NRP has no
+# GPU for us: `fishsense_core.laser.LaserDetector` picks
+# `"cuda" if torch.cuda.is_available() else "cpu"` and `predict_laser_image`
+# passes no device, so this pod produces the *same predictions*, just slowly.
+#
+# **Exactly one of this and `...-gpu` is scaled up at a time**, and the
+# api-worker decides which — after `kubernetes.gpu_max_start_failures`
+# consecutive failed GPU starts it scales the GPU one to 0 and this one to
+# `kubernetes.gpu_fallback_replicas`, for `kubernetes.gpu_fallback_minutes`,
+# then probes the GPU again. The bookkeeping lives in annotations on the GPU
+# Deployment. See `fishsense_api_workflow_worker.activities.gpu_fallback`.
+#
+# Steady state is `replicas: 0` and, on a healthy cluster, it stays there
+# indefinitely — this Deployment existing is not a sign anything is wrong.
+#
+# Apply via `kubectl apply -k deploy/k8s/data-worker`.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fishsense-data-processing-workflow-worker-gpu-cpu-fallback
+  labels:
+    app.kubernetes.io/name: fishsense-data-processing-workflow-worker-gpu-cpu-fallback
+    app.kubernetes.io/part-of: fishsense
+    app.kubernetes.io/component: gpu-cpu-fallback
+spec:
+  # `replicas` intentionally omitted — the api-worker owns it. See
+  # deployment.yaml's note; on the first apply k8s defaults it to 1 and the
+  # hourly sweeper drops it to 0.
+  revisionHistoryLimit: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fishsense-data-processing-workflow-worker-gpu-cpu-fallback
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: fishsense-data-processing-workflow-worker-gpu-cpu-fallback
+        app.kubernetes.io/part-of: fishsense
+        app.kubernetes.io/component: gpu-cpu-fallback
+    spec:
+      # fishsense-core ships only a cp313 x86_64 manylinux wheel; NRP
+      # also has arm64 nodes.
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      # No GPU toleration and no GPU node affinity, deliberately: if this pod
+      # were also restricted to GPU nodes it would fail to schedule for exactly
+      # the same reasons the GPU Deployment did, and the fallback would be
+      # worthless.
+      # We're a guest on a shared cluster — let NRP preempt our pods
+      # whenever it needs the capacity. No PodDisruptionBudget on
+      # purpose; an evicted activity just times out and re-runs
+      # (per-image predict is read-only against Garage and the SDK write is an
+      # upsert, so it is idempotent).
+      terminationGracePeriodSeconds: 45   # >= worker.py GRACEFUL_SHUTDOWN_TIMEOUT (30s) + slack
+      # The data-worker never talks to the k8s API (only the api-worker
+      # does, from outside the cluster) — don't mount a SA token.
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: worker
+          # Tag is overridden by kustomization.yaml (shared across all three).
+          image: ghcr.io/ucsd-e4e/fishsense-data-processing-workflow-worker:v2.4.1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: E4EFS_DOCKER
+              value: "true"
+            # The only thing distinguishing this pod from the CPU one.
+            - name: E4EFS_GENERAL__ROLE
+              value: "gpu"
+            # One image at a time. CPU inference is slow and memory-hungry;
+            # concurrency here buys little and risks the decode OOM.
+            - name: E4EFS_GENERAL__MAX_CONCURRENT_ACTIVITIES
+              value: "1"
+            - name: E4EFS_FISHSENSE_API__USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: fishsense-data-worker-secrets
+                  key: fishsense_api_username
+            - name: E4EFS_FISHSENSE_API__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: fishsense-data-worker-secrets
+                  key: fishsense_api_password
+            - name: E4EFS_OBJECT_STORE__ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: fishsense-data-worker-secrets
+                  key: object_store_access_key
+            - name: E4EFS_OBJECT_STORE__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: fishsense-data-worker-secrets
+                  key: object_store_secret_key
+          resources:
+            # Inference is CPU-bound here, so this asks for more cores than the
+            # GPU pod and runs one image at a time (`max_concurrent_activities`
+            # below). Do not raise that cap to claw back throughput: peak
+            # memory is dominated by the full-res rawpy decode (~1-3 GB per
+            # in-flight activity), which is what OOMKilled the worker into
+            # CrashLoopBackOff on 2026-07-21. A backlog here drains slowly on
+            # purpose — the alternative was not draining at all.
+            requests:
+              cpu: "4"
+              memory: 6Gi
+              ephemeral-storage: 2Gi
+            limits:
+              cpu: "8"
+              memory: 16Gi
+              ephemeral-storage: 7Gi
+              # No `nvidia.com/gpu` — the entire point of this Deployment.
+          volumeMounts:
+            - name: settings
+              mountPath: /e4efs/config/settings.toml
+              subPath: settings.toml
+              readOnly: true
+            - name: temporal-certs
+              mountPath: /certs
+              readOnly: true
+            - name: logs
+              mountPath: /e4efs/logs
+            - name: cache
+              mountPath: /e4efs/cache
+            - name: scratch
+              mountPath: /e4efs/data
+      volumes:
+        - name: settings
+          configMap:
+            name: fishsense-data-worker-settings   # kustomize rewrites to the hashed name
+        - name: temporal-certs
+          # Shared with the CPU Deployment — same `CN=fishsense-worker`
+          # identity, so the slot's nrp_cert_sync keeps rotating exactly one
+          # Secret for all three pods.
+          secret:
+            secretName: fishsense-data-worker-temporal-certs
+            items:
+              - key: client.pem
+                path: client/fishsense-data-processing-workflow-worker.pem
+              - key: client.key
+                path: client/fishsense-data-processing-workflow-worker.key
+              - key: root-ca.pem
+                path: ca/root-ca.pem
+        - name: logs
+          emptyDir:
+            sizeLimit: 1Gi
+        - name: cache
+          emptyDir:
+            sizeLimit: 2Gi
+        - name: scratch
+          emptyDir:
+            sizeLimit: 4Gi

--- a/deploy/k8s/data-worker/deployment-gpu.yaml
+++ b/deploy/k8s/data-worker/deployment-gpu.yaml
@@ -1,0 +1,203 @@
+# fishsense-data-processing-workflow-worker-gpu — NRP/Kubernetes Deployment.
+#
+# The GPU half of the split data-worker: role `gpu`, serving
+# `fishsense_data_processing_gpu_queue`. Two torch inference stages run here:
+# `predict_laser_image` (the laser detector, which genuinely needs a GPU) and
+# the retired `predict_slate_image` (which does not — 202 ms/frame on CPU — but
+# rides along on the card that is already here).
+#
+# The queue means *prefer* a GPU, not require one: see the fallback below.
+#
+# Same image as the CPU Deployment; `E4EFS_GENERAL__ROLE` is what differs.
+#
+# **This Deployment is allowed to be unschedulable.** NRP is a shared cluster
+# and a Turing-or-newer card with free capacity is not guaranteed. Nothing else
+# in the pipeline waits on it, and when it repeatedly fails to start, the
+# api-worker scales
+# `fishsense-data-processing-workflow-worker-gpu-cpu-fallback` up instead —
+# the same checkpoint on the CPU, slowly. See
+# `fishsense_api_workflow_worker.activities.gpu_fallback`.
+#
+# That mechanism keeps its bookkeeping in annotations on THIS Deployment's
+# metadata (`fishsense.e4e.ucsd.edu/gpu-start-failures`, `gpu-wedged-since`,
+# `gpu-fallback-until`). They are absent when everything is healthy, so their
+# presence is itself the signal. An operator can force a fallback with
+# `kubectl annotate deploy ... gpu-start-failures=3 --overwrite`, or end one
+# early by removing `gpu-fallback-until`. `kubectl apply` does not clear them —
+# apply only prunes fields it previously managed, and these are written by the
+# api-worker.
+#
+# Replica count is owned by the api-worker, exactly as for the CPU Deployment.
+#
+# Apply via `kubectl apply -k deploy/k8s/data-worker`.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fishsense-data-processing-workflow-worker-gpu
+  labels:
+    app.kubernetes.io/name: fishsense-data-processing-workflow-worker-gpu
+    app.kubernetes.io/part-of: fishsense
+    app.kubernetes.io/component: gpu
+spec:
+  # `replicas` intentionally omitted — the api-worker owns it. See
+  # deployment.yaml's note; on the first apply k8s defaults it to 1 and the
+  # hourly sweeper drops it to 0.
+  revisionHistoryLimit: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fishsense-data-processing-workflow-worker-gpu
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: fishsense-data-processing-workflow-worker-gpu
+        app.kubernetes.io/part-of: fishsense
+        app.kubernetes.io/component: gpu
+    spec:
+      # fishsense-core ships only a cp313 x86_64 manylinux wheel; NRP
+      # also has arm64 nodes.
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      # NRP/Nautilus GPU nodes are commonly tainted `nvidia.com/gpu:NoSchedule`;
+      # tolerate it so we can land there. Harmless on untainted nodes.
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      # GPU compute-capability floor. The laser-detector's torch build
+      # (cu13x / cuDNN 9.2) dropped support for GPUs with SM < 7.5, so a
+      # conv2d on an older card dies at runtime with "cuDNN version 92000 is
+      # not compatible with devices with SM < 7.5" — observed live when NRP
+      # scheduled us onto a GTX 1080 Ti (SM 6.1). Require SM >= 7.5: Turing
+      # (major 7, minor 5) OR Ampere/Ada/Hopper/Blackwell+ (major >= 8).
+      # Excludes Pascal (6.x) and Volta (7.0). Labels come from NVIDIA GPU
+      # Feature Discovery (runs on NRP's GPU nodes). The two nodeSelectorTerms
+      # are OR'd; this AND's with the amd64 nodeSelector above.
+      #
+      # This is also the single biggest reason this Deployment can be
+      # unschedulable, which is what the CPU fallback exists for.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: nvidia.com/gpu.compute.major
+                    operator: In
+                    values: ["8", "9", "10", "11", "12"]
+              - matchExpressions:
+                  - key: nvidia.com/gpu.compute.major
+                    operator: In
+                    values: ["7"]
+                  - key: nvidia.com/gpu.compute.minor
+                    operator: In
+                    values: ["5"]
+      # We're a guest on a shared cluster — let NRP preempt our pods
+      # whenever it needs the capacity. No PodDisruptionBudget on
+      # purpose; an evicted activity just times out and re-runs
+      # (per-image predict is read-only against Garage and the SDK write is an
+      # upsert, so it is idempotent).
+      terminationGracePeriodSeconds: 45   # >= worker.py GRACEFUL_SHUTDOWN_TIMEOUT (30s) + slack
+      # The data-worker never talks to the k8s API (only the api-worker
+      # does, from outside the cluster) — don't mount a SA token.
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: worker
+          # Tag is overridden by kustomization.yaml — the same `images:` entry
+          # covers all three Deployments, since they share one image.
+          image: ghcr.io/ucsd-e4e/fishsense-data-processing-workflow-worker:v2.4.1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: E4EFS_DOCKER
+              value: "true"
+            # The only thing distinguishing this pod from the CPU one.
+            - name: E4EFS_GENERAL__ROLE
+              value: "gpu"
+            - name: E4EFS_FISHSENSE_API__USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: fishsense-data-worker-secrets
+                  key: fishsense_api_username
+            - name: E4EFS_FISHSENSE_API__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: fishsense-data-worker-secrets
+                  key: fishsense_api_password
+            - name: E4EFS_OBJECT_STORE__ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: fishsense-data-worker-secrets
+                  key: object_store_access_key
+            - name: E4EFS_OBJECT_STORE__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: fishsense-data-worker-secrets
+                  key: object_store_secret_key
+          resources:
+            # Lighter on CPU than the CPU Deployment: this pod decodes a raw
+            # frame per image but does the heavy work on the GPU. Memory still
+            # has to cover a full-res rawpy decode (~1-3 GB per in-flight
+            # activity) plus the checkpoint's host-side buffers, so it keeps
+            # the same ceiling — the 2026-07-21 OOMKill/CrashLoopBackOff was a
+            # decode-memory problem, not a GPU one.
+            requests:
+              cpu: "2"
+              memory: 6Gi
+              ephemeral-storage: 2Gi
+            limits:
+              cpu: "4"
+              memory: 16Gi
+              ephemeral-storage: 7Gi
+              # Extended resources must appear in limits; k8s copies it to
+              # requests.
+              nvidia.com/gpu: "1"
+          volumeMounts:
+            - name: settings
+              mountPath: /e4efs/config/settings.toml
+              subPath: settings.toml
+              readOnly: true
+            - name: temporal-certs
+              mountPath: /certs
+              readOnly: true
+            - name: logs
+              mountPath: /e4efs/logs
+            - name: cache
+              mountPath: /e4efs/cache
+            - name: scratch
+              mountPath: /e4efs/data
+      volumes:
+        - name: settings
+          configMap:
+            name: fishsense-data-worker-settings   # kustomize rewrites to the hashed name
+        - name: temporal-certs
+          # Shared with the CPU Deployment — same `CN=fishsense-worker`
+          # identity, so the slot's nrp_cert_sync keeps rotating exactly one
+          # Secret for all three pods.
+          secret:
+            secretName: fishsense-data-worker-temporal-certs
+            items:
+              - key: client.pem
+                path: client/fishsense-data-processing-workflow-worker.pem
+              - key: client.key
+                path: client/fishsense-data-processing-workflow-worker.key
+              - key: root-ca.pem
+                path: ca/root-ca.pem
+        - name: logs
+          emptyDir:
+            sizeLimit: 1Gi
+        - name: cache
+          emptyDir:
+            sizeLimit: 2Gi
+        - name: scratch
+          emptyDir:
+            sizeLimit: 4Gi

--- a/deploy/k8s/data-worker/deployment.yaml
+++ b/deploy/k8s/data-worker/deployment.yaml
@@ -1,6 +1,18 @@
-# fishsense-data-processing-workflow-worker — NRP/Kubernetes Deployment.
+# fishsense-data-processing-workflow-worker — NRP/Kubernetes Deployment (CPU).
 #
-# This is the data-worker's deployment (it no longer runs via compose).
+# The CPU half of the split data-worker: role `cpu`, serving
+# `fishsense_data_processing_queue`. That is eight of the ten stages —
+# rectify/overlay/JPEG (0.1 / 2 / 5.1 / 9), frame clustering, laser
+# calibration, fish measurement, laser depth, and laser-label validation. The
+# two torch inference stages live in deployment-gpu.yaml.
+#
+# **It requests no GPU, and that is the point.** Until 2026-08-25 one
+# Deployment served every stage and requested `nvidia.com/gpu: 1` with node
+# affinity pinned to compute capability >= 7.5, so all of the above was gated
+# on NRP finding a Turing-or-newer card with free capacity — and then held that
+# card idle through the hours of rawpy decode that dominate a real dive. The
+# torch inference stages now live in deployment-gpu.yaml on their own queue.
+#
 # The api-worker (on the orchestrator) drives this Deployment's replica
 # count: parent workflows
 # scale it up to kubernetes.active_replicas before dispatching a child,
@@ -46,38 +58,10 @@ spec:
       # also has arm64 nodes.
       nodeSelector:
         kubernetes.io/arch: amd64
-      # The laser-detector predict stage runs a torch checkpoint on the GPU
-      # (resources below request one). NRP/Nautilus GPU nodes are commonly
-      # tainted `nvidia.com/gpu:NoSchedule`; tolerate it so we can land there.
-      # Harmless on untainted nodes.
-      tolerations:
-        - key: nvidia.com/gpu
-          operator: Exists
-          effect: NoSchedule
-      # GPU compute-capability floor. The laser-detector's torch build
-      # (cu13x / cuDNN 9.2) dropped support for GPUs with SM < 7.5, so a
-      # conv2d on an older card dies at runtime with "cuDNN version 92000 is
-      # not compatible with devices with SM < 7.5" — observed live when NRP
-      # scheduled us onto a GTX 1080 Ti (SM 6.1). Require SM >= 7.5: Turing
-      # (major 7, minor 5) OR Ampere/Ada/Hopper/Blackwell+ (major >= 8).
-      # Excludes Pascal (6.x) and Volta (7.0). Labels come from NVIDIA GPU
-      # Feature Discovery (runs on NRP's GPU nodes). The two nodeSelectorTerms
-      # are OR'd; this AND's with the amd64 nodeSelector above.
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: nvidia.com/gpu.compute.major
-                    operator: In
-                    values: ["8", "9", "10", "11", "12"]
-              - matchExpressions:
-                  - key: nvidia.com/gpu.compute.major
-                    operator: In
-                    values: ["7"]
-                  - key: nvidia.com/gpu.compute.minor
-                    operator: In
-                    values: ["5"]
+      # No GPU toleration and no GPU node affinity on purpose: this pod must be
+      # schedulable on any ordinary amd64 node. Adding either back here would
+      # re-couple the whole pipeline to GPU capacity.
+      #
       # We're a guest on a shared cluster — let NRP preempt our pods
       # whenever it needs the capacity. No PodDisruptionBudget on
       # purpose; an evicted activity just times out and re-runs
@@ -110,6 +94,11 @@ spec:
             # for settings); restated here for clarity.
             - name: E4EFS_DOCKER
               value: "true"
+            # Which half of the split worker this pod is. Set per Deployment
+            # rather than in the shared settings ConfigMap, which all three
+            # Deployments mount. See `roles.py` in the worker.
+            - name: E4EFS_GENERAL__ROLE
+              value: "cpu"
             # HTTP Basic creds the SDK presents to fishsense-api
             # (authentik basic-auth-passthrough on the API route).
             - name: E4EFS_FISHSENSE_API__USERNAME
@@ -164,13 +153,7 @@ spec:
               # can fill to its own cap without tripping the container's
               # overall ephemeral-storage limit and getting evicted first.
               ephemeral-storage: 7Gi
-              # One GPU for the laser-detector predict stage (torch checkpoint).
-              # Extended resources must appear in limits; k8s copies it to
-              # requests. The whole data-worker pod carries the GPU (one
-              # Deployment, one queue) — idle during the non-laser stages, but
-              # the worker scales to zero when the queue is quiet and NRP is
-              # GPU-rich, so a dedicated GPU deployment is only an optimization.
-              nvidia.com/gpu: "1"
+              # Deliberately NO `nvidia.com/gpu` here — see the header.
           volumeMounts:
             - name: settings
               mountPath: /e4efs/config/settings.toml

--- a/deploy/k8s/data-worker/kustomization.yaml
+++ b/deploy/k8s/data-worker/kustomization.yaml
@@ -12,18 +12,30 @@ kind: Kustomization
 # NRP_KUBECONFIG context's default.
 namespace: e4e-fishsense
 
+# Three Deployments, one image, two task queues:
+#   deployment.yaml                  role=cpu, no GPU request
+#   deployment-gpu.yaml              role=gpu, nvidia.com/gpu: 1
+#   deployment-gpu-cpu-fallback.yaml role=gpu, no GPU request
+# The last two both serve `fishsense_data_processing_gpu_queue`; the api-worker
+# scales exactly one of them up. See each file's header.
 resources:
   - deployment.yaml
+  - deployment-gpu.yaml
+  - deployment-gpu-cpu-fallback.yaml
 
 # Builds the `fishsense-data-worker-settings` ConfigMap from the TOML
 # file in this directory and appends a content hash to its name, so a
-# settings change rolls the Deployment. The Deployment references the
-# base name; kustomize rewrites it to the hashed name.
+# settings change rolls the Deployments. All three reference the base
+# name; kustomize rewrites it to the hashed name. Per-Deployment
+# differences (the worker role, the fallback's activity cap) are env vars
+# in the manifests rather than separate ConfigMaps.
 configMapGenerator:
   - name: fishsense-data-worker-settings
     files:
       - settings.toml
 
+# One entry covers all three Deployments — they run the same image, differing
+# only by `E4EFS_GENERAL__ROLE`. CI's `kustomize edit set image` is unchanged.
 images:
   - name: ghcr.io/ucsd-e4e/fishsense-data-processing-workflow-worker
     newTag: v2.16.4

--- a/libs/fishsense-shared/src/fishsense_shared/__init__.py
+++ b/libs/fishsense-shared/src/fishsense_shared/__init__.py
@@ -33,6 +33,10 @@ from fishsense_shared.preprocess_contracts import (
     PreprocessSpeciesImagesInput,
     SlatePredictionResult,
 )
+from fishsense_shared.task_queues import (
+    DATA_PROCESSING_GPU_TASK_QUEUE,
+    DATA_PROCESSING_TASK_QUEUE,
+)
 from fishsense_shared.temporal import (
     build_tls_config,
     ensure_schedule,
@@ -49,6 +53,8 @@ __all__ = [
     "PreflightImage",
     "RejectedImage",
     "SubfolderReport",
+    "DATA_PROCESSING_GPU_TASK_QUEUE",
+    "DATA_PROCESSING_TASK_QUEUE",
     "ClusterDiveFrameImage",
     "ClusterDiveFramesInput",
     "ExceptionGroupErrorLogging",

--- a/libs/fishsense-shared/src/fishsense_shared/task_queues.py
+++ b/libs/fishsense-shared/src/fishsense_shared/task_queues.py
@@ -1,0 +1,41 @@
+"""Temporal task-queue names shared by the api-worker and the data-worker.
+
+These live here for the same reason `preprocess_contracts.py` and
+`object_store.py` do: a task-queue name is an agreement *between* the two
+workers, so neither owns it. The api-worker names the queue when it dispatches
+a child workflow; the data-worker names the queue it polls. A typo on either
+side is silent — the child is accepted by the Temporal server and simply sits
+`Running` until its execution timeout, hours later, with nothing in either
+worker's logs to say why.
+
+Two queues, split by whether the work needs a GPU:
+
+* ``DATA_PROCESSING_TASK_QUEUE`` — the CPU stages: rectify/overlay/JPEG
+  (0.1 / 2 / 5.1 / 9), frame clustering, laser calibration, fish measurement,
+  laser depth, laser-label validation. Nine activities, none of which import
+  torch.
+* ``DATA_PROCESSING_GPU_TASK_QUEUE`` — the two model-inference stages
+  (`predict_laser_image`, and the retired `predict_slate_image`), which run a
+  torch checkpoint through `fishsense_core.laser.LaserDetector`.
+
+The split exists because the two have opposite scheduling needs. Before it,
+one Deployment served everything and requested ``nvidia.com/gpu: 1`` with node
+affinity pinned to compute capability >= 7.5 — so *every* stage was gated on
+NRP finding a Turing-or-newer GPU with free capacity, and the GPU sat idle
+through the hours of rawpy decode that dominate a real dive. Now the CPU
+Deployment carries no GPU request at all and cannot be blocked by GPU scarcity.
+
+The GPU queue is deliberately served by **two** Deployments — the GPU one and a
+CPU-only fallback that runs the same checkpoint on the CPU when the GPU one
+repeatedly fails to start. They share this queue name precisely so that no
+workflow has to know which is running; see
+`fishsense_api_workflow_worker.activities.gpu_fallback`.
+"""
+
+DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
+DATA_PROCESSING_GPU_TASK_QUEUE = "fishsense_data_processing_gpu_queue"
+
+__all__ = [
+    "DATA_PROCESSING_GPU_TASK_QUEUE",
+    "DATA_PROCESSING_TASK_QUEUE",
+]

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/ensure_gpu_worker_running_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/ensure_gpu_worker_running_activity.py
@@ -1,0 +1,171 @@
+"""Scale up whatever can serve the data-worker's GPU queue, and say which.
+
+The counterpart of `ensure_data_worker_running_activity` for
+`fishsense_data_processing_gpu_queue`. That queue is served by two
+Deployments running the same image in the same ``gpu`` role — one with a GPU,
+one without — and this activity picks between them, scales it up, waits for a
+pod, and returns the mode so the calling parent knows what happened:
+
+* ``gpu`` — the GPU Deployment is up (or k8s scaling isn't configured at all,
+  in which case the data-worker is assumed always-on, as it is locally).
+* ``cpu_fallback`` — the GPU Deployment has failed to start too many times;
+  the CPU-only Deployment is up and will run the same checkpoint slowly.
+* ``unavailable`` — nothing came up inside the start timeout. **The caller must
+  skip this firing**: dispatching a child onto a queue with no worker doesn't
+  fail, it hangs, sitting `Running` until its execution timeout hours later.
+
+The policy itself is pure and lives in `gpu_fallback.decide`; this module is
+only the I/O around it — one Deployment read (annotations *and* readiness from
+the same object, so the two can't disagree), the scale calls, the annotation
+write-back, and the readiness poll.
+
+**Why it waits.** The wait is what separates "the GPU is unavailable" from "the
+pod is still pulling its image". Without it, every cold start would count
+toward the fallback threshold and a healthy cluster would drift onto CPU
+inference. `resolve_scaling_config` clamps the wedge grace to no more than this
+timeout, so the observation that follows a timed-out wait always counts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+from temporalio import activity
+
+from fishsense_api_workflow_worker.activities.gpu_fallback import (
+    MODE_CPU_FALLBACK,
+    MODE_GPU,
+    MODE_UNAVAILABLE,
+    GpuDecision,
+    GpuState,
+    decide,
+)
+from fishsense_api_workflow_worker.activities.k8s_scaling import (
+    ScalingConfig,
+    apps_v1_api,
+    patch_deployment_annotations,
+    readiness,
+    resolve_scaling_config,
+    set_deployment_replicas,
+)
+
+#: How often to re-read a Deployment while waiting for a pod to go Ready.
+#: Tests set this to 0.
+POLL_INTERVAL_SECONDS = 10
+
+
+def _deployment_for(config: ScalingConfig, mode: str) -> str:
+    return (
+        config.gpu.fallback_deployment_name
+        if mode == MODE_CPU_FALLBACK
+        else config.gpu.deployment_name
+    )
+
+
+def _apply(config: ScalingConfig) -> GpuDecision:
+    """One decision cycle, all of it on a worker thread.
+
+    Reads the GPU Deployment once — the annotations carry the fallback state
+    and the same object carries readiness — runs the pure policy over it, then
+    writes the outcome: an absolute replica count for each Deployment (never an
+    increment, so overlapping parent firings converge rather than accumulate)
+    and the updated bookkeeping.
+    """
+    api = apps_v1_api(config.kubeconfig_path)
+    deployment = api.read_namespaced_deployment(
+        name=config.gpu.deployment_name, namespace=config.namespace
+    )
+    metadata = getattr(deployment, "metadata", None)
+    state = GpuState.from_annotations(getattr(metadata, "annotations", None))
+    status = readiness(deployment)
+
+    decision = decide(
+        state,
+        now=datetime.now(timezone.utc),
+        gpu_ready=status.ready,
+        gpu_wedged=status.wedged,
+        policy=config.gpu.policy,
+    )
+
+    set_deployment_replicas(
+        api, config.namespace, config.gpu.deployment_name, decision.gpu_replicas
+    )
+    set_deployment_replicas(
+        api,
+        config.namespace,
+        config.gpu.fallback_deployment_name,
+        decision.fallback_replicas,
+    )
+    if decision.state != state:
+        patch_deployment_annotations(
+            api,
+            config.namespace,
+            config.gpu.deployment_name,
+            decision.state.to_annotations(),
+        )
+    return decision
+
+
+def _is_ready(config: ScalingConfig, name: str) -> bool:
+    api = apps_v1_api(config.kubeconfig_path)
+    return readiness(
+        api.read_namespaced_deployment(name=name, namespace=config.namespace)
+    ).ready
+
+
+async def _wait_ready(config: ScalingConfig, name: str) -> bool:
+    """Poll ``name`` until a pod is Ready or the start timeout elapses.
+
+    Heartbeats so a long cold start doesn't look like a hung activity.
+    """
+    deadline = asyncio.get_running_loop().time() + config.gpu.start_timeout_seconds
+    while True:
+        if await asyncio.to_thread(_is_ready, config, name):
+            return True
+        if asyncio.get_running_loop().time() >= deadline:
+            return False
+        activity.heartbeat()
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+
+
+@activity.defn
+async def ensure_gpu_worker_running_activity() -> str:
+    """Bring up a worker for the GPU queue; return ``gpu`` / ``cpu_fallback``
+    / ``unavailable``."""
+    config = resolve_scaling_config()
+    if config is None:
+        activity.logger.info(
+            "k8s scaling not configured; assuming the GPU data-worker is always-on"
+        )
+        return MODE_GPU
+
+    decision = await asyncio.to_thread(_apply, config)
+    activity.logger.info("GPU capacity: %s (%s)", decision.mode, decision.reason)
+
+    if await _wait_ready(config, _deployment_for(config, decision.mode)):
+        return decision.mode
+
+    if decision.mode == MODE_GPU:
+        # The wait timed out, so this start failed. Observe it again — that is
+        # what increments the counter, and it may flip us to the CPU fallback.
+        decision = await asyncio.to_thread(_apply, config)
+        activity.logger.warning(
+            "GPU data-worker did not become ready within %ds: %s",
+            config.gpu.start_timeout_seconds,
+            decision.reason,
+        )
+        if decision.mode == MODE_CPU_FALLBACK and await _wait_ready(
+            config, config.gpu.fallback_deployment_name
+        ):
+            return MODE_CPU_FALLBACK
+
+    # Nothing is serving the queue. Say so rather than let the caller dispatch
+    # a child that would hang until its execution timeout.
+    activity.logger.warning(
+        "no worker could be started for the GPU queue (%s / %s); "
+        "skipping this firing - the cohort selector will pick the dive up again",
+        config.gpu.deployment_name,
+        config.gpu.fallback_deployment_name,
+    )
+    return MODE_UNAVAILABLE

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/gpu_fallback.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/gpu_fallback.py
@@ -1,0 +1,272 @@
+"""GPU -> CPU fallback policy for the data-worker's predict queue.
+
+`fishsense_data_processing_gpu_queue` is served by **two** Deployments running
+the same image in the same ``gpu`` role: one that requests
+``nvidia.com/gpu: 1`` and one that requests none and runs the same torch
+checkpoint on the CPU. Exactly one of them is scaled up at a time. This module
+decides which.
+
+It exists because the GPU one can fail to start for reasons entirely outside
+our control — NRP has no free Turing-or-newer card, our quota is exhausted, the
+node pool is drained, the image tag is bad — and when it does, the queue never
+drains. `fishsense_core.laser.LaserDetector` already picks
+``"cuda" if torch.cuda.is_available() else "cpu"`` and `predict_laser_image`
+passes no device, so the CPU Deployment produces the *same predictions*, just
+slowly. Slow predictions beat none: the requirement this implements is that
+nothing in the pipeline is ever blocked on a GPU being available.
+
+**The state lives in annotations on the GPU Deployment**, not in this process:
+a counter that resets whenever the api-worker restarts or the slot converges
+would never accumulate across a multi-hour outage, which is exactly the case
+the fallback is for. Annotations also make the state operator-visible
+(`kubectl describe`) and operator-editable — an operator can force a fallback
+with `kubectl annotate ... gpu-start-failures=3 --overwrite`, or end one early
+by removing `gpu-fallback-until`.
+
+`decide` is pure, and deliberately so: the interesting behavior is a sequence
+spanning hours (wedge, count, flip, hold, expire, probe) that cannot be
+reproduced quickly against a real cluster. `tests/test_gpu_fallback.py` walks
+the whole state machine in milliseconds.
+
+Two asymmetries worth keeping:
+
+* Counting is per *observation*, not per second of wedge — the wedge clock
+  restarts each time a failure is counted, so one continuous outage counts once
+  per parent firing (hourly) rather than instantly exhausting the budget.
+* The fallback window **expires**. Without it, one bad afternoon on NRP would
+  strand the pipeline on CPU inference permanently.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta, timezone
+from typing import Final, Mapping
+
+_log = logging.getLogger(__name__)
+
+# Annotation keys. Prefixed with our domain the same way
+# `deploy/incus/nrp_cert_sync` stamps `fishsense.e4e.ucsd.edu/leaf-sha256`.
+ANNOTATION_PREFIX: Final = "fishsense.e4e.ucsd.edu/"
+FAILURES_ANNOTATION: Final = f"{ANNOTATION_PREFIX}gpu-start-failures"
+WEDGED_SINCE_ANNOTATION: Final = f"{ANNOTATION_PREFIX}gpu-wedged-since"
+FALLBACK_UNTIL_ANNOTATION: Final = f"{ANNOTATION_PREFIX}gpu-fallback-until"
+
+MODE_GPU: Final = "gpu"
+MODE_CPU_FALLBACK: Final = "cpu_fallback"
+#: Neither Deployment came up inside the start timeout. The caller should skip
+#: this firing entirely rather than dispatch a child onto an unserved queue.
+MODE_UNAVAILABLE: Final = "unavailable"
+
+
+def _parse_timestamp(raw: str | None) -> datetime | None:
+    """Parse an annotation timestamp, treating a naive one as UTC.
+
+    Naive matters: these are hand-editable, and `kubectl annotate` by hand
+    rarely includes an offset. Reading a naive stamp as local time would shift
+    the fallback window by however far the box is from UTC.
+    """
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        _log.warning("ignoring unparseable GPU-fallback timestamp %r", raw)
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_timestamp(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass(frozen=True)
+class GpuState:
+    """Fallback bookkeeping, as read from / written to the GPU Deployment.
+
+    The default is "no history": no failed starts recorded, no wedge in
+    progress, not in fallback. Every malformed annotation degrades to this,
+    which costs at most a few extra GPU attempts and never a crash.
+    """
+
+    failures: int = 0
+    wedged_since: datetime | None = None
+    fallback_until: datetime | None = None
+
+    @classmethod
+    def from_annotations(cls, annotations: Mapping[str, str] | None) -> GpuState:
+        """Read state out of a Deployment's annotations, leniently.
+
+        These are operator-editable by design, so a typo must not take the
+        predict stage down — every unreadable field falls back to its default
+        with a warning rather than raising.
+        """
+        annotations = annotations or {}
+        raw_failures = annotations.get(FAILURES_ANNOTATION)
+        failures = 0
+        if raw_failures:
+            try:
+                failures = max(0, int(raw_failures))
+            except ValueError:
+                _log.warning(
+                    "ignoring unparseable %s=%r", FAILURES_ANNOTATION, raw_failures
+                )
+        return cls(
+            failures=failures,
+            wedged_since=_parse_timestamp(annotations.get(WEDGED_SINCE_ANNOTATION)),
+            fallback_until=_parse_timestamp(annotations.get(FALLBACK_UNTIL_ANNOTATION)),
+        )
+
+    def to_annotations(self) -> dict[str, str | None]:
+        """Annotation patch for this state.
+
+        A ``None`` value **removes** the annotation in a strategic-merge patch,
+        which is why an empty state clears all three rather than writing "0"
+        and two empty strings: `kubectl describe` on a healthy GPU Deployment
+        then shows no fallback bookkeeping at all, so the presence of any of
+        these keys is itself the signal that something went wrong.
+        """
+        return {
+            FAILURES_ANNOTATION: str(self.failures) if self.failures else None,
+            WEDGED_SINCE_ANNOTATION: _format_timestamp(self.wedged_since),
+            FALLBACK_UNTIL_ANNOTATION: _format_timestamp(self.fallback_until),
+        }
+
+
+@dataclass(frozen=True)
+class FallbackPolicy:
+    """Tunables, resolved from the api-worker's ``[kubernetes]`` config."""
+
+    active_replicas: int = 1
+    fallback_replicas: int = 1
+    max_start_failures: int = 3
+    wedge_grace: timedelta = timedelta(minutes=5)
+    fallback_window: timedelta = timedelta(hours=3)
+
+
+@dataclass(frozen=True)
+class GpuDecision:
+    """What to do now, and the state to write back."""
+
+    mode: str
+    gpu_replicas: int
+    fallback_replicas: int
+    state: GpuState
+    reason: str
+
+
+def _decide_wedged(
+    state: GpuState, *, now: datetime, policy: FallbackPolicy
+) -> GpuDecision:
+    """The GPU Deployment wants pods and has none Ready. Count it, or flip.
+
+    Split out of `decide` so each function reads as one decision rather than a
+    ladder; the ordering here is the whole policy.
+    """
+    if state.wedged_since is None:
+        # First sighting. A pod still pulling its image is not a failed start,
+        # so only start the clock.
+        return GpuDecision(
+            MODE_GPU,
+            policy.active_replicas,
+            0,
+            replace(state, wedged_since=now),
+            "GPU worker has no ready pod yet; starting the grace clock",
+        )
+
+    if now - state.wedged_since < policy.wedge_grace:
+        return GpuDecision(
+            MODE_GPU,
+            policy.active_replicas,
+            0,
+            state,
+            "GPU worker still starting, inside the grace window",
+        )
+
+    failures = state.failures + 1
+    if failures >= policy.max_start_failures:
+        return GpuDecision(
+            MODE_CPU_FALLBACK,
+            0,
+            policy.fallback_replicas,
+            GpuState(
+                failures=failures,
+                wedged_since=None,
+                fallback_until=now + policy.fallback_window,
+            ),
+            f"GPU worker failed to start {failures} times; "
+            f"falling back to CPU inference for {policy.fallback_window}",
+        )
+
+    # Restart the clock so a continuous wedge counts once per observation
+    # rather than on every poll.
+    return GpuDecision(
+        MODE_GPU,
+        policy.active_replicas,
+        0,
+        GpuState(failures=failures, wedged_since=now),
+        f"GPU worker failed to start ({failures}/{policy.max_start_failures}); "
+        "retrying on the GPU",
+    )
+
+
+def decide(
+    state: GpuState,
+    *,
+    now: datetime,
+    gpu_ready: bool,
+    gpu_wedged: bool,
+    policy: FallbackPolicy,
+) -> GpuDecision:
+    """Choose which Deployment serves the GPU queue, and update the state.
+
+    ``gpu_ready`` / ``gpu_wedged`` come from a single read of the GPU
+    Deployment (see `k8s_scaling.readiness`). Both are False for a Deployment
+    scaled to 0 — the ordinary cold-start case, which is neither success nor
+    failure.
+    """
+    if state.fallback_until is not None:
+        if now < state.fallback_until:
+            return GpuDecision(
+                MODE_CPU_FALLBACK,
+                0,
+                policy.fallback_replicas,
+                state,
+                f"in the CPU fallback window until {_format_timestamp(state.fallback_until)}",
+            )
+        # Expired. Clean slate, so the GPU gets a full budget of attempts
+        # again — a transient NRP shortage must not strand us on CPU forever.
+        return GpuDecision(
+            MODE_GPU,
+            policy.active_replicas,
+            0,
+            GpuState(),
+            "CPU fallback window expired; probing the GPU worker again",
+        )
+
+    if gpu_ready:
+        return GpuDecision(
+            MODE_GPU,
+            policy.active_replicas,
+            0,
+            GpuState(),
+            "GPU worker is ready",
+        )
+
+    if gpu_wedged:
+        return _decide_wedged(state, now=now, policy=policy)
+
+    # Scaled to zero, or scaled up with pods still being counted: neither a
+    # success nor a failure. Scale up and leave the bookkeeping alone.
+    return GpuDecision(
+        MODE_GPU,
+        policy.active_replicas,
+        0,
+        state,
+        "scaling the GPU worker up",
+    )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/k8s_scaling.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/k8s_scaling.py
@@ -26,8 +26,15 @@ accident:
 from __future__ import annotations
 
 import ssl
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import timedelta
 
+from fishsense_shared import (
+    DATA_PROCESSING_GPU_TASK_QUEUE,
+    DATA_PROCESSING_TASK_QUEUE,
+)
+
+from fishsense_api_workflow_worker.activities.gpu_fallback import FallbackPolicy
 from fishsense_api_workflow_worker.config import settings
 
 # Upper bound on the active-window replica count. >1 is only ever a
@@ -38,6 +45,34 @@ MAX_ACTIVE_REPLICAS = 4
 MIN_ACTIVE_REPLICAS = 1
 
 DEFAULT_DEPLOYMENT_NAME = "fishsense-data-processing-workflow-worker"
+# The GPU half of the split worker, and the CPU-only Deployment that serves the
+# same `fishsense_data_processing_gpu_queue` when the GPU one cannot start.
+# Exactly one of the two is ever scaled up; see `gpu_fallback`.
+DEFAULT_GPU_DEPLOYMENT_NAME = f"{DEFAULT_DEPLOYMENT_NAME}-gpu"
+DEFAULT_GPU_FALLBACK_DEPLOYMENT_NAME = f"{DEFAULT_GPU_DEPLOYMENT_NAME}-cpu-fallback"
+
+# The CPU fallback runs the same torch checkpoint without a GPU, so it is far
+# slower per image and there is no point running several. Capped low
+# independently of `active_replicas`, which sizes GPU pods.
+MAX_FALLBACK_REPLICAS = 2
+
+
+@dataclass(frozen=True)
+class GpuScalingConfig:
+    """Which Deployment serves the GPU queue, and when to stop waiting for it.
+
+    ``deployment_name`` requests a GPU; ``fallback_deployment_name`` does not
+    and runs the same torch checkpoint on the CPU. Exactly one is scaled up at
+    a time — see `activities.gpu_fallback`.
+    """
+
+    deployment_name: str = DEFAULT_GPU_DEPLOYMENT_NAME
+    fallback_deployment_name: str = DEFAULT_GPU_FALLBACK_DEPLOYMENT_NAME
+    # How long to wait for a pod before calling a start attempt failed. This is
+    # what separates "no GPU is available" from "the pod is still pulling its
+    # image".
+    start_timeout_seconds: int = 600
+    policy: FallbackPolicy = field(default_factory=FallbackPolicy)
 
 
 @dataclass(frozen=True)
@@ -49,6 +84,27 @@ class ScalingConfig:
     deployment_name: str
     active_replicas: int
     idle_cooldown_minutes: int
+    # Grouped rather than flattened: these four are one subsystem (which
+    # Deployment serves the GPU queue, and when to give up on the GPU one), and
+    # they are the only part of the config a caller that just wants the CPU
+    # worker never touches. Defaulted so such a caller — or a test — need not
+    # restate the GPU topology; `resolve_scaling_config` always sets it fully.
+    gpu: GpuScalingConfig = field(default_factory=GpuScalingConfig)
+
+    def sweep_targets(self) -> tuple[tuple[str, str], ...]:
+        """Every (deployment, task queue) pair the idle sweeper must consider.
+
+        Three Deployments, two queues: the CPU worker owns
+        `fishsense_data_processing_queue`, while the GPU worker and its CPU
+        fallback both serve `fishsense_data_processing_gpu_queue` (only one of
+        them is up at a time). Returning the pairing here keeps the sweeper
+        from having to know the topology.
+        """
+        return (
+            (self.deployment_name, DATA_PROCESSING_TASK_QUEUE),
+            (self.gpu.deployment_name, DATA_PROCESSING_GPU_TASK_QUEUE),
+            (self.gpu.fallback_deployment_name, DATA_PROCESSING_GPU_TASK_QUEUE),
+        )
 
 
 def resolve_scaling_config() -> ScalingConfig | None:
@@ -77,12 +133,62 @@ def resolve_scaling_config() -> ScalingConfig | None:
         min(int(section.get("active_replicas", 1)), MAX_ACTIVE_REPLICAS),
     )
     idle_cooldown_minutes = max(0, int(section.get("idle_cooldown_minutes", 15)))
+
+    # GPU names default off `deployment_name` rather than off the module
+    # constant, so overriding the CPU name (a test namespace, a second
+    # environment) carries the whole trio with it instead of silently pairing a
+    # renamed CPU Deployment with the stock GPU ones.
+    gpu_deployment_name = section.get("gpu_deployment_name") or f"{deployment_name}-gpu"
+    gpu_fallback_deployment_name = (
+        section.get("gpu_fallback_deployment_name")
+        or f"{gpu_deployment_name}-cpu-fallback"
+    )
+    # The grace window must not outlast the start timeout. `ensure_gpu_worker_
+    # running_activity` waits out `gpu_start_timeout_seconds` for a pod, then
+    # observes; if the grace were longer, that observation would always land
+    # inside it, no failure would ever be counted, and the CPU fallback could
+    # never trip — the one outcome this whole mechanism exists to prevent.
+    gpu_start_timeout_seconds = max(
+        0, int(section.get("gpu_start_timeout_seconds", 600))
+    )
+    wedge_grace_seconds = min(
+        max(0, int(section.get("gpu_wedge_grace_minutes", 5))) * 60,
+        gpu_start_timeout_seconds,
+    )
+    # The GPU count is deliberately NOT `active_replicas`. That setting now
+    # sizes the CPU worker, where more pods is simply more throughput; here
+    # each pod holds a GPU on a contended shared cluster. At 2 the second pod
+    # sat Pending on "Insufficient nvidia.com/gpu" (2026-08-20) — requesting
+    # and queueing for a card without using it. Defaults to 1, independently.
+    gpu_active_replicas = max(
+        MIN_ACTIVE_REPLICAS,
+        min(int(section.get("gpu_active_replicas", 1)), MAX_ACTIVE_REPLICAS),
+    )
+    fallback_policy = FallbackPolicy(
+        active_replicas=gpu_active_replicas,
+        fallback_replicas=max(
+            1, min(int(section.get("gpu_fallback_replicas", 1)), MAX_FALLBACK_REPLICAS)
+        ),
+        # At least 1, or the pipeline would drop to CPU inference on the very
+        # first observation and never actually try the GPU.
+        max_start_failures=max(1, int(section.get("gpu_max_start_failures", 3))),
+        wedge_grace=timedelta(seconds=wedge_grace_seconds),
+        fallback_window=timedelta(
+            minutes=max(1, int(section.get("gpu_fallback_minutes", 180)))
+        ),
+    )
     return ScalingConfig(
         kubeconfig_path=kubeconfig_path,
         namespace=namespace,
         deployment_name=deployment_name,
         active_replicas=active_replicas,
         idle_cooldown_minutes=idle_cooldown_minutes,
+        gpu=GpuScalingConfig(
+            deployment_name=gpu_deployment_name,
+            fallback_deployment_name=gpu_fallback_deployment_name,
+            start_timeout_seconds=gpu_start_timeout_seconds,
+            policy=fallback_policy,
+        ),
     )
 
 
@@ -185,14 +291,67 @@ def deployment_is_wedged(api, namespace: str, name: str) -> bool:
     scales it straight back up, and per-image activities are idempotent by
     design, so the children it interrupts simply re-run.
     """
-    deployment = api.read_namespaced_deployment(name=name, namespace=namespace)
+    return readiness(
+        api.read_namespaced_deployment(name=name, namespace=namespace)
+    ).wedged
+
+
+@dataclass(frozen=True)
+class Readiness:
+    """What one Deployment read says about whether its pods are serving.
+
+    ``ready`` and ``wedged`` are not complements: a Deployment scaled to 0 is
+    neither, which is the ordinary state of every data-worker Deployment for
+    most of the hour. `gpu_fallback.decide` depends on being able to tell that
+    third case apart — counting a scaled-to-zero Deployment as a failed start
+    would trip the CPU fallback during normal idle operation.
+    """
+
+    desired: int
+    ready_count: int
+
+    @property
+    def ready(self) -> bool:
+        """At least one pod is Ready, so the queue can drain."""
+        return self.ready_count > 0
+
+    @property
+    def wedged(self) -> bool:
+        """Pods are wanted and none is Ready."""
+        return self.desired > 0 and self.ready_count == 0
+
+
+def readiness(deployment) -> Readiness:
+    """Read `Readiness` off a Deployment object.
+
+    Takes the object rather than (api, namespace, name) so a caller that also
+    needs the annotations — `ensure_gpu_worker_running_activity` does — can
+    spend one API read on both instead of racing two.
+    """
     desired = (deployment.spec.replicas if deployment.spec else None) or 0
     status = deployment.status
     # k8s OMITS readyReplicas rather than sending 0, so this is None in exactly
     # the wedged case. Reading None as "unknown, assume healthy" is what would
     # keep the GPUs pinned.
-    ready = (status.ready_replicas if status else None) or 0
-    return desired > 0 and ready == 0
+    ready_count = (status.ready_replicas if status else None) or 0
+    return Readiness(desired=desired, ready_count=ready_count)
+
+
+def patch_deployment_annotations(
+    api, namespace: str, name: str, annotations: dict[str, str | None]
+) -> None:
+    """Merge annotations onto a Deployment; a ``None`` value removes the key.
+
+    This is a metadata-only strategic-merge patch. It deliberately never
+    touches `spec.template`, so it cannot roll the pods — an annotation write
+    on the *pod template* would restart the very worker we are trying to get
+    running. `tests/test_ensure_gpu_worker_running_activity.py` pins that.
+    """
+    api.patch_namespaced_deployment(
+        name=name,
+        namespace=namespace,
+        body={"metadata": {"annotations": annotations}},
+    )
 
 
 def set_deployment_replicas(api, namespace: str, name: str, replicas: int) -> None:

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/scale_down_data_worker_if_idle_activity.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/activities/scale_down_data_worker_if_idle_activity.py
@@ -1,4 +1,4 @@
-"""Scale the NRP data-worker back to zero when its task queue is quiet.
+"""Scale the NRP data-worker Deployments back to zero when their queues are quiet.
 
 Run hourly by ``ScaleDownIdleDataWorkerWorkflow`` (after the last
 preprocess/calibration parent firing). It's the *only* thing that
@@ -7,13 +7,24 @@ overlapping parents across stages can't fight it: they all converge
 on ``active_replicas``, and the sweeper drops it to 0 once nothing's
 running.
 
-"Quiet" = no workflow on ``fishsense_data_processing_queue`` is
-Running *and* none has closed within ``idle_cooldown_minutes`` (so a
-back-to-back dive doesn't thrash the pod up/down). The data-worker
-task queue is the right signal because every data-worker workflow —
-the four preprocess children, clustering, calibration, measurement,
-laser-label validation — runs there; querying by task queue means
-there's no workflow-type list to keep in sync.
+There are three Deployments across two task queues (see
+`k8s_scaling.ScalingConfig.sweep_targets`): the CPU worker on
+`fishsense_data_processing_queue`, and the GPU worker plus its CPU-only
+fallback, which both serve `fishsense_data_processing_gpu_queue`. Each
+Deployment is swept against the queue *it* serves, so a busy CPU queue never
+keeps a GPU pod alive and vice versa — the point of having split them.
+
+"Quiet" = no workflow on that task queue is Running *and* none has
+closed within ``idle_cooldown_minutes`` (so a back-to-back dive doesn't
+thrash the pod up/down). Querying by task queue means there's no
+workflow-type list to keep in sync.
+
+The sweeper writes **only** the scale subresource, never the GPU-fallback
+annotations. That separation is load-bearing: `gpu_fallback` reads
+`spec.replicas > 0 && no ready pod` as a failed start, and if scaling down for
+ordinary idleness also cleared the bookkeeping, a long GPU outage would keep
+resetting its own failure counter every hour and could never reach the
+fallback. `tests/test_scale_down_data_worker_if_idle_activity.py` pins it.
 
 No-op (returns ``False``) when k8s scaling isn't configured.
 """
@@ -23,7 +34,11 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timedelta, timezone
 
-from fishsense_shared import build_tls_config, temporal_namespace
+from fishsense_shared import (
+    DATA_PROCESSING_TASK_QUEUE,
+    build_tls_config,
+    temporal_namespace,
+)
 from temporalio import activity
 from temporalio.client import Client
 
@@ -35,12 +50,16 @@ from fishsense_api_workflow_worker.activities.k8s_scaling import (
 )
 from fishsense_api_workflow_worker.config import settings
 
-DATA_WORKER_TASK_QUEUE = "fishsense_data_processing_queue"
+# Retained under its original name for the integration test and any operator
+# script that imports it; the CPU worker's queue.
+DATA_WORKER_TASK_QUEUE = DATA_PROCESSING_TASK_QUEUE
 
 
-def _build_busy_query(cooldown_minutes: int) -> str:
-    """Temporal list-filter matching any workflow on the data-worker task
-    queue that's Running or closed within the last ``cooldown_minutes``.
+def _build_busy_query(
+    cooldown_minutes: int, task_queue: str = DATA_WORKER_TASK_QUEUE
+) -> str:
+    """Temporal list-filter matching any workflow on ``task_queue`` that's
+    Running or closed within the last ``cooldown_minutes``.
 
     A Running workflow has no ``CloseTime``, so the ``Running`` clause
     catches in-flight ones and the ``CloseTime >`` clause catches
@@ -51,15 +70,17 @@ def _build_busy_query(cooldown_minutes: int) -> str:
         datetime.now(timezone.utc) - timedelta(minutes=cooldown_minutes)
     ).strftime("%Y-%m-%dT%H:%M:%SZ")
     return (
-        f'TaskQueue = "{DATA_WORKER_TASK_QUEUE}" '
+        f'TaskQueue = "{task_queue}" '
         f'and (ExecutionStatus = "Running" or CloseTime > "{cutoff}")'
     )
 
 
-async def _data_worker_task_queue_busy(cooldown_minutes: int) -> bool:
-    """True iff a workflow on the data-worker task queue is Running or
-    closed within the last ``cooldown_minutes``."""
-    query = _build_busy_query(cooldown_minutes)
+async def _data_worker_task_queue_busy(
+    cooldown_minutes: int, task_queue: str = DATA_WORKER_TASK_QUEUE
+) -> bool:
+    """True iff a workflow on ``task_queue`` is Running or closed within the
+    last ``cooldown_minutes``."""
+    query = _build_busy_query(cooldown_minutes, task_queue)
     client = await Client.connect(
         f"{settings.temporal.host}:{settings.temporal.port}",
         tls=build_tls_config(settings.temporal),
@@ -70,64 +91,81 @@ async def _data_worker_task_queue_busy(cooldown_minutes: int) -> bool:
     return False
 
 
+async def _busy_task_queues(
+    task_queues: tuple[str, ...], cooldown_minutes: int
+) -> set[str]:
+    """Which of ``task_queues`` are busy. Each is queried once, however many
+    Deployments serve it."""
+    return {
+        task_queue
+        for task_queue in task_queues
+        if await _data_worker_task_queue_busy(cooldown_minutes, task_queue)
+    }
+
+
 @activity.defn
 async def scale_down_data_worker_if_idle_activity() -> bool:
-    """Scale the data-worker Deployment to 0 iff its task queue is quiet.
+    """Scale each data-worker Deployment to 0 iff the queue it serves is quiet.
 
-    Returns ``True`` if it scaled down, ``False`` otherwise (still
-    busy, within cooldown, or scaling disabled).
+    Returns ``True`` if it scaled anything down, ``False`` otherwise (all
+    still busy, within cooldown, or scaling disabled).
     """
     config = resolve_scaling_config()
     if config is None:
         activity.logger.info("k8s scaling not configured; nothing to scale down")
         return False
 
-    busy = await _data_worker_task_queue_busy(config.idle_cooldown_minutes)
-
-    def _sweep() -> str:
-        """Return the outcome: ``idle``, ``wedged`` or ``busy``.
-
-        One thread hop and one k8s client for the whole decision — the wedge
-        check and the scale call share both.
-        """
-        api = apps_v1_api(config.kubeconfig_path)
-        if busy and not deployment_is_wedged(
-            api, config.namespace, config.deployment_name
-        ):
-            return "busy"
-        outcome = "wedged" if busy else "idle"
-        set_deployment_replicas(api, config.namespace, config.deployment_name, 0)
-        return outcome
-
-    outcome = await asyncio.to_thread(_sweep)
-
-    if outcome == "busy":
-        activity.logger.info(
-            "data-worker task queue still busy or within %d-minute cooldown "
-            "and the worker is healthy; leaving %s/%s replicas as-is",
-            config.idle_cooldown_minutes,
-            config.namespace,
-            config.deployment_name,
-        )
-        return False
-
-    if outcome == "wedged":
-        # WARNING, not info: reclaiming the pods bounds the cost but fixes
-        # nothing. Something is stopping the data-worker from starting, and the
-        # queue backlog this leaves behind is real work that is not happening.
-        activity.logger.warning(
-            "data-worker %s/%s has no Ready pod but its task queue is busy - "
-            "it cannot drain and was holding replicas for nothing; scaled to 0. "
-            "Check pod status (CrashLoopBackOff? expired Temporal cert? "
-            "unschedulable?) - the next parent with work will scale it back up.",
-            config.namespace,
-            config.deployment_name,
-        )
-        return True
-
-    activity.logger.info(
-        "data-worker task queue idle; scaled %s/%s to 0",
-        config.namespace,
-        config.deployment_name,
+    targets = config.sweep_targets()
+    busy = await _busy_task_queues(
+        tuple({task_queue for _, task_queue in targets}),
+        config.idle_cooldown_minutes,
     )
-    return True
+
+    def _sweep() -> list[tuple[str, str]]:
+        """Return the (deployment, outcome) pairs. One k8s client for the whole
+        pass — the wedge checks and the scale calls share it."""
+        api = apps_v1_api(config.kubeconfig_path)
+        outcomes = []
+        for name, task_queue in targets:
+            if task_queue in busy and not deployment_is_wedged(
+                api, config.namespace, name
+            ):
+                outcomes.append((name, "busy"))
+                continue
+            outcomes.append((name, "wedged" if task_queue in busy else "idle"))
+            set_deployment_replicas(api, config.namespace, name, 0)
+        return outcomes
+
+    outcomes = await asyncio.to_thread(_sweep)
+
+    for name, outcome in outcomes:
+        if outcome == "busy":
+            activity.logger.info(
+                "task queue for %s/%s still busy or within %d-minute cooldown "
+                "and the worker is healthy; leaving replicas as-is",
+                config.namespace,
+                name,
+                config.idle_cooldown_minutes,
+            )
+        elif outcome == "wedged":
+            # WARNING, not info: reclaiming the pods bounds the cost but fixes
+            # nothing. Something is stopping this worker from starting, and the
+            # queue backlog this leaves behind is real work that is not
+            # happening. For the GPU Deployment this is also what
+            # `ensure_gpu_worker_running_activity` counts toward the CPU
+            # fallback, so a persistent wedge there does eventually route
+            # around itself.
+            activity.logger.warning(
+                "data-worker %s/%s has no Ready pod but its task queue is busy - "
+                "it cannot drain and was holding replicas for nothing; scaled to 0. "
+                "Check pod status (CrashLoopBackOff? expired Temporal cert? "
+                "unschedulable?) - the next parent with work will scale it back up.",
+                config.namespace,
+                name,
+            )
+        else:
+            activity.logger.info(
+                "task queue idle; scaled %s/%s to 0", config.namespace, name
+            )
+
+    return any(outcome != "busy" for _, outcome in outcomes)

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/config.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/config.py
@@ -93,6 +93,36 @@ _VALIDATORS = [
     # many minutes — so a back-to-back dive doesn't thrash the pod.
     # `resolve_scaling_config` floors a negative value at 0.
     Validator("kubernetes.idle_cooldown_minutes", cast=int, default=15),
+    # --- GPU split + CPU fallback -------------------------------------------
+    # `fishsense_data_processing_gpu_queue` is served by two Deployments
+    # running the same image: one that requests a GPU and one that does not and
+    # runs the same torch checkpoint on the CPU. Exactly one is scaled up at a
+    # time. Both names default off `kubernetes.deployment_name`, so the trio
+    # stays consistent if that is overridden. See `activities.gpu_fallback`.
+    Validator("kubernetes.gpu_deployment_name", cast=str),
+    Validator("kubernetes.gpu_fallback_deployment_name", cast=str),
+    # CPU inference is slow per image and there is little point running several
+    # in parallel; clamped to [1, 2] in `resolve_scaling_config`.
+    # How many GPU pods to hold while the predict stage is active. Separate
+    # from `active_replicas` (which sizes the CPU worker) because each of these
+    # holds a card on a contended cluster. Clamped to [1, 4].
+    Validator("kubernetes.gpu_active_replicas", cast=int, default=1),
+    Validator("kubernetes.gpu_fallback_replicas", cast=int, default=1),
+    # How long to wait for a pod before calling a start attempt failed. This is
+    # what separates "no GPU is available" from "the pod is still pulling its
+    # image" — without it every cold start would count toward the fallback.
+    Validator("kubernetes.gpu_start_timeout_seconds", cast=int, default=600),
+    # Failed starts before the GPU queue is handed to the CPU-only Deployment.
+    # Floored at 1 in `resolve_scaling_config` so the GPU is always tried.
+    Validator("kubernetes.gpu_max_start_failures", cast=int, default=3),
+    # How long to stay on CPU inference before probing the GPU again. It must
+    # expire: without it a single bad afternoon on NRP would strand the predict
+    # stage on slow CPU inference permanently.
+    Validator("kubernetes.gpu_fallback_minutes", cast=int, default=180),
+    # Minimum age of a wedge before it counts as a failed start. Clamped to at
+    # most `gpu_start_timeout_seconds` in `resolve_scaling_config` — a longer
+    # grace would swallow every observation and the fallback could never trip.
+    Validator("kubernetes.gpu_wedge_grace_minutes", cast=int, default=5),
     # Garage (S3-compatible) object store — replaces the nginx
     # file-exchange. Single bucket; the data-worker reads staged raw
     # `.ORF` + slate PDFs from it and writes processed JPEGs back. This

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/worker.py
@@ -37,6 +37,9 @@ from fishsense_api_workflow_worker.activities.cleanup_raw_bytes_for_dive_activit
 from fishsense_api_workflow_worker.activities.ensure_data_worker_running_activity import (  # pylint: disable=line-too-long
     ensure_data_worker_running_activity,
 )
+from fishsense_api_workflow_worker.activities.ensure_gpu_worker_running_activity import (  # pylint: disable=line-too-long
+    ensure_gpu_worker_running_activity,
+)
 from fishsense_api_workflow_worker.activities.scale_down_data_worker_if_idle_activity import (  # pylint: disable=line-too-long
     scale_down_data_worker_if_idle_activity,
 )
@@ -752,6 +755,7 @@ async def main():
                 stage_slate_pdf_activity,
                 cleanup_raw_bytes_for_dive_activity,
                 ensure_data_worker_running_activity,
+                ensure_gpu_worker_running_activity,
                 scale_down_data_worker_if_idle_activity,
             ],
         )

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/_dispatch.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/_dispatch.py
@@ -34,15 +34,19 @@ from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 from temporalio.exceptions import WorkflowAlreadyStartedError
 
 with workflow.unsafe.imports_passed_through():
+    from fishsense_shared import (
+        DATA_PROCESSING_GPU_TASK_QUEUE,
+        DATA_PROCESSING_TASK_QUEUE,
+    )
+
     from fishsense_api_workflow_worker.workflows._retry_policies import (
         SCALING_RETRY_POLICY,
         SDK_FAIL_FAST_RETRY_POLICY,
         STAGE_RAW_RETRY_POLICY,
     )
 
-DATA_PROCESSING_TASK_QUEUE = "fishsense_data_processing_queue"
-
 __all__ = [
+    "DATA_PROCESSING_GPU_TASK_QUEUE",
     "DATA_PROCESSING_TASK_QUEUE",
     "STAGE_RAW_RETRY_POLICY",
     "cleanup_raw",
@@ -54,6 +58,7 @@ __all__ = [
     "stage_raw",
     "stage_slate_pdf",
     "wake_data_worker",
+    "wake_gpu_worker",
 ]
 
 
@@ -92,6 +97,33 @@ async def wake_data_worker() -> None:
         "ensure_data_worker_running_activity",
         args=(),
         schedule_to_close_timeout=timedelta(minutes=5),
+        retry_policy=SCALING_RETRY_POLICY,
+    )
+
+
+async def wake_gpu_worker() -> str:
+    """Bring up a worker for the GPU predict queue, and report which one.
+
+    The GPU counterpart of `wake_data_worker`, and it returns a value because
+    the caller has a decision to make. `fishsense_data_processing_gpu_queue` is
+    served by two Deployments — one with a GPU, one running the same checkpoint
+    on the CPU — and when neither can start, the honest answer is
+    ``"unavailable"``. **A parent that gets that must not dispatch its child.**
+    Dispatching onto an unserved queue does not fail; it hangs, sitting
+    `Running` until the child's execution timeout hours later, having also
+    staged the dive's raw `.ORF` bytes from the NAS for nothing.
+
+    Returns ``"gpu"``, ``"cpu_fallback"`` or ``"unavailable"`` — see
+    `activities.gpu_fallback`.
+    """
+    return await workflow.execute_activity(
+        "ensure_gpu_worker_running_activity",
+        args=(),
+        # Longer than `wake_data_worker`'s 5 minutes because this one waits for
+        # a pod (`gpu_start_timeout_seconds`, 10 min by default) and may then
+        # wait for a second one after flipping to the CPU fallback.
+        schedule_to_close_timeout=timedelta(minutes=30),
+        heartbeat_timeout=timedelta(minutes=5),
         retry_policy=SCALING_RETRY_POLICY,
     )
 
@@ -142,8 +174,15 @@ async def dispatch_child(
     child_id: str,
     execution_timeout: timedelta,
     result_type: type | None = None,
+    task_queue: str = DATA_PROCESSING_TASK_QUEUE,
 ) -> Any:
     """Start the data-worker child and wait for it.
+
+    ``task_queue`` selects which half of the split data-worker runs it: the
+    CPU queue by default, or `DATA_PROCESSING_GPU_TASK_QUEUE` for the two
+    predict stages. Caller-supplied because the queue is the *only* thing that
+    routes work between the two, and getting it wrong is silent — the child is
+    accepted and simply never picked up.
 
     The child id is deterministic (`preprocess-laser-{dive_id}`) and the
     reuse policy is **ALLOW_DUPLICATE**, not `ALLOW_DUPLICATE_FAILED_ONLY`.
@@ -167,7 +206,7 @@ async def dispatch_child(
             workflow_name,
             inputs,
             id=child_id,
-            task_queue=DATA_PROCESSING_TASK_QUEUE,
+            task_queue=task_queue,
             execution_timeout=execution_timeout,
             id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
             result_type=result_type,

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/predict_laser_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/predict_laser_images_parent_workflow.py
@@ -16,6 +16,17 @@ fires with `overlap=SKIP`; the child id is deterministic
 (`predict-laser-{dive_id}`) with `ALLOW_DUPLICATE` so a dive can re-predict
 images that became eligible later; per-image predict activities are read-only
 against Garage + the SDK upsert is idempotent.
+
+**This is the only parent that dispatches to the GPU queue.** The data-worker
+is split in two — `fishsense_data_processing_queue` for the CPU stages,
+`fishsense_data_processing_gpu_queue` for the laser detector — so nothing else
+in the pipeline is gated on a GPU being schedulable. The GPU queue is served by
+either the GPU Deployment or, after repeated failed starts, a CPU-only one
+running the same checkpoint slowly; `wake_gpu_worker` decides and reports which
+(see `activities.gpu_fallback`). When it reports that neither could start, this
+parent returns **before staging any bytes**: the dive is left in the cohort and
+picked up next hour, which is strictly better than staging its raw `.ORF`s from
+the NAS and then hanging a child on an unserved queue for two hours.
 """
 
 from datetime import timedelta
@@ -23,6 +34,9 @@ from typing import List
 
 from fishsense_shared import LaserPredictionResult, PredictLaserImagesInput
 from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from fishsense_api_workflow_worker.activities.gpu_fallback import MODE_UNAVAILABLE
 
 from fishsense_api_workflow_worker.workflows import _dispatch
 
@@ -59,14 +73,30 @@ class PredictLaserImagesParentWorkflow:
         if not inputs.images:
             return inputs.dive_id
 
-        await _dispatch.wake_data_worker()
+        mode = await _dispatch.wake_gpu_worker()
+        if mode == MODE_UNAVAILABLE:
+            # Nothing is serving the GPU queue — not the GPU worker, not the
+            # CPU fallback. Bail before staging: a child dispatched now would
+            # not fail, it would sit Running until its two-hour execution
+            # timeout. The dive stays in the cohort for the next firing.
+            workflow.logger.warning(
+                "no worker available for the laser-predict queue; "
+                "skipping dive_id=%d this firing",
+                inputs.dive_id,
+            )
+            return None
+
+        workflow.logger.info("laser predict running on %s capacity", mode)
         await _dispatch.stage_raw(dive_id)
         results: List[LaserPredictionResult] = await _dispatch.dispatch_child(
             "PredictLaserImagesWorkflow",
             inputs,
             child_id=f"predict-laser-{dive_id}",
-            execution_timeout=timedelta(hours=2),
+            # Generous enough to cover the CPU fallback, which runs the same
+            # checkpoint without a GPU and is far slower per image.
+            execution_timeout=timedelta(hours=6),
             result_type=List[LaserPredictionResult],
+            task_queue=_dispatch.DATA_PROCESSING_GPU_TASK_QUEUE,
         )
 
         if results:

--- a/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/predict_slate_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/src/fishsense_api_workflow_worker/workflows/predict_slate_images_parent_workflow.py
@@ -16,7 +16,7 @@ read it as part of the live pipeline.
 Model-assisted slate labeling. Picks the next HIGH-priority dive needing slate
 predictions, resolves its unpredicted slate-frame set + template + camera
 intrinsics via SDK, stages the raw `.ORF` bytes AND the slate template PDF, and
-dispatches the data-worker's CPU `PredictSlateImagesWorkflow`. The child returns
+dispatches the data-worker's `PredictSlateImagesWorkflow`. The child returns
 one gated prediction per frame; the parent persists them
 (`put_slate_prediction`) so the dive-slate populate step can serve them as Label
 Studio pre-annotations (assisted review).
@@ -30,6 +30,16 @@ Same cluster-correctness invariants as the laser-predict parent: `overlap=SKIP`;
 deterministic child id (`predict-slate-{dive_id}`) with `ALLOW_DUPLICATE` so a
 dive can re-predict frames that became eligible later; per-image predict is
 read-only against Garage + the SDK upsert is idempotent.
+
+Also like the laser-predict parent, it dispatches to
+`fishsense_data_processing_gpu_queue`, which means **prefer a GPU, not require
+one** — that queue is served by the GPU Deployment or, when it can't start, a
+CPU-only one running the same checkpoint. The slate masker does not need a GPU
+(fishsense-core measures it at 202 ms/frame on CPU) but goes faster on the card
+the laser stage already has, and this way it is never gated on one. When
+`wake_gpu_worker` reports that neither Deployment could start, the parent
+returns before staging any bytes rather than hanging a child on an unserved
+queue.
 """
 
 from datetime import timedelta
@@ -37,6 +47,9 @@ from typing import List
 
 from fishsense_shared import PredictSlateImagesInput, SlatePredictionResult
 from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from fishsense_api_workflow_worker.activities.gpu_fallback import MODE_UNAVAILABLE
 
 from fishsense_api_workflow_worker.workflows import _dispatch
 
@@ -73,7 +86,16 @@ class PredictSlateImagesParentWorkflow:
         if not inputs.images:
             return inputs.dive_id
 
-        await _dispatch.wake_data_worker()
+        mode = await _dispatch.wake_gpu_worker()
+        if mode == MODE_UNAVAILABLE:
+            workflow.logger.warning(
+                "no worker available for the slate-predict queue; "
+                "skipping dive_id=%d this firing",
+                inputs.dive_id,
+            )
+            return None
+
+        workflow.logger.info("slate predict running on %s capacity", mode)
         await _dispatch.stage_raw(dive_id)
         # The predict activity rectifies the raw frame AND renders the PDF
         # into the template, so both must be staged first.
@@ -87,8 +109,12 @@ class PredictSlateImagesParentWorkflow:
             "PredictSlateImagesWorkflow",
             inputs,
             child_id=f"predict-slate-{dive_id}",
-            execution_timeout=timedelta(hours=2),
+            # Room for the CPU fallback, which runs the same checkpoint without
+            # a GPU. Less of a stretch than the laser stage's — the slate mask
+            # is only ~202 ms/frame on CPU.
+            execution_timeout=timedelta(hours=4),
             result_type=List[SlatePredictionResult],
+            task_queue=_dispatch.DATA_PROCESSING_GPU_TASK_QUEUE,
         )
 
         if results:

--- a/services/fishsense-api-workflow-worker/tests/test_backfill_slate_predictions_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_backfill_slate_predictions_workflow.py
@@ -24,8 +24,9 @@ from fishsense_shared import (
     PredictSlateImagesInput,
     SlatePredictionResult,
 )
+from fishsense_api_workflow_worker.activities.gpu_fallback import MODE_GPU
 from fishsense_api_workflow_worker.workflows._dispatch import (
-    DATA_PROCESSING_TASK_QUEUE,
+    DATA_PROCESSING_GPU_TASK_QUEUE,
 )
 from fishsense_api_workflow_worker.workflows.backfill_slate_predictions_workflow import (  # noqa: E501  pylint: disable=line-too-long
     BackfillSlatePredictionsWorkflow,
@@ -100,9 +101,11 @@ def _predict_parent_stubs(calls: List[Tuple[str, int]]):
             images=[PredictSlateImage(image_id=1, checksum="a")],
         )
 
-    @activity.defn(name="ensure_data_worker_running_activity")
-    async def ensure() -> None:
-        return None
+    # The slate predict child runs on the GPU queue — "prefer a GPU", served by
+    # the GPU Deployment or its CPU-only fallback.
+    @activity.defn(name="ensure_gpu_worker_running_activity")
+    async def ensure() -> str:
+        return MODE_GPU
 
     @activity.defn(name="stage_raw_bytes_for_dive_activity")
     async def stage_raw(dive_id: int) -> None:
@@ -141,7 +144,7 @@ async def test_predict_parent_calls_backfill_after_persist():
             activities=acts,
         ), Worker(
             env.client,
-            task_queue=DATA_PROCESSING_TASK_QUEUE,
+            task_queue=DATA_PROCESSING_GPU_TASK_QUEUE,
             workflows=[_StubSlateChild],
             activities=acts,
         ):

--- a/services/fishsense-api-workflow-worker/tests/test_ensure_gpu_worker_running_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_ensure_gpu_worker_running_activity.py
@@ -1,0 +1,263 @@
+"""Unit tests for ensure_gpu_worker_running_activity.
+
+Kubernetes is mocked. What is pinned here is the contract the predict parents
+depend on: which Deployment ends up scaled up, what mode the parent is told to
+expect, and — the point of the whole feature — that a GPU that will not start
+eventually hands its queue to the CPU-only Deployment instead of stalling.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from temporalio.testing import ActivityEnvironment
+
+from fishsense_api_workflow_worker.activities import (
+    ensure_gpu_worker_running_activity as sut,
+)
+from fishsense_api_workflow_worker.activities.gpu_fallback import (
+    FAILURES_ANNOTATION,
+    FALLBACK_UNTIL_ANNOTATION,
+    MODE_CPU_FALLBACK,
+    MODE_GPU,
+    MODE_UNAVAILABLE,
+    FallbackPolicy,
+)
+from fishsense_api_workflow_worker.activities.k8s_scaling import (
+    GpuScalingConfig,
+    ScalingConfig,
+)
+
+GPU = "fishsense-data-processing-workflow-worker-gpu"
+FALLBACK = "fishsense-data-processing-workflow-worker-gpu-cpu-fallback"
+
+
+def _config(**gpu_overrides) -> ScalingConfig:
+    gpu = {
+        "deployment_name": GPU,
+        "fallback_deployment_name": FALLBACK,
+        # 0 = one readiness check with no waiting. Cheap, and it means a test
+        # says what is broken via `_Cluster(broken=...)` rather than by timing.
+        "start_timeout_seconds": 0,
+        "policy": FallbackPolicy(
+            active_replicas=1,
+            fallback_replicas=1,
+            max_start_failures=3,
+            wedge_grace=timedelta(0),
+            fallback_window=timedelta(hours=3),
+        ),
+    }
+    gpu.update(gpu_overrides)
+    return ScalingConfig(
+        kubeconfig_path="/tmp/nrp.kubeconfig",
+        namespace="fishsense",
+        deployment_name="fishsense-data-processing-workflow-worker",
+        active_replicas=1,
+        idle_cooldown_minutes=15,
+        gpu=GpuScalingConfig(**gpu),
+    )
+
+
+class _Cluster:
+    """A tiny stand-in for the two Deployments this activity drives.
+
+    Pods go Ready as soon as they are asked for, which models a healthy
+    cluster — so each test only has to say what is *broken*, via ``broken``.
+    A Deployment listed there accepts a replica count and never reports a Ready
+    pod, which is exactly the shape of an unschedulable GPU request, an
+    exhausted quota, or a CrashLoopBackOff.
+    """
+
+    def __init__(self, broken: set[str] | None = None):
+        self.broken = broken or set()
+        self.replicas = {GPU: 0, FALLBACK: 0}
+        self.ready = {GPU: 0, FALLBACK: 0}
+        self.annotations: dict[str, dict[str, str]] = {GPU: {}, FALLBACK: {}}
+        self.patched_bodies: list[dict] = []
+
+    def _set_replicas(self, name: str, count: int) -> None:
+        self.replicas[name] = count
+        self.ready[name] = 0 if name in self.broken else count
+
+    def api(self):
+        api = MagicMock()
+
+        def _read(name, namespace):  # pylint: disable=unused-argument
+            return SimpleNamespace(
+                metadata=SimpleNamespace(annotations=dict(self.annotations[name])),
+                spec=SimpleNamespace(replicas=self.replicas[name]),
+                status=SimpleNamespace(ready_replicas=self.ready[name] or None),
+            )
+
+        def _scale(name, namespace, body):  # pylint: disable=unused-argument
+            self._set_replicas(name, body["spec"]["replicas"])
+
+        def _patch(name, namespace, body):  # pylint: disable=unused-argument
+            self.patched_bodies.append(body)
+            for key, value in body["metadata"]["annotations"].items():
+                if value is None:
+                    self.annotations[name].pop(key, None)
+                else:
+                    self.annotations[name][key] = value
+
+        api.read_namespaced_deployment.side_effect = _read
+        api.patch_namespaced_deployment_scale.side_effect = _scale
+        api.patch_namespaced_deployment.side_effect = _patch
+        return api
+
+
+def _install(monkeypatch, cluster, config):
+    monkeypatch.setattr(sut, "resolve_scaling_config", lambda: config)
+    monkeypatch.setattr(sut, "apps_v1_api", lambda _path: cluster.api())
+
+
+async def _run():
+    return await ActivityEnvironment().run(sut.ensure_gpu_worker_running_activity)
+
+
+@pytest.mark.asyncio
+async def test_noop_when_scaling_is_not_configured(monkeypatch):
+    """Local devcontainer / pre-NRP: the worker is assumed always-on, so the
+    parent should dispatch to the GPU queue exactly as before."""
+    monkeypatch.setattr(sut, "resolve_scaling_config", lambda: None)
+    monkeypatch.setattr(
+        sut, "apps_v1_api", lambda *_a: pytest.fail("must not touch k8s")
+    )
+    assert await _run() == MODE_GPU
+
+
+@pytest.mark.asyncio
+async def test_cold_start_scales_the_gpu_deployment_up(monkeypatch):
+    cluster = _Cluster()
+    _install(monkeypatch, cluster, _config())
+    assert await _run() == MODE_GPU
+    assert cluster.replicas[GPU] == 1
+    assert cluster.replicas[FALLBACK] == 0
+
+
+@pytest.mark.asyncio
+async def test_a_ready_gpu_keeps_the_fallback_down(monkeypatch):
+    cluster = _Cluster()
+    cluster.replicas[GPU], cluster.ready[GPU] = 1, 1
+    _install(monkeypatch, cluster, _config())
+    assert await _run() == MODE_GPU
+    assert cluster.replicas[FALLBACK] == 0
+
+
+@pytest.mark.asyncio
+async def test_repeated_failed_starts_hand_the_queue_to_the_cpu_fallback(
+    monkeypatch,
+):
+    """The headline behavior: a GPU that never schedules must not stall the
+    predict stage forever.
+
+    Bounded so the test fails loudly rather than looping if the fallback ever
+    stops tripping. The bound is generous on purpose — what matters is that it
+    converges within a couple of hourly firings, not the exact count.
+    """
+    cluster = _Cluster(broken={GPU})
+    config = _config()
+    _install(monkeypatch, cluster, config)
+
+    firings = 0
+    while True:
+        firings += 1
+        mode = await _run()
+        if mode == MODE_CPU_FALLBACK:
+            break
+        assert firings <= config.gpu.policy.max_start_failures + 1, (
+            "the GPU queue never fell back to CPU"
+        )
+
+    assert cluster.replicas[GPU] == 0
+    assert cluster.replicas[FALLBACK] == 1
+    assert FALLBACK_UNTIL_ANNOTATION in cluster.annotations[GPU]
+
+
+@pytest.mark.asyncio
+async def test_the_fallback_window_is_held_then_released(monkeypatch):
+    cluster = _Cluster()
+    config = _config()
+    _install(monkeypatch, cluster, config)
+
+    # Already in fallback, window still open.
+    future = datetime.now(timezone.utc) + timedelta(hours=1)
+    cluster.annotations[GPU][FALLBACK_UNTIL_ANNOTATION] = future.strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    assert await _run() == MODE_CPU_FALLBACK
+    assert cluster.replicas[FALLBACK] == 1
+    assert cluster.replicas[GPU] == 0
+
+    # Window expired → probe the GPU again, and drop the fallback.
+    past = datetime.now(timezone.utc) - timedelta(minutes=1)
+    cluster.annotations[GPU][FALLBACK_UNTIL_ANNOTATION] = past.strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    assert await _run() == MODE_GPU
+    assert cluster.replicas[GPU] == 1
+    assert cluster.replicas[FALLBACK] == 0
+    assert FALLBACK_UNTIL_ANNOTATION not in cluster.annotations[GPU]
+    assert FAILURES_ANNOTATION not in cluster.annotations[GPU]
+
+
+@pytest.mark.asyncio
+async def test_reports_unavailable_when_the_fallback_cannot_start_either(
+    monkeypatch,
+):
+    """Nothing can serve the queue. The parent must be told, so it skips this
+    firing instead of dispatching a child that would hang until its execution
+    timeout hours later."""
+    cluster = _Cluster(broken={GPU, FALLBACK})
+    config = _config()
+    _install(monkeypatch, cluster, config)
+    cluster.annotations[GPU][FALLBACK_UNTIL_ANNOTATION] = (
+        datetime.now(timezone.utc) + timedelta(hours=1)
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert await _run() == MODE_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_waits_for_a_pod_before_declaring_the_start_failed(monkeypatch):
+    """A cold pod that becomes Ready inside the start timeout is a success, not
+    a failed attempt — otherwise every image pull would count toward the
+    fallback threshold."""
+    cluster = _Cluster(broken={GPU})
+    _install(monkeypatch, cluster, _config(start_timeout_seconds=60))
+    monkeypatch.setattr(sut, "POLL_INTERVAL_SECONDS", 0)
+
+    api = cluster.api()
+    inner_read = api.read_namespaced_deployment.side_effect
+    polls = {"n": 0}
+
+    def _read(name, namespace):
+        """The pod finishes pulling its image on the third poll."""
+        polls["n"] += 1
+        if polls["n"] >= 3:
+            cluster.broken.discard(GPU)
+            cluster.ready[GPU] = cluster.replicas[GPU]
+        return inner_read(name=name, namespace=namespace)
+
+    api.read_namespaced_deployment.side_effect = _read
+    monkeypatch.setattr(sut, "apps_v1_api", lambda _path: api)
+
+    assert await _run() == MODE_GPU
+    assert FAILURES_ANNOTATION not in cluster.annotations[GPU]
+
+
+@pytest.mark.asyncio
+async def test_never_patches_a_pod_template(monkeypatch):
+    """Tripwire. Annotation writes go on the Deployment's own metadata; putting
+    them on `spec.template` would roll the pods on every firing — restarting
+    the very worker we are trying to get started."""
+    cluster = _Cluster(broken={GPU})
+    _install(monkeypatch, cluster, _config())
+    cluster.replicas[GPU] = 1
+    await _run()
+    assert cluster.patched_bodies, "expected at least one annotation patch"
+    for body in cluster.patched_bodies:
+        assert set(body) == {"metadata"}
+        assert set(body["metadata"]) == {"annotations"}

--- a/services/fishsense-api-workflow-worker/tests/test_gpu_fallback.py
+++ b/services/fishsense-api-workflow-worker/tests/test_gpu_fallback.py
@@ -1,0 +1,241 @@
+"""The GPU -> CPU fallback state machine.
+
+`decide` is pure so the whole policy can be exercised without a cluster: the
+interesting behavior is a multi-hour sequence (wedge, count, flip, hold,
+expire, probe) that is impractical to reproduce against a real NRP Deployment
+and impossible to reproduce quickly.
+
+The rule these tests exist to protect is the top-level requirement: **the
+pipeline must never be blocked on a GPU being available.** A GPU worker that
+cannot schedule must eventually hand its queue to a CPU one, and must
+eventually give the GPU another chance so a transient NRP shortage doesn't
+strand us on slow CPU inference forever.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from fishsense_api_workflow_worker.activities.gpu_fallback import (
+    FALLBACK_UNTIL_ANNOTATION,
+    FAILURES_ANNOTATION,
+    MODE_CPU_FALLBACK,
+    MODE_GPU,
+    WEDGED_SINCE_ANNOTATION,
+    FallbackPolicy,
+    GpuState,
+    decide,
+)
+
+NOW = datetime(2026, 8, 25, 12, 0, tzinfo=timezone.utc)
+POLICY = FallbackPolicy(
+    active_replicas=1,
+    fallback_replicas=1,
+    max_start_failures=3,
+    wedge_grace=timedelta(minutes=5),
+    fallback_window=timedelta(hours=3),
+)
+
+
+def _decide(state, *, now=NOW, ready=False, wedged=False, policy=POLICY):
+    return decide(state, now=now, gpu_ready=ready, gpu_wedged=wedged, policy=policy)
+
+
+# --- cold start / happy path -------------------------------------------------
+
+
+def test_cold_deployment_scales_the_gpu_up_and_touches_no_state():
+    """First firing of a quiet hour: replicas are 0, so the Deployment is
+    neither ready nor wedged. Scale it up and decide nothing."""
+    decision = _decide(GpuState())
+    assert decision.mode == MODE_GPU
+    assert (decision.gpu_replicas, decision.fallback_replicas) == (1, 0)
+    assert decision.state == GpuState()
+
+
+def test_ready_gpu_clears_a_partial_failure_history():
+    """A GPU that comes back must not carry old failures toward the threshold
+    — otherwise unrelated blips across days eventually trip the fallback."""
+    decision = _decide(
+        GpuState(failures=2, wedged_since=NOW - timedelta(hours=1)), ready=True
+    )
+    assert decision.mode == MODE_GPU
+    assert decision.gpu_replicas == 1
+    assert decision.state == GpuState()
+
+
+# --- counting failed starts --------------------------------------------------
+
+
+def test_first_wedge_observation_only_starts_the_grace_clock():
+    """A pod that is merely still pulling its image is not a failed start."""
+    decision = _decide(GpuState(), wedged=True)
+    assert decision.state.failures == 0
+    assert decision.state.wedged_since == NOW
+    assert decision.mode == MODE_GPU
+
+
+def test_wedge_inside_the_grace_window_does_not_count():
+    state = GpuState(wedged_since=NOW - timedelta(minutes=4))
+    decision = _decide(state, wedged=True)
+    assert decision.state.failures == 0
+    assert decision.state.wedged_since == state.wedged_since
+
+
+def test_wedge_past_the_grace_window_counts_once_and_restarts_the_clock():
+    """The clock restart is what makes this once *per observation* rather than
+    once per second of a continuous wedge."""
+    decision = _decide(
+        GpuState(wedged_since=NOW - timedelta(minutes=6)), wedged=True
+    )
+    assert decision.state.failures == 1
+    assert decision.state.wedged_since == NOW
+    assert decision.mode == MODE_GPU
+    assert decision.gpu_replicas == 1
+
+
+def test_below_the_threshold_the_gpu_keeps_being_retried():
+    decision = _decide(
+        GpuState(failures=1, wedged_since=NOW - timedelta(minutes=30)), wedged=True
+    )
+    assert decision.state.failures == 2
+    assert decision.mode == MODE_GPU
+    assert decision.state.fallback_until is None
+
+
+# --- the flip ----------------------------------------------------------------
+
+
+def test_reaching_the_threshold_flips_to_the_cpu_fallback():
+    decision = _decide(
+        GpuState(failures=2, wedged_since=NOW - timedelta(minutes=30)), wedged=True
+    )
+    assert decision.mode == MODE_CPU_FALLBACK
+    assert decision.gpu_replicas == 0
+    assert decision.fallback_replicas == 1
+    assert decision.state.fallback_until == NOW + POLICY.fallback_window
+
+
+def test_inside_the_fallback_window_the_gpu_stays_down():
+    """Held even if the GPU Deployment would now report ready — the whole
+    point of the window is not to thrash back and forth."""
+    state = GpuState(failures=3, fallback_until=NOW + timedelta(hours=1))
+    decision = _decide(state, ready=True)
+    assert decision.mode == MODE_CPU_FALLBACK
+    assert (decision.gpu_replicas, decision.fallback_replicas) == (0, 1)
+    assert decision.state == state
+
+
+def test_an_expired_window_probes_the_gpu_again_with_a_clean_slate():
+    """Without this the first sustained GPU outage would strand the pipeline on
+    slow CPU inference permanently."""
+    decision = _decide(
+        GpuState(failures=3, fallback_until=NOW - timedelta(minutes=1))
+    )
+    assert decision.mode == MODE_GPU
+    assert (decision.gpu_replicas, decision.fallback_replicas) == (1, 0)
+    assert decision.state == GpuState()
+
+
+def test_the_probe_can_fail_all_the_way_back_into_fallback():
+    """Full round trip: expire -> probe -> wedge repeatedly -> fallback again.
+
+    Pins the real cost of a re-probe, which is one observation more than
+    `max_start_failures`: from a clean slate the first sighting only starts the
+    grace clock. At the hourly parent cadence a fresh GPU outage therefore
+    takes ~4 firings to reach CPU inference.
+    """
+    state = GpuState(failures=3, fallback_until=NOW - timedelta(minutes=1))
+    now = NOW
+    state = _decide(state, now=now).state
+    assert state == GpuState()
+
+    observations = 0
+    while True:
+        now += timedelta(hours=1)
+        observations += 1
+        decision = _decide(state, now=now, wedged=True)
+        state = decision.state
+        if decision.mode == MODE_CPU_FALLBACK:
+            break
+        assert observations <= POLICY.max_start_failures + 1, "never fell back"
+
+    assert observations == POLICY.max_start_failures + 1
+    assert state.fallback_until == now + POLICY.fallback_window
+
+
+def test_replica_counts_come_from_the_policy():
+    policy = FallbackPolicy(
+        active_replicas=3,
+        fallback_replicas=2,
+        max_start_failures=1,
+        wedge_grace=timedelta(0),
+        fallback_window=timedelta(hours=1),
+    )
+    assert _decide(GpuState(), policy=policy).gpu_replicas == 3
+    flipped = _decide(
+        GpuState(wedged_since=NOW - timedelta(minutes=1)),
+        wedged=True,
+        policy=policy,
+    )
+    assert flipped.mode == MODE_CPU_FALLBACK
+    assert flipped.fallback_replicas == 2
+
+
+# --- annotation round trip ---------------------------------------------------
+
+
+def test_state_round_trips_through_annotations():
+    state = GpuState(
+        failures=2,
+        wedged_since=NOW - timedelta(minutes=10),
+        fallback_until=NOW + timedelta(hours=2),
+    )
+    assert GpuState.from_annotations(state.to_annotations()) == state
+
+
+def test_empty_state_clears_every_annotation():
+    """Cleared, not written as "0"/"" — so `kubectl describe` on a healthy GPU
+    Deployment shows no fallback bookkeeping at all."""
+    annotations = GpuState().to_annotations()
+    assert set(annotations) == {
+        FAILURES_ANNOTATION,
+        WEDGED_SINCE_ANNOTATION,
+        FALLBACK_UNTIL_ANNOTATION,
+    }
+    assert all(value is None for value in annotations.values())
+
+
+def test_missing_annotations_read_as_the_empty_state():
+    assert GpuState.from_annotations(None) == GpuState()
+    assert GpuState.from_annotations({}) == GpuState()
+    assert GpuState.from_annotations({"unrelated": "x"}) == GpuState()
+
+
+@pytest.mark.parametrize(
+    "annotations",
+    [
+        {FAILURES_ANNOTATION: "not-a-number"},
+        {WEDGED_SINCE_ANNOTATION: "yesterday"},
+        {FALLBACK_UNTIL_ANNOTATION: ""},
+        {FAILURES_ANNOTATION: "-4"},
+    ],
+)
+def test_malformed_annotations_degrade_to_the_default_rather_than_raising(
+    annotations,
+):
+    """These are hand-editable by operators (that is the point of keeping the
+    state here), so a typo must not take the predict stage down. It degrades to
+    "no history", which costs at most a few extra GPU attempts."""
+    assert GpuState.from_annotations(annotations) == GpuState()
+
+
+def test_naive_timestamps_are_read_as_utc():
+    """`kubectl annotate` by hand won't always include the offset. Reading a
+    naive stamp as local time would shift the window by hours."""
+    state = GpuState.from_annotations(
+        {FALLBACK_UNTIL_ANNOTATION: "2026-08-25T15:00:00"}
+    )
+    assert state.fallback_until == datetime(2026, 8, 25, 15, 0, tzinfo=timezone.utc)

--- a/services/fishsense-api-workflow-worker/tests/test_k8s_scaling.py
+++ b/services/fishsense-api-workflow-worker/tests/test_k8s_scaling.py
@@ -140,3 +140,70 @@ def test_deployment_is_wedged_tolerates_a_status_less_deployment():
     deployment = SimpleNamespace(spec=SimpleNamespace(replicas=2), status=None)
     api = _api_returning(deployment)
     assert k8s_scaling.deployment_is_wedged(api, "fishsense", "data-worker") is True
+
+
+def _gpu_config(monkeypatch, **section):
+    monkeypatch.setattr(
+        k8s_scaling,
+        "settings",
+        {"kubernetes": {"kubeconfig_path": "/tmp/kc", "namespace": "ns", **section}},
+    )
+    return k8s_scaling.resolve_scaling_config()
+
+
+def test_gpu_deployment_names_default_off_the_cpu_name(monkeypatch):
+    """Overriding one name must carry the whole trio, or a renamed CPU
+    Deployment silently pairs with the stock GPU ones."""
+    cfg = _gpu_config(monkeypatch, deployment_name="dw")
+    assert cfg.gpu.deployment_name == "dw-gpu"
+    assert cfg.gpu.fallback_deployment_name == "dw-gpu-cpu-fallback"
+
+
+def test_gpu_replica_count_is_independent_of_the_cpu_one(monkeypatch):
+    """`active_replicas` sizes the CPU worker; each GPU pod holds a card on a
+    contended cluster, so raising CPU throughput must not silently ask NRP for
+    more GPUs."""
+    cfg = _gpu_config(monkeypatch, active_replicas=4)
+    assert cfg.active_replicas == 4
+    assert cfg.gpu.policy.active_replicas == 1
+
+    cfg = _gpu_config(monkeypatch, gpu_active_replicas=99)
+    assert cfg.gpu.policy.active_replicas == k8s_scaling.MAX_ACTIVE_REPLICAS
+
+
+def test_fallback_replicas_clamped(monkeypatch):
+    cfg = _gpu_config(monkeypatch, gpu_fallback_replicas=99)
+    assert cfg.gpu.policy.fallback_replicas == k8s_scaling.MAX_FALLBACK_REPLICAS
+    cfg = _gpu_config(monkeypatch, gpu_fallback_replicas=0)
+    assert cfg.gpu.policy.fallback_replicas == 1
+
+
+def test_max_start_failures_is_floored_at_one(monkeypatch):
+    """At 0 the pipeline would drop to CPU inference on the first observation
+    and never actually try the GPU."""
+    assert _gpu_config(monkeypatch, gpu_max_start_failures=0) \
+        .gpu.policy.max_start_failures == 1
+
+
+def test_wedge_grace_cannot_outlast_the_start_timeout(monkeypatch):
+    """The activity waits out the start timeout and then observes. A longer
+    grace would swallow every observation, no failure would ever be counted,
+    and the CPU fallback could never trip."""
+    cfg = _gpu_config(
+        monkeypatch, gpu_wedge_grace_minutes=60, gpu_start_timeout_seconds=120
+    )
+    assert cfg.gpu.policy.wedge_grace.total_seconds() == 120
+
+
+def test_sweep_targets_pair_each_deployment_with_the_queue_it_serves(monkeypatch):
+    from fishsense_shared import (
+        DATA_PROCESSING_GPU_TASK_QUEUE,
+        DATA_PROCESSING_TASK_QUEUE,
+    )
+
+    cfg = _gpu_config(monkeypatch, deployment_name="dw")
+    assert cfg.sweep_targets() == (
+        ("dw", DATA_PROCESSING_TASK_QUEUE),
+        ("dw-gpu", DATA_PROCESSING_GPU_TASK_QUEUE),
+        ("dw-gpu-cpu-fallback", DATA_PROCESSING_GPU_TASK_QUEUE),
+    )

--- a/services/fishsense-api-workflow-worker/tests/test_k8s_scaling_integration.py
+++ b/services/fishsense-api-workflow-worker/tests/test_k8s_scaling_integration.py
@@ -12,10 +12,21 @@ locally without a cluster.
 Covers what the unit tests mock away: `ensure_data_worker_running_activity`
 and `scale_down_data_worker_if_idle_activity` patching a real
 Deployment's ``.spec.replicas``, `apps_v1_api`/`load_kube_config`
-working against a real kubeconfig, and `resolve_scaling_config` against
-real-ish settings. The Temporal `list_workflows` query that
-`scale_down` uses is mocked here and exercised against a real Temporal
-in `test_scale_down_query_integration.py`.
+working against a real kubeconfig, `resolve_scaling_config` against
+real-ish settings, and the GPU fallback's annotation round-trip — where a
+``None`` value has to actually REMOVE the key, which only a real apiserver
+can confirm. The Temporal `list_workflows` query that `scale_down` uses is
+mocked here and exercised against a real Temporal in
+`test_scale_down_query_integration.py`.
+
+**Which Deployment a wedge test points at is load-bearing.** kind has no GPU
+nodes, so `...-worker-gpu` — which requests `nvidia.com/gpu: 1` and carries a
+compute-capability node affinity — is *permanently* Unschedulable there. That
+is a deterministic, honest wedge. The CPU Deployment used to be wedged for the
+same reason, but as of the GPU/CPU split it requests no GPU: it is now merely
+slow to fail (big image pull, then a Temporal connect against stub certs), so
+asserting it is wedged would be a race. The wedge tests therefore use the GPU
+Deployment.
 """
 
 from __future__ import annotations
@@ -28,6 +39,8 @@ from temporalio.testing import ActivityEnvironment
 
 from fishsense_api_workflow_worker.activities import (
     ensure_data_worker_running_activity as ensure_mod,
+    ensure_gpu_worker_running_activity as ensure_gpu_mod,
+    gpu_fallback,
     k8s_scaling,
     scale_down_data_worker_if_idle_activity as scale_down_mod,
 )
@@ -35,6 +48,10 @@ from fishsense_api_workflow_worker.activities import (
 pytestmark = pytest.mark.k8s
 
 DEPLOYMENT = "fishsense-data-processing-workflow-worker"
+# Permanently Unschedulable on kind (GPU request + compute-capability
+# affinity), which is exactly what makes it a deterministic wedge fixture.
+GPU_DEPLOYMENT = f"{DEPLOYMENT}-gpu"
+GPU_FALLBACK_DEPLOYMENT = f"{GPU_DEPLOYMENT}-cpu-fallback"
 
 
 @pytest.fixture
@@ -71,6 +88,13 @@ def configure_scaling(monkeypatch, kubeconfig, namespace):
                 "deployment_name": DEPLOYMENT,
                 "active_replicas": 2,
                 "idle_cooldown_minutes": 0,
+                # No waiting for a pod: on kind nothing ever becomes Ready, so
+                # the default 600s would just stall the job. With the grace at
+                # 0 and a single permitted failure, the fallback flip is
+                # reached in a bounded number of calls.
+                "gpu_start_timeout_seconds": 0,
+                "gpu_wedge_grace_minutes": 0,
+                "gpu_max_start_failures": 1,
             }
         },
     )
@@ -91,16 +115,23 @@ def _api(kubeconfig: str):
     return k8s_scaling.apps_v1_api(kubeconfig)
 
 
-def _replicas(kubeconfig: str, namespace: str) -> int:
+def _replicas(kubeconfig: str, namespace: str, name: str = DEPLOYMENT) -> int:
     # Read the Deployment's .spec.replicas (a `*int32`, so 0 round-trips),
     # NOT the Scale subresource — autoscaling/v1 ScaleSpec.replicas is a
     # plain int32 with `omitempty`, so the API omits it when the count is
     # 0 and the Python client deserializes that as None.
-    return _api(kubeconfig).read_namespaced_deployment(DEPLOYMENT, namespace).spec.replicas
+    return _api(kubeconfig).read_namespaced_deployment(name, namespace).spec.replicas
 
 
-def _set_replicas(kubeconfig: str, namespace: str, n: int) -> None:
-    k8s_scaling.set_deployment_replicas(_api(kubeconfig), namespace, DEPLOYMENT, n)
+def _set_replicas(
+    kubeconfig: str, namespace: str, n: int, name: str = DEPLOYMENT
+) -> None:
+    k8s_scaling.set_deployment_replicas(_api(kubeconfig), namespace, name, n)
+
+
+def _annotations(kubeconfig: str, namespace: str, name: str) -> dict:
+    meta = _api(kubeconfig).read_namespaced_deployment(name, namespace).metadata
+    return meta.annotations or {}
 
 
 async def test_ensure_running_scales_the_real_deployment_up(
@@ -117,7 +148,7 @@ async def test_ensure_running_scales_the_real_deployment_up(
 async def test_scale_down_when_idle_zeroes_the_real_deployment(
     configure_scaling, kubeconfig, namespace, monkeypatch
 ):
-    async def _not_busy(_cooldown: int) -> bool:
+    async def _not_busy(_cooldown: int, _task_queue: str = "") -> bool:
         return False
 
     monkeypatch.setattr(scale_down_mod, "_data_worker_task_queue_busy", _not_busy)
@@ -135,13 +166,13 @@ async def test_scale_down_leaves_a_busy_healthy_deployment_alone(
     """Busy + able to make progress = leave it running.
 
     `deployment_is_wedged` is stubbed False here because this cluster cannot
-    produce the honest version of "healthy": the Deployment requests
-    `nvidia.com/gpu: 1` with a compute-capability node affinity, and kind has
-    no GPU nodes, so its pods are permanently Unschedulable and never Ready.
-    That same fact is what makes the wedge test below real rather than
-    simulated.
+    produce the honest version of "healthy": nothing ever reaches Ready on
+    kind — the GPU Deployment is permanently Unschedulable, and the other two
+    would have to pull a multi-GB image and then reach krg-prod Temporal with
+    stub certs. The wedge test below needs no such stub, which is what makes
+    it real rather than simulated.
     """
-    async def _busy(_cooldown: int) -> bool:
+    async def _busy(_cooldown: int, _task_queue: str = "") -> bool:
         return True
 
     monkeypatch.setattr(scale_down_mod, "_data_worker_task_queue_busy", _busy)
@@ -163,13 +194,22 @@ async def test_deployment_is_wedged_against_a_real_apiserver(
     as None) rather than 0 when nothing is Ready — a real apiserver is the only
     thing that can confirm that, and reading None as "unknown, assume healthy"
     is precisely what pinned prod's GPUs from 2026-08-14.
+
+    Uses the GPU Deployment: its pods are Unschedulable on kind for a
+    structural reason (no node satisfies `nvidia.com/gpu`), so "no Ready pod"
+    holds immediately and forever rather than only until an image finishes
+    pulling.
     """
-    _set_replicas(kubeconfig, namespace, 1)
-    assert k8s_scaling.deployment_is_wedged(_api(kubeconfig), namespace, DEPLOYMENT)
+    _set_replicas(kubeconfig, namespace, 1, GPU_DEPLOYMENT)
+    assert k8s_scaling.deployment_is_wedged(
+        _api(kubeconfig), namespace, GPU_DEPLOYMENT
+    )
 
     # Scaled to zero, nothing is held, so there is nothing to reclaim.
-    _set_replicas(kubeconfig, namespace, 0)
-    assert not k8s_scaling.deployment_is_wedged(_api(kubeconfig), namespace, DEPLOYMENT)
+    _set_replicas(kubeconfig, namespace, 0, GPU_DEPLOYMENT)
+    assert not k8s_scaling.deployment_is_wedged(
+        _api(kubeconfig), namespace, GPU_DEPLOYMENT
+    )
 
 
 async def test_scale_down_reclaims_a_wedged_busy_deployment(
@@ -182,14 +222,85 @@ async def test_scale_down_reclaims_a_wedged_busy_deployment(
     because the Temporal client cert had expired and every pod crash-looped.
     Before this behaviour existed the sweeper read "busy" and left the replicas
     up, so the Deployment held NRP GPUs indefinitely while draining nothing.
+
+    Asserted on the GPU Deployment because that is the one kind wedges
+    deterministically; the sweep covers all three in the same pass.
     """
-    async def _busy(_cooldown: int) -> bool:
+    async def _busy(_cooldown: int, _task_queue: str = "") -> bool:
         return True
 
     monkeypatch.setattr(scale_down_mod, "_data_worker_task_queue_busy", _busy)
-    _set_replicas(kubeconfig, namespace, 2)
+    _set_replicas(kubeconfig, namespace, 2, GPU_DEPLOYMENT)
     result = await ActivityEnvironment().run(
         scale_down_mod.scale_down_data_worker_if_idle_activity
     )
     assert result is True
-    assert _replicas(kubeconfig, namespace) == 0
+    assert _replicas(kubeconfig, namespace, GPU_DEPLOYMENT) == 0
+
+
+async def test_annotation_patch_removes_a_key_on_a_real_apiserver(
+    configure_scaling, kubeconfig, namespace
+):
+    """`GpuState.to_annotations()` returns None for every field it wants gone,
+    and the fallback's whole "absent means healthy" contract rests on a None
+    value actually REMOVING the key rather than storing an empty string.
+
+    That is strategic-merge-patch semantics, so a mock cannot confirm it — the
+    unit tests assert the call shape, and this asserts the apiserver agrees.
+    """
+    api = _api(kubeconfig)
+    k8s_scaling.patch_deployment_annotations(
+        api, namespace, GPU_DEPLOYMENT, {"fishsense.e4e.ucsd.edu/itest": "1"}
+    )
+    assert _annotations(kubeconfig, namespace, GPU_DEPLOYMENT).get(
+        "fishsense.e4e.ucsd.edu/itest"
+    ) == "1"
+
+    k8s_scaling.patch_deployment_annotations(
+        api, namespace, GPU_DEPLOYMENT, {"fishsense.e4e.ucsd.edu/itest": None}
+    )
+    assert (
+        "fishsense.e4e.ucsd.edu/itest"
+        not in _annotations(kubeconfig, namespace, GPU_DEPLOYMENT)
+    )
+
+
+async def test_gpu_worker_falls_back_to_cpu_against_a_real_cluster(
+    configure_scaling, kubeconfig, namespace
+):
+    """The headline behaviour, end to end on a real apiserver.
+
+    kind can never schedule the GPU Deployment, which is precisely the prod
+    condition the fallback exists for (no free Turing-or-newer card, exhausted
+    quota, drained pool). Repeated calls must therefore give up on it and bring
+    the CPU-only Deployment up instead.
+
+    Asserts replica counts rather than the returned mode: nothing reaches Ready
+    on kind, so the activity honestly reports `unavailable` throughout. What
+    matters — and what only a real apiserver proves — is that the flip was
+    persisted, driven by annotations it read back from the cluster.
+    """
+    _set_replicas(kubeconfig, namespace, 0, GPU_DEPLOYMENT)
+    _set_replicas(kubeconfig, namespace, 0, GPU_FALLBACK_DEPLOYMENT)
+    # Start from a clean slate — an empty state clears all three annotations.
+    k8s_scaling.patch_deployment_annotations(
+        _api(kubeconfig),
+        namespace,
+        GPU_DEPLOYMENT,
+        gpu_fallback.GpuState().to_annotations(),
+    )
+
+    for _ in range(5):
+        await ActivityEnvironment().run(
+            ensure_gpu_mod.ensure_gpu_worker_running_activity
+        )
+        if _replicas(kubeconfig, namespace, GPU_FALLBACK_DEPLOYMENT) == 1:
+            break
+    else:
+        pytest.fail("the GPU queue never fell back to the CPU Deployment")
+
+    assert _replicas(kubeconfig, namespace, GPU_DEPLOYMENT) == 0
+    assert (
+        gpu_fallback.FALLBACK_UNTIL_ANNOTATION
+        in _annotations(kubeconfig, namespace, GPU_DEPLOYMENT)
+    )

--- a/services/fishsense-api-workflow-worker/tests/test_predict_laser_images_parent_workflow.py
+++ b/services/fishsense-api-workflow-worker/tests/test_predict_laser_images_parent_workflow.py
@@ -3,10 +3,17 @@
 
 Pins down:
   1. Selector None -> parent returns None, no resolver/child.
-  2. Full path: dispatches the child on the data-worker queue with the
+  2. Full path: dispatches the child on the data-worker **GPU** queue with the
      deterministic id `predict-laser-{dive_id}`, then persists the child's
      results and returns the dive_id.
   3. Resolver returning 0 images skips the child + persist.
+  4. No GPU *or* CPU-fallback worker available -> the parent bails before
+     staging anything.
+
+(2) and (4) are the halves of the GPU split. This is the only parent that
+dispatches to `fishsense_data_processing_gpu_queue`; the stub child is
+registered there and nowhere else, so a regression that sent it back to the CPU
+queue would hang rather than pass.
 
 The child stub returns predictions; the persist stub records what the parent
 handed it (via an activity, so it survives the workflow sandbox boundary).
@@ -28,8 +35,13 @@ from fishsense_shared import (
     PredictLaserImage,
     PredictLaserImagesInput,
 )
+from fishsense_api_workflow_worker.activities.gpu_fallback import (
+    MODE_CPU_FALLBACK,
+    MODE_GPU,
+    MODE_UNAVAILABLE,
+)
 from fishsense_api_workflow_worker.workflows._dispatch import (
-    DATA_PROCESSING_TASK_QUEUE,
+    DATA_PROCESSING_GPU_TASK_QUEUE,
 )
 from fishsense_api_workflow_worker.workflows.predict_laser_images_parent_workflow import (  # noqa: E501  pylint: disable=line-too-long
     PredictLaserImagesParentWorkflow,
@@ -57,7 +69,7 @@ class _StubChild:
         ]
 
 
-def _stubs(dive_id, images, child_ids, persisted):
+def _stubs(dive_id, images, child_ids, persisted, staged=None, mode=MODE_GPU):
     @activity.defn(name="select_next_high_priority_dive_for_laser_prediction_activity")
     async def selector() -> int | None:
         return dive_id
@@ -72,13 +84,14 @@ def _stubs(dive_id, images, child_ids, persisted):
             wavelength=None,
         )
 
-    @activity.defn(name="ensure_data_worker_running_activity")
-    async def ensure() -> None:
-        return None
+    @activity.defn(name="ensure_gpu_worker_running_activity")
+    async def ensure_gpu() -> str:
+        return mode
 
     @activity.defn(name="stage_raw_bytes_for_dive_activity")
     async def stage(d: int) -> None:
-        return None
+        if staged is not None:
+            staged.append(d)
 
     @activity.defn(name="cleanup_raw_bytes_for_dive_activity")
     async def cleanup(d: int) -> None:
@@ -93,15 +106,15 @@ def _stubs(dive_id, images, child_ids, persisted):
     async def record(workflow_id: str, d: int) -> None:
         child_ids.append(workflow_id)
 
-    return [selector, resolver, ensure, stage, cleanup, persist, record]
+    return [selector, resolver, ensure_gpu, stage, cleanup, persist, record]
 
 
-async def _run(env, dive_id, images, child_ids, persisted):
-    activities = _stubs(dive_id, images, child_ids, persisted)
+async def _run(env, dive_id, images, child_ids, persisted, staged=None, mode=MODE_GPU):
+    activities = _stubs(dive_id, images, child_ids, persisted, staged, mode)
     # Two workers: the parent (+ its activities) on the parent queue, and the
-    # stub child on the data-processing queue the parent dispatches to — the
-    # activities are registered on both so the child's _record_child_dispatch
-    # and the parent's persist both resolve.
+    # stub child on the data-processing GPU queue the parent dispatches to —
+    # the activities are registered on both so the child's
+    # _record_child_dispatch and the parent's persist both resolve.
     async with Worker(
         env.client,
         task_queue="test-predict-parent",
@@ -109,7 +122,7 @@ async def _run(env, dive_id, images, child_ids, persisted):
         activities=activities,
     ), Worker(
         env.client,
-        task_queue=DATA_PROCESSING_TASK_QUEUE,
+        task_queue=DATA_PROCESSING_GPU_TASK_QUEUE,
         workflows=[_StubChild],
         activities=activities,
     ):
@@ -154,5 +167,38 @@ async def test_no_images_skips_child_and_persist():
     async with await WorkflowEnvironment.start_time_skipping() as env:
         result = await _run(env, 440, [], child_ids, persisted)
     assert result == 440
+    assert not child_ids
+    assert not persisted
+
+
+@pytest.mark.asyncio
+async def test_cpu_fallback_capacity_still_dispatches():
+    """A CPU-fallback pod serves the same queue, so the parent's path is
+    identical — the mode is informational, not routing."""
+    child_ids: List[str] = []
+    persisted: List = []
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        result = await _run(
+            env, 441, [(1, "a")], child_ids, persisted, mode=MODE_CPU_FALLBACK
+        )
+    assert result == 441
+    assert child_ids == ["predict-laser-441"]
+
+
+@pytest.mark.asyncio
+async def test_unavailable_capacity_bails_before_staging_anything():
+    """No worker can serve the GPU queue. Staging the dive's raw `.ORF` bytes
+    from the NAS and then dispatching would not fail — the child would sit
+    Running until its execution timeout — so the parent must stop here and let
+    the cohort selector re-offer the dive next hour."""
+    child_ids: List[str] = []
+    persisted: List = []
+    staged: List[int] = []
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        result = await _run(
+            env, 442, [(1, "a")], child_ids, persisted, staged, MODE_UNAVAILABLE
+        )
+    assert result is None
+    assert not staged
     assert not child_ids
     assert not persisted

--- a/services/fishsense-api-workflow-worker/tests/test_scale_down_data_worker_if_idle_activity.py
+++ b/services/fishsense-api-workflow-worker/tests/test_scale_down_data_worker_if_idle_activity.py
@@ -1,11 +1,16 @@
 # pylint: disable=unnecessary-lambda,protected-access
 """Unit tests for scale_down_data_worker_if_idle_activity.
 
-The hourly sweeper scales the NRP data-worker Deployment to 0 only
-when its task queue has had no running or recently-closed workflow.
-The Temporal-busy check and the k8s client are mocked; this pins:
-disabled → no-op; busy → leave replicas; idle → scale to 0; and the
-shape of the Temporal list-filter query.
+The hourly sweeper scales each NRP data-worker Deployment to 0 only when the
+task queue *it* serves has had no running or recently-closed workflow. There
+are three Deployments over two queues — the CPU worker, the GPU worker, and the
+GPU worker's CPU-only fallback — so the per-queue pairing is itself part of
+what is pinned here: a busy CPU queue must not keep a GPU pod alive.
+
+The Temporal-busy check and the k8s client are mocked; this pins: disabled →
+no-op; busy → leave replicas; wedged-but-busy → scale down anyway; idle →
+scale to 0; that the sweeper never writes the GPU-fallback annotations; and
+the shape of the Temporal list-filter query.
 """
 
 from __future__ import annotations
@@ -13,29 +18,62 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
+from fishsense_shared import (
+    DATA_PROCESSING_GPU_TASK_QUEUE,
+    DATA_PROCESSING_TASK_QUEUE,
+)
 from temporalio.testing import ActivityEnvironment
 
 from fishsense_api_workflow_worker.activities import (
     scale_down_data_worker_if_idle_activity as sut,
 )
-from fishsense_api_workflow_worker.activities.k8s_scaling import ScalingConfig
+from fishsense_api_workflow_worker.activities.k8s_scaling import (
+    GpuScalingConfig,
+    ScalingConfig,
+)
+
+CPU_DEPLOYMENT = "fishsense-data-processing-workflow-worker"
+GPU_DEPLOYMENT = f"{CPU_DEPLOYMENT}-gpu"
+FALLBACK_DEPLOYMENT = f"{GPU_DEPLOYMENT}-cpu-fallback"
+ALL_DEPLOYMENTS = [CPU_DEPLOYMENT, GPU_DEPLOYMENT, FALLBACK_DEPLOYMENT]
 
 
 def _config(cooldown: int = 15) -> ScalingConfig:
     return ScalingConfig(
         kubeconfig_path="/tmp/nrp.kubeconfig",
         namespace="fishsense",
-        deployment_name="fishsense-data-processing-workflow-worker",
+        deployment_name=CPU_DEPLOYMENT,
         active_replicas=1,
         idle_cooldown_minutes=cooldown,
+        gpu=GpuScalingConfig(
+            deployment_name=GPU_DEPLOYMENT,
+            fallback_deployment_name=FALLBACK_DEPLOYMENT,
+        ),
     )
 
 
-def _stub_busy(monkeypatch, value: bool) -> None:
-    async def _busy(_cooldown: int) -> bool:
-        return value
+def _stub_busy(monkeypatch, value: bool | set[str]) -> None:
+    """Mark every queue busy/idle, or name exactly the busy queues."""
+    busy = (
+        {DATA_PROCESSING_TASK_QUEUE, DATA_PROCESSING_GPU_TASK_QUEUE}
+        if value is True
+        else (set() if value is False else value)
+    )
+
+    async def _busy(_cooldown: int, task_queue: str = DATA_PROCESSING_TASK_QUEUE):
+        return task_queue in busy
 
     monkeypatch.setattr(sut, "_data_worker_task_queue_busy", _busy)
+
+
+def _record_scales(monkeypatch) -> list:
+    calls: list = []
+    monkeypatch.setattr(
+        sut,
+        "set_deployment_replicas",
+        lambda _api, ns, name, n: calls.append((ns, name, n)),
+    )
+    return calls
 
 
 @pytest.mark.asyncio
@@ -64,6 +102,7 @@ async def test_does_not_scale_down_when_busy_and_worker_is_healthy(monkeypatch):
         "set_deployment_replicas",
         lambda *_a, **_k: pytest.fail("must not scale a busy, healthy data-worker"),
     )
+
     result = await ActivityEnvironment().run(
         sut.scale_down_data_worker_if_idle_activity
     )
@@ -87,34 +126,87 @@ async def test_scales_down_a_wedged_worker_even_though_the_queue_looks_busy(
     _stub_busy(monkeypatch, True)
     monkeypatch.setattr(sut, "apps_v1_api", lambda path: MagicMock())
     monkeypatch.setattr(sut, "deployment_is_wedged", lambda *_a, **_k: True)
-    calls: list = []
-    monkeypatch.setattr(
-        sut,
-        "set_deployment_replicas",
-        lambda a, ns, name, n: calls.append((ns, name, n)),
-    )
+    calls = _record_scales(monkeypatch)
     result = await ActivityEnvironment().run(
         sut.scale_down_data_worker_if_idle_activity
     )
     assert result is True
-    assert calls == [("fishsense", "fishsense-data-processing-workflow-worker", 0)]
+    assert [name for _ns, name, _n in calls] == ALL_DEPLOYMENTS
 
 
 @pytest.mark.asyncio
-async def test_scales_to_zero_when_idle(monkeypatch):
+async def test_scales_every_deployment_to_zero_when_idle(monkeypatch):
+    monkeypatch.setattr(sut, "resolve_scaling_config", lambda: _config())
+    _stub_busy(monkeypatch, False)
+    monkeypatch.setattr(sut, "apps_v1_api", lambda path: MagicMock())
+    calls = _record_scales(monkeypatch)
+    result = await ActivityEnvironment().run(
+        sut.scale_down_data_worker_if_idle_activity
+    )
+    assert result is True
+    assert calls == [("fishsense", name, 0) for name in ALL_DEPLOYMENTS]
+
+
+@pytest.mark.asyncio
+async def test_a_busy_cpu_queue_does_not_keep_the_gpu_pods_alive(monkeypatch):
+    """The reason the split exists. Before it, one queue served everything, so
+    hours of rectify work held a GPU the whole time."""
+    monkeypatch.setattr(sut, "resolve_scaling_config", lambda: _config())
+    _stub_busy(monkeypatch, {DATA_PROCESSING_TASK_QUEUE})
+    monkeypatch.setattr(sut, "apps_v1_api", lambda path: MagicMock())
+    monkeypatch.setattr(sut, "deployment_is_wedged", lambda *_a, **_k: False)
+    calls = _record_scales(monkeypatch)
+    await ActivityEnvironment().run(sut.scale_down_data_worker_if_idle_activity)
+    assert [name for _ns, name, _n in calls] == [
+        GPU_DEPLOYMENT,
+        FALLBACK_DEPLOYMENT,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_busy_gpu_queue_does_not_keep_the_cpu_worker_alive(monkeypatch):
+    monkeypatch.setattr(sut, "resolve_scaling_config", lambda: _config())
+    _stub_busy(monkeypatch, {DATA_PROCESSING_GPU_TASK_QUEUE})
+    monkeypatch.setattr(sut, "apps_v1_api", lambda path: MagicMock())
+    monkeypatch.setattr(sut, "deployment_is_wedged", lambda *_a, **_k: False)
+    calls = _record_scales(monkeypatch)
+    await ActivityEnvironment().run(sut.scale_down_data_worker_if_idle_activity)
+    assert [name for _ns, name, _n in calls] == [CPU_DEPLOYMENT]
+
+
+@pytest.mark.asyncio
+async def test_never_touches_the_gpu_fallback_annotations(monkeypatch):
+    """Tripwire. `gpu_fallback` reads "replicas wanted, no Ready pod" as a
+    failed start and counts it on the GPU Deployment's annotations. If routine
+    idle scale-downs also rewrote those, a multi-hour GPU outage would reset
+    its own failure counter every hour and could never reach the CPU
+    fallback — silently defeating the whole feature."""
     monkeypatch.setattr(sut, "resolve_scaling_config", lambda: _config())
     _stub_busy(monkeypatch, False)
     api = MagicMock()
     monkeypatch.setattr(sut, "apps_v1_api", lambda path: api)
-    calls: list = []
-    monkeypatch.setattr(
-        sut, "set_deployment_replicas", lambda a, ns, name, n: calls.append((ns, name, n))
+    await ActivityEnvironment().run(sut.scale_down_data_worker_if_idle_activity)
+    api.patch_namespaced_deployment.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_queries_each_task_queue_once_not_once_per_deployment(monkeypatch):
+    """Two GPU Deployments share one queue; asking Temporal twice for the same
+    answer is pure waste on an hourly job."""
+    monkeypatch.setattr(sut, "resolve_scaling_config", lambda: _config())
+    monkeypatch.setattr(sut, "apps_v1_api", lambda path: MagicMock())
+    _record_scales(monkeypatch)
+    asked: list[str] = []
+
+    async def _busy(_cooldown, task_queue=DATA_PROCESSING_TASK_QUEUE):
+        asked.append(task_queue)
+        return False
+
+    monkeypatch.setattr(sut, "_data_worker_task_queue_busy", _busy)
+    await ActivityEnvironment().run(sut.scale_down_data_worker_if_idle_activity)
+    assert sorted(asked) == sorted(
+        {DATA_PROCESSING_TASK_QUEUE, DATA_PROCESSING_GPU_TASK_QUEUE}
     )
-    result = await ActivityEnvironment().run(
-        sut.scale_down_data_worker_if_idle_activity
-    )
-    assert result is True
-    assert calls == [("fishsense", "fishsense-data-processing-workflow-worker", 0)]
 
 
 def test_busy_query_targets_data_worker_task_queue_with_running_or_recent_close():
@@ -123,3 +215,8 @@ def test_busy_query_targets_data_worker_task_queue_with_running_or_recent_close(
     assert 'ExecutionStatus = "Running"' in query
     # A recent-close cutoff timestamp (RFC3339, Z-suffixed) is present.
     assert 'CloseTime > "20' in query and query.rstrip().endswith('Z")')
+
+
+def test_busy_query_can_target_the_gpu_task_queue():
+    query = sut._build_busy_query(15, DATA_PROCESSING_GPU_TASK_QUEUE)
+    assert f'TaskQueue = "{DATA_PROCESSING_GPU_TASK_QUEUE}"' in query

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_slate_image.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/activities/predict_slate_image.py
@@ -48,12 +48,45 @@ _log = logging.getLogger(__name__)
 # local checkpoint path overrides the HuggingFace download. The classical path
 # (board_mask=None) is a supported fallback (~13 pts less coverage), so any
 # load/inference failure degrades gracefully instead of failing the frame.
+#
+# This activity runs on `fishsense_data_processing_gpu_queue` and *prefers* a
+# GPU (see `_preferred_device`) without requiring one: that queue is served by
+# a GPU Deployment or, when it can't start, a CPU-only one. Two independent
+# degradations therefore sit under it — GPU -> CPU inference, and
+# BoardMasker -> classical estimator.
 DEFAULT_SLATE_CHECKPOINT_PATH = os.environ.get("E4EFS_SLATE_DETECTOR__CHECKPOINT", "")
 _MASKER: Any = None
 _MASKER_LOADED = False
 # See `_get_masker` — the flag must only ever be published *after* `_MASKER`,
 # and the lock is what stops a concurrent caller reading the pair mid-load.
 _MASKER_LOCK = threading.Lock()
+
+
+def _preferred_device() -> str:
+    """``"cuda"`` when a GPU is actually usable in this process, else ``"cpu"``.
+
+    `BoardMasker` defaults to ``device="cpu"`` and does NOT auto-select CUDA
+    the way `LaserDetector` does, so without this the mask ran on the CPU even
+    on a GPU-scheduled pod — which it silently did for this activity's whole
+    life. fishsense-core's default is a reasonable one for a 202 ms/frame model
+    that it assumed would never be GPU-scheduled; this activity now runs on the
+    GPU queue, so it asks.
+
+    "Prefer", not "require": this stage degrades all the way down — no GPU
+    means CPU inference, and no torch at all means the classical estimator
+    (`_get_masker` returns None). Any failure here just means CPU.
+    """
+    try:
+        import torch  # pylint: disable=import-error
+
+        if torch.cuda.is_available():
+            return "cuda"
+    except Exception:  # pylint: disable=broad-except
+        # torch missing or a broken CUDA runtime — the caller's own try/except
+        # would catch it later anyway, but there is no reason to ask for a
+        # device we could not verify.
+        _log.debug("no usable CUDA device; BoardMasker will run on the CPU")
+    return "cpu"
 
 
 def _get_masker() -> Any:
@@ -83,13 +116,16 @@ def _get_masker() -> Any:
                 BoardMasker,
             )
 
+            device = _preferred_device()
             if DEFAULT_SLATE_CHECKPOINT_PATH and os.path.exists(
                 DEFAULT_SLATE_CHECKPOINT_PATH
             ):
-                _MASKER = BoardMasker.from_checkpoint(DEFAULT_SLATE_CHECKPOINT_PATH)
+                _MASKER = BoardMasker.from_checkpoint(
+                    DEFAULT_SLATE_CHECKPOINT_PATH, device=device
+                )
             else:
-                _MASKER = BoardMasker.from_pretrained()
-            _log.info("loaded BoardMasker (learned board mask)")
+                _MASKER = BoardMasker.from_pretrained(device=device)
+            _log.info("loaded BoardMasker (learned board mask) device=%s", device)
         except Exception as exc:  # pylint: disable=broad-except
             # torch/hf missing, no network, or bad checkpoint — fall back to the
             # classical estimator. The mask only adds coverage; it's never required.

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/config.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/config.py
@@ -13,6 +13,8 @@ from fishsense_shared import (
     url_condition,
 )
 
+from fishsense_data_processing_workflow_worker.role_names import ROLE_ALL, ROLES
+
 APP_NAME = "e4efs_data_processing_workflow_worker"
 
 
@@ -33,6 +35,20 @@ _VALIDATORS = [
         cast=int,
         default=4,
         condition=lambda x: x > 0,
+    ),
+    # Which half of the split worker this process is. `cpu` polls
+    # `fishsense_data_processing_queue` (rectify/cluster/calibrate/measure/
+    # depth/validate); `gpu` polls `fishsense_data_processing_gpu_queue` (the
+    # two torch predict stages). `all` runs both in one process and is the
+    # default so the devcontainer and the integration tests still serve every
+    # queue the api-worker dispatches to; the k8s Deployments each set
+    # `E4EFS_GENERAL__ROLE` explicitly. See `roles.py`.
+    Validator(
+        "general.role",
+        required=True,
+        cast=str,
+        default=ROLE_ALL,
+        condition=lambda x: x in ROLES,
     ),
     Validator("temporal.host", required=True, cast=str, condition=validators.hostname),
     Validator("temporal.port", required=True, cast=int, default=7233),

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/role_names.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/role_names.py
@@ -1,0 +1,47 @@
+"""Role vocabulary: the values `general.role` accepts, and their task queues.
+
+Deliberately a leaf module — it imports nothing from this package. `config.py`
+validates `general.role` against `ROLES`, and `roles.py` (which imports every
+activity and workflow to build the registration lists) imports these names and
+re-exports them. Putting the constants in `roles.py` itself is the obvious
+thing and it does not work: `config` -> `roles` -> `activities.utils` ->
+`config` is a cycle, and it fails at worker startup rather than at test time.
+
+Split by whether the work needs a GPU:
+
+* ``cpu`` — rectify/overlay/JPEG (stages 0.1 / 2 / 5.1 / 9), frame clustering,
+  laser calibration, fish measurement, laser depth, laser-label validation.
+* ``gpu`` — the two torch stages, `predict_laser_image` and the retired
+  `predict_slate_image`.
+* ``all`` — both roles in one process. Not a third kind of work: it is what
+  the devcontainer and the integration tests run so a local process still
+  serves every queue the api-worker dispatches to.
+"""
+
+from typing import Final
+
+from fishsense_shared import (
+    DATA_PROCESSING_GPU_TASK_QUEUE,
+    DATA_PROCESSING_TASK_QUEUE,
+)
+
+ROLE_CPU: Final = "cpu"
+ROLE_GPU: Final = "gpu"
+ROLE_ALL: Final = "all"
+
+#: Every value `general.role` accepts.
+ROLES: Final = (ROLE_CPU, ROLE_GPU, ROLE_ALL)
+
+#: Single-role task queues. ``all`` is absent on purpose — it is two queues.
+ROLE_TASK_QUEUES: Final[dict[str, str]] = {
+    ROLE_CPU: DATA_PROCESSING_TASK_QUEUE,
+    ROLE_GPU: DATA_PROCESSING_GPU_TASK_QUEUE,
+}
+
+__all__ = [
+    "ROLES",
+    "ROLE_ALL",
+    "ROLE_CPU",
+    "ROLE_GPU",
+    "ROLE_TASK_QUEUES",
+]

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/roles.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/roles.py
@@ -1,0 +1,234 @@
+"""What each data-worker role registers, and on which task queue.
+
+The data-worker runs in one of two roles, and the split is by whether the work
+needs a GPU:
+
+* ``cpu`` — the nine stages that are pure CPU: rectify/overlay/JPEG for stages
+  0.1 / 2 / 5.1 / 9, frame clustering, laser calibration, fish measurement,
+  laser depth, and laser-label validation.
+* ``gpu`` — the two torch inference stages: `predict_laser_image`
+  (`fishsense_core.laser.LaserDetector`) and the retired `predict_slate_image`
+  (`fishsense_core.slate.BoardMasker`).
+
+The GPU queue means **prefer a GPU, not require one**, and that distinction is
+what makes it the right home for both. It is served by a GPU Deployment *or*,
+when that repeatedly fails to start, a CPU-only one running the same
+checkpoints — so landing a stage here buys it a GPU when there is one without
+ever gating it on there being one.
+
+The two stages want that for different reasons. The laser detector genuinely
+needs the GPU; it is slow enough on CPU that the fallback is a degradation.
+The slate masker does not — fishsense-core measures it at 202 ms/frame on CPU
+and defaults `BoardMasker(device=)` to ``"cpu"`` for exactly that reason — but
+it is still a torch model that goes faster on a card that is already there for
+the laser stage, and it costs nothing to let it use one. `predict_slate_image`
+now passes a device explicitly; before that it ran on the CPU even on the
+GPU-pinned pod, which nothing in the code said out loud.
+
+Before the split there was one process, one queue, and one Deployment that
+requested ``nvidia.com/gpu: 1`` with node affinity pinned to compute capability
+>= 7.5. That meant *every* stage waited on NRP finding a Turing-or-newer GPU
+with free capacity, and the GPU then sat idle through the hours of rawpy decode
+that dominate a real dive. Splitting the roles is what lets the CPU Deployment
+carry no GPU request at all.
+
+``all`` is not a third role — it is "both roles in one process", which is what
+the devcontainer and the integration tests use so a local run still serves
+every queue the api-worker dispatches to.
+
+**Keeping the two lists exhaustive is the whole contract here**, and
+`tests/test_worker_roles.py` asserts it, because both ways of getting it wrong
+are silent. An activity in neither list is registered nowhere: its workflow's
+`execute_activity` sits pending until schedule-to-close, hours later, with
+nothing logged by either worker. An activity in both is registered on a queue
+whose pod may have no GPU at all. Neither surfaces until a dive is being
+processed in prod. Add a new activity to exactly one list.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Final, NamedTuple, Sequence
+
+from fishsense_data_processing_workflow_worker.role_names import (
+    ROLE_ALL,
+    ROLE_CPU,
+    ROLE_GPU,
+    ROLE_TASK_QUEUES,
+    ROLES,
+)
+
+from fishsense_data_processing_workflow_worker.activities.cluster_dive_frames import (
+    cluster_dive_frames,
+)
+from fishsense_data_processing_workflow_worker.activities.compute_laser_depths_activity import (  # noqa: E501  pylint: disable=line-too-long
+    compute_laser_depths_activity,
+)
+from fishsense_data_processing_workflow_worker.activities.measure_fish_activity import (
+    measure_fish_activity,
+)
+from fishsense_data_processing_workflow_worker.activities.perform_laser_calibration_activity import (  # noqa: E501  pylint: disable=line-too-long
+    perform_laser_calibration_activity,
+)
+from fishsense_data_processing_workflow_worker.activities.predict_laser_image import (
+    predict_laser_image,
+)
+from fishsense_data_processing_workflow_worker.activities.predict_slate_image import (
+    predict_slate_image,
+)
+from fishsense_data_processing_workflow_worker.activities.preprocess_headtail_image import (  # noqa: E501  pylint: disable=line-too-long
+    preprocess_headtail_image,
+)
+from fishsense_data_processing_workflow_worker.activities.preprocess_laser_image import (
+    preprocess_laser_image,
+)
+from fishsense_data_processing_workflow_worker.activities.preprocess_slate_image import (
+    preprocess_slate_image,
+)
+from fishsense_data_processing_workflow_worker.activities.preprocess_species_image import (  # noqa: E501  pylint: disable=line-too-long
+    preprocess_species_image,
+)
+from fishsense_data_processing_workflow_worker.activities.validate_laser_labels_for_dive_activity import (  # noqa: E501  pylint: disable=line-too-long
+    validate_laser_labels_for_dive_activity,
+)
+from fishsense_data_processing_workflow_worker.workflows.compute_laser_depths_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    ComputeLaserDepthsWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.dive_frame_clustering_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    DiveFrameClusteringWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.measure_fish_workflow import (
+    MeasureFishWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.perform_laser_calibration_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PerformLaserCalibrationWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.predict_laser_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PredictLaserImagesWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.predict_slate_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PredictSlateImagesWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.preprocess_headtail_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PreprocessHeadtailImagesWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.preprocess_laser_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PreprocessLaserImagesWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.preprocess_slate_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PreprocessSlateImagesWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.preprocess_species_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PreprocessSpeciesImagesWorkflow,
+)
+from fishsense_data_processing_workflow_worker.workflows.validate_laser_labels_for_dive_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    ValidateLaserLabelsForDiveWorkflow,
+)
+
+CPU_WORKFLOWS: Final[Sequence[type]] = (
+    ComputeLaserDepthsWorkflow,
+    DiveFrameClusteringWorkflow,
+    MeasureFishWorkflow,
+    PerformLaserCalibrationWorkflow,
+    PreprocessHeadtailImagesWorkflow,
+    PreprocessLaserImagesWorkflow,
+    PreprocessSlateImagesWorkflow,
+    PreprocessSpeciesImagesWorkflow,
+    ValidateLaserLabelsForDiveWorkflow,
+)
+
+CPU_ACTIVITIES: Final[Sequence[Callable[..., Any]]] = (
+    cluster_dive_frames,
+    compute_laser_depths_activity,
+    measure_fish_activity,
+    perform_laser_calibration_activity,
+    preprocess_headtail_image,
+    preprocess_laser_image,
+    preprocess_slate_image,
+    preprocess_species_image,
+    validate_laser_labels_for_dive_activity,
+)
+
+# The torch inference stages. `predict_slate_image` is RETIRED (2026-08-03 —
+# the ECC gate does not transfer out of distribution) and its schedule is
+# actively deleted at api-worker startup, but it stays registered so a future
+# evaluation can start it by hand, and it should get a GPU when one is there.
+GPU_WORKFLOWS: Final[Sequence[type]] = (
+    PredictLaserImagesWorkflow,
+    PredictSlateImagesWorkflow,
+)
+
+GPU_ACTIVITIES: Final[Sequence[Callable[..., Any]]] = (
+    predict_laser_image,
+    predict_slate_image,
+)
+
+#: The union, for the exhaustiveness tripwire in `tests/test_worker_roles.py`.
+ALL_WORKFLOWS: Final[Sequence[type]] = (*CPU_WORKFLOWS, *GPU_WORKFLOWS)
+ALL_ACTIVITIES: Final[Sequence[Callable[..., Any]]] = (
+    *CPU_ACTIVITIES,
+    *GPU_ACTIVITIES,
+)
+
+
+class Registration(NamedTuple):
+    """One Temporal worker's worth of wiring: a queue and what serves it."""
+
+    task_queue: str
+    workflows: Sequence[type]
+    activities: Sequence[Callable[..., Any]]
+
+
+_REGISTRATIONS: Final[dict[str, Registration]] = {
+    ROLE_CPU: Registration(ROLE_TASK_QUEUES[ROLE_CPU], CPU_WORKFLOWS, CPU_ACTIVITIES),
+    ROLE_GPU: Registration(ROLE_TASK_QUEUES[ROLE_GPU], GPU_WORKFLOWS, GPU_ACTIVITIES),
+}
+
+
+def registration_for_role(role: str) -> Registration:
+    """Return the single role's wiring.
+
+    Raises for ``all`` as well as for an unknown role: ``all`` is two queues,
+    so there is no one answer, and quietly returning the CPU half would leave
+    the GPU queue unserved — a stall with no error anywhere.
+    """
+    try:
+        return _REGISTRATIONS[role]
+    except KeyError:
+        raise ValueError(
+            f"{role!r} is not a single data-worker role; "
+            f"expected one of {sorted(_REGISTRATIONS)} "
+            f"(use {ROLE_ALL!r} with build_workers to serve both queues)"
+        ) from None
+
+
+def registrations_for_role(role: str) -> list[Registration]:
+    """Return every worker `role` should run — two entries for ``all``."""
+    if role == ROLE_ALL:
+        return [_REGISTRATIONS[ROLE_CPU], _REGISTRATIONS[ROLE_GPU]]
+    return [registration_for_role(role)]
+
+
+def queue_for_role(role: str) -> str:
+    """Task queue a single role polls."""
+    return registration_for_role(role).task_queue
+
+
+# Re-exported from `role_names` so callers have one import for "roles": the
+# vocabulary and the wiring. `config.py` must keep importing the leaf module
+# directly — importing this one would cycle back through the activities.
+__all__ = [
+    "ALL_ACTIVITIES",
+    "ALL_WORKFLOWS",
+    "CPU_ACTIVITIES",
+    "CPU_WORKFLOWS",
+    "GPU_ACTIVITIES",
+    "GPU_WORKFLOWS",
+    "ROLES",
+    "ROLE_ALL",
+    "ROLE_CPU",
+    "ROLE_GPU",
+    "Registration",
+    "queue_for_role",
+    "registration_for_role",
+    "registrations_for_role",
+]

--- a/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
+++ b/services/fishsense-data-processing-workflow-worker/src/fishsense_data_processing_workflow_worker/worker.py
@@ -3,87 +3,34 @@
 Single ``build_worker`` construction point (shared with tests) plus the
 ``main`` scale-to-zero-friendly run loop. Caps activity concurrency to keep
 the CPU-heavy per-image rectify/decode work under the pod's memory limit.
+
+The worker runs in one of two roles — ``cpu`` or ``gpu`` — each polling its
+own task queue, or ``all`` (both, in one process) for local development. What
+each role registers lives in `roles.py`; this module only turns a role into
+Temporal ``Worker`` objects and runs them.
 """
 
 import asyncio
 import logging
 import signal
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import AsyncExitStack
 from datetime import timedelta
 
-from fishsense_shared import build_tls_config, temporal_namespace
+from fishsense_shared import (
+    DATA_PROCESSING_TASK_QUEUE,
+    build_tls_config,
+    temporal_namespace,
+)
 from temporalio.client import Client
 from temporalio.worker import Worker
 
-from fishsense_data_processing_workflow_worker.activities.cluster_dive_frames import (
-    cluster_dive_frames,
-)
-from fishsense_data_processing_workflow_worker.activities.compute_laser_depths_activity import (  # noqa: E501  pylint: disable=line-too-long
-    compute_laser_depths_activity,
-)
-from fishsense_data_processing_workflow_worker.activities.measure_fish_activity import (
-    measure_fish_activity,
-)
-from fishsense_data_processing_workflow_worker.activities.perform_laser_calibration_activity import (  # noqa: E501  pylint: disable=line-too-long
-    perform_laser_calibration_activity,
-)
-from fishsense_data_processing_workflow_worker.activities.preprocess_species_image import (
-    preprocess_species_image,
-)
-from fishsense_data_processing_workflow_worker.activities.preprocess_headtail_image import (
-    preprocess_headtail_image,
-)
-from fishsense_data_processing_workflow_worker.activities.predict_laser_image import (
-    predict_laser_image,
-)
-from fishsense_data_processing_workflow_worker.activities.predict_slate_image import (
-    predict_slate_image,
-)
-from fishsense_data_processing_workflow_worker.activities.preprocess_laser_image import (
-    preprocess_laser_image,
-)
-from fishsense_data_processing_workflow_worker.activities.preprocess_slate_image import (
-    preprocess_slate_image,
-)
-from fishsense_data_processing_workflow_worker.activities.validate_laser_labels_for_dive_activity import (  # noqa: E501  pylint: disable=line-too-long
-    validate_laser_labels_for_dive_activity,
-)
+from fishsense_data_processing_workflow_worker import roles
 from fishsense_data_processing_workflow_worker.config import configure_logging, settings
-from fishsense_data_processing_workflow_worker.workflows.dive_frame_clustering_workflow import (
-    DiveFrameClusteringWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.compute_laser_depths_workflow import (  # noqa: E501  pylint: disable=line-too-long
-    ComputeLaserDepthsWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.measure_fish_workflow import (
-    MeasureFishWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.perform_laser_calibration_workflow import (  # noqa: E501  pylint: disable=line-too-long
-    PerformLaserCalibrationWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.preprocess_species_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
-    PreprocessSpeciesImagesWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.preprocess_headtail_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
-    PreprocessHeadtailImagesWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.predict_laser_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
-    PredictLaserImagesWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.predict_slate_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
-    PredictSlateImagesWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.preprocess_laser_images_workflow import (
-    PreprocessLaserImagesWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.preprocess_slate_images_workflow import (
-    PreprocessSlateImagesWorkflow,
-)
-from fishsense_data_processing_workflow_worker.workflows.validate_laser_labels_for_dive_workflow import (  # noqa: E501  pylint: disable=line-too-long
-    ValidateLaserLabelsForDiveWorkflow,
-)
 
-TASK_QUEUE_NAME = "fishsense_data_processing_queue"
+# Retained for the CPU queue's historical name so existing callers and tests
+# keep reading one constant. `roles.queue_for_role` is the general form.
+TASK_QUEUE_NAME = DATA_PROCESSING_TASK_QUEUE
 
 # How long in-flight activities get to finish when the worker is asked to
 # stop. On NRP the api-worker scales this deployment to zero when idle, so
@@ -119,50 +66,63 @@ async def schedule_workflows(_: Client):
     """
 
 
+def _build(
+    client: Client,
+    activity_executor: ThreadPoolExecutor,
+    max_concurrent_activities: int,
+    registration: roles.Registration,
+) -> Worker:
+    """Turn one role's wiring into a Temporal ``Worker``."""
+    return Worker(
+        client,
+        task_queue=registration.task_queue,
+        max_concurrent_activities=max_concurrent_activities,
+        workflows=list(registration.workflows),
+        activity_executor=activity_executor,
+        activities=list(registration.activities),
+        graceful_shutdown_timeout=GRACEFUL_SHUTDOWN_TIMEOUT,
+    )
+
+
 def build_worker(
     client: Client,
     activity_executor: ThreadPoolExecutor,
     max_concurrent_activities: int = DEFAULT_MAX_CONCURRENT_ACTIVITIES,
+    role: str = roles.ROLE_CPU,
 ) -> Worker:
-    """Construct the data-worker Temporal worker.
+    """Construct one role's Temporal worker.
 
     Single construction point so the worker config (workflows, activities,
     graceful-shutdown window, activity concurrency cap) is exercised by tests
     without standing up the full ``main`` loop.
+
+    Raises ``ValueError`` for ``all`` — that is two queues, so it has no single
+    answer. Use ``build_workers``.
     """
-    return Worker(
+    return _build(
         client,
-        task_queue=TASK_QUEUE_NAME,
-        max_concurrent_activities=max_concurrent_activities,
-        workflows=[
-            ComputeLaserDepthsWorkflow,
-            DiveFrameClusteringWorkflow,
-            MeasureFishWorkflow,
-            PerformLaserCalibrationWorkflow,
-            PreprocessSpeciesImagesWorkflow,
-            PreprocessHeadtailImagesWorkflow,
-            PredictLaserImagesWorkflow,
-            PredictSlateImagesWorkflow,
-            PreprocessLaserImagesWorkflow,
-            PreprocessSlateImagesWorkflow,
-            ValidateLaserLabelsForDiveWorkflow,
-        ],
-        activity_executor=activity_executor,
-        activities=[
-            cluster_dive_frames,
-            compute_laser_depths_activity,
-            measure_fish_activity,
-            perform_laser_calibration_activity,
-            predict_laser_image,
-            predict_slate_image,
-            preprocess_species_image,
-            preprocess_headtail_image,
-            preprocess_laser_image,
-            preprocess_slate_image,
-            validate_laser_labels_for_dive_activity,
-        ],
-        graceful_shutdown_timeout=GRACEFUL_SHUTDOWN_TIMEOUT,
+        activity_executor,
+        max_concurrent_activities,
+        roles.registration_for_role(role),
     )
+
+
+def build_workers(
+    client: Client,
+    activity_executor: ThreadPoolExecutor,
+    max_concurrent_activities: int = DEFAULT_MAX_CONCURRENT_ACTIVITIES,
+    role: str = roles.ROLE_ALL,
+) -> list[Worker]:
+    """Every worker this process should run for ``role``.
+
+    One entry for ``cpu``/``gpu``; both for ``all``, which is what the
+    devcontainer and the integration tests use so a local process still serves
+    every queue the api-worker dispatches to.
+    """
+    return [
+        _build(client, activity_executor, max_concurrent_activities, registration)
+        for registration in roles.registrations_for_role(role)
+    ]
 
 
 async def main():
@@ -171,13 +131,15 @@ async def main():
     configure_logging()
     log = logging.getLogger()
 
+    role = settings.general.get("role", roles.ROLE_ALL)
     tls_config = build_tls_config(settings.temporal)
 
     log.info(
-        "connecting to Temporal host=%s:%d tls=%s",
+        "connecting to Temporal host=%s:%d tls=%s role=%s",
         settings.temporal.host,
         settings.temporal.port,
         bool(tls_config),
+        role,
     )
     client = await Client.connect(
         f"{settings.temporal.host}:{settings.temporal.port}",
@@ -191,14 +153,25 @@ async def main():
         loop.add_signal_handler(sig, interrupt_event.set)
 
     with ThreadPoolExecutor(max_workers=settings.general.max_workers) as executor:
-        async with build_worker(
+        workers = build_workers(
             client,
             executor,
             settings.general.get(
                 "max_concurrent_activities", DEFAULT_MAX_CONCURRENT_ACTIVITIES
             ),
-        ):
-            log.info("Worker started, scheduling workflows...")
+            role=role,
+        )
+        # AsyncExitStack rather than a single `async with`: the `all` role runs
+        # two workers (one per queue) in this one process, and both must be
+        # entered and — importantly — drained on the way out. Exiting the stack
+        # gives each its own graceful-shutdown window.
+        async with AsyncExitStack() as stack:
+            for worker in workers:
+                await stack.enter_async_context(worker)
+            log.info(
+                "Worker started on %s, scheduling workflows...",
+                ", ".join(worker.config()["task_queue"] for worker in workers),
+            )
             await schedule_workflows(client)
             await interrupt_event.wait()
             log.info(

--- a/services/fishsense-data-processing-workflow-worker/tests/test_predict_slate_image.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_predict_slate_image.py
@@ -137,3 +137,69 @@ def test_get_masker_falls_back_to_none_and_caches(monkeypatch):
     assert sut._get_masker() is None
     assert sut._get_masker() is None  # cached
     assert calls["n"] == 1  # loaded once, failure cached
+
+
+def _reset_masker(monkeypatch, checkpoint=""):
+    # pylint: disable=protected-access
+    monkeypatch.setattr(sut, "DEFAULT_SLATE_CHECKPOINT_PATH", checkpoint)
+    monkeypatch.setattr(sut, "_MASKER", None)
+    monkeypatch.setattr(sut, "_MASKER_LOADED", False)
+
+
+@pytest.mark.parametrize(
+    ("cuda_available", "expected"), [(True, "cuda"), (False, "cpu")]
+)
+def test_preferred_device_follows_cuda_availability(
+    monkeypatch, cuda_available, expected
+):
+    # pylint: disable=protected-access
+    """`BoardMasker` defaults to device="cpu" and, unlike `LaserDetector`, does
+    NOT auto-select CUDA — so without asking, the mask runs on the CPU even on
+    a GPU pod. It did exactly that for this activity's whole life."""
+    import torch
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: cuda_available)
+    assert sut._preferred_device() == expected
+
+
+def test_preferred_device_is_cpu_when_torch_is_unusable(monkeypatch):
+    # pylint: disable=protected-access
+    """A broken CUDA runtime must degrade to CPU, not fail the frame. This
+    stage has two independent fallbacks under it and neither should be
+    triggered by merely asking what device to use."""
+    import torch
+
+    def _boom():
+        raise RuntimeError("no CUDA driver")
+
+    monkeypatch.setattr(torch.cuda, "is_available", _boom)
+    assert sut._preferred_device() == "cpu"
+
+
+def test_masker_is_loaded_onto_the_preferred_device(monkeypatch):
+    # pylint: disable=protected-access
+    """The move to the GPU queue is cosmetic unless the device is passed
+    through — pin that it reaches both load paths."""
+    import fishsense_core.slate as slate_mod
+
+    monkeypatch.setattr(sut, "_preferred_device", lambda: "cuda")
+    seen = {}
+
+    def _from_pretrained(*_a, device="cpu", **_k):
+        seen["pretrained"] = device
+        return object()
+
+    def _from_checkpoint(_path, *_a, device="cpu", **_k):
+        seen["checkpoint"] = device
+        return object()
+
+    monkeypatch.setattr(slate_mod.BoardMasker, "from_pretrained", _from_pretrained)
+    monkeypatch.setattr(slate_mod.BoardMasker, "from_checkpoint", _from_checkpoint)
+
+    _reset_masker(monkeypatch)
+    assert sut._get_masker() is not None
+    assert seen == {"pretrained": "cuda"}
+
+    _reset_masker(monkeypatch, checkpoint=__file__)  # any path that exists
+    assert sut._get_masker() is not None
+    assert seen["checkpoint"] == "cuda"

--- a/services/fishsense-data-processing-workflow-worker/tests/test_worker_roles.py
+++ b/services/fishsense-data-processing-workflow-worker/tests/test_worker_roles.py
@@ -1,0 +1,145 @@
+"""Role split: which queue a worker polls, and what it registers.
+
+The data-worker used to be one process on one queue whose pod requested
+``nvidia.com/gpu: 1``, so every stage — nine CPU activities included — was
+gated on NRP scheduling a Turing-or-newer GPU. It is now split by role: the
+``cpu`` role serves `fishsense_data_processing_queue` and the ``gpu`` role
+serves `fishsense_data_processing_gpu_queue`, which only the two torch
+inference stages land on.
+
+The load-bearing test here is `test_every_registration_lands_in_exactly_one
+_role`. The split is two hand-maintained lists, and the failure mode of
+getting it wrong is silent in both directions: an activity in neither list is
+never registered anywhere, so its workflow's `execute_activity` sits pending
+until the schedule-to-close timeout with nothing logged; an activity in both
+is registered on a queue whose pod may have no GPU. Neither shows up until a
+dive is being processed in prod.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from fishsense_shared import (
+    DATA_PROCESSING_GPU_TASK_QUEUE,
+    DATA_PROCESSING_TASK_QUEUE,
+)
+from temporalio.testing import WorkflowEnvironment
+
+from fishsense_data_processing_workflow_worker import roles
+from fishsense_data_processing_workflow_worker.activities.predict_slate_image import (
+    predict_slate_image,
+)
+from fishsense_data_processing_workflow_worker.workflows.predict_slate_images_workflow import (  # noqa: E501  pylint: disable=line-too-long
+    PredictSlateImagesWorkflow,
+)
+from fishsense_data_processing_workflow_worker.worker import (
+    build_worker,
+    build_workers,
+)
+
+
+def test_role_queues_are_distinct_and_come_from_the_shared_contract():
+    assert roles.queue_for_role(roles.ROLE_CPU) == DATA_PROCESSING_TASK_QUEUE
+    assert roles.queue_for_role(roles.ROLE_GPU) == DATA_PROCESSING_GPU_TASK_QUEUE
+    assert DATA_PROCESSING_TASK_QUEUE != DATA_PROCESSING_GPU_TASK_QUEUE
+
+
+def test_every_registration_lands_in_exactly_one_role():
+    """No activity or workflow may be in both role lists or in neither.
+
+    Both mistakes are silent in prod — see the module docstring.
+    """
+    assert not set(roles.CPU_ACTIVITIES) & set(roles.GPU_ACTIVITIES)
+    assert not set(roles.CPU_WORKFLOWS) & set(roles.GPU_WORKFLOWS)
+    assert set(roles.CPU_ACTIVITIES) | set(roles.GPU_ACTIVITIES) == set(
+        roles.ALL_ACTIVITIES
+    )
+    assert set(roles.CPU_WORKFLOWS) | set(roles.GPU_WORKFLOWS) == set(
+        roles.ALL_WORKFLOWS
+    )
+
+
+def test_gpu_role_holds_exactly_the_torch_inference_stages():
+    """The GPU queue carries the two torch models and nothing else. Anything
+    else there would wait on the GPU-capacity handshake for no benefit."""
+    assert {activity.__name__ for activity in roles.GPU_ACTIVITIES} == {
+        "predict_laser_image",
+        "predict_slate_image",
+    }
+    assert {workflow.__name__ for workflow in roles.GPU_WORKFLOWS} == {
+        "PredictLaserImagesWorkflow",
+        "PredictSlateImagesWorkflow",
+    }
+
+
+def test_slate_prediction_prefers_the_gpu_without_requiring_one():
+    """`predict_slate_image` is on the GPU queue even though it does not need a
+    GPU (fishsense-core measures the mask at 202 ms/frame on CPU).
+
+    That is safe precisely because the GPU queue means *prefer*, not *require*:
+    it is served by the GPU Deployment or, when that can't start, a CPU-only
+    one. So the stage gets the card the laser detector already needs, and is
+    never gated on there being one.
+    """
+    assert predict_slate_image in roles.GPU_ACTIVITIES
+    assert PredictSlateImagesWorkflow in roles.GPU_WORKFLOWS
+
+
+@pytest.mark.parametrize(
+    ("role", "expected_queue"),
+    [
+        (roles.ROLE_CPU, DATA_PROCESSING_TASK_QUEUE),
+        (roles.ROLE_GPU, DATA_PROCESSING_GPU_TASK_QUEUE),
+    ],
+)
+@pytest.mark.asyncio
+async def test_build_worker_polls_the_queue_for_its_role(role, expected_queue):
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            worker = build_worker(env.client, executor, role=role)
+            assert worker.config()["task_queue"] == expected_queue
+
+
+@pytest.mark.asyncio
+async def test_build_worker_rejects_the_all_role():
+    """``all`` is two queues, so it cannot produce one Worker. Callers that
+    want it must use ``build_workers``; silently returning just the CPU half
+    would leave the GPU queue unserved."""
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            with pytest.raises(ValueError):
+                build_worker(env.client, executor, role=roles.ROLE_ALL)
+
+
+@pytest.mark.asyncio
+async def test_build_worker_rejects_an_unknown_role():
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            with pytest.raises(ValueError):
+                build_worker(env.client, executor, role="tpu")
+
+
+@pytest.mark.asyncio
+async def test_build_workers_all_serves_both_queues_in_one_process():
+    """The devcontainer default. One process, both queues — so local runs and
+    the integration tests behave exactly as they did before the split."""
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            workers = build_workers(env.client, executor, role=roles.ROLE_ALL)
+            assert {worker.config()["task_queue"] for worker in workers} == {
+                DATA_PROCESSING_TASK_QUEUE,
+                DATA_PROCESSING_GPU_TASK_QUEUE,
+            }
+
+
+@pytest.mark.asyncio
+async def test_build_workers_single_role_returns_one_worker():
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            workers = build_workers(env.client, executor, role=roles.ROLE_GPU)
+            assert len(workers) == 1
+            assert (
+                workers[0].config()["task_queue"] == DATA_PROCESSING_GPU_TASK_QUEUE
+            )


### PR DESCRIPTION
Part 2 of 2. **Stacked on #631** — targets that branch; merge #631 first and this retargets to `main`.

Completes the GPU/CPU split and adds the half that makes the guarantee real: **nothing in the pipeline is ever blocked on a GPU being available.**

## Two independent mechanisms

**1. Eight stages stopped needing a GPU at all.** The CPU Deployment now carries no `nvidia.com/gpu`, no `nvidia.com/gpu:NoSchedule` toleration, and no SM >= 7.5 affinity. It schedules on any amd64 node.

**2. The GPU queue means *prefer* a GPU, not *require* one.** `fishsense_data_processing_gpu_queue` is served by two Deployments running the same image in the same `gpu` role — `...-worker-gpu` (requests a card) and `...-worker-gpu-cpu-fallback` (requests none) — of which exactly one is scaled up.

That second point is what makes it correct to put `predict_slate_image` on the GPU queue at all. It does **not** need a card — fishsense-core measures the board mask at 202 ms/frame on CPU and says so in its own docstring — but it goes faster on the one the laser detector already requires, and this way it is never gated on there being one.

**The fallback required no detector code.** `LaserDetector.__init__` already picks `"cuda" if torch.cuda.is_available() else "cpu"` and the activity passes no device, so the CPU pod produces the *same predictions*, just slowly.

## The fallback state machine

After `gpu_max_start_failures` (3) consecutive failed GPU starts, the api-worker scales the GPU Deployment to 0 and the fallback to `gpu_fallback_replicas` for `gpu_fallback_minutes` (180), then probes the GPU again. A "failed start" is `spec.replicas > 0` with no Ready pod after `gpu_start_timeout_seconds` (600) — long enough that an image pull is not mistaken for an outage.

**The window expires on purpose.** Without it, one bad afternoon on NRP would strand the stage on CPU inference permanently.

`decide()` is pure, so the whole multi-hour sequence (wedge, count, flip, hold, expire, probe) is exercised in milliseconds rather than against a real cluster.

### State lives in annotations on the GPU Deployment, not in the api-worker

A counter that reset on every api-worker restart or slot converge would never accumulate across the multi-hour outage the fallback exists for. Annotations also make it operator-visible and operator-editable:

```bash
# Force CPU inference now (you know the GPU pool is drained):
kubectl -n e4e-fishsense annotate deploy fishsense-data-processing-workflow-worker-gpu \
  fishsense.e4e.ucsd.edu/gpu-start-failures=3 --overwrite

# End a fallback early:
kubectl -n e4e-fishsense annotate deploy fishsense-data-processing-workflow-worker-gpu \
  fishsense.e4e.ucsd.edu/gpu-fallback-until- fishsense.e4e.ucsd.edu/gpu-start-failures-
```

All three annotations are **absent when healthy**, so their presence is itself the signal.

### Three details are load-bearing, each with a tripwire test

- **The hourly sweeper writes only `deployments/scale`, never the annotations.** If routine idle scale-downs cleared them, a long GPU outage would reset its own failure counter every hour and could never reach the fallback — silently defeating the feature.
- **`wedge_grace` is clamped to `gpu_start_timeout_seconds`.** The activity waits out the start timeout and *then* observes; a longer grace would swallow every observation and the fallback could never trip.
- **The annotation patch never touches `spec.template`**, which would roll the very pods we are trying to get started.

### `unavailable` means bail, not dispatch

When neither Deployment can start, the predict parents return **before staging any bytes**. Dispatching onto an unserved queue does not fail — it hangs until the child's execution timeout, having staged the dive's raw `.ORF`s from the NAS for nothing. The dive stays in the cohort for the next firing.

## Other changes worth a look

- **`kubernetes.gpu_active_replicas` is separate from `active_replicas`.** The latter now sizes CPU pods, where more is just more throughput; each GPU pod holds a card on a contended cluster. Coupling them would mean scaling CPU throughput silently asks NRP for more GPUs. Both default to 1 — and raising `active_replicas` is now an ordinary quota decision.
- **The sweeper pairs each Deployment with the queue *it* serves**, so a busy CPU queue never keeps a GPU pod alive. Each queue is asked once, not once per Deployment.
- **A GPU rollout failure in `deploy.yml` is a `::warning::`, not a job failure.** Failing there would mean a GPU shortage on NRP blocked shipping the CPU stages — exactly the coupling this removes.

## Deploy notes

- **Drain in-flight `PredictLaserImagesParentWorkflow` runs at deploy.** Its command sequence changed (new activity, new child queue, 2h -> 6h child timeout for the CPU path). Both predict parents are hourly and short-lived; the slate one is retired.
- First `kubectl apply -k` defaults all three Deployments to 1 replica; the hourly sweeper drops them to 0 within the hour.
- **No RBAC change needed** — the deploy identity already has `patch` on `deployments`.
- Ideally merge the data-worker auto-deploy PR before the api-worker one, though either order self-heals within a deploy cycle and affects only the predict stages.

## Verification

- 1,281 tests pass (508 api-worker, 414 api, 191 data-worker, 168 shared); `black --check` clean, pylint 10.00/10 on every changed and new file.
- `kustomize build` renders all three Deployments with the shared image tag and hashed ConfigMap; `nvidia.com/gpu` appears on exactly one.
- New: `test_gpu_fallback.py` (19 tests over the pure policy) and `test_ensure_gpu_worker_running_activity.py` (8, against a fake cluster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
