### PR TITLE
feat(api): add Priority.NONE and Dive.notes for parking a dive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -764,6 +764,27 @@ stage will touch, and re-running is safe (`dives.post` upserts on `path`, the
 scan skips registered frames without downloading, a fully-skipped re-run still
 commits).
 
+**`Priority.NONE` means "deliberately excluded", LOW means "not yet."**
+Added 2026-08-27 with `Dive.notes`. Every cohort selects `== HIGH`, so LOW
+and NONE are equally invisible to the pipeline — the distinction is for the
+human reading the table. LOW cannot carry intent, because it is the state
+every dive passes through on ingest, so a dive parked forever and a dive
+waiting its turn were indistinguishable. `notes` is free text and nothing in
+the pipeline reads it; it exists so the reason travels with the row. The
+standing example is dive 437, labelled `V-Slate 7` — a slate with no scan, so
+it can never be calibrated and can never be measured.
+
+Two things about the migration (`b3d5e91a7c42`) worth knowing before adding a
+fourth member: `priority` is a Postgres *native enum*, so a new value needs
+`ALTER TYPE ... ADD VALUE`, guarded on the dialect because the migration tests
+run against SQLite (which renders the column as VARCHAR). The `IF NOT EXISTS`
+is load-bearing, not defensive — `lifespan` runs `create_all` *before*
+`run_alembic_upgrade`, so on a fresh database the type already exists with the
+new member and the bare statement would raise `DuplicateObject` and stop the
+API from starting. The downgrade drops `notes` only: Postgres cannot remove an
+enum value, and rebuilding the type would have to decide what to do with rows
+already sitting at NONE.
+
 **Non-recursion is precedent, not simplification.** Spider walked the tree but
 assigned `dive = image.parent.relative_to(data_root)`, so a nested folder always
 became its own dive row. Attaching a subdirectory's frames to the named dive

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/_generated.py
@@ -276,6 +276,7 @@ class Priority(Enum):
 
     LOW = 'LOW'
     HIGH = 'HIGH'
+    NONE = 'NONE'
 
 
 class SlatePrediction(BaseModel):
@@ -372,6 +373,7 @@ class Dive(BaseModel):
     dive_datetime: AwareDatetime | None = Field(None, title='Dive Datetime')
     priority: Priority | None = 'LOW'
     flip_dive_slate: bool | None = Field(False, title='Flip Dive Slate')
+    notes: str | None = Field(None, title='Notes')
     camera_id: int | None = Field(None, title='Camera Id')
     dive_slate_id: int | None = Field(None, title='Dive Slate Id')
     calibration_dive_id: int | None = Field(None, title='Calibration Dive Id')

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/dive.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/dive.py
@@ -22,3 +22,7 @@ class Dive(ModelBase):
     # column existed — older API responses, worker test fixtures — still
     # validate. A newly-added optional column must be optional on the wire.
     calibration_dive_id: int | None = None
+    # Defaulted for the same reason as `calibration_dive_id` above: a newly
+    # added optional column must be optional on the wire, or every consumer
+    # built against an older API response fails validation.
+    notes: str | None = None

--- a/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/priority.py
+++ b/libs/fishsense-api-sdk/src/fishsense_api_sdk/models/priority.py
@@ -8,3 +8,11 @@ class Priority(str, Enum):
 
     LOW = "LOW"
     HIGH = "HIGH"
+
+    # "Deliberately excluded", as distinct from LOW's "not yet". Every dive is
+    # created LOW and promoted by ingest's finalize step, so LOW cannot say
+    # anything about intent -- a dive parked forever and a dive waiting its
+    # turn look identical. NONE is filtered out by the cohort selectors the
+    # same way LOW is; the difference is only legible to a human, which is why
+    # it travels with `Dive.notes`.
+    NONE = "NONE"

--- a/services/fishsense-api/src/fishsense_api/alembic/versions/b3d5e91a7c42_add_dive_notes_and_none_priority.py
+++ b/services/fishsense-api/src/fishsense_api/alembic/versions/b3d5e91a7c42_add_dive_notes_and_none_priority.py
@@ -1,0 +1,72 @@
+"""add Dive.notes and Priority.NONE
+
+Revision ID: b3d5e91a7c42
+Revises: a4c17f2b9e08
+Create Date: 2026-08-27 00:00:00.000000
+
+`NONE` is a third priority meaning "deliberately excluded", as opposed to
+LOW's "not yet". `notes` carries the reason. See `models/priority.py`.
+
+Two dialect-specific details, both of which fail loudly if got wrong:
+
+* `priority` is a Postgres *native enum type*, so a new member needs
+  `ALTER TYPE ... ADD VALUE`. SQLite renders the same column as VARCHAR and
+  has no such statement, so the call is guarded on the dialect — the
+  migration tests in this repo run against in-memory SQLite.
+* `IF NOT EXISTS` is required, not belt-and-braces. `lifespan` runs
+  `SQLModel.metadata.create_all` before `run_alembic_upgrade`, so a fresh
+  database already has the type built from the model *including* `NONE`
+  by the time this runs.
+
+`ALTER TYPE ... ADD VALUE` has been transaction-safe since Postgres 12
+(prod is 17), so it needs no autocommit block. The added label must not be
+*used* in the same transaction, and nothing here does.
+"""
+
+# pylint: skip-file
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b3d5e91a7c42"
+down_revision: Union[str, Sequence[str], None] = "a4c17f2b9e08"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+ENUM_TYPE_NAME = "priority"
+NEW_MEMBER = "NONE"
+
+
+def add_enum_value_sql(dialect_name: str) -> str | None:
+    """The `ALTER TYPE` for `dialect_name`, or None where it doesn't apply.
+
+    Split out as a plain function so the Postgres-only statement is
+    assertable from a SQLite test run.
+    """
+    if dialect_name != "postgresql":
+        return None
+    return f"ALTER TYPE {ENUM_TYPE_NAME} ADD VALUE IF NOT EXISTS '{NEW_MEMBER}'"
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("dive", sa.Column("notes", sa.String(), nullable=True))
+
+    sql = add_enum_value_sql(op.get_bind().dialect.name)
+    if sql is not None:
+        op.execute(sql)
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Only `notes` is reversible. Postgres cannot drop a value from an enum
+    type, and faking it (rebuild the type, rewrite the column) would have to
+    decide what to do with any row already sitting at NONE — silently
+    rewriting an operator's deliberate exclusion back to LOW is worse than
+    leaving an unused label in the type.
+    """
+    op.drop_column("dive", "notes")

--- a/services/fishsense-api/src/fishsense_api/models/dive.py
+++ b/services/fishsense-api/src/fishsense_api/models/dive.py
@@ -18,6 +18,15 @@ class Dive(ModelBase, table=True):
     priority: Priority = Field(default=Priority.LOW, sa_column=Column(Enum(Priority)))
     flip_dive_slate: bool | None = Field(default=False)
 
+    # Free-text operator note. Exists to carry the *reason* a dive is in an
+    # unusual state — overwhelmingly, why it was set `Priority.NONE`. Nothing
+    # in the pipeline reads it: it is for the human looking at a dive that
+    # will never drain and asking why. Deliberately unstructured, because the
+    # reasons are one-offs (a slate with no scan, a corrupted card, a dive
+    # shot on a rig whose calibration was never recoverable) and any schema
+    # we invented for them would be wrong by the third case.
+    notes: str | None = Field(default=None)
+
     camera_id: int | None = Field(default=None, foreign_key="camera.id")
     dive_slate_id: int | None = Field(default=None, foreign_key="diveslate.id")
 

--- a/services/fishsense-api/src/fishsense_api/models/priority.py
+++ b/services/fishsense-api/src/fishsense_api/models/priority.py
@@ -8,3 +8,11 @@ class Priority(str, Enum):
 
     LOW = "LOW"
     HIGH = "HIGH"
+
+    # "Deliberately excluded", as distinct from LOW's "not yet". Every dive is
+    # created LOW and promoted by ingest's finalize step, so LOW cannot say
+    # anything about intent -- a dive parked forever and a dive waiting its
+    # turn look identical. NONE is filtered out by the cohort selectors the
+    # same way LOW is; the difference is only legible to a human, which is why
+    # it travels with `Dive.notes`.
+    NONE = "NONE"

--- a/services/fishsense-api/tests/test_dive_none_priority_and_notes.py
+++ b/services/fishsense-api/tests/test_dive_none_priority_and_notes.py
@@ -1,0 +1,198 @@
+"""`Priority.NONE` + `Dive.notes` — parking a dive with a stated reason.
+
+Some dives can never complete the pipeline for a reason that lives outside
+the data: dive 437 was labelled `V-Slate 7`, and no scan of that slate
+exists, so it can never be calibrated and can never be measured. LOW was
+the only way to keep it out of the hourly cohorts, but LOW means "not yet"
+— it is the state every freshly-ingested dive passes through — so a parked
+dive is indistinguishable from one merely waiting its turn, and the reason
+lives nowhere at all.
+
+`NONE` says "deliberately excluded"; `notes` says why. Both are needed:
+the enum without the note re-raises "why is this one NONE?" every time
+someone reads the table, and the note without the enum has nowhere to hang.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.fixture
+async def session():
+    import fishsense_api.database  # noqa: F401  # pylint: disable=unused-import
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as open_session:
+        yield open_session
+    await engine.dispose()
+
+
+def _camera_with_intrinsics(session, camera_id: int = 1):
+    """`post_dive` validates camera + intrinsics on the effective row."""
+    from fishsense_api.models.camera import Camera
+    from fishsense_api.models.camera_intrinsics import CameraIntrinsics
+
+    session.add(
+        Camera(
+            id=camera_id,
+            name=f"FSL{camera_id:02d}",
+            serial_number=f"SN{camera_id:06d}",
+        )
+    )
+    session.add(
+        CameraIntrinsics(
+            id=camera_id,
+            camera_id=camera_id,
+            fx=1.0,
+            fy=1.0,
+            cx=1.0,
+            cy=1.0,
+            k1=0.0,
+            k2=0.0,
+            p1=0.0,
+            p2=0.0,
+            k3=0.0,
+        )
+    )
+
+
+def _body(**overrides):
+    from fishsense_api.models.dive import Dive
+
+    fields = {
+        "path": "/dev/null/parked",
+        "dive_datetime": datetime(2025, 1, 1, tzinfo=timezone.utc),
+        "camera_id": 1,
+    }
+    fields.update(overrides)
+    return Dive(**fields)
+
+
+# --- the enum itself -------------------------------------------------------
+
+
+def test_priority_has_none_member():
+    from fishsense_api.models.priority import Priority
+
+    assert Priority.NONE.value == "NONE"
+
+
+def test_sdk_priority_mirrors_none():
+    """The SDK enum is hand-mirrored; drift here is a wire-format break."""
+    from fishsense_api.models.priority import Priority as ApiPriority
+    from fishsense_api_sdk.models.priority import Priority as SdkPriority
+
+    assert SdkPriority.NONE.value == "NONE"
+    assert {p.value for p in SdkPriority} == {p.value for p in ApiPriority}
+
+
+# --- persistence -----------------------------------------------------------
+
+
+async def test_none_priority_round_trips(session):
+    from fishsense_api.controllers.dive_controller import post_dive
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.priority import Priority
+
+    _camera_with_intrinsics(session)
+    await session.flush()
+
+    dive_id = await post_dive(_body(priority=Priority.NONE), session=session)
+
+    assert (await session.get(Dive, dive_id)).priority is Priority.NONE
+
+
+async def test_notes_round_trip(session):
+    from fishsense_api.controllers.dive_controller import post_dive
+    from fishsense_api.models.dive import Dive
+
+    _camera_with_intrinsics(session)
+    await session.flush()
+
+    note = "V-Slate 7; no scan exists, so this dive can never be calibrated."
+    dive_id = await post_dive(_body(notes=note), session=session)
+
+    assert (await session.get(Dive, dive_id)).notes == note
+
+
+async def test_notes_survive_a_partial_repost(session):
+    """The overlay in `post_dive` must not null `notes`.
+
+    Same failure shape the overlay already guards for `dive_slate_id` and
+    `calibration_dive_id`: a body that mentions only `priority` would
+    otherwise wipe the reason the dive was parked in the first place.
+    """
+    from fishsense_api.controllers.dive_controller import post_dive
+    from fishsense_api.models.dive import Dive
+    from fishsense_api.models.priority import Priority
+
+    _camera_with_intrinsics(session)
+    await session.flush()
+
+    note = "V-Slate 7; no scan exists."
+    dive_id = await post_dive(
+        _body(priority=Priority.NONE, notes=note), session=session
+    )
+
+    # A later re-post that only speaks about priority.
+    await post_dive(
+        _body(priority=Priority.LOW),
+        session=session,
+    )
+
+    row = await session.get(Dive, dive_id)
+    assert row.priority is Priority.LOW
+    assert row.notes == note
+
+
+async def test_unknown_priority_still_422s(session):
+    """The coercion guard must keep rejecting garbage once NONE exists."""
+    from fastapi import HTTPException
+
+    from fishsense_api.controllers.dive_controller import post_dive
+    from fishsense_api.models.dive import Dive
+
+    _camera_with_intrinsics(session)
+    await session.flush()
+
+    body = Dive.model_construct(
+        path="/dev/null/bad",
+        dive_datetime=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        camera_id=1,
+        priority="URGENT",
+    )
+    with pytest.raises(HTTPException) as exc:
+        await post_dive(body, session=session)
+    assert exc.value.status_code == 422
+
+
+# --- the point of the enum: cohort exclusion -------------------------------
+
+
+async def test_none_priority_dive_is_not_selected_by_a_cohort(session):
+    """A parked dive must be invisible to the hourly selectors.
+
+    Stage 0.1 is the broadest cohort (an image with no laser label at all),
+    so a dive that escapes this one escapes nothing else either.
+    """
+    from tests_support.db import dive, image
+
+    from fishsense_api.controllers.dive_cohort_controller import (
+        select_next_for_laser_preprocessing,
+    )
+    from fishsense_api.models.priority import Priority
+
+    session.add(dive(1, priority=Priority.NONE))
+    session.add(image(10, 1))
+    await session.flush()
+
+    assert await select_next_for_laser_preprocessing(session=session) is None

--- a/services/fishsense-api/tests/test_dive_notes_none_priority_migration.py
+++ b/services/fishsense-api/tests/test_dive_notes_none_priority_migration.py
@@ -1,0 +1,125 @@
+"""The `Dive.notes` + `Priority.NONE` migration.
+
+Two halves with very different failure modes:
+
+* `notes` is an ordinary `add_column`, portable everywhere.
+* `NONE` is a new label on the Postgres native enum type `priority`, which
+  needs `ALTER TYPE ... ADD VALUE`. That statement does not exist on SQLite
+  (where SQLModel renders the enum as a VARCHAR + CHECK), so it has to be
+  dialect-guarded or every migration test in this suite dies on it.
+
+The `IF NOT EXISTS` is load-bearing rather than defensive. `lifespan` runs
+`SQLModel.metadata.create_all` *before* `run_alembic_upgrade`, so on a fresh
+database the enum type is created from the model — already carrying `NONE` —
+and the migration then runs against it. Without `IF NOT EXISTS` that path
+raises `DuplicateObject` and the API never finishes starting.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+import sqlalchemy as sa
+
+
+@pytest.fixture
+def migration():
+    from fishsense_api.alembic.versions import (
+        b3d5e91a7c42_add_dive_notes_and_none_priority as mod,
+    )
+
+    return mod
+
+
+@pytest.fixture
+def engine():
+    """A `dive` table shaped like the pre-migration schema."""
+    eng = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    table = sa.Table(
+        "dive",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("path", sa.String(255)),
+        sa.Column("dive_datetime", sa.DateTime(timezone=True)),
+        sa.Column("priority", sa.String()),
+    )
+    metadata.create_all(eng)
+    return eng, table
+
+
+def _run_upgrade(migration, conn):
+    from alembic.migration import MigrationContext
+    from alembic.operations import Operations
+
+    with Operations.context(MigrationContext.configure(conn)):
+        migration.upgrade()
+
+
+def _columns(conn) -> set[str]:
+    return {c["name"] for c in sa.inspect(conn).get_columns("dive")}
+
+
+# --- the portable half -----------------------------------------------------
+
+
+def test_adds_the_notes_column(migration, engine):
+    eng, _ = engine
+    with eng.begin() as conn:
+        _run_upgrade(migration, conn)
+        assert "notes" in _columns(conn)
+
+
+def test_notes_is_nullable_so_existing_rows_survive(migration, engine):
+    """Every dive in prod predates this column; a NOT NULL would fail the
+    migration outright on a non-empty table."""
+    eng, table = engine
+    with eng.begin() as conn:
+        conn.execute(
+            table.insert().values(
+                id=1,
+                path="d/1",
+                dive_datetime=datetime(2024, 8, 21, tzinfo=timezone.utc),
+                priority="HIGH",
+            )
+        )
+        _run_upgrade(migration, conn)
+
+        assert conn.execute(sa.text("SELECT notes FROM dive")).scalar() is None
+
+
+def test_upgrade_does_not_raise_on_sqlite(migration, engine):
+    """The dialect guard, stated as a test.
+
+    Without it the Postgres-only `ALTER TYPE` reaches SQLite and every
+    migration test in the suite fails on an unrelated change.
+    """
+    eng, _ = engine
+    with eng.begin() as conn:
+        _run_upgrade(migration, conn)   # must not raise
+
+
+# --- the Postgres-only half ------------------------------------------------
+
+
+def test_enum_sql_is_emitted_for_postgres(migration):
+    sql = migration.add_enum_value_sql("postgresql")
+
+    assert sql is not None
+    normalized = " ".join(sql.split()).upper()
+    assert "ALTER TYPE" in normalized
+    assert "PRIORITY" in normalized
+    assert "'NONE'" in normalized
+
+
+def test_enum_sql_is_idempotent(migration):
+    """`create_all` may already have built the type with NONE in it."""
+    sql = migration.add_enum_value_sql("postgresql")
+
+    assert "IF NOT EXISTS" in " ".join(sql.split()).upper()
+
+
+@pytest.mark.parametrize("dialect", ["sqlite", "mysql"])
+def test_no_enum_sql_off_postgres(migration, dialect):
+    assert migration.add_enum_value_sql(dialect) is None


### PR DESCRIPTION
## Why

Some dives can never complete the pipeline for a reason that lives outside the data. The case that prompted this: **dive 437** (`101624_Alligator0_FSL01`) is labelled `V-Slate 7`, and no scan of that slate exists — so it can never be calibrated by stage 13 and can never be measured by stage 14.

`LOW` was the only way to keep such a dive out of the hourly cohorts, but LOW cannot carry intent. It is the state every dive passes through on ingest (`create_dive` writes LOW regardless of the request; `finalize_dive` promotes it), so a dive parked forever and a dive waiting its turn look identical — and the reason lives nowhere at all.

`NONE` says "deliberately excluded". `notes` says why.

## What

| File | Change |
|---|---|
| `models/priority.py` (API + SDK) | `NONE = "NONE"` |
| `models/dive.py` (API) | `notes: str \| None` |
| `models/dive.py` (SDK) | `notes: str \| None = None` — defaulted, like `calibration_dive_id` |
| `_generated.py` | regenerated |
| `alembic/versions/b3d5e91a7c42_…` | new migration |
| `CLAUDE.md` | documented the semantics |

**No cohort selector changes were needed.** All 12 selectors already filter `Dive.priority == Priority.HIGH`, so NONE is excluded automatically. The difference between LOW and NONE is legible only to a human, which is why it travels with `notes`.

`notes` is free text and nothing in the pipeline reads it — deliberately unstructured, because the reasons are one-offs (a slate with no scan, a corrupted card, a rig whose calibration was never recoverable) and any schema invented for them would be wrong by the third case.

## Two dialect details in the migration

* **`priority` is a Postgres native enum** (verified against prod: `typname='priority'`, labels LOW/HIGH), so a new member needs `ALTER TYPE ... ADD VALUE`. That statement does not exist on SQLite, where the migration tests in this repo run and SQLModel renders the column as VARCHAR — so it is dialect-guarded. Extracted as `add_enum_value_sql(dialect_name)` so the Postgres-only statement stays assertable from a SQLite run.
* **`IF NOT EXISTS` is load-bearing, not defensive.** `lifespan` runs `SQLModel.metadata.create_all` *before* `run_alembic_upgrade`, so on a fresh database the enum type is built from the model already carrying `NONE`, and the bare statement would raise `DuplicateObject` and stop the API from starting.

`ALTER TYPE ... ADD VALUE` has been transaction-safe since Postgres 12 (prod is 17), so no autocommit block is needed. The new label must not be *used* in the same transaction, and nothing here does.

**Downgrade drops `notes` only.** Postgres cannot remove a value from an enum type, and rebuilding it would have to decide what to do with rows already sitting at NONE — silently rewriting an operator's deliberate exclusion back to LOW is worse than leaving an unused label in the type.

## Tests

14 new tests, written first, each failing for the right reason before the implementation landed.

- `test_dive_none_priority_and_notes.py` — enum member, SDK mirror parity, NONE round-trip, notes round-trip, unknown-priority still 422s, and **NONE excluded from a cohort** (stage 0.1, the broadest — a dive that escapes it escapes everything).
- `test_dive_notes_none_priority_migration.py` — column added, nullable so existing rows survive, upgrade does not raise on SQLite (the dialect guard stated as a test), and the enum SQL is emitted only for Postgres and only idempotently.

One worth calling out: `test_notes_survive_a_partial_repost`. `post_dive`'s overlay iterates `model_fields_set` generically, so `notes` is already protected the way `dive_slate_id` and `calibration_dive_id` are — no code change was required. The test pins it because a future refactor to explicit field handling would silently wipe the reason a dive was parked, and nothing would report it.

Full suites green: **428 API, 142 SDK.** `black --check` clean, pylint 10.00 on the changed files.

## Deploy note

The migration must ship before any dive can be set to NONE — until the `ALTER TYPE` has run, the write fails on the enum constraint. Dive 437 is not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
